### PR TITLE
Include the database.yml file in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,7 +27,5 @@ yarn-debug.log*
 # Ignore .env file
 .env
 
-config/database.yml
-
 # Ignore git repo
 .git


### PR DESCRIPTION
This shouldn't be needed but something in the PostGIS adapter is trying to
explicitly load this file whether needed or not.


