### PR TITLE
Switched to using PostGIS enabled version of Postgres

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,13 +3,14 @@ pool:
 
 variables:
   imageName: school-experience
+  POSTGRES_IMAGE: mdillon/postgis:11-alpine
   POSTGRESS_PASSWORD: secret
-  DATABASE_URL: postgres://postgres:secret@postgres/school_experience_test
-  WEB_URL: postgres://postgres:secret@postgres/school_experience
+  DATABASE_URL: postgis://postgres:secret@postgres/school_experience_test
+  WEB_URL: postgis://postgres:secret@postgres/school_experience
   SECRET_KEY_BASE: stubbed
 
 steps:
-  - script: docker run --name=postgres -e POSTGRES_PASSWORD -d postgres
+  - script: docker run --name=postgres -e POSTGRES_PASSWORD -d $(POSTGRES_IMAGE)
     displayName: Launch Postgres # done early to give it time to boot
   - script: docker build -t $(imageName) .
     displayName: Build Docker Image


### PR DESCRIPTION
Within the Azure Pipeline, we run Postgres from a Docker Image

The official image does include support the PostGIS extension within the Docker
image, so `create extension postgis` will always fail.

Switching to mdillon's fork which includes the PostGIS extension. This has 10M
downloads at this point and seems to be regularly updated. The running container
is not accessible outside of the internal Docker network within the CI
environment so this seems safe to depend upon from a security perspective
despite being a non official image.


