### PR TITLE
SE-29 #comment Adds registrations placements form

### DIFF
--- a/app/controllers/candidate/registrations/personal_details_controller.rb
+++ b/app/controllers/candidate/registrations/personal_details_controller.rb
@@ -1,0 +1,3 @@
+class Candidate::Registrations::PersonalDetailsController < ApplicationController
+  def new; end
+end

--- a/app/controllers/candidate/registrations/placements_controller.rb
+++ b/app/controllers/candidate/registrations/placements_controller.rb
@@ -1,0 +1,32 @@
+class Candidate::Registrations::PlacementsController < ApplicationController
+  def new
+    @placement = Candidate::Registrations::Placement.new
+  end
+
+  def create
+    @placement = Candidate::Registrations::Placement.new placement_params
+    if @placement.valid?
+      persist! @placement
+      redirect_to new_candidate_registrations_personal_detail_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def placement_params
+    params.require(:candidate_registrations_placement).permit \
+      :date_start,
+      :date_end,
+      :objectives,
+      :access_needs,
+      :access_needs_details
+  end
+
+  def persist!(placement)
+    #registration = Registraion.new(session[:registration])
+    #registration.placement = placement
+    session[:registration] = { placement: placement.attributes }
+  end
+end

--- a/app/services/candidate/registrations/placement.rb
+++ b/app/services/candidate/registrations/placement.rb
@@ -1,0 +1,82 @@
+class Candidate::Registrations::Placement
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  MAX_WORDS_FOR_OBJECTIVE = 50
+
+  attribute :date_start, :date
+  attribute :date_end, :date
+  attribute :objectives, :string
+  attribute :access_needs, :boolean
+  attribute :access_needs_details, :string
+
+  validates :date_start, presence: true
+  validate  :date_start_is_a_date, if: -> { date_start.present? }
+  validates :date_end, presence: true
+  validate  :date_end_is_a_date, if: -> { date_end.present? }
+  validate  :date_start_is_not_in_the_past, if: -> { date_start_is_a_date? }
+  validate  :date_end_not_before_date_start, if: -> { date_start_is_a_date? && date_end_is_a_date? }
+  validates :objectives, presence: true
+  validate  :objectives_not_too_long, if: -> { objectives.present? }
+  validates :access_needs, inclusion: { in: [true, false], message: "Please select an option" }
+  validates :access_needs_details, presence: true, if: -> { access_needs.present? }
+
+private
+
+  def date_start_is_a_date
+    unless date_start_is_a_date?
+      errors.add :date_start, 'is not a date'
+    end
+  end
+
+  def date_start_is_a_date?
+    is_a_date? date_start
+  end
+
+  def date_end_is_a_date
+    unless date_end_is_a_date?
+      errors.add :date_end, 'is not a date'
+    end
+  end
+
+  def date_end_is_a_date?
+    is_a_date? date_end
+  end
+
+  def is_a_date?(maybe_date)
+    Date.parse maybe_date.to_s
+    true
+  rescue ArgumentError
+    false
+  end
+
+  def date_start_is_not_in_the_past
+    if date_start_is_in_the_past?
+      errors.add :date_start, 'should not be in the past'
+    end
+  end
+
+  def date_start_is_in_the_past?
+    date_start < Date.today
+  end
+
+  def date_end_not_before_date_start
+    unless date_end_not_before_date_start?
+      errors.add :date_end, 'should not be before prefered start date'
+    end
+  end
+
+  def date_end_not_before_date_start?
+    date_end > date_start
+  end
+
+  def objectives_not_too_long
+    if objectives_too_long?
+      errors.add :objectives, 'Please use 50 words or fewer'
+    end
+  end
+
+  def objectives_too_long?
+    objectives.scan(/\w/).size > MAX_WORDS_FOR_OBJECTIVE
+  end
+end

--- a/app/views/candidate/registrations/personal_details/new.html.erb
+++ b/app/views/candidate/registrations/personal_details/new.html.erb
@@ -1,0 +1,1 @@
+Register your details with us so you can get school experience placements.

--- a/app/views/candidate/registrations/placements/new.html.erb
+++ b/app/views/candidate/registrations/placements/new.html.erb
@@ -1,0 +1,36 @@
+Request school experience placement
+
+<%= form_for @placement do |f| %>
+  <div>
+    <%= f.label :date_start, 'Start Date' %>
+    <%= f.date_field :date_start %>
+    <%= f.object.errors[:date_start].join('  ') %>
+  </div>
+
+  <div>
+    <%= f.label :date_end, 'End Date' %>
+    <%= f.date_field :date_end %>
+    <%= f.object.errors[:date_end].join('  ') %>
+  </div>
+
+  <div>
+    <%= f.label :objectives %>
+    <%= f.text_field :objectives %>
+    <%= f.object.errors[:objectives].join('  ') %>
+  </div>
+
+  <div>
+    <%= f.radio_button :access_needs, '1' %>
+    <%= f.label :access_needs, 'Yes', value: '1' %>
+    <%= f.radio_button :access_needs, '0' %>
+    <%= f.label :access_needs, 'No', value: '0' %>
+    <%= f.label :access_needs_details %>
+    <%= f.text_field :access_needs_details %>
+    <%= f.object.errors[:access_needs].join('  ') %>
+  </div>
+
+  <div>
+    <%= f.submit 'Continue' %>
+  </div>
+<% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,14 @@ Rails.application.routes.draw do
   namespace :candidate do
     root to: 'home#index'
 
-    resources :schools, only: [:index, :show] do
+    resources :schools, only: %i(index show) do
       get 'request_placement', to: 'placement_requests#new'
       post 'request_placement', to: 'placement_requests#create'
+    end
+
+    namespace :registrations do
+      resources :placements, only: %i(new create)
+      resources :personal_details, only: %i(new)
     end
   end
 end

--- a/spec/controllers/candidate/registrations/placements_controller_spec.rb
+++ b/spec/controllers/candidate/registrations/placements_controller_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+describe Candidate::Registrations::PlacementsController, type: :request do
+  let! :tomorrow do
+    Date.tomorrow
+  end
+
+  context '#new' do
+    before do
+      get '/candidate/registrations/placements/new'
+    end
+
+    it 'responds with 200' do
+      expect(response.status).to eq 200
+    end
+
+    it 'renders the new form' do
+      expect(response.body).to render_template :new
+    end
+  end
+
+  context '#create' do
+    before do
+      post '/candidate/registrations/placements', params: placement_params
+    end
+
+    context 'invalid' do
+      let :placement_params do
+        { candidate_registrations_placement: { date_start: tomorrow } }
+      end
+
+      it 'rerenders the new form' do
+        expect(response.body).to render_template :new
+      end
+    end
+
+    context 'valid' do
+      let :placement_params do
+        {
+          candidate_registrations_placement: {
+            date_start: tomorrow,
+            date_end: (tomorrow + 3.days),
+            objectives: 'Become a teacher',
+            access_needs: false
+          }
+        }
+      end
+
+      it 'stores the placement details in the session' do
+        expect(session[:registration][:placement]).to eq(
+          "date_start" => tomorrow,
+          "date_end" => (tomorrow + 3.days),
+          "objectives" => 'Become a teacher',
+          "access_needs" => false,
+          "access_needs_details" => nil
+        )
+      end
+
+      it 'redirects to the next step' do
+        expect(response).to redirect_to \
+          '/candidate/registrations/personal_details/new'
+      end
+    end
+  end
+end

--- a/spec/features/candidate/registrations_spec.rb
+++ b/spec/features/candidate/registrations_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+feature 'Candidate Registrations', type: :feature do
+  let! :today do
+    Date.today
+  end
+
+  let! :tomorrow do
+    today + 1.day
+  end
+
+  scenario 'Navigate to registrations/placements/new' do
+    visit '/candidate/registrations/placements/new'
+
+    expect(page).to have_text 'Request school experience placement'
+  end
+
+  scenario 'Submit registrations/placements form with errors' do
+    visit '/candidate/registrations/placements/new'
+
+    fill_in 'Start Date', with: today
+    fill_in 'End Date',   with: tomorrow
+    fill_in 'Objectives', with: 'I enjoy teaching'
+
+    click_button 'Continue'
+
+    expect(page).to have_text 'Please select an option'
+  end
+
+  scenario 'Submit registrations/placements form successfully' do
+    visit '/candidate/registrations/placements/new'
+
+    fill_in 'Start Date', with: today
+    fill_in 'End Date',   with: tomorrow
+    fill_in 'Objectives', with: 'I enjoy teaching'
+    choose 'No'
+
+    click_button 'Continue'
+
+    expect(page.current_path).to eq '/candidate/registrations/personal_details/new'
+  end
+end

--- a/spec/services/candidate/registrations/placement_spec.rb
+++ b/spec/services/candidate/registrations/placement_spec.rb
@@ -1,0 +1,137 @@
+require 'rails_helper'
+
+describe Candidate::Registrations::Placement, type: :model do
+  let! :today do
+    Date.today
+  end
+
+  context 'attributes' do
+    it { is_expected.to respond_to :date_start }
+    it { is_expected.to respond_to :date_end }
+    it { is_expected.to respond_to :objectives }
+    it { is_expected.to respond_to :access_needs }
+  end
+
+  context 'validations' do
+    before :each do
+      placement.validate
+    end
+
+    context 'when date_start is not present' do
+      let :placement do
+        described_class.new
+      end
+
+      it 'adds an error to date_start' do
+        expect(placement.errors[:date_start]).to eq \
+          ["can't be blank"]
+      end
+    end
+
+    context 'when date_start is not a date' do
+      let :placement do
+        described_class.new date_start: 'Im not a date'
+      end
+
+      it 'adds an error to date_start' do
+        expect(placement.errors[:date_start]).to eq \
+          ["can't be blank"]
+      end
+    end
+
+    context 'when date_end is not present' do
+      let :placement do
+        described_class.new
+      end
+
+      it 'adds an error to date_end' do
+        expect(placement.errors[:date_end]).to eq \
+          ["can't be blank"]
+      end
+    end
+
+    context 'when date_end is not a date' do
+      let :placement do
+        described_class.new date_end: 'Im not a date'
+      end
+
+      it 'adds an error to date_end' do
+        expect(placement.errors[:date_end]).to eq \
+          ["can't be blank"]
+      end
+    end
+
+    context 'when date_end is before date_start' do
+      let :placement do
+        described_class.new \
+          date_start: today,
+          date_end: (today - 3.days)
+      end
+
+      it 'adds an error to date_end' do
+        expect(placement.errors[:date_end]).to eq \
+          ["should not be before prefered start date"]
+      end
+    end
+
+    context 'when date_start is in the past' do
+      let :placement do
+        described_class.new \
+          date_start: 3.days.ago,
+          date_end: today
+      end
+
+      it 'adds an error to date_start' do
+        expect(placement.errors[:date_start]).to eq \
+          ["should not be in the past"]
+      end
+    end
+
+    context 'when objectives are not present' do
+      let :placement do
+        described_class.new
+      end
+
+      it 'adds an error to objectives' do
+        expect(placement.errors[:objectives]).to eq \
+          ["can't be blank"]
+      end
+    end
+
+    context 'when objectives are too long' do
+      let :placement do
+        described_class.new \
+          objectives: 51.times.map { 'word' }.join(' ')
+      end
+
+      it 'adds an error to objectives' do
+        expect(placement.errors[:objectives]).to eq \
+          ["Please use 50 words or fewer"]
+      end
+    end
+
+    context 'when access_needs are not a boolean' do
+      let :placement do
+        described_class.new
+      end
+
+      it 'adds an error to access_needs' do
+        expect(placement.errors[:access_needs]).to eq \
+          ['Please select an option']
+      end
+    end
+
+    context 'when access_needs are present' do
+      context 'when access_needs_details are not present' do
+        let :placement do
+          described_class.new access_needs: true
+        end
+
+        it 'adds an error to access_needs_details' do
+          expect(placement.errors[:access_needs_details]).to eq \
+            ["can't be blank"]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds initial placements form for candidate registrations.
UI is unstyled. To be added in future ticket.
Successful form submission persists placement information in candidate's
session.
Opted to break up the registration 'wizard' into separate end points,
each backed by a separate form model. This avoids some of the
complexities of conditioning validations based on the wizard step.

### Comments

Opened a ticket to get feed back on the validation errors SE-167
Opened a ticket to implement styling / use form builder SE-168
Also not sure if the features specs are over kill and will be superseded by the cucumber feature specs, if they are I'll open a ticket to remove them, just needed something to drive the TDD