### PR TITLE
Add a migration that ensures PostGIS is enabled

### DIFF
--- a/db/migrate/20190116152522_enable_postgis_extension.rb
+++ b/db/migrate/20190116152522_enable_postgis_extension.rb
@@ -1,0 +1,5 @@
+class EnablePostgisExtension < ActiveRecord::Migration[5.2]
+  def change
+    enable_extension :postgis
+  end
+end


### PR DESCRIPTION
### Context

Ensure PostGIS is enabled

### Guidance to review

Note that [`enable_extension`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/PostgreSQLAdapter.html#method-i-enable_extension) only enables if it's not already enabled.
