### PR TITLE
SE-142 #comment Add registrations personal details form

### DIFF
--- a/app/controllers/candidate/registrations/account_infos_controller.rb
+++ b/app/controllers/candidate/registrations/account_infos_controller.rb
@@ -1,0 +1,3 @@
+class Candidate::Registrations::AccountInfosController < Candidate::RegistrationsController
+  def new; end
+end

--- a/app/controllers/candidate/registrations/personal_details_controller.rb
+++ b/app/controllers/candidate/registrations/personal_details_controller.rb
@@ -1,3 +1,27 @@
-class Candidate::Registrations::PersonalDetailsController < ApplicationController
-  def new; end
+class Candidate::Registrations::PersonalDetailsController < Candidate::RegistrationsController
+  def new
+    @personal_details = Candidate::Registrations::PersonalDetail.new
+  end
+
+  def create
+    @personal_details = Candidate::Registrations::PersonalDetail.new personal_detail_params
+    if @personal_details.valid?
+      current_registration[:personal_details] = @personal_details.attributes
+      redirect_to new_candidate_registrations_account_info_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def personal_detail_params
+    params.require(:candidate_registrations_personal_detail).permit \
+      :building,
+      :street,
+      :town_or_city,
+      :county,
+      :postcode,
+      :phone
+  end
 end

--- a/app/controllers/candidate/registrations/placements_controller.rb
+++ b/app/controllers/candidate/registrations/placements_controller.rb
@@ -1,4 +1,4 @@
-class Candidate::Registrations::PlacementsController < ApplicationController
+class Candidate::Registrations::PlacementsController < Candidate::RegistrationsController
   def new
     @placement = Candidate::Registrations::Placement.new
   end
@@ -6,7 +6,7 @@ class Candidate::Registrations::PlacementsController < ApplicationController
   def create
     @placement = Candidate::Registrations::Placement.new placement_params
     if @placement.valid?
-      persist! @placement
+      current_registration[:placement] = @placement.attributes
       redirect_to new_candidate_registrations_personal_detail_path
     else
       render :new
@@ -22,11 +22,5 @@ private
       :objectives,
       :access_needs,
       :access_needs_details
-  end
-
-  def persist!(placement)
-    #registration = Registraion.new(session[:registration])
-    #registration.placement = placement
-    session[:registration] = { placement: placement.attributes }
   end
 end

--- a/app/controllers/candidate/registrations_controller.rb
+++ b/app/controllers/candidate/registrations_controller.rb
@@ -1,0 +1,7 @@
+class Candidate::RegistrationsController < ApplicationController
+private
+
+  def current_registration
+    session[:registration] ||= {}
+  end
+end

--- a/app/services/candidate/registrations/personal_detail.rb
+++ b/app/services/candidate/registrations/personal_detail.rb
@@ -1,0 +1,18 @@
+class Candidate::Registrations::PersonalDetail
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :building, :string
+  attribute :street, :string
+  attribute :town_or_city, :string
+  attribute :county, :string
+  attribute :postcode, :string
+  attribute :phone, :string
+
+  validates :building, presence: true
+  validates :street, presence: true
+  validates :town_or_city, presence: true
+  validates :county, presence: true
+  validates :postcode, presence: true
+  validates :phone, presence: true
+end

--- a/app/views/candidate/registrations/account_infos/new.html.erb
+++ b/app/views/candidate/registrations/account_infos/new.html.erb
@@ -1,0 +1,1 @@
+We need some more details

--- a/app/views/candidate/registrations/personal_details/new.html.erb
+++ b/app/views/candidate/registrations/personal_details/new.html.erb
@@ -1,1 +1,43 @@
 Register your details with us so you can get school experience placements.
+
+<%= form_for @personal_details do |f| %>
+  <div>
+    <%= f.label :building %>
+    <%= f.text_field :building %>
+    <%= f.object.errors[:building].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :street %>
+    <%= f.text_field :street %>
+    <%= f.object.errors[:street].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :town_or_city %>
+    <%= f.text_field :town_or_city %>
+    <%= f.object.errors[:town_or_city].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :county %>
+    <%= f.text_field :county %>
+    <%= f.object.errors[:county].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :postcode %>
+    <%= f.text_field :postcode %>
+    <%= f.object.errors[:postcode].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :phone %>
+    <%= f.telephone_field :phone %>
+    <%= f.object.errors[:phone].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.submit 'Continue' %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,8 @@ Rails.application.routes.draw do
 
     namespace :registrations do
       resources :placements, only: %i(new create)
-      resources :personal_details, only: %i(new)
+      resources :personal_details, only: %i(new create)
+      resource :account_info, only: %i(new)
     end
   end
 end

--- a/spec/controllers/candidate/registrations/personal_details_controller_spec.rb
+++ b/spec/controllers/candidate/registrations/personal_details_controller_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+describe Candidate::Registrations::PersonalDetailsController, type: :request do
+  context '#new' do
+    before do
+      get '/candidate/registrations/personal_details/new'
+    end
+
+    it 'responds with 200' do
+      expect(response.status).to eq 200
+    end
+
+    it 'renders the new form' do
+      expect(response.body).to render_template :new
+    end
+  end
+
+  context '#create' do
+    before do
+      post '/candidate/registrations/personal_details',
+        params: personal_detail_params
+    end
+
+    context 'invalid' do
+      let :personal_detail_params do
+        {
+          candidate_registrations_personal_detail: {
+            building: 'Test house',
+            street: 'Test street',
+            town_or_city: 'Test Town',
+            county: 'Testshire',
+            postcode: 'TE57 1NG'
+          }
+        }
+      end
+
+      it 'rerenders the new template' do
+        expect(response).to render_template :new
+      end
+    end
+
+    context 'valid' do
+      let :personal_detail_params do
+        {
+          candidate_registrations_personal_detail: {
+            building: 'Test house',
+            street: 'Test street',
+            town_or_city: 'Test Town',
+            county: 'Testshire',
+            postcode: 'TE57 1NG',
+            phone: '01234567890',
+          }
+        }
+      end
+
+      it 'stores the personal details in the session' do
+        expect(session[:registration][:personal_details]).to eq(
+          "building" => 'Test house',
+          "street" => 'Test street',
+          "town_or_city" => 'Test Town',
+          "county" => 'Testshire',
+          "postcode" => 'TE57 1NG',
+          "phone" => '01234567890'
+        )
+      end
+
+      it 'redirects to the next step' do
+        expect(response).to redirect_to '/candidate/registrations/account_info/new'
+      end
+    end
+  end
+end

--- a/spec/features/candidate/registrations_spec.rb
+++ b/spec/features/candidate/registrations_spec.rb
@@ -39,4 +39,33 @@ feature 'Candidate Registrations', type: :feature do
 
     expect(page.current_path).to eq '/candidate/registrations/personal_details/new'
   end
+
+  scenario 'Submit registrations/personal_details form with errors' do
+    visit '/candidate/registrations/personal_details/new'
+
+    fill_in 'Building', with: 'Test house'
+    fill_in 'Street', with: 'Test street'
+    fill_in 'Town or city', with: 'Test Town'
+    fill_in 'County', with: 'Testshire'
+    fill_in 'Postcode', with: 'TE57 1NG'
+
+    click_button 'Continue'
+
+    expect(page).to have_text "can't be blank"
+  end
+
+  scenario 'Submit registrations/personal_details form successfully' do
+    visit '/candidate/registrations/personal_details/new'
+
+    fill_in 'Building', with: 'Test house'
+    fill_in 'Street', with: 'Test street'
+    fill_in 'Town or city', with: 'Test Town'
+    fill_in 'County', with: 'Testshire'
+    fill_in 'Postcode', with: 'TE57 1NG'
+    fill_in 'Phone', with: '01234567890'
+
+    click_button 'Continue'
+
+    expect(page.current_path).to eq '/candidate/registrations/account_info/new'
+  end
 end

--- a/spec/services/candidate/registrations/personal_detail_spec.rb
+++ b/spec/services/candidate/registrations/personal_detail_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+describe Candidate::Registrations::PersonalDetail, type: :model do
+  context 'attributes' do
+    it { is_expected.to respond_to :building }
+    it { is_expected.to respond_to :street }
+    it { is_expected.to respond_to :town_or_city }
+    it { is_expected.to respond_to :county }
+    it { is_expected.to respond_to :postcode }
+    it { is_expected.to respond_to :phone }
+  end
+
+  context 'validations' do
+    before :each do
+      personal_detail.validate
+    end
+
+    context 'when building is not present' do
+      let :personal_detail do
+        described_class.new
+      end
+
+      it 'adds an error to building' do
+        expect(personal_detail.errors[:building]).to eq ["can't be blank"]
+      end
+    end
+
+    context 'when street is not present' do
+      let :personal_detail do
+        described_class.new
+      end
+
+      it 'adds an error to street' do
+        expect(personal_detail.errors[:street]).to eq ["can't be blank"]
+      end
+    end
+
+    context 'when town_or_city is not present' do
+      let :personal_detail do
+        described_class.new
+      end
+
+      it 'adds an error to town_or_city' do
+        expect(personal_detail.errors[:town_or_city]).to eq ["can't be blank"]
+      end
+    end
+
+    context 'when county is not present' do
+      let :personal_detail do
+        described_class.new
+      end
+
+      it 'adds an error to county' do
+        expect(personal_detail.errors[:county]).to eq ["can't be blank"]
+      end
+    end
+
+    context 'when postcode is not present' do
+      let :personal_detail do
+        described_class.new
+      end
+
+      it 'adds an error to postcode' do
+        expect(personal_detail.errors[:postcode]).to eq ["can't be blank"]
+      end
+    end
+
+    context 'when phone is not present' do
+      let :personal_detail do
+        described_class.new
+      end
+
+      it 'adds an error to phone' do
+        expect(personal_detail.errors[:phone]).to eq ["can't be blank"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds initial personal details form for candidate registrations.
UI is unstyled. To be added in ticket #SE-172.
Successful form submission persists the candidate's personal details
information to the session.
Registration related controllers now inherit from RegistraionsController
so we have a single place to managed the current registration session
and avoid overwriting it at each end point.
Only basic presence validations have been added for the personal details fields
until more information on validation requirements have been gathered
(#SE-170)

### Context
Again only the skeleton so far. Have tickets open for fleshing out the UI and the validation errors. Just want to get the basic flow through the 'wizard' sorted before moving on to the styling during the week.

