### PR TITLE
SE-143 #comment Add registrations account info form

### DIFF
--- a/app/controllers/candidate/registrations/account_infos_controller.rb
+++ b/app/controllers/candidate/registrations/account_infos_controller.rb
@@ -1,3 +1,27 @@
 class Candidate::Registrations::AccountInfosController < Candidate::RegistrationsController
-  def new; end
+  def new
+    @account_info = Candidate::Registrations::AccountInfo.new
+  end
+
+  def create
+    @account_info = Candidate::Registrations::AccountInfo.new account_info_params
+    if @account_info.valid?
+      current_registration[:account_info] = @account_info.attributes
+      redirect_to new_candidate_registrations_background_and_security_check_path
+    else
+      render :new
+    end
+  end
+
+private
+
+  def account_info_params
+    params.require(:candidate_registrations_account_info).permit \
+      :degree_stage,
+      :degree_stage_explaination,
+      :degree_subject,
+      :teaching_stage,
+      :subject_first_choice,
+      :subject_second_choice
+  end
 end

--- a/app/controllers/candidate/registrations/background_and_security_checks_controller.rb
+++ b/app/controllers/candidate/registrations/background_and_security_checks_controller.rb
@@ -1,0 +1,3 @@
+class Candidate::Registrations::BackgroundAndSecurityChecksController < Candidate::RegistrationsController
+  def new; end
+end

--- a/app/services/candidate/registrations/account_info.rb
+++ b/app/services/candidate/registrations/account_info.rb
@@ -1,0 +1,45 @@
+class Candidate::Registrations::AccountInfo
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  OPTIONS_CONFIG = YAML.load_file "#{Rails.root}/config/candidate_form_options.yml"
+  NOT_APPLYING_FOR_DEGREE = "I don't have a degree and am not studying for one".freeze
+
+  def self.degree_subjects
+    OPTIONS_CONFIG.fetch 'DEGREE_SUBJECTS'
+  end
+
+  def self.degree_stages
+    OPTIONS_CONFIG.fetch 'DEGREE_STAGES'
+  end
+
+  def self.subject_choices
+    # has same options as degree_subjects in alpha
+    OPTIONS_CONFIG.fetch 'DEGREE_SUBJECTS'
+  end
+
+  def self.teaching_stages
+    OPTIONS_CONFIG.fetch 'TEACHING_STAGES'
+  end
+
+  attribute :degree_stage, :string
+  attribute :degree_stage_explaination, :string
+  attribute :degree_subject, :string
+  attribute :teaching_stage, :string
+  attribute :subject_first_choice, :string
+  attribute :subject_second_choice, :string
+
+  validates :degree_stage, presence: true
+  validates :degree_stage, inclusion: degree_stages
+  validates :degree_stage_explaination, presence: true, if: -> { degree_stage == 'Other'.freeze }
+  validates :degree_subject, presence: true
+  validates :degree_subject, inclusion: degree_subjects
+  validates :degree_subject, inclusion: ['Not applicable'], if: -> { degree_stage == NOT_APPLYING_FOR_DEGREE }
+  validates :degree_subject, exclusion: ['Not applicable'], unless: -> { degree_stage == NOT_APPLYING_FOR_DEGREE }
+  validates :teaching_stage, presence: true
+  validates :teaching_stage, inclusion: teaching_stages
+  validates :subject_first_choice, presence: true
+  validates :subject_first_choice, inclusion: subject_choices
+  validates :subject_second_choice, presence: true
+  validates :subject_second_choice, inclusion: subject_choices
+end

--- a/app/views/candidate/registrations/account_infos/new.html.erb
+++ b/app/views/candidate/registrations/account_infos/new.html.erb
@@ -1,1 +1,50 @@
 We need some more details
+
+<%= form_for @account_info do |f| %>
+  <div>
+    <% Candidate::Registrations::AccountInfo.degree_stages.each do |degree_stage| %>
+      <%= f.radio_button :degree_stage, degree_stage %>
+      <%= f.label :degree_stage, value: degree_stage %>
+    <% end %>
+    <%= f.object.errors[:degree_stage].join(' ') %>
+    <%= f.label :degree_stage_explaination %>
+    <%= f.text_area :degree_stage_explaination %>
+    <%= f.object.errors[:degree_stage_explaination].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :degree_subject %>
+    <%= f.select :degree_subject,
+      options_for_select(Candidate::Registrations::AccountInfo.degree_subjects),
+      prompt: '' %>
+    <%= f.object.errors[:degree_subject].join(' ') %>
+  </div>
+
+  <div>
+    <% Candidate::Registrations::AccountInfo.teaching_stages.each do |teaching_stage| %>
+      <%= f.radio_button :teaching_stage, teaching_stage %>
+      <%= f.label :teaching_stage, value: teaching_stage %>
+    <% end %>
+    <%= f.object.errors[:teaching_stage].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :subject_first_choice %>
+    <%= f.select :subject_first_choice,
+      options_for_select(Candidate::Registrations::AccountInfo.subject_choices),
+      prompt: '' %>
+    <%= f.object.errors[:subject_first_choice].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.label :subject_second_choice %>
+    <%= f.select :subject_second_choice,
+      options_for_select(Candidate::Registrations::AccountInfo.subject_choices),
+      prompt: '' %>
+    <%= f.object.errors[:subject_second_choice].join(' ') %>
+  </div>
+
+  <div>
+    <%= f.submit 'Continue' %>
+  </div>
+<% end %>

--- a/app/views/candidate/registrations/background_and_security_checks/new.html.erb
+++ b/app/views/candidate/registrations/background_and_security_checks/new.html.erb
@@ -1,0 +1,1 @@
+background_and_security_checks

--- a/config/candidate_form_options.yml
+++ b/config/candidate_form_options.yml
@@ -1,0 +1,78 @@
+---
+DEGREE_STAGES:
+  - I don't have a degree and am not studying for one
+  - Graduate or postgraduate
+  - Final year
+  - Second year
+  - First year
+  - Other
+
+TEACHING_STAGES:
+  - I'm thinking about teaching and want to find out more
+  - I want to become a teacher
+  - I’ve applied for teacher training
+  - I've been accepted on teacher training
+
+DEGREE_SUBJECTS:
+  - Not applicable
+  - Architecture
+  - Art
+  - Astronomy
+  - Bioscience
+  - Business
+  - Chemical engineering
+  - Chemistry
+  - Childcare
+  - Citizenship
+  - Civil engineering
+  - Classical languages
+  - Classics
+  - Computer studies
+  - Dentistry
+  - Design and technology
+  - Drama and performing arts
+  - Economics
+  - Education
+  - Electronic engineering
+  - English
+  - Environmental science
+  - Finance and accounting
+  - Food
+  - Forensic science
+  - French
+  - General engineering
+  - General science
+  - Geography
+  - Geology &amp; earth science
+  - German
+  - Health
+  - History
+  - HR
+  - ICT
+  - Italian
+  - Law
+  - Leisure and tourism
+  - Linguistics
+  - Manufacturing
+  - Mathematics
+  - Media studies and communications
+  - Medicine
+  - Music
+  - Other languages
+  - Outdoor activities
+  - Pharmacology
+  - Philosophy
+  - Physical education
+  - Physics
+  - Politics
+  - Product design
+  - Psychology
+  - Religious education
+  - Social science
+  - Sociology
+  - Spanish
+  - Sports science
+  - Systems, control and engineering
+  - Textiles
+  - Theology
+  - Training

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,8 @@ Rails.application.routes.draw do
     namespace :registrations do
       resources :placements, only: %i(new create)
       resources :personal_details, only: %i(new create)
-      resource :account_info, only: %i(new)
+      resources :account_infos, only: %i(new create)
+      resources :background_and_security_checks, only: %i(new)
     end
   end
 end

--- a/spec/controllers/candidate/registrations/account_infos_controller_spec.rb
+++ b/spec/controllers/candidate/registrations/account_infos_controller_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe Candidate::Registrations::AccountInfosController, type: :request do
+  context '#new' do
+    before do
+      get '/candidate/registrations/account_infos/new'
+    end
+
+    it 'renders the new template' do
+      expect(response).to render_template :new
+    end
+  end
+
+  context '#create' do
+    before do
+      post '/candidate/registrations/account_infos', params: account_info_params
+    end
+
+    context 'invalid' do
+      let :account_info_params do
+        {
+          candidate_registrations_account_info: {
+            degree_stage: "I don't have a degree and am not studying for one",
+            degree_subject: "geology &amp; earth science",
+            teaching_stage: "I want to become a teacher",
+            subject_first_choice: "Astronomy",
+            subject_second_choice: "History"
+          }
+        }
+      end
+
+      it 'rerenders the new template' do
+        expect(response).to render_template :new
+      end
+    end
+
+    context 'valid' do
+      let :account_info_params do
+        {
+          candidate_registrations_account_info: {
+            degree_stage: "I don't have a degree and am not studying for one",
+            degree_subject: "Not applicable",
+            teaching_stage: "I want to become a teacher",
+            subject_first_choice: "Astronomy",
+            subject_second_choice: "History"
+          }
+        }
+      end
+
+      it 'stores the personal details in the session' do
+        expect(session[:registration][:account_info]).to eq(
+          "degree_stage" =>  "I don't have a degree and am not studying for one",
+          "degree_stage_explaination" => nil,
+          "degree_subject" =>  "Not applicable",
+          "teaching_stage" =>  "I want to become a teacher",
+          "subject_first_choice" =>  "Astronomy",
+          "subject_second_choice" =>  "History"
+        )
+      end
+
+      it 'redirects to the next step' do
+        expect(response).to redirect_to '/candidate/registrations/background_and_security_checks/new'
+      end
+    end
+  end
+end

--- a/spec/controllers/candidate/registrations/personal_details_controller_spec.rb
+++ b/spec/controllers/candidate/registrations/personal_details_controller_spec.rb
@@ -65,7 +65,7 @@ describe Candidate::Registrations::PersonalDetailsController, type: :request do
       end
 
       it 'redirects to the next step' do
-        expect(response).to redirect_to '/candidate/registrations/account_info/new'
+        expect(response).to redirect_to '/candidate/registrations/account_infos/new'
       end
     end
   end

--- a/spec/features/candidate/registrations_spec.rb
+++ b/spec/features/candidate/registrations_spec.rb
@@ -66,6 +66,34 @@ feature 'Candidate Registrations', type: :feature do
 
     click_button 'Continue'
 
-    expect(page.current_path).to eq '/candidate/registrations/account_info/new'
+    expect(page.current_path).to eq '/candidate/registrations/account_infos/new'
+  end
+
+  scenario 'Submit registrations/account-info form with errors' do
+    visit '/candidate/registrations/account_infos/new'
+
+    choose 'Graduate or postgraduate'
+    select 'Physics', from: 'Degree subject'
+    choose 'I want to become a teacher'
+    select 'Physics', from: 'Subject first choice'
+
+    click_button 'Continue'
+
+    expect(page).to have_text "can't be blank"
+  end
+
+  scenario 'Submit registrations/account-info form successfully' do
+    visit '/candidate/registrations/account_infos/new'
+
+    choose 'Graduate or postgraduate'
+    select 'Physics', from: 'Degree subject'
+    choose 'I want to become a teacher'
+    select 'Physics', from: 'Subject first choice'
+    select 'Mathematics', from: 'Subject second choice'
+
+    click_button 'Continue'
+
+    expect(page.current_path).to eq \
+      '/candidate/registrations/background_and_security_checks/new'
   end
 end

--- a/spec/services/candidate/registrations/account_info_spec.rb
+++ b/spec/services/candidate/registrations/account_info_spec.rb
@@ -1,0 +1,83 @@
+require 'rails_helper'
+
+describe Candidate::Registrations::AccountInfo, type: :model do
+  context 'attributes' do
+    it { is_expected.to respond_to :degree_stage }
+    it { is_expected.to respond_to :degree_stage_explaination }
+    it { is_expected.to respond_to :degree_subject }
+    it { is_expected.to respond_to :teaching_stage }
+    it { is_expected.to respond_to :subject_first_choice }
+    it { is_expected.to respond_to :subject_second_choice }
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_presence_of :degree_stage }
+
+    it do
+      is_expected.to validate_inclusion_of(:degree_stage).in_array \
+        described_class.degree_stages
+    end
+
+    context 'when degree stage is "Other"' do
+      before do
+        allow(subject).to receive(:degree_stage) { "Other" }
+      end
+
+      it { is_expected.to validate_presence_of :degree_stage_explaination }
+    end
+
+    context 'when degree stage is not "Other"' do
+      it { is_expected.not_to validate_presence_of :degree_stage_explaination }
+    end
+
+    it { is_expected.to validate_presence_of :degree_subject }
+
+    it do
+      is_expected.to validate_inclusion_of(:degree_subject).in_array \
+        described_class.degree_subjects
+    end
+
+    context 'when degree stage is "I don\'t have a degree and am not studying for one"' do
+      before do
+        allow(subject).to receive(:degree_stage) { "I don't have a degree and am not studying for one" }
+      end
+
+      it do
+        is_expected.to validate_inclusion_of(:degree_subject).in_array \
+          ['Not applicable']
+      end
+    end
+
+    context 'when degree stage is not "I don\'t have a degree and am not studying for one"' do
+      before do
+        allow(subject).to receive(:degree_stage) { 'Final year' }
+      end
+
+      it do
+        is_expected.to validate_exclusion_of(:degree_subject).in_array \
+          ['Not applicable']
+      end
+    end
+
+    it { is_expected.to validate_presence_of :teaching_stage }
+
+    it do
+      is_expected.to validate_inclusion_of(:teaching_stage).in_array \
+        described_class.teaching_stages
+    end
+
+    it { is_expected.to validate_presence_of :subject_first_choice }
+
+    it do
+      is_expected.to validate_inclusion_of(:subject_first_choice).in_array \
+        described_class.subject_choices
+    end
+
+    it { is_expected.to validate_presence_of :subject_second_choice }
+
+    it do
+      is_expected.to validate_inclusion_of(:subject_second_choice).in_array \
+        described_class.subject_choices
+    end
+  end
+end


### PR DESCRIPTION
Adds initial account info form for candidate registrations.
UI is unstyled. To be added in ticket #SE-172/
Sucessful form submission persistes the candidate's account information
to the session.

### Context

### Changes proposed in this pull request

### Guidance to review

