### PR TITLE
Pushing built docker image to registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,9 @@ pool:
 
 variables:
   imageName: school-experience
+  imageTag: $(Build.BuildId)
   POSTGRES_IMAGE: mdillon/postgis:11-alpine
+  # define three more variables dockerId, dockerPassword and dockerRegistry in the build pipeline in UI
   POSTGRESS_PASSWORD: secret
   DATABASE_URL: postgis://postgres:secret@postgres/school_experience_test
   WEB_URL: postgis://postgres:secret@postgres/school_experience
@@ -11,24 +13,30 @@ variables:
 
 steps:
   - script: docker run --name=postgres -e POSTGRES_PASSWORD -d $(POSTGRES_IMAGE)
-    displayName: Launch Postgres # done early to give it time to boot
-  - script: docker build -t $(imageName) .
-    displayName: Build Docker Image
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(imageName) rake db:create db:test:prepare
+    displayName: Launch Postgres # done early to give it time to boot
+  - script: docker build -f Dockerfile -t $(dockerRegistry)/$(imageName):$(imageTag) .
+    displayName: Build Docker Image $(imageName):$(imageTag)
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:test:prepare
     displayName: Create Testing databases, import schema and fixtures
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(imageName) rspec
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rspec
     displayName: Run the Specs
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true $(imageName) cucumber
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true $(dockerRegistry)/$(imageName):$(imageTag) cucumber
     displayName: Run the Cucumber features
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(imageName) brakeman --no-pager
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) brakeman --no-pager
     displayName: Run the Brakeman security scan
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL="$(WEB_URL)" -e SECRET_KEY_BASE=stubbed $(imageName) rake db:create db:schema:load
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL="$(WEB_URL)" -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:schema:load
     displayName: Create Smoketest database and import schema
-  - script: docker run -d --name=smoketest --health-interval=4s --link postgres:postgres -e DATABASE_URL="$(WEB_URL)" -e SECRET_KEY_BASE=stubbed $(imageName)
+  - script: docker run -d --name=smoketest --health-interval=4s --link postgres:postgres -e DATABASE_URL="$(WEB_URL)" -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag)
     displayName: Spin up app
   - script: sleep 15 # ugly but gives the web app time to boot
     displayName: Pause to allow app to boot
   - script: docker ps | grep smoketest | grep '(healthy)' || false
     displayName: Check app reports as Healthy
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(imageName) govuk-lint-ruby app lib spec
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) govuk-lint-ruby app lib spec
     displayName: Run the GovUK Lint check
+  - script: |
+      docker login $(dockerRegistry) -u $(dockerId) -p $pswd
+      docker push $(dockerRegistry)/$(imageName):$(imageTag)
+    env:
+      pswd: $(dockerPassword)
+    displayName: 'Push Docker image'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,4 +39,5 @@ steps:
       docker push $(dockerRegistry)/$(imageName):$(imageTag)
     env:
       pswd: $(dockerPassword)
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/feature/push-to-registry')
     displayName: 'Push Docker image'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,5 +39,5 @@ steps:
       docker push $(dockerRegistry)/$(imageName):$(imageTag)
     env:
       pswd: $(dockerPassword)
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/feature/push-to-registry')
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: 'Push Docker image'


### PR DESCRIPTION
### Context

We need to push images to a container registry so they be consumed by different environments 

### Changes proposed in this pull request

The pipeline now has an additional step which pushes to an Azure private registry. This step is skipped unless the the build is off of the master branch. 

### Guidance to review

This has been tested with a condition testing for this branch, then changed to test for the master branch. The two builds in Azure DevOps resulted in the docker push step running for the former (and succeeding) and being skipped for the latter (since the pipeline was being run on a branch other than master).

