### PR TITLE
Add password protection for all controllers when enabled

### DIFF
--- a/config/initializers/password_protection.rb
+++ b/config/initializers/password_protection.rb
@@ -1,0 +1,6 @@
+if ENV['SECURE_USERNAME'].present? && ENV['SECURE_PASSWORD'].present?
+  ApplicationController.http_basic_authenticate_with(
+    name: ENV['SECURE_USERNAME'],
+    password: ENV['SECURE_PASSWORD']
+  )
+end


### PR DESCRIPTION
### Context

GDS requires sites which are development to not be publicly accessible. Currently we don't have a means to enable password protection at the infrastructure level

### Changes proposed in this pull request

Added an initialiser to set http_basic_auth checks within ApplicationController when the appropriate
environment variables are set.

### Guidance to review

access can be quickly tested with

```bash
bundle exec rails s
curl -v http://localhost/
```

and 

```bash
SECURE_USERNAME=username SECURE_PASSWORD=password bundle exec rails s
curl -v --user username:password http://localhost/
```
