### PR TITLE
Use existing docker image for build cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pool:
 
 variables:
   imageName: school-experience
-  imageTag: $(Build.BuildId)
+  imageTag: v$(Build.BuildId)
   POSTGRES_IMAGE: mdillon/postgis:11-alpine
   # define three more variables dockerId, dockerPassword and dockerRegistry in the build pipeline in UI
   POSTGRESS_PASSWORD: secret
@@ -38,6 +38,9 @@ steps:
     displayName: Check app reports as Healthy
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) govuk-lint-ruby app lib spec
     displayName: Run the GovUK Lint check
-  - script: docker push $(dockerRegistry)/$(imageName):$(imageTag)
+  - script: |
+      docker push $(dockerRegistry)/$(imageName):$(imageTag)
+      docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(dockerRegistry)/$(imageName):latest
+      docker push $(dockerRegistry)/$(imageName):latest
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: 'Push Docker image'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,9 @@ steps:
     displayName: 'Docker login'
   - script: docker run --name=postgres -e POSTGRES_PASSWORD -d $(POSTGRES_IMAGE)
     displayName: Launch Postgres # done early to give it time to boot
-  - script: docker build -f Dockerfile -t $(dockerRegistry)/$(imageName):$(imageTag) .
+  - script: docker pull $(dockerRegistry)/$(imageName):latest || true
+    displayName: Retrieve latest Docker build to use as cache
+  - script: docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):latest -t $(dockerRegistry)/$(imageName):$(imageTag) .
     displayName: Build Docker Image $(imageName):$(imageTag)
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:test:prepare
     displayName: Create Testing databases, import schema and fixtures

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,13 @@ steps:
     displayName: Launch Postgres # done early to give it time to boot
   - script: docker pull $(dockerRegistry)/$(imageName):latest || true
     displayName: Retrieve latest Docker build to use as cache
+    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):latest -t $(dockerRegistry)/$(imageName):$(imageTag) .
-    displayName: Build Docker Image $(imageName):$(imageTag)
+    displayName: Build Docker Image $(imageName):$(imageTag) using Cache
+    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+  - script: docker build -f Dockerfile -t $(dockerRegistry)/$(imageName):$(imageTag) .
+    displayName: Build Docker Image $(imageName):$(imageTag) without Cache
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:test:prepare
     displayName: Create Testing databases, import schema and fixtures
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rspec

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,10 +22,10 @@ steps:
     displayName: Retrieve latest Docker build to use as cache
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):latest -t $(dockerRegistry)/$(imageName):$(imageTag) .
-    displayName: Build Docker Image $(imageName):$(imageTag) using Cache
+    displayName: Build Docker Image using Cache
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: docker build -f Dockerfile -t $(dockerRegistry)/$(imageName):$(imageTag) .
-    displayName: Build Docker Image $(imageName):$(imageTag) without Cache
+    displayName: Build Docker Image without Cache
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:test:prepare
     displayName: Create Testing databases, import schema and fixtures

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,10 @@ variables:
   SECRET_KEY_BASE: stubbed
 
 steps:
+  - script: docker login $(dockerRegistry) -u $(dockerId) -p $pswd
+    env:
+      pswd: $(dockerPassword)
+    displayName: 'Docker login'
   - script: docker run --name=postgres -e POSTGRES_PASSWORD -d $(POSTGRES_IMAGE)
     displayName: Launch Postgres # done early to give it time to boot
   - script: docker build -f Dockerfile -t $(dockerRegistry)/$(imageName):$(imageTag) .
@@ -34,10 +38,6 @@ steps:
     displayName: Check app reports as Healthy
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) govuk-lint-ruby app lib spec
     displayName: Run the GovUK Lint check
-  - script: |
-      docker login $(dockerRegistry) -u $(dockerId) -p $pswd
-      docker push $(dockerRegistry)/$(imageName):$(imageTag)
-    env:
-      pswd: $(dockerPassword)
+  - script: docker push $(dockerRegistry)/$(imageName):$(imageTag)
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: 'Push Docker image'


### PR DESCRIPTION
### Context

Builds in CI are currently quite slow because a full Docker image gets built on every run

### Changes proposed in this pull request

1. The login to the Docker Registry is moved earlier in the process
2. The image when built is tagged as :latest as well as a specific version if on master
3. Both images are pushed if on master
4. The build process will attempt to pull the :latest image
5. The build process will use the :latest image as a cache to build the new image from

### Guidance to review

This was constrained to its own branch but I dropped that commit and its now back on the `master` branch

Builds 370 - 373 show the evolution of the successful builds in this branch