### PR TITLE
Allow finer control of Cucumber via env vars

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,10 @@ development:
 # Do not set this db to the same as development or production.
 test: &test
   <<: *default
-  database: school_experience_candidate_test
+  host: <%= ENV.fetch('CUC_DB_HOST') { 'localhost' } %>
+  database: <%= ENV.fetch('CUC_DB_DATABASE') { 'school_experience_candidate_test' } %>
+  username: <%= ENV.fetch('CUC_DB_USERNAME') { nil } %>
+  password: <%= ENV.fetch('CUC_DB_PASSWORD') { nil } %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -84,6 +87,3 @@ production:
   database: <%= ENV['DB_DATABASE'] %>
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
-
-cucumber:
-  <<: *test

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -36,6 +36,10 @@ rescue NameError
   raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
 end
 
+if ENV['CUC_DB_CLEANER'] == 'false'
+  Cucumber::Rails::Database.autorun_database_cleaner = false
+end
+
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.
 # See the DatabaseCleaner documentation for details. Example:
 #
@@ -55,4 +59,3 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
-


### PR DESCRIPTION
### Context

We were unable to make Cucumber run against a specified host/database via the use of environment variables and the Cucumber section of `database.yml` appeared to be ignored.

### Changes proposed in this pull request

Allow settings in the test environment to be overridden giving us a little more flexibility when running Cucumber tests in Azure. Also allow `autorun_database_cleaner` to be disabled.

### Guidance to review

Make sure it looks sane
