### PR TITLE
SE-250 #comment moves candidates registrations under school resouce

### DIFF
--- a/app/controllers/candidates/registrations/account_checks_controller.rb
+++ b/app/controllers/candidates/registrations/account_checks_controller.rb
@@ -9,7 +9,7 @@ module Candidates
         @account_check = AccountCheck.new account_check_params
         if @account_check.valid?
           persist @account_check
-          redirect_to new_candidates_registrations_address_path
+          redirect_to new_candidates_school_registrations_address_path(current_school)
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/addresses_controller.rb
+++ b/app/controllers/candidates/registrations/addresses_controller.rb
@@ -9,7 +9,7 @@ module Candidates
         @address = Address.new address_params
         if @address.valid?
           persist @address
-          redirect_to new_candidates_registrations_subject_preference_path
+          redirect_to new_candidates_school_registrations_subject_preference_path(current_school)
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/background_checks_controller.rb
+++ b/app/controllers/candidates/registrations/background_checks_controller.rb
@@ -9,7 +9,7 @@ module Candidates
         @background_check = BackgroundCheck.new background_check_params
         if @background_check.valid?
           persist @background_check
-          redirect_to candidates_registrations_application_preview_path
+          redirect_to candidates_school_registrations_application_preview_path(current_school)
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -9,7 +9,7 @@ module Candidates
         @placement_preference = PlacementPreference.new placement_preference_params
         if @placement_preference.valid?
           persist @placement_preference
-          redirect_to new_candidates_registrations_account_check_path
+          redirect_to new_candidates_school_registrations_account_check_path(current_school)
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -14,7 +14,7 @@ module Candidates
       end
 
       def create
-        redirect_to candidates_registrations_placement_request_path
+        redirect_to candidates_school_registrations_placement_request_path(current_school)
       end
     end
   end

--- a/app/controllers/candidates/registrations/subject_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/subject_preferences_controller.rb
@@ -9,7 +9,7 @@ module Candidates
         @subject_preference = SubjectPreference.new subject_preference_params
         if @subject_preference.valid?
           persist @subject_preference
-          redirect_to new_candidates_registrations_background_check_path
+          redirect_to new_candidates_school_registrations_background_check_path(current_school)
         else
           render :new
         end

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -9,5 +9,10 @@ module Candidates
     def current_registration
       session[:registration] ||= {}
     end
+
+    def current_school
+      'URN'
+    end
+    helper_method :current_school
   end
 end

--- a/app/views/candidates/registrations/account_checks/new.html.erb
+++ b/app/views/candidates/registrations/account_checks/new.html.erb
@@ -7,7 +7,7 @@
       website, we can use them to speed up your placement request.
     </p>
 
-    <%= form_for @account_check, url: candidates_registrations_account_check_path do |f| %>
+    <%= form_for @account_check, url: candidates_school_registrations_account_check_path(current_school) do |f| %>
       <%= GovukElementsErrorsHelper.error_summary @account_check, 'There is a problem', '' %>
       <fieldset class="govuk-fieldset">
         <%= f.text_field :full_name %>

--- a/app/views/candidates/registrations/addresses/new.html.erb
+++ b/app/views/candidates/registrations/addresses/new.html.erb
@@ -2,7 +2,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Unfortunately, we don’t have your details</h1>
       <p>Register your details with us so you can get school experience placements.</p>
-      <%= form_for @address, url: candidates_registrations_address_path do |f| %>
+      <%= form_for @address, url: candidates_school_registrations_address_path(current_school) do |f| %>
         <%= GovukElementsErrorsHelper.error_summary @address, 'There is a problem', '' %>
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -27,6 +27,6 @@
       By submitting this notification you’re confirming, to the best of your knowledge, the details you’re providing are correct.
     </p>
     <p>GDPR STATEMENT AND CONTENT PATTERN HERE</p>
-    <%= button_to 'Accept and send', candidates_registrations_placement_request_path, class: 'govuk-button' %>
+    <%= button_to 'Accept and send', candidates_school_registrations_placement_request_path(current_school), class: 'govuk-button' %>
   </div>
 </div>

--- a/app/views/candidates/registrations/background_checks/new.html.erb
+++ b/app/views/candidates/registrations/background_checks/new.html.erb
@@ -3,7 +3,7 @@
     <h1 class="govuk-heading-l">Background and security checks</h1>
     <p>Some schools will carry out these kinds of checks before offering placements.</p>
 
-    <%= form_for @background_check, url: candidates_registrations_background_check_path do |f| %>
+    <%= form_for @background_check, url: candidates_school_registrations_background_check_path(current_school) do |f| %>
       <%= GovukElementsErrorsHelper.error_summary @background_check, 'There is a problem', '' %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/candidates/registrations/placement_preferences/new.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/new.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-l">Request school experience placement</h1>
 <p>Tell us a few details so we can forward your requirements to the school.</p>
 
-<%= form_for @placement_preference, url: candidates_registrations_placement_preference_path do |f| %>
+<%= form_for @placement_preference, url: candidates_school_registrations_placement_preference_path(current_school) do |f| %>
   <%= GovukElementsErrorsHelper.error_summary @placement_preference, 'There is a problem', '' %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/candidates/registrations/subject_preferences/new.html.erb
+++ b/app/views/candidates/registrations/subject_preferences/new.html.erb
@@ -1,7 +1,7 @@
 <h1 class="govuk-heading-l">We need some more details</h1>
 <p>The following will be used to help schools offer you school experience placements.</p>
 
-<%= form_for @subject_preference, url: candidates_registrations_subject_preference_path do |f| %>
+<%= form_for @subject_preference, url: candidates_school_registrations_subject_preference_path(current_school) do |f| %>
   <%= GovukElementsErrorsHelper.error_summary @subject_preference, 'There is a problem', '' %>
   <fieldset class="govuk-fieldset">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,18 +6,15 @@ Rails.application.routes.draw do
     root to: 'home#index'
 
     resources :schools, only: %i{index show} do
-      get 'request_placement', to: 'placement_requests#new'
-      post 'request_placement', to: 'placement_requests#create'
-    end
-
-    namespace :registrations do
-      resource :placement_preference, only: %i(new create)
-      resource :account_check, only: %i(new create)
-      resource :address, only: %i(new create)
-      resource :subject_preference, only: %i(new create)
-      resource :background_check, only: %i(new create)
-      resource :application_preview, only: %i(show)
-      resource :placement_request, only: %i(show create)
+      namespace :registrations do
+        resource :placement_preference, only: %i(new create)
+        resource :account_check, only: %i(new create)
+        resource :address, only: %i(new create)
+        resource :subject_preference, only: %i(new create)
+        resource :background_check, only: %i(new create)
+        resource :application_preview, only: %i(show)
+        resource :placement_request, only: %i(show create)
+      end
     end
   end
   resolve('Candidates::SchoolSearch') { %i{candidates schools} }

--- a/spec/controllers/candidates/registrations/account_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/account_checks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Candidates::Registrations::AccountChecksController, type: :request do
   context '#new' do
     before do
-      get '/candidates/registrations/account_check/new'
+      get '/candidates/schools/URN/registrations/account_check/new'
     end
 
     it 'renders the new template' do
@@ -13,7 +13,7 @@ describe Candidates::Registrations::AccountChecksController, type: :request do
 
   context '#create' do
     before do
-      post '/candidates/registrations/account_check',
+      post '/candidates/schools/URN/registrations/account_check',
         params: account_check_params
     end
 
@@ -50,7 +50,7 @@ describe Candidates::Registrations::AccountChecksController, type: :request do
 
       it 'redirects to the next step' do
         expect(response).to redirect_to \
-          '/candidates/registrations/address/new'
+          '/candidates/schools/URN/registrations/address/new'
       end
     end
   end

--- a/spec/controllers/candidates/registrations/addresses_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/addresses_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Candidates::Registrations::AddressesController, type: :request do
   context '#new' do
     before do
-      get '/candidates/registrations/address/new'
+      get '/candidates/schools/URN/registrations/address/new'
     end
 
     it 'responds with 200' do
@@ -17,7 +17,7 @@ describe Candidates::Registrations::AddressesController, type: :request do
 
   context '#create' do
     before do
-      post '/candidates/registrations/address',
+      post '/candidates/schools/URN/registrations/address',
         params: address_params
     end
 
@@ -65,7 +65,7 @@ describe Candidates::Registrations::AddressesController, type: :request do
       end
 
       it 'redirects to the next step' do
-        expect(response).to redirect_to '/candidates/registrations/subject_preference/new'
+        expect(response).to redirect_to '/candidates/schools/URN/registrations/subject_preference/new'
       end
     end
   end

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Candidates::Registrations::BackgroundChecksController, type: :request do
   context '#new' do
     before do
-      get '/candidates/registrations/background_check/new'
+      get '/candidates/schools/URN/registrations/background_check/new'
     end
 
     it 'renders the new form' do
@@ -13,7 +13,7 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
 
   context '#create' do
     before do
-      post '/candidates/registrations/background_check/',
+      post '/candidates/schools/URN/registrations/background_check/',
         params: background_check_params
     end
 
@@ -43,7 +43,7 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
 
       it 'redirects to the next step' do
         expect(response).to redirect_to \
-          '/candidates/registrations/application_preview'
+          '/candidates/schools/URN/registrations/application_preview'
       end
     end
   end

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -7,7 +7,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
 
   context '#new' do
     before do
-      get '/candidates/registrations/placement_preference/new'
+      get '/candidates/schools/URN/registrations/placement_preference/new'
     end
 
     it 'responds with 200' do
@@ -21,7 +21,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
 
   context '#create' do
     before do
-      post '/candidates/registrations/placement_preference',
+      post '/candidates/schools/URN/registrations/placement_preference',
         params: placement_preference_params
     end
 
@@ -63,7 +63,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
 
       it 'redirects to the next step' do
         expect(response).to redirect_to \
-          '/candidates/registrations/account_check/new'
+          '/candidates/schools/URN/registrations/account_check/new'
       end
     end
   end

--- a/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe Candidates::Registrations::SubjectPreferencesController, type: :request do
   context '#new' do
     before do
-      get '/candidates/registrations/subject_preference/new'
+      get '/candidates/schools/URN/registrations/subject_preference/new'
     end
 
     it 'renders the new template' do
@@ -13,7 +13,7 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
 
   context '#create' do
     before do
-      post '/candidates/registrations/subject_preference', params: subject_preference_params
+      post '/candidates/schools/URN/registrations/subject_preference', params: subject_preference_params
     end
 
     context 'invalid' do
@@ -60,7 +60,7 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
 
       it 'redirects to the next step' do
         expect(response).to redirect_to \
-          '/candidates/registrations/background_check/new'
+          '/candidates/schools/URN/registrations/background_check/new'
       end
     end
   end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -19,7 +19,7 @@ feature 'Candidate Registrations', type: :feature do
 
   scenario 'Candidate Registraion Journey' do
     # Begin wizard journey
-    visit '/candidates/registrations/placement_preference/new'
+    visit '/candidates/schools/URN/registrations/placement_preference/new'
     expect(page).to have_text 'Request school experience placement'
 
     # Submit registrations/placement_preference form with errors
@@ -56,7 +56,7 @@ feature 'Candidate Registrations', type: :feature do
     choose 'No'
     click_button 'Continue'
     expect(page.current_path).to eq \
-      '/candidates/registrations/account_check/new'
+      '/candidates/schools/URN/registrations/account_check/new'
 
     # Submit account checks form with errors
     fill_in 'Full name', with: 'testy mctest'
@@ -67,7 +67,7 @@ feature 'Candidate Registrations', type: :feature do
     fill_in 'Full name', with: 'testy mctest'
     fill_in 'Email address', with: 'test@example.com'
     click_button 'Continue'
-    expect(page.current_path).to eq '/candidates/registrations/address/new'
+    expect(page.current_path).to eq '/candidates/schools/URN/registrations/address/new'
 
     # Submit registrations/address form with errors
     fill_in 'Building', with: 'Test house'
@@ -87,7 +87,7 @@ feature 'Candidate Registrations', type: :feature do
     fill_in 'UK telephone number', with: '01234567890'
     click_button 'Continue'
     expect(page.current_path).to eq \
-      '/candidates/registrations/subject_preference/new'
+      '/candidates/schools/URN/registrations/subject_preference/new'
 
     # Submit registrations/subject_preference form with errors
     choose 'Graduate or postgraduate'
@@ -105,7 +105,7 @@ feature 'Candidate Registrations', type: :feature do
     select 'Mathematics', from: 'Second choice'
     click_button 'Continue'
     expect(page.current_path).to eq \
-      '/candidates/registrations/background_check/new'
+      '/candidates/schools/URN/registrations/background_check/new'
 
     # Submit registrations/background_check form with errors
     click_button 'Continue'
@@ -115,7 +115,7 @@ feature 'Candidate Registrations', type: :feature do
     choose 'Yes'
     click_button 'Continue'
     expect(page.current_path).to eq \
-      '/candidates/registrations/application_preview'
+      '/candidates/schools/URN/registrations/application_preview'
 
     # Expect preview to match the data we successfully submited
     expect(page).to have_text 'Full name testy mctest'


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Moves the candidate registration journey under the schools resource. References `current_school` which for the time being just returns `URN` as a place holder.

I've opened SE-304 to handle the user changing the urn param, causing the registration session not to map to the school it was started on

### Guidance to review

