### PR TITLE
Added Delayed::Job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem 'canonical-rails'
 gem 'govuk_elements_form_builder', github: 'DFE-Digital/govuk_elements_form_builder'
 
 gem 'acts_as_list'
+gem 'delayed_job_active_record'
 
 gem "hiredis"
 gem "redis", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,11 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
+    delayed_job_active_record (4.1.3)
+      activerecord (>= 3.0, < 5.3)
+      delayed_job (>= 3.0, < 5)
     diff-lcs (1.3)
     dotenv (2.6.0)
     dotenv-rails (2.6.0)
@@ -338,6 +343,7 @@ DEPENDENCIES
   chromedriver-helper
   cucumber-rails
   database_cleaner
+  delayed_job_active_record
   dotenv-rails
   factory_bot_rails
   foreman

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@
 2. Run `yarn` to install node dependencies
 3. Run `bin/rails db:setup` to set up the database development and test schemas, and seed with test data.
 4. If you don't wish to use the first Redis Database, set the `REDIS_URL`, eg in the `.env` file
-5. Run `bundle exec rails s` to launch the app on http://localhost:5000.
+5. Run `bundle exec rails s` to launch the app on http://localhost:3000.
+6. If in production, DelayedJob is needed for background job processing - run `bundle exec rake jobs:work`
 
-## Whats included in this boilerplate?
+## Whats included in this App?
 
 - Rails 5.2 with Webpacker
 - SassC (replacement for deprecated sass-rails)
@@ -28,6 +29,7 @@
 - Autoprefixer rails
 - RSpec
 - Dotenv (managing environment variables)
+- Dockerfile to package app for deployment
 - Azure DevOps integration
 
 ## Linting
@@ -36,6 +38,12 @@ It's best to lint just your app directories and not those belonging to the frame
 
 ```bash
 bundle exec govuk-lint-ruby app lib spec
+```
+
+Seems to be an issue with files already known to git being ignored. If so use
+
+```bash
+GIT_DIR=ignore bundle exec govuk-lint-ruby app lib spec
 ```
 
 ## HTTP Basic Auth access control

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,6 @@ Rails.application.configure do
     url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL'].presence
   }
   config.session_store :cache_store, key: 'schoolex-session'
+
+  config.active_job.queue_adapter = :delayed_job
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Use the test adapter for active jobs
+  config.active_job.queue_adapter = :test
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,3 @@
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.max_run_time = 5.minutes
+Delayed::Worker.sleep_delay = 15

--- a/db/migrate/20190205164245_create_delayed_jobs.rb
+++ b/db/migrate/20190205164245_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_05_091721) do
+ActiveRecord::Schema.define(version: 2019_02_05_164245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,21 @@ ActiveRecord::Schema.define(version: 2019_02_05_091721) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_bookings_subjects_on_name", unique: true
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   add_foreign_key "bookings_schools", "bookings_school_types"


### PR DESCRIPTION
### Context

In production we'll need a way to run potentially slow tasks in the background.

### Changes proposed in this pull request

Adds DJ, sets up some useful defaults. Configures it as the default queue adapter in production, sets 
`:test_adapter` as the queue adapter in the test environment.

Leaves `:async` as the default adapter in development since DJ is an implementation detail and we're writing jobs against the ActiveJob API.

**Note**
I've not added the `bin/delayed_job` file - this isn't useful anyway with a dependence on `daemons` gem and I don't think there's a good reason for a rails process to be worrying about daemonisation when Docker can do it with more control, monitoring, auto restart, etc - Likewise outside of Docker, the modern expectation is that SystemD handles the daemonisation rather than the process itself.