### PR TITLE
Show school screen

### DIFF
--- a/app/assets/stylesheets/global-styles.scss
+++ b/app/assets/stylesheets/global-styles.scss
@@ -2,3 +2,8 @@ body {
   @include govuk-text-colour;
   @include govuk-font($size: 16);
 }
+
+.column-top-border {
+  @include govuk-responsive-padding(2, "top") ;
+  border-top: govuk-spacing(2) solid govuk-colour("blue");
+}

--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -68,3 +68,19 @@
     }
   }
 }
+
+#candidate-school-details ul {
+  @extend .govuk-list ;
+  @extend .govuk-list--bullet ;
+  @extend .govuk-body-s ;
+
+  a {
+    @extend .govuk-link ;
+  }
+
+  li {
+    @include govuk-responsive-margin(4, "top") ;
+    @include govuk-responsive-margin(4, "bottom") ;
+  }
+}
+

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -4,7 +4,10 @@ class Candidates::SchoolsController < ApplicationController
   end
 
   def show
-    # Shut linter up
+    @school = OpenStruct.new(
+      name: "A school",
+      postcode: "MA1 1AM"
+    )
   end
 
 private

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -4,10 +4,7 @@ class Candidates::SchoolsController < ApplicationController
   end
 
   def show
-    @school = OpenStruct.new(
-      name: "A school",
-      postcode: "MA1 1AM"
-    )
+    @school = OpenStruct.new(YAML.load_file('demo-school.yml'))
   end
 
 private

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -1,0 +1,12 @@
+module Candidates::SchoolHelper
+  def format_school_address(school)
+    safe_join([
+      school.address_1.presence,
+      school.address_2.presence,
+      school.address_3.presence,
+      school.town.presence,
+      school.county.presence,
+      school.postcode.presence,
+    ].compact, ", ")
+  end
+end

--- a/app/javascript/controllers/back_link_controller.js
+++ b/app/javascript/controllers/back_link_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "stimulus"
+
+// This replaces a back link with an actual 'pop' from the users browser
+// history, rather than being a forward navigation to what we think was their
+// previous url
+export default class extends Controller {
+
+  connect() {
+    this.element.addEventListener('click', function(ev) {
+      ev.preventDefault() ;
+
+      window.history.back(-1);
+
+      return false;
+    }) ;
+  }
+}

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -58,10 +58,6 @@ class Bookings::School < ApplicationRecord
     end
   end
 
-  def address
-    [address_1, address_2, address_3, county, postcode].compact.join(", ")
-  end
-
   def to_param
     urn
   end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -61,4 +61,8 @@ class Bookings::School < ApplicationRecord
   def address
     [address_1, address_2, address_3, county, postcode].compact.join(", ")
   end
+
+  def to_param
+    urn
+  end
 end

--- a/app/models/candidates/school.rb
+++ b/app/models/candidates/school.rb
@@ -2,7 +2,7 @@ class Candidates::School
   class << self
     def find(identifier)
       # Note currently using id, will be converted to URN when available
-      Bookings::School.find_by!(id: identifier)
+      Bookings::School.find_by!(urn: identifier)
     end
 
     def phases

--- a/app/views/candidates/schools/_form.html.erb
+++ b/app/views/candidates/schools/_form.html.erb
@@ -1,3 +1,5 @@
+<%= link_to 'Back', root_path, class: 'govuk-back-link' %>
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="govuk-form-group" id="search-form">

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -53,7 +53,7 @@
                     <li><strong>Address:</strong> <%= format_school_address result %></li>
                     <li><strong>Education phase:</strong> <%= result.phases.map(&:name).join(', ') %></li>
                     <li><strong>Fees:</strong> &pound;<%= result.fee %></li>
-                    <li><strong>School type:</strong> <%= result.school_type.name %></li>
+                    <li><strong>School type:</strong> <%= result.school_type&.name %></li>
                     <li><strong>Subjects:</strong> <%= result.subjects.to_sentence %></li>
                 </ul>
             </li>

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -50,10 +50,10 @@
             <li class="school-result">
                 <strong class="name"><%= link_to result.name, candidates_school_path(index + 1) %></strong>
                 <ul>
-                    <li><strong>Address:</strong> <%= result.address %></li>
+                    <li><strong>Address:</strong> <%= format_school_address result %></li>
                     <li><strong>Education phase:</strong> <%= result.phases.map(&:name).join(', ') %></li>
                     <li><strong>Fees:</strong> &pound;<%= result.fee %></li>
-                    <li><strong>School type:</strong> <%= result.school_type %></li>
+                    <li><strong>School type:</strong> <%= result.school_type.name %></li>
                     <li><strong>Subjects:</strong> <%= result.subjects.to_sentence %></li>
                 </ul>
             </li>

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -2,73 +2,35 @@
             class: 'govuk-back-link',
             data: {controller: 'back-link'} %>
 
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-row govuk-!-margin-top-4">
+    <div class="govuk-grid-column-two-thirds" id="candidate-school-details">
         <h1 class="govuk-heading-l"><%= @school.name %></h1>
 
-        <p>
-            We’re a thriving community school serving a cosmopolitan community
-            in North Manchester with more than 1,700 pupils.
-        </p>
-
-        <p>
-            Our pupils’ GCSE scores are above the national average and, with
-            more than 63 languages spoken at our school, we’re highly skilled in
-            meeting the needs of bilingual children.
-        </p>
-
-        <p>
-            We’re also a barrier free school and cater fully for the needs of
-            pupils with movement difficulties while our work with hearing
-            impaired children is well supported by the local authority and other
-            agencies.
-        </p>
+        <%= simple_format @school.description %>
 
         <h1 class="govuk-heading-m">About our school</h1>
 
         <p>
-            <b>Age range:</b> 3 to 16 years (nursery, primary and secondary)
+            <b>Age range:</b> <%= @school.age_range %>
         </p>
 
         <p>
-            <b>Specialisms:</b> Arts, bilingual students and SEN.
+            <b>Specialisms:</b> <%= @school.specialisms %>.
         </p>
 
+        <% unless @school.links.empty? %>
         <p>
             <b>For more information about our school use the following links:</b>
         </p>
 
-        <p>
+        <ul>
+            <% for link_pair in @school.links %>
             <li>
-                <a class="govuk-link" href="https://www.abrahammoss.manchester.sch.uk/">
-                    <%= @school.name %> website
-                </a>
+                <%= link_to link_pair['text'], link_pair['link'] %>
             </li>
-        </p>
-
-        <p>
-            <li>
-                <a class="govuk-link" href="https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/105560#school-dashboard">
-                    <%= @school.name %> Get Information About Schools page
-                </a>
-            </li>
-        </p>
-
-        <p>
-            <li>
-                <a class="govuk-link" href="https://reports.ofsted.gov.uk/provider/28/105560">
-                    Ofsted report: <%= @school.name %>
-                </a>
-            </li>
-        </p>
-
-        <p>
-            <li>
-                <a class="govuk-link" href="https://www.compare-school-performance.service.gov.uk/school/105560/abraham-moss-community-school">
-                    Performance information: <%= @school.name %>
-                </a>
-            </li>
-        </p>
+            <% end %>
+        </ul>
+        <% end %>
 
         <h1 class="govuk-heading-m">Placement information</h1>
 
@@ -85,7 +47,7 @@
         </p>
 
 
-        <p><b>Placement subjects:</b> {{ data['school-subjects'] }}.</p>
+        <p><b>Placement subjects:</b> <%= @school.subjects.to_sentence %>.</p>
 
         <h1 class="govuk-heading-m">Location</h1>
 
@@ -98,46 +60,45 @@
         </p>
     </div>
 
-    <div class="govuk-grid-column-one-third app-related-items ">
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-9 column-top-border">        
         <h3 class="govuk-heading-m">Address</h3>
         <p class="govuk-body">
-            {{ data['school-address'] }}.
+            <%= @school.address %>.
         </p>
 
         <h3 class="govuk-heading-s">DBS check required</h3>
         <p class="govuk-body">
-          Yes
+          <%= @school.dbs ? 'Yes' : 'No' %>
         </p>
 
         <h3 class="govuk-heading-s">Fee</h3>
         <p class="govuk-body">
-          Yes - £50 per placement
+          <%= @school.fee %>
         </p>
 
         <h3 class="govuk-heading-s">Dress code</h3>
         <p class="govuk-body">
-		  Yes - business attire with male attendees expected to wear a collar and tie
+            <%= @school.dress_code %>
         </p>
 
         <h3 class="govuk-heading-s">Start and finish times</h3>
         <p class="govuk-body">
-          8am to 5pm
+            <%= @school.times %>
         </p>
 
         <h3 class="govuk-heading-s">Parking</h3>
         <p class="govuk-body">
-            Limited on-site parking arranged as part of placement. Local
-            paid-for on-street parking around school site for £3 per day
+            <%= @school.parking %>
         </p>
 
         <h3 class="govuk-heading-s">Accessibility details</h3>
         <p class="govuk-body">
-            Ramp access and disabled parking available on site
+            <%= @school.accessibility %>
         </p>
 
         <h3 class="govuk-heading-s">Teacher training offered</h3>
         <p class="govuk-body">
-            Yes. We offer training opportunities for a mainstream ITT programme
+            <%= @school.training_offered %>
         </p>
     </div>
 </div>

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -1,2 +1,143 @@
-<h1>Candidates::Schools#show</h1>
-<p>Find me in app/views/candidates/schools/show.html.erb</p>
+<%= link_to 'Back', :back,
+            class: 'govuk-back-link',
+            data: {controller: 'back-link'} %>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l"><%= @school.name %></h1>
+
+        <p>
+            We’re a thriving community school serving a cosmopolitan community
+            in North Manchester with more than 1,700 pupils.
+        </p>
+
+        <p>
+            Our pupils’ GCSE scores are above the national average and, with
+            more than 63 languages spoken at our school, we’re highly skilled in
+            meeting the needs of bilingual children.
+        </p>
+
+        <p>
+            We’re also a barrier free school and cater fully for the needs of
+            pupils with movement difficulties while our work with hearing
+            impaired children is well supported by the local authority and other
+            agencies.
+        </p>
+
+        <h1 class="govuk-heading-m">About our school</h1>
+
+        <p>
+            <b>Age range:</b> 3 to 16 years (nursery, primary and secondary)
+        </p>
+
+        <p>
+            <b>Specialisms:</b> Arts, bilingual students and SEN.
+        </p>
+
+        <p>
+            <b>For more information about our school use the following links:</b>
+        </p>
+
+        <p>
+            <li>
+                <a class="govuk-link" href="https://www.abrahammoss.manchester.sch.uk/">
+                    <%= @school.name %> website
+                </a>
+            </li>
+        </p>
+
+        <p>
+            <li>
+                <a class="govuk-link" href="https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/105560#school-dashboard">
+                    <%= @school.name %> Get Information About Schools page
+                </a>
+            </li>
+        </p>
+
+        <p>
+            <li>
+                <a class="govuk-link" href="https://reports.ofsted.gov.uk/provider/28/105560">
+                    Ofsted report: <%= @school.name %>
+                </a>
+            </li>
+        </p>
+
+        <p>
+            <li>
+                <a class="govuk-link" href="https://www.compare-school-performance.service.gov.uk/school/105560/abraham-moss-community-school">
+                    Performance information: <%= @school.name %>
+                </a>
+            </li>
+        </p>
+
+        <h1 class="govuk-heading-m">Placement information</h1>
+
+        <p>
+            <b>Individual requirements:</b> Must have a degree and be planning
+            to become a teacher.
+        </p>
+
+        <p>
+            <b>Placement details:</b> Attendees will observe lessons in their
+            chosen subjects and may get the chance to interact with pupils and
+            classroom activities. Only offer key stage 1 experience for primary
+            placements.
+        </p>
+
+
+        <p><b>Placement subjects:</b> {{ data['school-subjects'] }}.</p>
+
+        <h1 class="govuk-heading-m">Location</h1>
+
+        <img class="school-map" src="/public/images/abschool.jpg" width="250" height="172" />
+
+        <p>
+            <a class="govuk-button" href="/register/request">
+                Request placement
+            </a>
+        </p>
+    </div>
+
+    <div class="govuk-grid-column-one-third app-related-items ">
+        <h3 class="govuk-heading-m">Address</h3>
+        <p class="govuk-body">
+            {{ data['school-address'] }}.
+        </p>
+
+        <h3 class="govuk-heading-s">DBS check required</h3>
+        <p class="govuk-body">
+          Yes
+        </p>
+
+        <h3 class="govuk-heading-s">Fee</h3>
+        <p class="govuk-body">
+          Yes - £50 per placement
+        </p>
+
+        <h3 class="govuk-heading-s">Dress code</h3>
+        <p class="govuk-body">
+		  Yes - business attire with male attendees expected to wear a collar and tie
+        </p>
+
+        <h3 class="govuk-heading-s">Start and finish times</h3>
+        <p class="govuk-body">
+          8am to 5pm
+        </p>
+
+        <h3 class="govuk-heading-s">Parking</h3>
+        <p class="govuk-body">
+            Limited on-site parking arranged as part of placement. Local
+            paid-for on-street parking around school site for £3 per day
+        </p>
+
+        <h3 class="govuk-heading-s">Accessibility details</h3>
+        <p class="govuk-body">
+            Ramp access and disabled parking available on site
+        </p>
+
+        <h3 class="govuk-heading-s">Teacher training offered</h3>
+        <p class="govuk-body">
+            Yes. We offer training opportunities for a mainstream ITT programme
+        </p>
+    </div>
+</div>

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -8,7 +8,7 @@
 
         <%= simple_format @school.description %>
 
-        <h1 class="govuk-heading-m">About our school</h1>
+        <h2 class="govuk-heading-m">About our school</h2>
 
         <p>
             <b>Age range:</b> <%= @school.age_range %>
@@ -32,7 +32,7 @@
         </ul>
         <% end %>
 
-        <h1 class="govuk-heading-m">Placement information</h1>
+        <h2 class="govuk-heading-m">Placement information</h2>
 
         <p>
             <b>Individual requirements:</b> Must have a degree and be planning

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -38,22 +38,18 @@
             <h2 class="govuk-heading-m">Placement information</h2>
 
             <p>
-                <b>Individual requirements:</b> Must have a degree and be planning
-                to become a teacher.
+                <b>Individual requirements:</b> <%= @school.requirements %>
             </p>
 
             <p>
-                <b>Placement details:</b> Attendees will observe lessons in their
-                chosen subjects and may get the chance to interact with pupils and
-                classroom activities. Only offer key stage 1 experience for primary
-                placements.
+                <b>Placement details:</b> <%= @school.placement_details %>
             </p>
 
             <p>
                 <b>Placement subjects:</b> <%= @school.subjects.to_sentence %>.
             </p>
         </div>
-        
+
         <%- if false -%>
         <div>
             <h1 class="govuk-heading-m">Location</h1>
@@ -69,7 +65,7 @@
         </p>
     </div>
 
-    <div class="govuk-grid-column-one-third govuk-!-margin-top-9 column-top-border">        
+    <div class="govuk-grid-column-one-third govuk-!-margin-top-9 column-top-border">
         <h3 class="govuk-heading-m">Address</h3>
         <p class="govuk-body">
             <%= @school.address %>.

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -38,11 +38,15 @@
             <h2 class="govuk-heading-m">Placement information</h2>
 
             <p>
-                <b>Individual requirements:</b> <%= @school.requirements %>
+                <b>Individual requirements:</b> Must have a degree and be planning
+                to become a teacher.
             </p>
 
             <p>
-                <b>Placement details:</b> <%= @school.placement_details %>
+                <b>Placement details:</b> Attendees will observe lessons in their
+                chosen subjects and may get the chance to interact with pupils and
+                classroom activities. Only offer key stage 1 experience for primary
+                placements.
             </p>
 
             <p>
@@ -68,7 +72,7 @@
     <div class="govuk-grid-column-one-third govuk-!-margin-top-9 column-top-border">
         <h3 class="govuk-heading-m">Address</h3>
         <p class="govuk-body">
-            <%= @school.address %>.
+            <%= format_school_address @school %>.
         </p>
 
         <h3 class="govuk-heading-s">DBS check required</h3>

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -8,50 +8,59 @@
 
         <%= simple_format @school.description %>
 
-        <h2 class="govuk-heading-m">About our school</h2>
+        <div>
+            <h2 class="govuk-heading-m">About our school</h2>
 
-        <p>
-            <b>Age range:</b> <%= @school.age_range %>
-        </p>
+            <p>
+                <b>Age range:</b> <%= @school.age_range %>
+            </p>
 
-        <p>
-            <b>Specialisms:</b> <%= @school.specialisms %>.
-        </p>
+            <p>
+                <b>Specialisms:</b> <%= @school.specialisms %>.
+            </p>
 
-        <% unless @school.links.empty? %>
-        <p>
-            <b>For more information about our school use the following links:</b>
-        </p>
+            <% unless @school.links.empty? %>
+            <p>
+                <b>For more information about our school use the following links:</b>
+            </p>
 
-        <ul>
-            <% for link_pair in @school.links %>
-            <li>
-                <%= link_to link_pair['text'], link_pair['link'] %>
-            </li>
+            <ul>
+                <% for link_pair in @school.links %>
+                <li>
+                    <%= link_to link_pair['text'], link_pair['link'] %>
+                </li>
+                <% end %>
+            </ul>
             <% end %>
-        </ul>
-        <% end %>
+        </div>
 
-        <h2 class="govuk-heading-m">Placement information</h2>
+        <div>
+            <h2 class="govuk-heading-m">Placement information</h2>
 
-        <p>
-            <b>Individual requirements:</b> Must have a degree and be planning
-            to become a teacher.
-        </p>
+            <p>
+                <b>Individual requirements:</b> Must have a degree and be planning
+                to become a teacher.
+            </p>
 
-        <p>
-            <b>Placement details:</b> Attendees will observe lessons in their
-            chosen subjects and may get the chance to interact with pupils and
-            classroom activities. Only offer key stage 1 experience for primary
-            placements.
-        </p>
+            <p>
+                <b>Placement details:</b> Attendees will observe lessons in their
+                chosen subjects and may get the chance to interact with pupils and
+                classroom activities. Only offer key stage 1 experience for primary
+                placements.
+            </p>
 
+            <p>
+                <b>Placement subjects:</b> <%= @school.subjects.to_sentence %>.
+            </p>
+        </div>
+        
+        <%- if false -%>
+        <div>
+            <h1 class="govuk-heading-m">Location</h1>
 
-        <p><b>Placement subjects:</b> <%= @school.subjects.to_sentence %>.</p>
-
-        <h1 class="govuk-heading-m">Location</h1>
-
-        <img class="school-map" src="/public/images/abschool.jpg" width="250" height="172" />
+            <img class="school-map" src="/public/images/abschool.jpg" width="250" height="172" />
+        </div>
+        <%- end -%>
 
         <p>
             <a class="govuk-button" href="/register/request">

--- a/demo-school.yml
+++ b/demo-school.yml
@@ -29,7 +29,12 @@ subjects:
 - Art
 - Physics
 - Music
-address: Long Millgate, XXX
+address_1: Long Millgate
+address_2: XXX
+address_3:
+town: Manchester
+county:
+postcode:
 dbs: true
 fee: "Yes - £50 per placement"
 dress_code: Yes - business attire with male attendees expected to wear a collar and tie

--- a/demo-school.yml
+++ b/demo-school.yml
@@ -1,0 +1,39 @@
+name: The Creative Studio
+description: "We're a thriving community school serving a cosmopolitan community
+in North Manchester with more than 1,700 pupils.\n
+
+Our pupils' GCSE scores are above the national average and, with more than 63
+languages spoken at our school, we're highly skilled in meeting the needs of
+bilingual children.\n
+
+We're also a barrier free school and cater fully for the needs of pupils with
+movement difficulties while our work with hearing impaired children is well
+supported by the local authority and other agencies."
+postcode: MA1 1AM
+age_range: 3 to 16 (nursery, primary and secondary)
+specialisms: Arts, bilingual students and SEN
+links:
+  - text: The Creative Studio website
+    link: "https://www.abrahammoss.manchester.sch.uk/"
+  - text: The Creative Studio Get Information About Schools page
+    link: "https://get-information-schools.service.gov.uk/Establishments/Establishment/Details/105560#school-dashboard"
+  - text: "Ofsted report: The Creative Studio"
+    link: "https://reports.ofsted.gov.uk/provider/28/105560"
+  - text: "Performance information: The Creative Studio"
+    link: "https://reports.ofsted.gov.uk/provider/28/105560"
+requirements: Must have a degree and be planning to become a teacher.
+placement_details: Attendees will observe lessons in their chosen subjects and may get the chance to interact with pupils and classroom activities. Only offer key stage 1 experience for primary placements
+subjects:
+- Maths
+- English
+- Art
+- Physics
+- Music
+address: Long Millgate, XXX
+dbs: true
+fee: "Yes - £50 per placement"
+dress_code: Yes - business attire with male attendees expected to wear a collar and tie
+times: 8am to 5pm
+parking: Limited on-site parking arranged as part of placement. Local paid-for on-street parking around school site for £3 per day
+accessibility: Ramp access and disabled parking available on site
+training_offered: Yes. We offer training opportunities for a a mainstream ITT programme.

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -18,9 +18,12 @@ RSpec.describe Candidates::SchoolsController, type: :request do
   end
 
   context "GET #show" do
-  #  it "returns http success" do
-  #     get :show, id: '123456'
-  #    expect(response).to have_http_status(:success)
-  #  end
+    before { get candidates_school_path('123456') }
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template('show')
+      expect(assigns(:school)).to_not be_nil
+    end
   end
 end

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe Candidates::SchoolsController, type: :request do
   end
 
   context "GET #show" do
-    before { get candidates_school_path('123456') }
+    before do
+      @school = create(:bookings_school)
+      get candidates_school_path(@school.urn)
+    end
 
     it "returns http success" do
       expect(response).to have_http_status(:success)

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe Candidates::SchoolHelper, type: :helper do
+  context '.format_school_address' do
+    before do
+      @school = OpenStruct.new(
+        address_1: nil,
+        address_2: 'Picadilly Gate',
+        address_3: '',
+        town: 'Manchester',
+        county: 'Manchester',
+        postcode: 'MA1 1AM'
+      )
+
+      @formatted = format_school_address(@school)
+    end
+
+    it 'should be html_safe' do
+      expect(@formatted.html_safe?).to be true
+    end
+
+    it 'should concatenate non blank fields' do
+      expect(@formatted).to eq "Picadilly Gate, Manchester, Manchester, MA1 1AM"
+    end
+  end
+end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -59,6 +59,14 @@ describe Bookings::School, type: :model do
     end
   end
 
+  describe 'Paramterisation' do
+    subject { create(:bookings_school) }
+
+    specify do
+      expect(subject.to_param).to eq(subject.urn)
+    end
+  end
+
   describe 'Scopes' do
     subject { Bookings::School }
 

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -181,23 +181,4 @@ describe Bookings::School, type: :model do
       end
     end
   end
-
-  context 'Methods' do
-    context '#address' do
-      subject do
-        create(
-          :bookings_school,
-          address_1: "Address 1",
-          address_2: "Address 2",
-          address_3: nil,
-          county: "County",
-          postcode: "M1 2WD"
-        )
-      end
-
-      specify "it should omit missing fields and delimit with commas" do
-        expect(subject.address).to eql("Address 1, Address 2, County, M1 2WD")
-      end
-    end
-  end
 end

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -22,12 +22,16 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
         [[1, 'Primary'], [2, 'Seconday'], [3, '16 to 18']]
       )
 
-      assign :search, Candidates::SchoolSearch.new(
+      @school = build(:bookings_school)
+      @search = Candidates::SchoolSearch.new(
         query: 'Manchester',
         phases: %w{3},
         max_fee: '60',
         subjects: %w{1 3}
       )
+      allow(@search).to receive(:results).and_return([@school])
+
+      assign :search, @search
 
       render
     end
@@ -53,6 +57,12 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
       expect(rendered).to have_css '#search-filter'
       expect(rendered).to have_checked_field 'max_fee', count: 1
       expect(rendered).to have_unchecked_field 'max_fee', count: 3
+    end
+
+    it "shows results" do
+      expect(rendered).to have_css 'li.school-result'
+      expect(rendered).to have_css 'li.school-result>strong a', text: @school.name
+      expect(rendered).to have_css 'li.school-result ul li', count: 5
     end
   end
 end

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -1,5 +1,16 @@
 require 'rails_helper'
 
-RSpec.describe "schools/show.html.erb", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe "candidates/schools/show.html.erb", type: :view do
+  let(:demo_school) do
+    OpenStruct.new YAML.load_file('demo-school.yml')
+  end
+
+  before do
+    assign :school, demo_school
+    render
+  end
+
+  it "will include the schools name" do
+    expect(rendered).to have_css('h1', text: demo_school.name)
+  end
 end


### PR DESCRIPTION
### Context

As a user viewing a result I expect to see further information relating to the school

### Changes proposed in this pull request

Adds a schools information page

### Guidance to review

Currently this is implemented against a stub file, rather than the correct information from the DB. Since there needs to be further fields added to the DB schema