### PR TITLE
Enable running Cucumber tests against a remote server

### DIFF
--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -7,3 +7,4 @@ std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --tags 'not @wip'"
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip'
+cd: <%= std_opts %> --tags 'not @remoteapp' features

--- a/features/candidates/schools/search/results.feature
+++ b/features/candidates/schools/search/results.feature
@@ -6,7 +6,8 @@ Feature: Schools search page
     Background:
         Given the phases 'Primary' and 'Secondary' exist
         Given there are some schools with a range of fees containing the word 'Manchester'
-
+    
+    @remoteapp
     Scenario: Search result contents
         Given I have searched for 'Manchester' and am on the results page
         And there are 3 results
@@ -16,7 +17,8 @@ Feature: Schools search page
             | Fees        |
             | School type |
             | Subjects    |
-
+    
+    @remoteapp
     Scenario: Filtering by Education Phase
         Given I have searched for 'Manchester' and am on the results page
         Then I should see a 'Phases' filter on the left
@@ -25,6 +27,7 @@ Feature: Schools search page
             | Primary   |
             | Secondary |
 
+    @remoteapp
     Scenario: Filtering by Fees
         Given there are some subjects
         When I have searched for 'Manchester' and am on the results page

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -59,3 +59,17 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
+
+if ENV['SELENIUM_HUB_HOSTNAME'].present?
+  Capybara.run_server = false
+  Capybara.app_host = "#{ENV['APP_URL']}"
+  Capybara.javascript_driver = :chrome
+  Capybara.default_driver = :selenium_remote
+  Capybara.register_driver :selenium_remote do |app|
+    Capybara::Selenium::Driver.new(app,
+        :browser => :remote,
+        :url => "http://#{ENV['SELENIUM_HUB_HOSTNAME']}:4444/wd/hub",
+        :desired_capabilities => :chrome)
+  end
+end
+


### PR DESCRIPTION
### Context

We need to be able to run cucumber tests against a remote application instance to functionally test the application in a managed environment. This pull request is a pre requisite for functional testing within the CD pipeline. The changes will only enable functional testing using Chrome, further work will introduce Firefox (if that is a DfE/GDS browser requirement) using a similar approach.

Cucumber testing against IE will have to be done on the Azure DevOps agent itself (since IE is not available within Docker container). The hosted Azure DevOps agent does have the required driver and browser binaries but accessing the source code within the build pipeline is problematic.

### Changes proposed in this pull request

The changes introduced enable the use of the remote Selenium server with Capybara this is enabled via the presence of an environment variable

    SELENIUM_HUB_HOSTNAME=selenium

The Selenium server needs to know the hostname of the remote application instance, this is specified via

    APP_URL='http://school-experience:3000'

Currently some Cucumber tests update the database within a transaction whose boundaries are the scenario. This relies on an in-process application server instance. These  scenarios are annotated with a tag `@remoteapp` for the time being. The Cucumber tests are then run with a profile which excludes these scenarios

    cucumber --profile=cd


### Guidance to review

This was tested using docker as follows

Start Postgres container

      docker run --name=postgres -e POSTGRES_PASSWORD=secret -p 5432:5432 -d mdillon/postgis:11-alpine

Start the application container

    docker run --name=school-experience --link postgres:postgres -e DATABASE_URL=postgis://postgres:secret@postgres/school_experience -e SECRET_KEY_BASE=stubbed -p 3000:3000 -d school-experience:latest

Start Selenium container

    docker run --name=selenium --link school-experience:school-experience -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome

Run the cucumber tests

    docker run --rm --link postgres:postgres --link selenium:selenium -e SELENIUM_HUB_HOSTNAME=selenium -e CUC_DB_HOST=postgres -e CUC_DB_DATABASE=school_experience -e CUC_DB_USERNAME=postgres -e CUC_DB_PASSWORD=secret -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL='http://school-experience:3000' school-experience:latest cucumber --profile=cd


