### PR TITLE
Refactor registration session

### DIFF
--- a/app/controllers/candidates/registrations/application_previews_controller.rb
+++ b/app/controllers/candidates/registrations/application_previews_controller.rb
@@ -2,7 +2,12 @@ module Candidates
   module Registrations
     class ApplicationPreviewsController < RegistrationsController
       def show
-        @application_preview = ApplicationPreview.new current_registration
+        @application_preview = ApplicationPreview.new \
+          account_check: current_registration.fetch(AccountCheck),
+          placement_preference: current_registration.fetch(PlacementPreference),
+          address: current_registration.fetch(Address),
+          subject_preference: current_registration.fetch(SubjectPreference),
+          background_check: current_registration.fetch(BackgroundCheck)
       end
     end
   end

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -3,11 +3,11 @@ module Candidates
   private
 
     def persist(model)
-      current_registration[model.model_name.param_key] = model.attributes
+      current_registration.save model
     end
 
     def current_registration
-      session[:registration] ||= {}
+      @current_registration ||= Registrations::RegistrationSession.new(session)
     end
 
     def current_urn

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -9,11 +9,11 @@ module Candidates
         :background_check
 
       def initialize(registration)
-        @account_check = AccountCheck.new registration.fetch(AccountCheck.model_name.param_key)
-        @placement_preference = PlacementPreference.new registration.fetch(PlacementPreference.model_name.param_key)
-        @address = Address.new registration.fetch(Address.model_name.param_key)
-        @subject_preference = SubjectPreference.new registration.fetch(SubjectPreference.model_name.param_key)
-        @background_check = BackgroundCheck.new registration.fetch(BackgroundCheck.model_name.param_key)
+        @account_check = registration.fetch(AccountCheck)
+        @placement_preference = registration.fetch(PlacementPreference)
+        @address = registration.fetch(Address)
+        @subject_preference = registration.fetch(SubjectPreference)
+        @background_check = registration.fetch(BackgroundCheck)
       end
 
       def full_name

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -8,12 +8,12 @@ module Candidates
         :subject_preference,
         :background_check
 
-      def initialize(registration)
-        @account_check = registration.fetch(AccountCheck)
-        @placement_preference = registration.fetch(PlacementPreference)
-        @address = registration.fetch(Address)
-        @subject_preference = registration.fetch(SubjectPreference)
-        @background_check = registration.fetch(BackgroundCheck)
+      def initialize(account_check:, placement_preference:, address:, subject_preference:, background_check:)
+        @account_check = account_check
+        @placement_preference = placement_preference
+        @address = address
+        @subject_preference = subject_preference
+        @background_check = background_check
       end
 
       def full_name

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -1,0 +1,21 @@
+# Simple wrapper around Rails session.
+# Encapsulates storing and retrieving registration wizard models from the 
+# session.
+module Candidates
+  module Registrations
+    class RegistrationSession
+      def initialize(session)
+        @registration_session = session['registration'] ||= {}
+      end
+
+      def save(model)
+        @registration_session[model.model_name.param_key] = model.attributes
+      end
+
+      def fetch(klass)
+        klass.new @registration_session.fetch(klass.model_name.param_key)
+      end
+    end
+  end
+end
+

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -1,5 +1,5 @@
 # Simple wrapper around Rails session.
-# Encapsulates storing and retrieving registration wizard models from the 
+# Encapsulates storing and retrieving registration wizard models from the
 # session.
 module Candidates
   module Registrations
@@ -18,4 +18,3 @@ module Candidates
     end
   end
 end
-

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -78,9 +78,8 @@ describe Candidates::Registrations::ApplicationPreview do
 
   context '#full_address' do
     it 'returns the correct value' do
-      expect(subject.full_address).to eq <<-ADDRESS.squish
-        Test building, Test street, Test town, Testshire, TE57 1NG
-      ADDRESS
+      expect(subject.full_address).to eq \
+        "Test building, Test street, Test town, Testshire, TE57 1NG"
     end
   end
 

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -21,48 +21,54 @@ describe Candidates::Registrations::ApplicationPreview do
     true
   end
 
-  let :valid_registraion_session do
-    {
-      'registration' => {
-        "candidates_registrations_account_check" => {
-          "full_name" => "Testy McTest",
-          "email" => "test@example.com"
-        },
-        "candidates_registrations_placement_preference" => {
-          "date_start" => placement_date_start.strftime('%Y-%m-%d'),
-          "date_end" => placement_date_end.strftime('%Y-%m-%d'),
-          "objectives" => "test the software",
-          "access_needs" => access_needs,
-          "access_needs_details" => access_needs_details
-        },
-        "candidates_registrations_address" => {
-          "building" => "Test building",
-          "street" => "Test street",
-          "town_or_city" => "Test town",
-          "county" => "Testshire",
-          "postcode" => "TE57 1NG",
-          "phone" => "01234567890"
-        },
-        "candidates_registrations_subject_preference" => {
-          "degree_stage" => "I don't have a degree and am not studying for one",
-          "degree_stage_explaination" => "",
-          "degree_subject" => "Not applicable",
-          "teaching_stage" => "I'm thinking about teaching and want to find out more",
-          "subject_first_choice" => "Architecture",
-          "subject_second_choice" => "Mathematics"
-        },
-        "candidates_registrations_background_check" => {
-          "has_dbs_check" => has_dbs_check
-        }
-      }
-    }
+  let :account_check do
+    double Candidates::Registrations::AccountCheck,
+      full_name: 'Testy McTest',
+      email: 'test@example.com'
   end
 
-  let :current_registration do
-    Candidates::Registrations::RegistrationSession.new valid_registraion_session
+  let :address do
+    double Candidates::Registrations::Address,
+      building: "Test building",
+      street: "Test street",
+      town_or_city: "Test town",
+      county: "Testshire",
+      postcode: "TE57 1NG",
+      phone: "01234567890"
   end
 
-  subject { described_class.new current_registration }
+  let :background_check do
+    double Candidates::Registrations::BackgroundCheck,
+      has_dbs_check: has_dbs_check
+  end
+
+  let :placement_preference do
+    double Candidates::Registrations::PlacementPreference,
+      date_start: placement_date_start,
+      date_end: placement_date_end,
+      objectives: "test the software",
+      access_needs: access_needs,
+      access_needs_details: access_needs_details
+  end
+
+  let :subject_preference do
+    double Candidates::Registrations::SubjectPreference,
+      degree_stage: "I don't have a degree and am not studying for one",
+      degree_stage_explaination: "",
+      degree_subject: "Not applicable",
+      teaching_stage: "I'm thinking about teaching and want to find out more",
+      subject_first_choice: "Architecture",
+      subject_second_choice: "Mathematics"
+  end
+
+  subject do
+    described_class.new \
+      account_check: account_check,
+      placement_preference: placement_preference,
+      address: address,
+      subject_preference: subject_preference,
+      background_check: background_check
+  end
 
   context '#full_name' do
     it 'returns the correct value' do

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -23,40 +23,46 @@ describe Candidates::Registrations::ApplicationPreview do
 
   let :valid_registraion_session do
     {
-      "candidates_registrations_account_check" => {
-        "full_name" => "Testy McTest",
-        "email" => "test@example.com"
-      },
-      "candidates_registrations_placement_preference" => {
-        "date_start" => placement_date_start.strftime('%Y-%m-%d'),
-        "date_end" => placement_date_end.strftime('%Y-%m-%d'),
-        "objectives" => "test the software",
-        "access_needs" => access_needs,
-        "access_needs_details" => access_needs_details
-      },
-      "candidates_registrations_address" => {
-        "building" => "Test building",
-        "street" => "Test street",
-        "town_or_city" => "Test town",
-        "county" => "Testshire",
-        "postcode" => "TE57 1NG",
-        "phone" => "01234567890"
-      },
-      "candidates_registrations_subject_preference" => {
-        "degree_stage" => "I don't have a degree and am not studying for one",
-        "degree_stage_explaination" => "",
-        "degree_subject" => "Not applicable",
-        "teaching_stage" => "I'm thinking about teaching and want to find out more",
-        "subject_first_choice" => "Architecture",
-        "subject_second_choice" => "Mathematics"
-      },
-      "candidates_registrations_background_check" => {
-        "has_dbs_check" => has_dbs_check
+      'registration' => {
+        "candidates_registrations_account_check" => {
+          "full_name" => "Testy McTest",
+          "email" => "test@example.com"
+        },
+        "candidates_registrations_placement_preference" => {
+          "date_start" => placement_date_start.strftime('%Y-%m-%d'),
+          "date_end" => placement_date_end.strftime('%Y-%m-%d'),
+          "objectives" => "test the software",
+          "access_needs" => access_needs,
+          "access_needs_details" => access_needs_details
+        },
+        "candidates_registrations_address" => {
+          "building" => "Test building",
+          "street" => "Test street",
+          "town_or_city" => "Test town",
+          "county" => "Testshire",
+          "postcode" => "TE57 1NG",
+          "phone" => "01234567890"
+        },
+        "candidates_registrations_subject_preference" => {
+          "degree_stage" => "I don't have a degree and am not studying for one",
+          "degree_stage_explaination" => "",
+          "degree_subject" => "Not applicable",
+          "teaching_stage" => "I'm thinking about teaching and want to find out more",
+          "subject_first_choice" => "Architecture",
+          "subject_second_choice" => "Mathematics"
+        },
+        "candidates_registrations_background_check" => {
+          "has_dbs_check" => has_dbs_check
+        }
       }
     }
   end
 
-  subject { described_class.new valid_registraion_session }
+  let :current_registration do
+    Candidates::Registrations::RegistrationSession.new valid_registraion_session
+  end
+
+  subject { described_class.new current_registration }
 
   context '#full_name' do
     it 'returns the correct value' do

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -18,9 +18,7 @@ describe Candidates::Registrations::RegistrationSession do
 
     context 'when registration key is set' do
       let :session do
-        {
-          'registration' => { 'some' => 'information' }
-        }
+        { 'registration' => { 'some' => 'information' } }
       end
 
       it "doesn't over write the registration key" do
@@ -34,12 +32,8 @@ describe Candidates::Registrations::RegistrationSession do
       { 'registration' => { 'some' => 'information' } }
     end
 
-    let :model_klass do
-      Candidates::Registrations::BackgroundCheck
-    end
-
     let :model do
-      model_klass.new has_dbs_check: true
+      Candidates::Registrations::BackgroundCheck.new has_dbs_check: true
     end
 
     before do

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -1,0 +1,84 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::RegistrationSession do
+  context '#initialize' do
+    before do
+      described_class.new session
+    end
+
+    context 'when registration key is not set' do
+      let :session do
+        {}
+      end
+
+      it 'adds the registration key to the session' do
+        expect(session['registration']).to eq({})
+      end
+    end
+
+    context 'when registration key is set' do
+      let :session do
+        {
+          'registration' => { 'some' => 'information' }
+        }
+      end
+
+      it "doesn't over write the registration key" do
+        expect(session['registration']).to eq({ 'some' => 'information' })
+      end
+    end
+  end
+
+  context '#save' do
+    let :session do
+      { 'registration' => { 'some' => 'information' } }
+    end
+
+    let :model_klass do
+      Candidates::Registrations::BackgroundCheck
+    end
+
+    let :model do
+      model_klass.new has_dbs_check: true
+    end
+
+    before do
+      described_class.new(session).save model
+    end
+
+    it 'stores the models attributes under the correct key' do
+      expect(
+        session['registration']['candidates_registrations_background_check']
+      ).to eq({ 'has_dbs_check' => true })
+    end
+
+    it 'doesnt over write other keys' do
+      expect(session['registration']['some']).to eq 'information'
+    end
+  end
+
+  context '#fetch' do
+    let :session do
+      {
+        'registration' => {
+          'candidates_registrations_background_check' => {
+            'has_dbs_check' => true
+          }
+        }
+      }
+    end
+
+    let :model_klass do
+      Candidates::Registrations::BackgroundCheck
+    end
+
+    let :returned_model do
+      described_class.new(session).fetch model_klass
+    end
+
+    it 'instantiates and returns the model correctly' do
+      expect(returned_model).to be_a model_klass
+      expect(returned_model.has_dbs_check).to be true
+    end
+  end
+end

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -24,7 +24,7 @@ describe Candidates::Registrations::RegistrationSession do
       end
 
       it "doesn't over write the registration key" do
-        expect(session['registration']).to eq({ 'some' => 'information' })
+        expect(session['registration']).to eq 'some' => 'information'
       end
     end
   end
@@ -49,7 +49,7 @@ describe Candidates::Registrations::RegistrationSession do
     it 'stores the models attributes under the correct key' do
       expect(
         session['registration']['candidates_registrations_background_check']
-      ).to eq({ 'has_dbs_check' => true })
+      ).to eq 'has_dbs_check' => true
     end
 
     it 'doesnt over write other keys' do


### PR DESCRIPTION
### Context
Was having an issue with stubbing the session in some specs. Added this wrapper class to keep the knowledge of to read / write models to / from the session in one place. Also has the benefit of cleaning up some of the specs.

### Changes proposed in this pull request
Introduce session wrapper.
Refactors how application preview presenter is initialized.

### Guidance to review

