### PR TITLE
Removed Hiredis gem since no ssl suppot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'govuk_elements_form_builder', github: 'DFE-Digital/govuk_elements_form_buil
 
 gem 'acts_as_list'
 
-gem "hiredis"
 gem "redis", "~> 4.0"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,7 +143,6 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    hiredis (0.6.3)
     i18n (1.5.3)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
@@ -344,7 +343,6 @@ DEPENDENCIES
   geocoder
   govuk-lint
   govuk_elements_form_builder!
-  hiredis
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pg_search


### PR DESCRIPTION
### Context

Hiredis gem prevents us from connecting to SSL encrypted Redis servers. It offers most benefit in large batched requests which is not our use case so is of limited benefit and obvious cost.

### Changes proposed in this pull request

Remove `hiredis` gem

### Guidance to review
