### PR TITLE
Feature/candidate registrations refactor for editing

### DIFF
--- a/app/services/candidates/registrations/account_check.rb
+++ b/app/services/candidates/registrations/account_check.rb
@@ -1,11 +1,8 @@
 module Candidates
   module Registrations
-    class AccountCheck
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
-      attribute :full_name
-      attribute :email
+    class AccountCheck < RegistrationStep
+      attribute :full_name, :string
+      attribute :email, :string
 
       validates :full_name, presence: true
       validates :email, presence: true

--- a/app/services/candidates/registrations/address.rb
+++ b/app/services/candidates/registrations/address.rb
@@ -1,9 +1,6 @@
 module Candidates
   module Registrations
-    class Address
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class Address < RegistrationStep
       attribute :building, :string
       attribute :street, :string
       attribute :town_or_city, :string

--- a/app/services/candidates/registrations/background_check.rb
+++ b/app/services/candidates/registrations/background_check.rb
@@ -1,9 +1,6 @@
 module Candidates
   module Registrations
-    class BackgroundCheck
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class BackgroundCheck < RegistrationStep
       attribute :has_dbs_check, :boolean
 
       validates :has_dbs_check, inclusion: [true, false]

--- a/app/services/candidates/registrations/placement_preference.rb
+++ b/app/services/candidates/registrations/placement_preference.rb
@@ -1,9 +1,6 @@
 module Candidates
   module Registrations
-    class PlacementPreference
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class PlacementPreference < RegistrationStep
       # This allows us to parse multi-part date parameters like an ActiveRecord object.
       include ActiveRecord::AttributeAssignment
       class ActiveModel::Type::Date

--- a/app/services/candidates/registrations/registration_step.rb
+++ b/app/services/candidates/registrations/registration_step.rb
@@ -11,8 +11,9 @@ module Candidates
         created_at.present?
       end
 
-      def persist!
-        return unless valid?
+      # Flag the model as having being persisted
+      def persisted!
+        validate!
         self.updated_at = DateTime.now
         self.created_at = self.updated_at unless persisted?
       end

--- a/app/services/candidates/registrations/registration_step.rb
+++ b/app/services/candidates/registrations/registration_step.rb
@@ -1,0 +1,21 @@
+module Candidates
+  module Registrations
+    class RegistrationStep
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :created_at, :datetime
+      attribute :updated_at, :datetime
+
+      def persisted?
+        created_at.present?
+      end
+
+      def persist!
+        return unless valid?
+        self.updated_at = DateTime.now
+        self.created_at = self.updated_at unless persisted?
+      end
+    end
+  end
+end

--- a/app/services/candidates/registrations/subject_preference.rb
+++ b/app/services/candidates/registrations/subject_preference.rb
@@ -1,9 +1,6 @@
 module Candidates
   module Registrations
-    class SubjectPreference
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class SubjectPreference < RegistrationStep
       OPTIONS_CONFIG = YAML.load_file "#{Rails.root}/config/candidate_form_options.yml"
       NOT_APPLYING_FOR_DEGREE = "I don't have a degree and am not studying for one".freeze
       DEGREE_STAGE_REQUIRING_EXPLINATIONN = 'Other'.freeze

--- a/spec/controllers/candidates/registrations/account_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/account_checks_controller_spec.rb
@@ -44,7 +44,9 @@ describe Candidates::Registrations::AccountChecksController, type: :request do
       it 'stores the account_check details in the session' do
         expect(session['registration']['candidates_registrations_account_check']).to eq(
           'full_name' => 'test name',
-          'email' => 'test@example.com'
+          'email' => 'test@example.com',
+          'created_at' => nil,
+          'updated_at' => nil
         )
       end
 

--- a/spec/controllers/candidates/registrations/addresses_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/addresses_controller_spec.rb
@@ -60,7 +60,9 @@ describe Candidates::Registrations::AddressesController, type: :request do
           "town_or_city" => 'Test Town',
           "county" => 'Testshire',
           "postcode" => 'TE57 1NG',
-          "phone" => '01234567890'
+          "phone" => '01234567890',
+          "created_at" => nil,
+          "updated_at" => nil
         )
       end
 

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -38,7 +38,9 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
 
       it 'stores the dbs check in the session' do
         expect(session['registration']['candidates_registrations_background_check']).to eq \
-          'has_dbs_check' => true
+          'has_dbs_check' => true,
+          "created_at" => nil,
+          "updated_at" => nil
       end
 
       it 'redirects to the next step' do

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -57,7 +57,9 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
           "date_end" => (tomorrow + 3.days),
           "objectives" => 'Become a teacher',
           "access_needs" => false,
-          "access_needs_details" => nil
+          "access_needs_details" => nil,
+          "created_at" => nil,
+          "updated_at" => nil
         )
       end
 

--- a/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
@@ -70,7 +70,9 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
           "teaching_stage" =>  "I want to become a teacher",
           "subject_first_choice" =>  "Astronomy",
           "subject_second_choice" =>  "History",
-          "urn" => "URN"
+          "urn" => "URN",
+          "created_at" => nil,
+          "updated_at" => nil
         )
       end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/services/candidates/registrations/account_check_spec.rb
+++ b/spec/services/candidates/registrations/account_check_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::AccountCheck, type: :model do
+  it_behaves_like 'a registration step'
+
   it { is_expected.to respond_to :full_name }
   it { is_expected.to respond_to :email }
 

--- a/spec/services/candidates/registrations/address_spec.rb
+++ b/spec/services/candidates/registrations/address_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::Address, type: :model do
+  it_behaves_like 'a registration step'
+
   context 'attributes' do
     it { is_expected.to respond_to :building }
     it { is_expected.to respond_to :street }

--- a/spec/services/candidates/registrations/background_check_spec.rb
+++ b/spec/services/candidates/registrations/background_check_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::BackgroundCheck, type: :model do
+  it_behaves_like 'a registration step'
+
   context 'attributes' do
     it { is_expected.to respond_to :has_dbs_check }
   end

--- a/spec/services/candidates/registrations/placement_preference_spec.rb
+++ b/spec/services/candidates/registrations/placement_preference_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::PlacementPreference, type: :model do
+  it_behaves_like 'a registration step'
+
   let! :today do
     Date.today
   end

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -43,7 +43,10 @@ describe Candidates::Registrations::RegistrationSession do
     it 'stores the models attributes under the correct key' do
       expect(
         session['registration']['candidates_registrations_background_check']
-      ).to eq 'has_dbs_check' => true
+      ).to eq \
+        'has_dbs_check' => true,
+        'created_at' => nil,
+        'updated_at' => nil
     end
 
     it 'doesnt over write other keys' do

--- a/spec/services/candidates/registrations/subject_preference_spec.rb
+++ b/spec/services/candidates/registrations/subject_preference_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::SubjectPreference, type: :model do
+  it_behaves_like 'a registration step'
+
   let :school_urn do
     'URN'
   end

--- a/spec/support/registration_step_shared_examples.rb
+++ b/spec/support/registration_step_shared_examples.rb
@@ -1,0 +1,107 @@
+shared_examples 'a registration step' do
+  let! :datetime do
+    DateTime.now
+  end
+
+  let! :new_datetime do
+    datetime + 1.day
+  end
+
+  subject do
+    described_class.new
+  end
+
+  context 'methods' do
+    it { is_expected.to respond_to :persisted? }
+    it { is_expected.to respond_to :persisted! }
+    it { is_expected.to respond_to :created_at }
+    it { is_expected.to respond_to :updated_at }
+  end
+
+  context 'unpersisted' do
+    before do
+      allow(DateTime).to receive(:now) { datetime }
+    end
+
+    context '#created_at' do
+      it 'is nil' do
+        expect(subject.created_at).to eq nil
+      end
+    end
+
+    context '#updated_at' do
+      it 'is nil' do
+        expect(subject.updated_at).to eq nil
+      end
+    end
+
+    context '#persisted?' do
+      it 'is false' do
+        expect(subject).not_to be_persisted
+      end
+    end
+
+    context '#persisted!' do
+      context 'when invalid' do
+        it 'raises a validation error' do
+          expect { subject.persisted! }.to raise_error \
+            ActiveModel::ValidationError
+        end
+      end
+
+      context 'when valid' do
+        before do
+          allow(subject).to receive(:valid?) { true }
+          subject.persisted!
+        end
+
+        it 'sets the created_at' do
+          expect(subject.created_at).to eq datetime
+        end
+
+        it 'sets the updated_at' do
+          expect(subject.updated_at).to eq datetime
+        end
+      end
+    end
+  end
+
+  context 'persisted' do
+    before do
+      # setting a value for created_at flags a model as persisted.
+      subject.created_at = datetime
+      allow(DateTime).to receive(:now) { new_datetime }
+    end
+
+    context '#persisted?' do
+      it 'is true' do
+        expect(subject).to be_persisted
+      end
+    end
+
+    context '#persisted!' do
+      context 'when invalid' do
+        # ie a bad update attempt
+        it 'raises a validation error' do
+          expect { subject.persisted! }.to raise_error \
+            ActiveModel::ValidationError
+        end
+      end
+
+      context 'when valid' do
+        before do
+          allow(subject).to receive(:valid?) { true }
+          subject.persisted!
+        end
+
+        it "doesn't change the created_at" do
+          expect(subject.created_at).to eq datetime
+        end
+
+        it 'sets the updated_at to the current time' do
+          expect(subject.updated_at).to eq new_datetime
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
I want to be able to pass the active model to form_for and have it set the correct method on the form for creates & updates to keep form behaviour as standard as possible. This is some preliminary refactoring to enable that.
The RegistrationStep base class sets created_at and updated_at time stamps which we use to determine whether a model is `persisted?`. Also by capturing the updated_at time stamp we can work out if a particular step in the wizard is being edited by a lot of candidates (if we decide to keep this information).

### Changes proposed in this pull request
Introduces a base class for the registration step

### Guidance to review
The `"created_at" => nil, "updated_at" => nil` additions to the specs are removed in a future commit when `RegistrationStep#persisted!` is actually called by `RegistraionSession#save`