### PR TITLE
Added optional Slack notification of Exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem 'delayed_job_active_record'
 
 gem "redis", "~> 4.0"
 
+gem 'exception_notification'
+gem 'slack-notifier'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,9 @@ GEM
       dotenv (= 2.6.0)
       railties (>= 3.2, < 6.0)
     erubi (1.8.0)
+    exception_notification (4.3.0)
+      actionmailer (>= 4.0, < 6)
+      activesupport (>= 4.0, < 6)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -291,6 +294,7 @@ GEM
       rubyzip (~> 1.2, >= 1.2.2)
     shoulda-matchers (4.0.0.rc1)
       activesupport (>= 4.2.0)
+    slack-notifier (2.3.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -344,6 +348,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   dotenv-rails
+  exception_notification
   factory_bot_rails
   foreman
   geocoder
@@ -362,6 +367,7 @@ DEPENDENCIES
   sassc-rails
   selenium-webdriver
   shoulda-matchers (= 4.0.0.rc1)
+  slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -57,4 +57,11 @@ SECURE_USERNAME = <my-username>
 SECURE_PASSWORD = <my-password>
 ```
 
+## Exception notification
 
+If required Exceptions Notifications can be sent to a Slack channel. This is 
+enabled and configured via environment variables.
+
+**SLACK_WEBHOOK** _(required)_ Webhook to use to post to Slack
+**SLACK_CHANNEL** _(optional)_ Channel to post to, should be left blank if hook defaults to a specifi channel
+**SLACK_ENV** _(optional)_ Identifier for deployment environment - eg Staging or Production

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,20 @@
+if ENV['SLACK_WEBHOOK'].present?
+  slack_opts = {
+    :webhook_url => ENV['SLACK_WEBHOOK'],
+    :additional_parameters => {
+      :mrkdwn => true
+    }
+  }
+
+  if ENV['SLACK_CHANNEL'].present?
+    slack_opts[:channel] = ENV['SLACK_CHANNEL']
+  end
+
+  if ENV['SLACK_ENV'].present?
+    slack_opts[:additional_fields] = [
+      { title: "Deployment Environment", value: ENV['SLACK_ENV'].to_s }
+    ]
+  end
+
+  Rails.application.config.middleware.use ExceptionNotification::Rack, slack: slack_opts
+end


### PR DESCRIPTION
### Context

Need to be able to report exceptions from Production environments

### Changes proposed in this pull request

Uses Slack notifier, which is available to us now.

### Guidance to review

There are other more comprehensive solutions (eg Sentry) but this gets us exception reporting for now. Doesn't fire unless env vars are set but works in both production and development if they are.
Webhook is available at the beginning of the chat in the private channel `school-exp-errors`. Vars can be set in `.env` file

**Note:** This doesn't include integration with ActiveJob failures - I'll get this merged than look at that next week