### PR TITLE
Search tidy ups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ group :development, :test do
   gem 'dotenv-rails'
 
   gem 'brakeman', '>= 4.4.0'
+
+  gem 'bullet'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
     brakeman (4.4.0)
     breasal (0.0.1)
     builder (3.2.3)
+    bullet (5.9.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (10.0.2)
     canonical-rails (0.2.5)
       rails (>= 4.1, < 6.1)
@@ -311,6 +314,7 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.4.1)
+    uniform_notifier (1.12.1)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -336,6 +340,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   brakeman (>= 4.4.0)
   breasal
+  bullet
   byebug
   canonical-rails
   capybara (>= 2.15)

--- a/app/assets/stylesheets/form-extensions.scss
+++ b/app/assets/stylesheets/form-extensions.scss
@@ -16,4 +16,8 @@
       width: auto;
     }
   }
+
+  input[type=submit].govuk-button {
+    margin-bottom: 0;
+  }
 }

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -4,7 +4,7 @@ class Candidates::SchoolsController < ApplicationController
   end
 
   def show
-    @school = OpenStruct.new(YAML.load_file('demo-school.yml'))
+    @school = Candidates::SchoolStub.find(params[:id])
   end
 
 private

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -10,6 +10,6 @@ class Candidates::SchoolsController < ApplicationController
 private
 
   def search_params
-    params.permit(:query, :location, :distance, :max_fee, phases: [], subjects: [])
+    params.permit(:query, :location, :distance, :max_fee, :order, phases: [], subjects: [])
   end
 end

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -9,4 +9,16 @@ module Candidates::SchoolHelper
       school.postcode.presence,
     ].compact, ", ")
   end
+
+  def format_school_subjects(school)
+    safe_subjects = school.subjects.map(&:name).map do |subj|
+      ERB::Util.h(subj)
+    end
+
+    safe_subjects.to_sentence.html_safe
+  end
+
+  def format_school_phases(school)
+    safe_join school.phases.map(&:name), ', '
+  end
 end

--- a/app/javascript/controllers/instant_filter_controller.js
+++ b/app/javascript/controllers/instant_filter_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
     const form = this.element ;
 
     this.element.addEventListener('change', function(ev) {
-      if (ev.target.nodeName == 'INPUT') {
+      if (ev.target.nodeName == 'INPUT' || ev.target.nodeName == 'SELECT') {
           form.submit() ;
       }
     }) ;

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -59,6 +59,6 @@ class Bookings::School < ApplicationRecord
   end
 
   def to_param
-    urn
+    urn.to_s.presence
   end
 end

--- a/app/models/candidates/school.rb
+++ b/app/models/candidates/school.rb
@@ -1,7 +1,6 @@
 class Candidates::School
   class << self
     def find(identifier)
-      # Note currently using id, will be converted to URN when available
       Bookings::School.find_by!(urn: identifier)
     end
 

--- a/app/models/candidates/school.rb
+++ b/app/models/candidates/school.rb
@@ -7,15 +7,11 @@ class Candidates::School
     end
 
     def phases
-      Bookings::Phase.all.map do |phase|
-        [phase.id, phase.name]
-      end
+      Bookings::Phase.all.pluck(:id, :name)
     end
 
     def subjects
-      Bookings::Subject.order(name: :asc).map do |subject|
-        [subject.id, subject.name]
-      end
+      Bookings::Subject.order(name: :asc).pluck(:id, :name)
     end
   end
 end

--- a/app/models/candidates/school.rb
+++ b/app/models/candidates/school.rb
@@ -2,8 +2,7 @@ class Candidates::School
   class << self
     def find(identifier)
       # Note currently using id, will be converted to URN when available
-      #Bookings::School.find_by!(urn: identifier)
-      Bookings::School.find(identifier)
+      Bookings::School.find_by!(urn: identifier)
     end
 
     def phases

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -19,10 +19,12 @@ module Candidates
       ['90', 'up to £90']
     ].freeze
 
-    attr_accessor :query, :location
-    attr_reader :distance, :subjects, :phases, :max_fee
+    attr_accessor :query, :location, :order
+    attr_reader :distance, :max_fee
 
     class << self
+      delegate :available_orders, to: Bookings::SchoolSearch
+
       def fees
         FEES
       end
@@ -34,6 +36,14 @@ module Candidates
 
     def distance=(dist_ids)
       @distance = dist_ids.present? ? dist_ids.to_i : nil
+    end
+
+    def subjects
+      @subjects ||= []
+    end
+
+    def phases
+      @phases ||= []
     end
 
     def subjects=(subj_ids)
@@ -62,7 +72,7 @@ module Candidates
     end
 
     def total_results
-      0
+      results.length
     end
 
   private
@@ -74,7 +84,8 @@ module Candidates
         radius: distance,
         subjects: subjects,
         phases: phases,
-        max_fee: max_fee
+        max_fee: max_fee,
+        requested_order: order
       )
     end
   end

--- a/app/models/candidates/school_stub.rb
+++ b/app/models/candidates/school_stub.rb
@@ -1,0 +1,29 @@
+class Candidates::SchoolStub
+  def self.find(identifier)
+    new Candidates::School.find(identifier)
+  end
+
+  def initialize(school)
+    @school = school
+    @fallback = YAML.load_file('demo-school.yml')
+  end
+
+  def respond_to_missing?(method, _include_private = false)
+    @school.respond_to?(method, false) || @fallback.keys?(method.to_s)
+  end
+
+  def method_missing(method, *args, &block)
+    if @school.respond_to?(method, false)
+      @school.public_send(method, *args, &block)
+    elsif @fallback.keys?(method.to_s)
+      @fallback[method.to_s]
+    else
+      super
+    end
+  end
+
+  # not sure why this isn't cascading through needed but this fixes it
+  def to_param
+    @school.to_param
+  end
+end

--- a/app/models/candidates/school_stub.rb
+++ b/app/models/candidates/school_stub.rb
@@ -15,7 +15,7 @@ class Candidates::SchoolStub
   def method_missing(method, *args, &block)
     if @school.respond_to?(method, false)
       @school.public_send(method, *args, &block)
-    elsif @fallback.keys?(method.to_s)
+    elsif @fallback.key?(method.to_s)
       @fallback[method.to_s]
     else
       super

--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -1,6 +1,16 @@
 class Bookings::SchoolSearch
   attr_accessor :query, :point, :radius, :subjects, :phases, :max_fee, :order
 
+  AVAILABLE_ORDERS = [
+    %w{distance Distance},
+    %w{fee Fee},
+    %w{name Name}
+  ].freeze
+
+  def self.available_orders
+    AVAILABLE_ORDERS.map
+  end
+
   def initialize(query, location: nil, radius: 10, subjects: nil, phases: nil, max_fee: nil, requested_order: 'distance')
     self.query    = query
     self.point    = geolocate(location)

--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -18,9 +18,10 @@ class Bookings::SchoolSearch
     Bookings::School
       .search(@query)
       .close_to(@point, radius: @radius)
-      .that_provide(@subjects)
-      .at_phases(@phases)
+      .that_provide(@subjects).includes(:subjects)
+      .at_phases(@phases).includes(:phases)
       .costing_upto(@max_fee)
+      .includes(:school_type)
       .reorder(@order)
   end
 

--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -13,7 +13,7 @@ class Bookings::SchoolSearch
 
   def initialize(query, location: nil, radius: 10, subjects: nil, phases: nil, max_fee: nil, requested_order: 'distance')
     self.query    = query
-    self.point    = geolocate(location)
+    self.point    = geolocate(location) if location.present?
     self.radius   = radius
     self.subjects = subjects
     self.phases   = phases

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -48,7 +48,7 @@
         <ul id="results">
             <% @search.results.each_with_index do |result, index| %>
             <li class="school-result">
-                <strong class="name"><%= link_to result.name, candidates_school_path(index + 1) %></strong>
+                <strong class="name"><%= link_to result.name, candidates_school_path(result) %></strong>
                 <ul>
                     <li><strong>Address:</strong> <%= format_school_address result %></li>
                     <li><strong>Education phase:</strong> <%= result.phases.map(&:name).join(', ') %></li>

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -58,10 +58,10 @@
                 <strong class="name"><%= link_to result.name, candidates_school_path(result) %></strong>
                 <ul>
                     <li><strong>Address:</strong> <%= format_school_address result %></li>
-                    <li><strong>Education phase:</strong> <%= result.phases.map(&:name).join(', ') %></li>
+                    <li><strong>Education phase:</strong> <%= format_school_phases result %></li>
                     <li><strong>Fees:</strong> &pound;<%= result.fee %></li>
                     <li><strong>School type:</strong> <%= result.school_type&.name %></li>
-                    <li><strong>Subjects:</strong> <%= result.subjects.map(&:name).to_sentence %></li>
+                    <li><strong>Subjects:</strong> <%= format_school_subjects result %></li>
                 </ul>
             </li>
             <% end %>

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -10,6 +10,7 @@
     <div class="govuk-grid-column-one-third filter-list" id="search-filter">
         <%= form_for @search, as: '', method: :get, data: {controller:'instant-filter'} do |f| %>
             <%= f.hidden_field :query %>
+            <%= f.hidden_field :location %>
             <%= f.hidden_field :distance %>
 
             <%= f.collection_check_boxes :phases, Candidates::School.phases, :first, :last %>
@@ -19,6 +20,7 @@
                                                     text_method: :last %>
 
             <%= f.collection_check_boxes :subjects, Candidates::School.subjects, :first, :last %>
+            <%= f.hidden_field :order %>
 
             <%= f.submit 'Update schools list', name: nil %>
         <% end %>
@@ -32,15 +34,20 @@
         <hr />
 
         <div class="sortby inline-fields">
-            <div class="drop govuk-form-group">
-                <label for="orderby">Sorted by</label>
-                <select name="orderby" id="OrderBy" aria-controls="js-search-results-info" class="govuk-select">
-                    <option value="" selected="">Distance</option>
-                    <option value="fee">Fee</option>
-                    <option value="SCHNAME_sort asc">Alphabetical A - Z</option>
-                    <option value="SCHNAME_sort desc">Alphabetical Z - A</option>
-                </select>
-            </div>
+            <%= form_for @search, as: '', method: :get, data: {controller:'instant-filter'} do |f| %>
+                <%= f.hidden_field :query %>
+                <%= f.hidden_field :location %>
+                <%= f.hidden_field :distance %>
+                <% for phase_id in f.object.phases %>
+                    <%= f.hidden_field :phases, multiple: true, value: phase_id, id: nil %>
+                <% end %>
+                <% for subject_id in f.object.subjects %>
+                    <%= f.hidden_field :subjects, multiple: true, value: subject_id, id: nil %>
+                <% end %>
+                <%= f.hidden_field :max_fee %>
+                <%= f.collection_select :order, f.object.class.available_orders, :first, :last %>
+                <%= f.submit "Change sort order", name: nil %>
+            <% end %>
         </div>
 
         <hr />

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -54,7 +54,7 @@
                     <li><strong>Education phase:</strong> <%= result.phases.map(&:name).join(', ') %></li>
                     <li><strong>Fees:</strong> &pound;<%= result.fee %></li>
                     <li><strong>School type:</strong> <%= result.school_type&.name %></li>
-                    <li><strong>Subjects:</strong> <%= result.subjects.to_sentence %></li>
+                    <li><strong>Subjects:</strong> <%= result.subjects.map(&:name).to_sentence %></li>
                 </ul>
             </li>
             <% end %>

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -64,7 +64,7 @@
 
         <p>
             <%= link_to "Request placement",
-                        candidates_school_registrations_placement_preference_path(@school.urn),
+                        new_candidates_school_registrations_placement_preference_path(@school),
                         class:"govuk-button" %>
         </p>
     </div>

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -50,7 +50,7 @@
             </p>
 
             <p>
-                <b>Placement subjects:</b> <%= @school.subjects.to_sentence %>.
+                <b>Placement subjects:</b> <%= format_school_subjects @school %>.
             </p>
         </div>
 

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -63,9 +63,9 @@
         <%- end -%>
 
         <p>
-            <a class="govuk-button" href="/register/request">
-                Request placement
-            </a>
+            <%= link_to "Request placement",
+                        candidates_school_registrations_placement_preference_path(@school.urn),
+                        class:"govuk-button" %>
         </p>
     </div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,10 @@ Rails.application.configure do
     url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL']
   }
   config.session_store :cache_store, key: 'schoolex-session'
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,4 +46,9 @@ Rails.application.configure do
 
   # Use the test adapter for active jobs
   config.active_job.queue_adapter = :test
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.raise = true
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,3 +107,4 @@ en:
         access_needs:
           true: "Yes"
           false: "No"
+      order: Sorted by

--- a/demo-school.yml
+++ b/demo-school.yml
@@ -1,4 +1,3 @@
-name: The Creative Studio
 description: "We're a thriving community school serving a cosmopolitan community
 in North Manchester with more than 1,700 pupils.\n
 
@@ -9,7 +8,6 @@ bilingual children.\n
 We're also a barrier free school and cater fully for the needs of pupils with
 movement difficulties while our work with hearing impaired children is well
 supported by the local authority and other agencies."
-postcode: MA1 1AM
 age_range: 3 to 16 (nursery, primary and secondary)
 specialisms: Arts, bilingual students and SEN
 links:
@@ -23,18 +21,6 @@ links:
     link: "https://reports.ofsted.gov.uk/provider/28/105560"
 requirements: Must have a degree and be planning to become a teacher.
 placement_details: Attendees will observe lessons in their chosen subjects and may get the chance to interact with pupils and classroom activities. Only offer key stage 1 experience for primary placements
-subjects:
-- Maths
-- English
-- Art
-- Physics
-- Music
-address_1: Long Millgate
-address_2: XXX
-address_3:
-town: Manchester
-county:
-postcode:
 dbs: true
 fee: "Yes - £50 per placement"
 dress_code: Yes - business attire with male attendees expected to wear a collar and tie
@@ -42,5 +28,4 @@ times: 8am to 5pm
 parking: Limited on-site parking arranged as part of placement. Local paid-for on-street parking around school site for £3 per day
 accessibility: Ramp access and disabled parking available on site
 training_offered: Yes. We offer training opportunities for a a mainstream ITT programme.
-to_param: 1000001
-urn: 1000001
+

--- a/demo-school.yml
+++ b/demo-school.yml
@@ -42,3 +42,5 @@ times: 8am to 5pm
 parking: Limited on-site parking arranged as part of placement. Local paid-for on-street parking around school site for £3 per day
 accessibility: Ramp access and disabled parking available on site
 training_offered: Yes. We offer training opportunities for a a mainstream ITT programme.
+to_param: 1000001
+urn: 1000001

--- a/features/step_definitions/candidates/landing_page_steps.rb
+++ b/features/step_definitions/candidates/landing_page_steps.rb
@@ -34,7 +34,7 @@ Then("I should be on the {string} page") do |string|
 end
 
 Then("I should be on the {string} page for my school of choice") do |string|
-  expect(page.current_path).to eql(path_for(string, school_id: @school.id))
+  expect(page.current_path).to eql(path_for(string, school: @school))
 end
 
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -8,7 +8,7 @@ end
 
 Given("I am on the {string} page for my school of choice") do |string|
   @school = FactoryBot.create(:bookings_school)
-  path_for(string, school_id: @school.id).tap do |p|
+  path_for(string, school: @school).tap do |p|
     visit(p)
     expect(page.current_path).to eql(p)
   end

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -1,13 +1,17 @@
-def path_for(descriptor, school_id: nil)
+def path_for(descriptor, school: nil)
+  if school && school.respond_to?(:to_param)
+    school = school.to_param
+  end
+
   mappings = {
     "landing" => [:root_path],
     "find a school" => [:candidates_schools_path],
-    "request school experience placement" => [:new_candidates_school_registrations_placement_preference_path, school_id],
-    "check if we already have your details" => [:new_candidates_school_registrations_account_check_path, school_id],
-    "candidate address" => [:new_candidates_school_registrations_address_path, school_id],
-    "candidate subjects" => [:new_candidates_school_registrations_subject_preference_path, school_id],
-    "background checks" => [:new_candidates_school_registrations_background_check_path, school_id],
-    "check your answers" => [:candidates_school_registrations_application_preview_path, school_id]
+    "request school experience placement" => [:new_candidates_school_registrations_placement_preference_path, school],
+    "check if we already have your details" => [:new_candidates_school_registrations_account_check_path, school],
+    "candidate address" => [:new_candidates_school_registrations_address_path, school],
+    "candidate subjects" => [:new_candidates_school_registrations_subject_preference_path, school],
+    "background checks" => [:new_candidates_school_registrations_background_check_path, school],
+    "check your answers" => [:candidates_school_registrations_application_preview_path, school]
   }
 
   (path = mappings[descriptor.downcase]) ? send(*path) : fail("No mapping for #{descriptor}")

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
   context "GET #show" do
     before do
       @school = create(:bookings_school)
-      get candidates_school_path(@school.urn)
+      get candidates_school_path(@school)
     end
 
     it "returns http success" do

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -1,6 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe Candidates::SchoolsController, type: :request do
+  before do
+    allow(Geocoder).to receive(:search).and_return([
+      OpenStruct.new(data: {'lat' => "53.4794892", 'lon' => "-2.2451148"})
+    ])
+  end
+
   context "GET #index" do
     before { get candidates_schools_path }
 
@@ -13,7 +19,33 @@ RSpec.describe Candidates::SchoolsController, type: :request do
     end
 
     it "excludes the search results" do
-      expect(response.body).to_not match(/School experience placements near/i)
+      expect(response.body).to_not match(/placements near/i)
+    end
+  end
+
+  context "GET #index with search params" do
+    let(:query_params) {
+      {
+        query: 'Something',
+        location: 'Manchester',
+        distance: '10',
+        phases: ['1'],
+        subjects: ['2','3'],
+        max_fee: '30',
+        order: 'Name'
+      }
+    }
+
+    before { get candidates_schools_path(query_params) }
+
+    it "assigns params to search model" do
+      expect(assigns(:search).query).to eq('Something')
+      expect(assigns(:search).location).to eq('Manchester')
+      expect(assigns(:search).distance).to eq(10)
+      expect(assigns(:search).phases).to eq([1])
+      expect(assigns(:search).subjects).to eq([2,3])
+      expect(assigns(:search).max_fee).to eq('30')
+      expect(assigns(:search).order).to eq('Name')
     end
   end
 

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Candidates::SchoolsController, type: :request do
-  before do
-    allow(Geocoder).to receive(:search).and_return([
-      OpenStruct.new(data: {'lat' => "53.4794892", 'lon' => "-2.2451148"})
-    ])
-  end
-
   context "GET #index" do
     before { get candidates_schools_path }
 
@@ -29,8 +23,8 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         query: 'Something',
         location: 'Manchester',
         distance: '10',
-        phases: ['1'],
-        subjects: ['2','3'],
+        phases: %w{1},
+        subjects: %w{2 3},
         max_fee: '30',
         order: 'Name'
       }
@@ -43,7 +37,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       expect(assigns(:search).location).to eq('Manchester')
       expect(assigns(:search).distance).to eq(10)
       expect(assigns(:search).phases).to eq([1])
-      expect(assigns(:search).subjects).to eq([2,3])
+      expect(assigns(:search).subjects).to eq([2, 3])
       expect(assigns(:search).max_fee).to eq('30')
       expect(assigns(:search).order).to eq('Name')
     end

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -23,4 +23,48 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
       expect(@formatted).to eq "Picadilly Gate, Manchester, Manchester, MA1 1AM"
     end
   end
+
+  context '.format_school_subjects' do
+    before do
+      @school = OpenStruct.new(
+        subjects: [
+          OpenStruct.new(id: 1, name: 'First'),
+          OpenStruct.new(id: 2, name: 'Second'),
+          OpenStruct.new(id: 3, name: 'Third')
+        ]
+      )
+
+      @formatted = format_school_subjects(@school)
+    end
+
+    it 'should be html_safe' do
+      expect(@formatted.html_safe?).to be true
+    end
+
+    it 'should turn them into a sentence' do
+      expect(@formatted).to eq "First, Second, and Third"
+    end
+  end
+
+  context '.format_school_phases' do
+    before do
+      @school = OpenStruct.new(
+        phases: [
+          OpenStruct.new(id: 1, name: 'First'),
+          OpenStruct.new(id: 2, name: 'Second'),
+          OpenStruct.new(id: 3, name: 'Third')
+        ]
+      )
+
+      @formatted = format_school_phases(@school)
+    end
+
+    it 'should be html_safe' do
+      expect(@formatted.html_safe?).to be true
+    end
+
+    it 'should turn them into a sentence' do
+      expect(@formatted).to eq "First, Second, Third"
+    end
+  end
 end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -63,7 +63,7 @@ describe Bookings::School, type: :model do
     subject { create(:bookings_school) }
 
     specify do
-      expect(subject.to_param).to eq(subject.urn)
+      expect(subject.to_param).to eq(subject.urn.to_s)
     end
   end
 

--- a/spec/models/candidates/school_spec.rb
+++ b/spec/models/candidates/school_spec.rb
@@ -6,7 +6,6 @@ describe Candidates::School do
 
     context('with valid identifier') do
       it "will return school" do
-        pending
         expect(described_class.find(@school.to_param)).to eq(@school)
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,6 +60,13 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
+
+  # Prevent unintended API access from Geocoder
+  config.before :each do
+    allow(Geocoder).to receive(:search).and_return([
+      OpenStruct.new(data: { 'lat' => "53.4794892", 'lon' => "-2.2451148" })
+    ])
+  end
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
   end
 
   it "will include the schools name" do
-    link = candidates_school_registrations_placement_preference_path(demo_school.urn)
+    link = new_candidates_school_registrations_placement_preference_path(demo_school)
 
     expect(rendered).to have_css('h1', text: demo_school.name)
     expect(rendered).to have_css("a.govuk-button[href=\"#{link}\"]")

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
   end
 
   it "will include the schools name" do
+    link = candidates_school_registrations_placement_preference_path(demo_school.urn)
+
     expect(rendered).to have_css('h1', text: demo_school.name)
+    expect(rendered).to have_css("a.govuk-button[href=\"#{link}\"]")
   end
 end

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -1,19 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe "candidates/schools/show.html.erb", type: :view do
-  let(:demo_school) do
-    OpenStruct.new YAML.load_file('demo-school.yml')
-  end
-
   before do
-    assign :school, demo_school
+    @school = Candidates::SchoolStub.new(create(:bookings_school))
+    assign :school, @school
+
     render
   end
 
   it "will include the schools name" do
-    link = new_candidates_school_registrations_placement_preference_path(demo_school)
+    link = new_candidates_school_registrations_placement_preference_path(@school)
 
-    expect(rendered).to have_css('h1', text: demo_school.name)
+    expect(rendered).to have_css('h1', text: @school.name)
     expect(rendered).to have_css("a.govuk-button[href=\"#{link}\"]")
   end
 end


### PR DESCRIPTION
### Context

Assorted tidy ups to the Candidates School Search screens

### Changes proposed in this pull request

1. Add Bullet
2. Fix N+1 issues
3. Make auto submit for forms recognise `<select>` changes
4. Optimise lookups of Subjects and Phases
5. Hooked up Sorting the results
6. Show some correct school fields on View School screen, fallback to stub data when fields not available
7. Prevent unintended Geocoder calls from Specs
8. Prevent unneeded Geocoder calls when no location supplied
9. Fixes for handling of URLs in Cucumber

### Guidance to review

There's a mixture of changes/fixes/clean-ups so maybe easier to look at commits in isolation