### PR TITLE
enable cucumber test in CD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :test do
 
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'chromedriver-helper', platforms: [:mri]
 
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -66,10 +66,19 @@ Cucumber::Rails::Database.javascript_strategy = :truncation
 
 Capybara.server = :puma, { Silent: true }
 
+if ENV['APP_URL'].present?
+  Capybara.app_host = "#{ENV['APP_URL']}"
+  Capybara.run_server = false
+end
+
 Capybara.register_driver :chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(disable-gpu) }
   )
+
+  if ENV['ChromeWebDriver'].present?
+    Selenium::WebDriver::Chrome.driver_path = "#{ENV['ChromeWebDriver']}/chromedriver.exe"
+  end
 
   Capybara::Selenium::Driver.new(
     app,
@@ -82,6 +91,10 @@ Capybara.register_driver :chrome_headless do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless disable-gpu) }
   )
+
+  if ENV['ChromeWebDriver'].present?
+    Selenium::WebDriver::Chrome.driver_path = "#{ENV['ChromeWebDriver']}/chromedriver.exe"
+  end
 
   Capybara::Selenium::Driver.new(
     app,
@@ -117,11 +130,8 @@ else
   Capybara.javascript_driver = :chrome_headless
 end
   
-Cucumber::Rails::Database.javascript_strategy = :truncation
-
 if ENV['SELENIUM_HUB_HOSTNAME'].present?
   Capybara.run_server = false
-  Capybara.app_host = "#{ENV['APP_URL']}"
   Capybara.javascript_driver = :chrome
   Capybara.default_driver = :selenium_remote
   Capybara.register_driver :selenium_remote do |app|


### PR DESCRIPTION
### Context

To be able to run the cucumber tests as functional tests in the continuous deployment development environment we need to manually set the chrome driver. We also need to be able to specify the application's remote URL.

### Changes proposed in this pull request

Introduces an environment variable `APP_URL` through which the applicaton URL is set.

The Azure DevOps agent publicises the location of the Chrome driver URL via an environment variable `ChromeWebDriver`. This pull request leverages this to set the driver path appropriately,

### Guidance to review

This has been tested by using this branch in the release pipeline.

