### PR TITLE
Added Exception Notification handling to Active Jobs

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,6 @@
 class ApplicationJob < ActiveJob::Base
+  # This does not supply a block for handling failure, this should be left to
+  # cascade up to DelayJob which will deal with notifying in the event of
+  # failure
+  retry_on(StandardError, attempts: 3, wait: :exponentially_longer)
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,6 @@ Rails.application.configure do
     Bullet.console = true
     Bullet.rails_logger = true
   end
+
+  config.active_job.queue_adapter = :delayed_job
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,6 +74,4 @@ Rails.application.configure do
     Bullet.console = true
     Bullet.rails_logger = true
   end
-
-  config.active_job.queue_adapter = :delayed_job
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,3 +1,7 @@
+require 'delayed_notification_plugin'
+
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_run_time = 5.minutes
 Delayed::Worker.sleep_delay = 15
+Delayed::Worker.max_attempts = 1
+Delayed::Worker.plugins << DelayedNotificationPlugin

--- a/lib/delayed_notification_plugin.rb
+++ b/lib/delayed_notification_plugin.rb
@@ -1,0 +1,8 @@
+class DelayedNotificationPlugin < Delayed::Plugin
+  callbacks do |lifecycle|
+    lifecycle.before(:failure) do |_worker, job, *_args, &_block|
+      ExceptionNotifier.notify_exception(job.error,
+        data: job.attributes.except('last_error'))
+    end
+  end
+end


### PR DESCRIPTION
### Context

Background jobs when misconfigured can result in silent failures which are very problematic.

### Changes proposed in this pull request

1. Add a hook in Delayed::Job to notify the Slack channel when jobs fail. 
2. Changed the parent ActiveJob class to retry 3 times with a back off. Failed jobs are explicitly not handled so that they will fall through to the notification hook in Delayed::Job and be retained in the DJ table.

### Guidance to review

Does the setup look sane.
