### PR TITLE
Fixed meta tags for responsive UI behaviour

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,9 +5,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
-    <%= tag :meta, property: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: image_url('govuk-opengraph-image.png') %>
-    <%= tag :meta, property: 'theme-color', content: '#0b0c0c' %>
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, name: 'og:image', content: image_url('govuk-opengraph-image.png') %>
+    <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
     <%= favicon_link_tag 'govuk-apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>


### PR DESCRIPTION
### Context

The interface doesn't resize correctly when on mobile devices

### Changes proposed in this pull request

The meta tags we inherited from the boilerplate are generating incorrect tags, this fixes them

### Guidance to review

Test using an emulated mobile device (as opposed to just resizing the browser window)