### PR TITLE
Mobile friendly school search form

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,20 @@
 $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 $govuk-global-styles: true;
+$govuk-grid-widths: (
+  one-twelth: 8.3333%,
+  two-twelths: 16.6666%,
+  five-twelths: 41.6666%,
+  seven-twelths: 58.3333%,
+  ten-twelths: 83.3333%,
+  eleven-twelths: 91.6666%,
+  one-quarter: 25%,
+  one-third: 33.3333%,
+  one-half: 50%,
+  two-thirds: 66.6666%,
+  three-quarters: 75%,
+  full: 100%
+);
 
 @import "../../../node_modules/govuk-frontend/all";
 @import "global-styles" ;

--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -38,33 +38,43 @@
   @extend %govuk-heading-m ;
 }
 
-#search-form {
-  label {
-    display: none;
+.school-search-form {
+  .school-search-form__search-field {
+    @include govuk-grid-column(one-third, $at: desktop, $class: false) ;
   }
 
-  select {
-    width: 100%;
+  .school-search-form__location-field {
+    @include govuk-grid-column(two-thirds, $class: false) ;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
   }
 
-  #location-field {
-    width: 59%;
-    display: inline-block;
-  }
+  .school-search-form__distance-field {
+    @include govuk-grid-column(one-third, $class: false) ;
+    margin-left: 0;
+    margin-right: 0;
+    padding-left: 0;
+    padding-right: 0;
 
-  #distance-field {
-    width: 39%;
-    display: inline-block;
-  }
-
-  #location-distance-fields {
-    div, input, select {
-      margin: 0;
+    select {
+      width: 100%;
     }
+  }
 
-    div {
-      padding: 0;
-      box-sizing: border-box;
+  .school-search-form__location-pair {
+    @include govuk-grid-column(one-half, $at: desktop, $class: false) ;
+  }
+
+  .school-search-form__submit {
+    @include govuk-grid-column(two-twelths, $class: false) ;
+
+    .govuk-button {
+      @include govuk-media-query($from: desktop) {
+        width: 100%;
+        margin-top: govuk-spacing(6);
+      }
     }
   }
 }

--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -61,10 +61,6 @@
     select {
       width: 100%;
     }
-
-    label {
-      visibility: hidden;
-    }
   }
 
   .school-search-form__location-pair {

--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -61,6 +61,10 @@
     select {
       width: 100%;
     }
+
+    label {
+      visibility: hidden;
+    }
   }
 
   .school-search-form__location-pair {

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -34,8 +34,14 @@ module Candidates
       end
     end
 
-    def distance=(dist_ids)
-      @distance = dist_ids.present? ? dist_ids.to_i : nil
+    def initialize(*args)
+      @distance = 3
+
+      super
+    end
+
+    def distance=(dist)
+      @distance = dist.present? ? dist.to_i : nil
     end
 
     def subjects

--- a/app/views/candidates/schools/_form.html.erb
+++ b/app/views/candidates/schools/_form.html.erb
@@ -12,21 +12,14 @@
                     </legend>
                     <p>This service is only available in England</p>
 
-                    <span id="search-hint" class="govuk-hint">
-                        For example: <strong>Manchester M1 1AD</strong><br/>
-                        OR
-                        <br/>
-                        <strong>Maths, special school, M1 1AD</strong>
-                    </span>
-
                     <div class="govuk-grid-row school-search-form">
                         <div class="school-search-form__search-field">
-                            <%= f.search_field :query, placeholder: 'search' %>
+                            <%= f.search_field :query, placeholder: 'e.g. maths, special school' %>
                         </div>
 
                         <div class="school-search-form__location-pair">
                             <div class="school-search-form__location-field">
-                                <%= f.text_field :location, placeholder: 'location' %>
+                                <%= f.text_field :location, placeholder: 'e.g. Manchester, M1 3BD' %>
                             </div>
 
                             <div class="school-search-form__distance-field">

--- a/app/views/candidates/schools/_form.html.erb
+++ b/app/views/candidates/schools/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-        <div class="govuk-form-group" id="search-form">
+        <div id="search-form">
             <%= form_for @search, as: '', method: :get do |f| %>
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
@@ -19,25 +19,27 @@
                         <strong>Maths, special school, M1 1AD</strong>
                     </span>
 
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-one-third">
+                    <div class="govuk-grid-row school-search-form">
+                        <div class="school-search-form__search-field">
                             <%= f.search_field :query, placeholder: 'search' %>
                         </div>
 
-                        <div class="govuk-grid-column-one-third" id="location-distance-fields">
-                            <div id="location-field">
+                        <div class="school-search-form__location-pair">
+                            <div class="school-search-form__location-field">
                                 <%= f.text_field :location, placeholder: 'location' %>
                             </div>
 
-                            <div id="distance-field">
+                            <div class="school-search-form__distance-field">
                                 <%= f.collection_select :distance,
                                     Candidates::SchoolSearch.distances, :first, :last,
                                     include_blank: 'distance' %>
                             </div>
                         </div>
 
-                        <div class="govuk-grid-column-one-third">
-                            <%= f.submit 'Find', name: nil %>
+                        <div class="school-search-form__submit">
+                            <div class="govuk-form-group">
+                                <%= f.submit 'Find', name: nil %>
+                            </div>
                         </div>
                     </div>
                 </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,3 +108,5 @@ en:
           true: "Yes"
           false: "No"
       order: Sorted by
+      query: Find what?
+      location: Where?

--- a/features/step_definitions/candidates/schools/search_steps.rb
+++ b/features/step_definitions/candidates/schools/search_steps.rb
@@ -6,7 +6,7 @@ end
 
 Then("it should have a blank search field") do
   within(@form) do
-    field = page.find_field('Query', type: 'search')
+    field = page.find_field('Find what?', type: 'search')
     expect(field.text).to be_blank
   end
 end

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -147,14 +147,14 @@ RSpec.describe Candidates::SchoolSearch do
       it('should be valid') { expect(subject.valid_search?).to be true }
     end
 
-    context 'with location' do
-      subject { described_class.new(location: 'Manchester') }
-      it('should be valid') { expect(subject.valid_search?).to be false }
+    context 'with only location' do
+      subject { described_class.new(location: 'Manchester', distance: '') }
+      it('should be invalid') { expect(subject.valid_search?).to be false }
     end
 
-    context 'with distance' do
+    context 'with only distance' do
       subject { described_class.new(distance: '10') }
-      it('should be valid') { expect(subject.valid_search?).to be false }
+      it('should be invalid') { expect(subject.valid_search?).to be false }
     end
 
     context 'with location and distance' do


### PR DESCRIPTION
### Context

The school search form doesn't behave correctly on mobile devices

### Changes proposed in this pull request

1. Extend grid system to support the functionality we require
2. Utilise grid system extensions on the School Search form

### Notes ###

Form should resize correctly when moving between mobile, tablet and desktop form factors