### PR TITLE
Feature/search improvements

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -36,7 +36,7 @@ class Bookings::School < ApplicationRecord
 
   scope :that_provide, ->(subject_ids) do
     if subject_ids.present?
-      joins(:subjects).where(bookings_subjects: { id: subject_ids }).distinct
+      joins(:subjects).where(bookings_subjects: { id: subject_ids })
     else
       all
     end
@@ -44,7 +44,7 @@ class Bookings::School < ApplicationRecord
 
   scope :at_phases, ->(phase_ids) do
     if phase_ids.present?
-      joins(:phases).where(bookings_phases: { id: phase_ids }).distinct
+      joins(:phases).where(bookings_phases: { id: phase_ids })
     else
       all
     end

--- a/app/models/concerns/full_text_search.rb
+++ b/app/models/concerns/full_text_search.rb
@@ -8,7 +8,11 @@ module FullTextSearch
     pg_search_scope :search_by_name,
       against: %i(name),
       using: {
-        tsearch: { any_word: true, prefix: true }
+        tsearch: {
+          any_word: true,
+          prefix: true,
+          normalization: 1
+        }
       }
 
     def self.search(query)

--- a/app/models/concerns/geographic_search.rb
+++ b/app/models/concerns/geographic_search.rb
@@ -16,21 +16,27 @@ module GeographicSearch
     # @param [String] column The name of the geographic column, defaults
     #   to 'coordinates'
     # @return [School::ActiveRecord_Relation] All matching records
-    scope :close_to, ->(point, radius: 10, column: 'coordinates') do
+    scope :close_to, ->(point, calculate_distance: false, radius: 10, column: 'coordinates') do
       if point.present?
-        select(
-          [
-            arel_table[Arel.star],
-            "st_distance(%<source>s, '%<destination>s', false) as distance" % {
-              source: column,
-              destination: point
-            }
-          ]
-        ).where("st_dwithin(%<column>s, '%<coordinates>s', %<radius>d)" % {
+        q = where("st_dwithin(%<column>s, '%<coordinates>s', %<radius>d)" % {
           column: column,
           coordinates: point,
           radius: Conversions::Distance::Miles::ToMetres.convert(radius)
         })
+
+        if calculate_distance
+          return q.select(
+            [
+              arel_table[Arel.star],
+              "st_distance(%<source>s, '%<destination>s', false) as distance" % {
+                source: column,
+                destination: point
+              }
+            ]
+          )
+        end
+
+        q
       else
         all
       end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -116,7 +116,7 @@ describe Bookings::School, type: :model do
               [maths, chemistry]   => [school_a, school_b],
               [maths, biology]     => [school_a, school_b, school_c]
             }.each do |subjects, results|
-              expect(subject.that_provide(subjects)).to match_array(results)
+              expect(subject.that_provide(subjects).uniq).to match_array(results)
             end
           end
         end

--- a/spec/services/bookings/school_search_spec.rb
+++ b/spec/services/bookings/school_search_spec.rb
@@ -233,17 +233,17 @@ describe Bookings::SchoolSearch do
         end
       end
 
-      context 'Alphabetical ordering (fallback)' do
+      context 'Search proximity ordering' do
         let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive") }
         let!(:bath) { create(:bookings_school, name: "Bath High School") }
         let!(:coventry) { create(:bookings_school, name: "Coventry Academy") }
 
         subject do
-          Bookings::SchoolSearch.new('').results
+          Bookings::SchoolSearch.new('Cardiff High').results
         end
 
         specify 'schools should be ordered alphabetically by name' do
-          expect(subject.map(&:name)).to eql([bath, cardiff, coventry].map(&:name))
+          expect(subject.map(&:name)).to eql([cardiff, bath].map(&:name))
         end
       end
     end

--- a/spec/services/bookings/school_search_spec.rb
+++ b/spec/services/bookings/school_search_spec.rb
@@ -233,10 +233,10 @@ describe Bookings::SchoolSearch do
         end
       end
 
-      context 'Search proximity ordering' do
-        let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive") }
+      context 'Search relevance ordering' do
         let!(:bath) { create(:bookings_school, name: "Bath High School") }
         let!(:coventry) { create(:bookings_school, name: "Coventry Academy") }
+        let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive") }
 
         subject do
           Bookings::SchoolSearch.new('Cardiff High').results
@@ -244,6 +244,20 @@ describe Bookings::SchoolSearch do
 
         specify 'schools should be ordered alphabetically by name' do
           expect(subject.map(&:name)).to eql([cardiff, bath].map(&:name))
+        end
+      end
+
+      context 'Sorting by name' do
+        let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive") }
+        let!(:bath) { create(:bookings_school, name: "Bath High School") }
+        let!(:coventry) { create(:bookings_school, name: "Coventry Academy") }
+
+        subject do
+          Bookings::SchoolSearch.new('', requested_order: 'name').results
+        end
+
+        specify 'schools should be ordered alphabetically by name' do
+          expect(subject.map(&:name)).to eql([bath, cardiff, coventry].map(&:name))
         end
       end
     end


### PR DESCRIPTION
### Context

Improve searching by setting the default ranking to relevance

### Changes proposed in this pull request

The scope provided by `FullTextSearch` now specifies how the ranking is [normalised](https://github.com/Casecommons/pg_search#normalization). We have opted for `1`, which

> 1 divides the rank by 1 + the logarithm of the document length

This means that a search for *Altrincham Grammar School* will rank *Altrincham School* above *Sale School*. Previously, because `School` is present in all they would all be ranked equally.

### Guidance to review

Ensure the changes are sensible and will fit in with how the frontend currently works.
