### PR TITLE
It turns out the og:image meta tag was correct.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csp_meta_tag %>
     <%= canonical_tag %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, name: 'og:image', content: image_url('govuk-opengraph-image.png') %>
+    <%= tag :meta, property: 'og:image', content: image_url('govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= favicon_link_tag 'govuk-mask-icon.svg', rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>


### PR DESCRIPTION
### Context

The Open Graph tags are actually RDF tags, and RDF tags use <meta property=""
instead of <meta name=""

### Changes proposed in this pull request
Revert to using the property attribute on the `og:image` meta tag

### Guidance to review

