### PR TITLE
Add RetryableError type to Notify class

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -3,23 +3,28 @@ class Notify
 
   API_KEY = Rails.application.credentials[:notify_api_key].freeze
 
-  class NotifyAPIKeyMissing < ArgumentError; end
+  class APIKeyMissing < ArgumentError; end
+  class RetryableError < ArgumentError; end
 
   def initialize(to:)
     self.to = to
     if API_KEY.present?
       self.notify_client = Notifications::Client.new(API_KEY)
     else
-      fail(NotifyAPIKeyMissing, "Notify API key is missing")
+      fail(APIKeyMissing, "Notify API key is missing")
     end
   end
 
   def despatch!
-    notify_client.send_email(
-      template_id: template_id,
-      email_address: @to,
-      personalisation: personalisation
-    )
+    begin
+      notify_client.send_email(
+        template_id: template_id,
+        email_address: @to,
+        personalisation: personalisation
+      )
+    rescue Notifications::Client::ServerError => e
+      raise RetryableError, e.message
+    end
   end
 
 private

--- a/spec/notify/notify_spec.rb
+++ b/spec/notify/notify_spec.rb
@@ -38,7 +38,7 @@ describe Notify do
 
       specify 'should raise a NotifyAPIKeyMissing error' do
         expect { described_class.new(to: to) }.to(
-          raise_error(Notify::NotifyAPIKeyMissing, "Notify API key is missing")
+          raise_error(Notify::APIKeyMissing, "Notify API key is missing")
         )
       end
     end


### PR DESCRIPTION
### Context

This error should be detectable by the calling classes and make it easy
to identify which failures should be retried. All other errors will
bubble through as before but Notifications::Client::ServerError will be
transformed into a Notify::RetryableError