### PR TITLE
refining timing script

### DIFF
--- a/script/check_timings.py
+++ b/script/check_timings.py
@@ -1,4 +1,4 @@
-# A python script has been written which processes the cucumber json output. It takes two arguments, the first argument 
+# A python script has been written which processes the cucumber json output. It takes two arguments, the first argument
 # is the location of the cucumber test result json file and the second is the minimum response time in nano seconds.
 #
 # Usage:
@@ -8,7 +8,7 @@
 
 import json
 import sys
-  
+
 with open(sys.argv[1]) as data_file:
     json_data = json.load(data_file)
 
@@ -16,13 +16,17 @@ failures = {}
 
 max_duration = int(sys.argv[2])
 
+print('ignoring first failure which is always slow for various reasons (starting up browser via driver etc.)')
+index=0
+
 for feature in json_data:
   for scenario in feature['elements']:
     if scenario['type'] == 'scenario':
       for step in scenario['steps']:
         if step['result']['status'] == 'passed':
-          if step['result']['duration'] > max_duration:
+          if step['result']['duration'] > max_duration and index > 0:
             failures[feature['id'] + ' ' + scenario['id'] + ' ' + step['name']] = step['result']['duration']
+          index = index + 1
 
 ninezeros = 1000000000
 
@@ -30,5 +34,5 @@ for key, value in failures.items():
   print("Duration {:.2f}s > {:.2f} {}".format( value/ninezeros, max_duration/ninezeros, key))
 
 if len(failures) > 0:
-  print("ERROR: some responses were too slow.") 
+  print("ERROR: some responses were too slow.")
   sys.exit(1)


### PR DESCRIPTION
### Context

The first step involves the spinning up of chrome and initiating communication via the driver. This results in a misleading slow first step duration.

### Changes proposed in this pull request

Ignore the first step duration.

### Guidance to review

Only minor script changes.

