### PR TITLE
Feature/initialize notify emails with registration objects

### DIFF
--- a/app/controllers/candidates/registrations/application_previews_controller.rb
+++ b/app/controllers/candidates/registrations/application_previews_controller.rb
@@ -2,12 +2,7 @@ module Candidates
   module Registrations
     class ApplicationPreviewsController < RegistrationsController
       def show
-        @application_preview = ApplicationPreview.new \
-          account_check: current_registration.account_check,
-          placement_preference: current_registration.placement_preference,
-          address: current_registration.address,
-          subject_preference: current_registration.subject_preference,
-          background_check: current_registration.background_check
+        @application_preview = ApplicationPreview.new current_registration
       end
     end
   end

--- a/app/notify/notify_email/candidate_request_confirmation.rb
+++ b/app/notify/notify_email/candidate_request_confirmation.rb
@@ -53,8 +53,24 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     super(to: to)
   end
 
-  def self.from_registration_session(application_preview, uuid)
-    # TODO for ease, allow initialisation via a RegistrationSession
+  def self.from_application_preview(to, application_preview)
+    NotifyEmail::CandidateRequestConfirmation.new(
+      to: to,
+      candidate_address: application_preview.full_address,
+      candidate_dbs_check_document: application_preview.dbs_check_document, candidate_degree_stage: application_preview.degree_stage,
+      candidate_degree_subject: application_preview.degree_subject,
+      candidate_disability_needs: application_preview.access_needs,
+      candidate_email_address: application_preview.email_address,
+      candidate_name: application_preview.full_name,
+      candidate_phone_number: application_preview.telephone_number,
+      candidate_teaching_stage: application_preview.teaching_stage,
+      candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
+      candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
+      placement_finish_date: application_preview.placement_date_end,
+      placement_outcome: application_preview.placement_outcome,
+      placement_start_date: application_preview.placement_date_start,
+      school_name: application_preview.school
+    )
   end
 
 private

--- a/app/notify/notify_email/school_request_confirmation.rb
+++ b/app/notify/notify_email/school_request_confirmation.rb
@@ -56,8 +56,25 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     super(to: to)
   end
 
-  def self.from_registration_session(application_preview, uuid)
-    # TODO for ease, allow initialisation via a RegistrationSession
+  def self.from_application_preview(to, application_preview)
+    NotifyEmail::SchoolRequestConfirmation.new(
+      to: to,
+      candidate_address: application_preview.full_address,
+      candidate_dbs_check_document: application_preview.dbs_check_document, candidate_degree_stage: application_preview.degree_stage,
+      candidate_degree_subject: application_preview.degree_subject,
+      candidate_disability_needs: application_preview.access_needs,
+      candidate_email_address: application_preview.email_address,
+      candidate_name: application_preview.full_name,
+      candidate_phone_number: application_preview.telephone_number,
+      candidate_teaching_stage: application_preview.teaching_stage,
+      candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
+      candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
+      placement_finish_date: application_preview.placement_date_end,
+      placement_outcome: application_preview.placement_outcome,
+      placement_start_date: application_preview.placement_date_start,
+      school_name: application_preview.school,
+      school_admin_name: "PLACEHOLDER FOR SCHOOL ADMIN"
+    )
   end
 
 private

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -1,7 +1,7 @@
 module Candidates
   module Registrations
     class ApplicationPreview
-      attr_accessor \
+      attr_reader \
         :account_check,
         :address,
         :placement_preference,
@@ -9,11 +9,11 @@ module Candidates
         :background_check
 
       def initialize(registration_session)
-        self.account_check = registration_session.account_check
-        self.placement_preference = registration_session.placement_preference
-        self.address = registration_session.address
-        self.subject_preference = registration_session.subject_preference
-        self.background_check = registration_session.background_check
+        @account_check = registration_session.account_check
+        @placement_preference = registration_session.placement_preference
+        @address = registration_session.address
+        @subject_preference = registration_session.subject_preference
+        @background_check = registration_session.background_check
       end
 
       def full_name

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -1,19 +1,19 @@
 module Candidates
   module Registrations
     class ApplicationPreview
-      attr_reader \
+      attr_accessor \
         :account_check,
         :address,
         :placement_preference,
         :subject_preference,
         :background_check
 
-      def initialize(account_check:, placement_preference:, address:, subject_preference:, background_check:)
-        @account_check = account_check
-        @placement_preference = placement_preference
-        @address = address
-        @subject_preference = subject_preference
-        @background_check = background_check
+      def initialize(registration_session)
+        self.account_check = registration_session.account_check
+        self.placement_preference = registration_session.placement_preference
+        self.address = registration_session.address
+        self.subject_preference = registration_session.subject_preference
+        self.background_check = registration_session.background_check
       end
 
       def full_name

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -43,8 +43,15 @@ module Candidates
       end
 
       def placement_availability
-        date_in_words(placement_preference.date_start) + ' to ' +
-          date_in_words(placement_preference.date_end)
+        "#{placement_date_start} to #{placement_date_end}"
+      end
+
+      def placement_date_start
+        date_in_words(placement_preference.date_start)
+      end
+
+      def placement_date_end
+        date_in_words(placement_preference.date_end)
       end
 
       def placement_outcome

--- a/spec/notify/notify_email/candidate_request_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_request_confirmation_spec.rb
@@ -17,4 +17,6 @@ describe NotifyEmail::CandidateRequestConfirmation do
     placement_finish_date: "2020-01-14",
     placement_outcome: "I enjoy teaching",
     placement_start_date: "2020-01-07"
+
+  it_should_behave_like "email template from application preview", false
 end

--- a/spec/notify/notify_email/school_request_confirmation_spec.rb
+++ b/spec/notify/notify_email/school_request_confirmation_spec.rb
@@ -18,4 +18,6 @@ describe NotifyEmail::SchoolRequestConfirmation do
     placement_start_date: "2020-01-07",
     school_name: "Springfield Elementary School",
     school_admin_name: "Seymour Skinner"
+
+  it_should_behave_like "email template from application preview", true
 end

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -102,6 +102,20 @@ describe Candidates::Registrations::ApplicationPreview do
     end
   end
 
+  context '#placement_date_start' do
+    it 'returns the correct value' do
+      expect(subject.placement_date_start).to eq \
+        placement_date_start.strftime('%d %B %Y')
+    end
+  end
+
+  context '#placement_date_end' do
+    it 'returns the correct value' do
+      expect(subject.placement_date_end).to eq \
+        placement_date_end.strftime('%d %B %Y')
+    end
+  end
+
   context '#placement_availability' do
     it 'returns the correct value' do
       expect(subject.placement_availability).to eq \

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -62,13 +62,17 @@ describe Candidates::Registrations::ApplicationPreview do
       school_name: 'Test school'
   end
 
-  subject do
-    described_class.new \
+  let :registration_session do
+    double Candidates::Registrations::RegistrationSession,
       account_check: account_check,
       placement_preference: placement_preference,
       address: address,
       subject_preference: subject_preference,
       background_check: background_check
+  end
+
+  subject do
+    described_class.new registration_session
   end
 
   context '#full_name' do

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -83,6 +83,13 @@ end
 
 shared_examples_for "email template from application preview" do |school_admin_included|
   describe ".from_application_preview" do
+    before do
+      stub_const(
+        'Notify::API_KEY',
+        ["somekey", SecureRandom.uuid, SecureRandom.uuid].join("-")
+      )
+    end
+
     specify { expect(described_class).to respond_to(:from_application_preview) }
 
     let!(:school) { create(:bookings_school, urn: 11048) }

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -79,3 +79,89 @@ shared_examples_for "email template" do |template_id, personalisation|
     end
   end
 end
+
+
+shared_examples_for "email template from application preview" do |school_admin_included|
+  describe ".from_application_preview" do
+    specify { expect(described_class).to respond_to(:from_application_preview) }
+
+    let!(:school) { create(:bookings_school, urn: 11048) }
+    let(:rs) { build(:registration_session) }
+    let(:to) { "morris.szyslak@moes.net" }
+    let(:ap) do
+      Candidates::Registrations::ApplicationPreview.new(
+        account_check: rs.account_check,
+        address: rs.address,
+        placement_preference: rs.placement_preference,
+        subject_preference: rs.subject_preference,
+        background_check: rs.background_check
+      )
+    end
+
+    subject { described_class.from_application_preview(to, ap) }
+
+    context 'correctly assigning attributes' do
+      specify 'candidate_address is correctly-assigned' do
+        expect(subject.candidate_address).to eql(ap.full_address)
+      end
+
+      specify 'candidate_dbs_check_document is correctly-assigned' do
+        expect(subject.candidate_dbs_check_document).to eql(ap.dbs_check_document)
+      end
+
+      specify 'candidate_degree_stage is correctly-assigned' do
+        expect(subject.candidate_degree_stage).to eql(ap.degree_stage)
+      end
+
+      specify 'candidate_disability_needs is correctly-assigned' do
+        expect(subject.candidate_disability_needs).to eql(ap.access_needs)
+      end
+
+      specify 'candidate_email_address is correctly-assigned' do
+        expect(subject.candidate_email_address).to eql(ap.email_address)
+      end
+
+      specify 'candidate_name is correctly-assigned' do
+        expect(subject.candidate_name).to eql(ap.full_name)
+      end
+
+      specify 'candidate_phone_number is correctly-assigned' do
+        expect(subject.candidate_phone_number).to eql(ap.telephone_number)
+      end
+
+      specify 'candidate_teaching_stage is correctly-assigned' do
+        expect(subject.candidate_teaching_stage).to eql(ap.teaching_stage)
+      end
+
+      specify 'candidate_teaching_subject_first_choice is correctly-assigned' do
+        expect(subject.candidate_teaching_subject_first_choice).to eql(ap.teaching_subject_first_choice)
+      end
+
+      specify 'candidate_teaching_subject_second_choice is correctly-assigned' do
+        expect(subject.candidate_teaching_subject_second_choice).to eql(ap.teaching_subject_second_choice)
+      end
+
+      specify 'placement_finish_date is correctly-assigned' do
+        expect(subject.placement_finish_date).to eql(ap.placement_date_end)
+      end
+
+      specify 'placement_outcome is correctly-assigned' do
+        expect(subject.placement_outcome).to eql(ap.placement_outcome)
+      end
+
+      specify 'placement_start_date is correctly-assigned' do
+        expect(subject.placement_start_date).to eql(ap.placement_date_start)
+      end
+
+      specify 'school_name is correctly-assigned' do
+        expect(subject.school_name).to eql(ap.school)
+      end
+
+      if school_admin_included
+        specify 'school_admin_name is correctly-assigned' do
+          expect(subject.school_admin_name).to match(/PLACEHOLDER/)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -88,15 +88,7 @@ shared_examples_for "email template from application preview" do |school_admin_i
     let!(:school) { create(:bookings_school, urn: 11048) }
     let(:rs) { build(:registration_session) }
     let(:to) { "morris.szyslak@moes.net" }
-    let(:ap) do
-      Candidates::Registrations::ApplicationPreview.new(
-        account_check: rs.account_check,
-        address: rs.address,
-        placement_preference: rs.placement_preference,
-        subject_preference: rs.subject_preference,
-        background_check: rs.background_check
-      )
-    end
+    let(:ap) { Candidates::Registrations::ApplicationPreview.new(rs) }
 
     subject { described_class.from_application_preview(to, ap) }
 

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -92,6 +92,8 @@ shared_examples_for "email template from application preview" do |school_admin_i
 
     subject { described_class.from_application_preview(to, ap) }
 
+    it { is_expected.to be_a(described_class) }
+
     context 'correctly assigning attributes' do
       specify 'candidate_address is correctly-assigned' do
         expect(subject.candidate_address).to eql(ap.full_address)


### PR DESCRIPTION
### Context

The `Candidates::Registrations::ApplicationPreview` object contains just about all we need to create `NotifyEmail::SchoolRequestConfirmation` and `NotifyEmail::CandidateRequestConfirmation` emails (as they both appear at similar points in the candidate journey). It makes sense to use the pre-built object to build the email.

### Changes proposed in this pull request

Fill out the `.from_application_preview` methods to allow creation of `NotifyEmail::SchoolRequestConfirmation` and `NotifyEmail::CandidateRequestConfirmation` objects by providing an `Candidates::Registrations::ApplicationPreview`.

Additionally, update the `Candidates::Registrations::ApplicationPreview` to allow it to be initialized directly from a `Candidates::Registration::RegistrationSession`, which simplifies the procedure considerably

### Guidance to review

Make sure the changes look sane and sensible