### PR TITLE
Feature/candidate registration confirmation email job

### DIFF
--- a/app/jobs/candidates/registrations/send_email_confirmation_job.rb
+++ b/app/jobs/candidates/registrations/send_email_confirmation_job.rb
@@ -1,0 +1,30 @@
+module Candidates
+  module Registrations
+    class SendEmailConfirmationJob < ApplicationJob
+      queue_as :default
+
+      retry_on \
+        Notify::RetryableError, wait: :exponentially_longer, attempts: 5
+
+      def perform(uuid)
+        registration_session = RegistrationStore.instance.retrieve! uuid
+
+        notification = NotifyEmail::CandidateMagicLink.new \
+          to: registration_session.account_check.email,
+          school_name: registration_session.subject_preference.school_name,
+          confirmation_link: confirmation_link(uuid, registration_session)
+
+        notification.despatch!
+      end
+
+    private
+
+      def confirmation_link(uuid, registration_session)
+        Rails.application.routes.url_helpers
+          .candidates_school_registrations_placement_request_url \
+            registration_session.subject_preference.school,
+            uuid: uuid
+      end
+    end
+  end
+end

--- a/app/services/candidates/registrations/behaviours/subject_preference.rb
+++ b/app/services/candidates/registrations/behaviours/subject_preference.rb
@@ -25,6 +25,10 @@ module Candidates
           validates :subject_second_choice, inclusion: { in: :available_subject_choices }, if: -> { subject_second_choice.present? }
         end
 
+        def school
+          @school ||= Candidates::School.find urn
+        end
+
         def school_name
           school.name
         end
@@ -50,10 +54,6 @@ module Candidates
         end
 
       private
-
-        def school
-          @school ||= Candidates::School.find urn
-        end
 
         def applying_for_degree?
           degree_stage != NOT_APPLYING_FOR_DEGREE

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,6 @@ Rails.application.configure do
     Bullet.console = true
     Bullet.rails_logger = true
   end
+
+  Rails.application.routes.default_url_options = { host: 'http://localhost:5000' }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,4 +51,6 @@ Rails.application.configure do
     Bullet.enable = true
     Bullet.raise = true
   end
+
+  Rails.application.routes.default_url_options = { host: 'example.com' }
 end

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -27,6 +27,11 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
     allow(NotifyEmail::CandidateMagicLink).to receive(:new) { notification }
   end
 
+  after do
+    # Clean up redis
+    Candidates::Registrations::RegistrationStore.instance.delete! uuid
+  end
+
   context '#perform' do
     context 'with errors' do
       context 'retryable error' do

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
+  include_context 'Stubbed candidates school'
+  include ActiveSupport::Testing::TimeHelpers
+
+  let :registration_session do
+    FactoryBot.build :registration_session
+  end
+
+  let :uuid do
+    'some-uuid'
+  end
+
+  let :notification do
+    double NotifyEmail::CandidateMagicLink, despatch!: true
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :inline
+
+    allow(SecureRandom).to receive(:urlsafe_base64) { uuid }
+
+    Candidates::Registrations::RegistrationStore.instance.store! \
+      registration_session
+
+    allow(NotifyEmail::CandidateMagicLink).to receive(:new) { notification }
+  end
+
+  context '#perform' do
+    context 'with errors' do
+      context 'retryable error' do
+        let :exponentially_longer do
+          3.seconds.from_now.to_f
+        end
+
+        before do
+          allow(described_class.queue_adapter).to receive :enqueue_at
+
+          allow(notification).to receive :despatch! do
+            raise Notify::RetryableError
+          end
+
+          freeze_time # so we can easily compare 3.seconds.from_now
+
+          described_class.perform_later uuid
+        end
+
+        it 'reenqueues the job' do
+          expect(described_class.queue_adapter).to \
+            have_received(:enqueue_at).with \
+              an_instance_of(described_class), exponentially_longer
+        end
+      end
+
+      context 'non retryable error' do
+        let :response_error_message do
+          double Net::HTTPResponse, code: 400, body: 'oh no!'
+        end
+
+        let :application_job_retry_limit do
+          3
+        end
+
+        before do
+          allow(notification).to receive :despatch! do
+            raise Notifications::Client::RequestError, response_error_message
+          end
+
+          allow_any_instance_of(described_class).to receive :executions do
+            application_job_retry_limit
+          end
+        end
+
+        it 'lets the error propogate' do
+          expect { described_class.perform_later uuid }.to raise_error \
+            Notifications::Client::RequestError
+        end
+      end
+    end
+
+    context 'without errors' do
+      before do
+        described_class.perform_later uuid
+      end
+
+      it 'builds the email correctly' do
+        expect(NotifyEmail::CandidateMagicLink).to have_received(:new).with \
+          to: 'test@example.com',
+          school_name: 'Test School',
+          confirmation_link: 'http://example.com/candidates/schools/11048/registrations/placement_request?uuid=some-uuid'
+      end
+
+      it 'sends the email' do
+        expect(notification).to have_received :despatch!
+      end
+    end
+  end
+end

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -12,7 +12,11 @@ shared_context 'Stubbed candidates school' do
   end
 
   let :school do
-    double Bookings::School, id: school_urn, subjects: subjects
+    double Bookings::School, \
+      id: school_urn,
+      subjects: subjects,
+      name: 'Test School',
+      to_param: school_urn
   end
 
   let :allowed_subject_choices do


### PR DESCRIPTION
### Context
We want to send confirmation emails in a background job to avoid blocking responding while the email is being sent.

### Changes proposed in this pull request
This pr adds the background job that sends the candidate confirmation email.
The job will retry if `NotifyEmail::CandidateMagicLink` raises `Notify::RetryableError`
Otherwise it will fall through to `ApplicationJob`'s error handling

### Guidance to review
Manual testing if so inclined.
Throw a byebug in `ApplicationPreviewsController#show`
Complete the wizard, so you have a session.
Store the current registration session in redis 'uuid = RegistrationStore.instance.store! current_registration` then enqueue yourself a job `SendEmailConfirmationJob.perform_later uuid`
