### PR TITLE
Feature/try matching email templates to attrs

### DIFF
--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -3,6 +3,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     :candidate_name,
     :placement_start_date,
     :placement_finish_date,
+    :school_address,
     :school_start_time,
     :school_finish_time,
     :school_dress_code,
@@ -16,13 +17,13 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     :placement_details,
     :placement_fee
 
-
   def initialize(
     to:,
     school_name:,
     candidate_name:,
     placement_start_date:,
     placement_finish_date:,
+    school_address:,
     school_start_time:,
     school_finish_time:,
     school_dress_code:,
@@ -41,6 +42,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     self.candidate_name = candidate_name
     self.placement_start_date = placement_start_date
     self.placement_finish_date = placement_finish_date
+    self.school_address = school_address
     self.school_start_time = school_start_time
     self.school_finish_time = school_finish_time
     self.school_dress_code = school_dress_code
@@ -69,6 +71,7 @@ private
       candidate_name: candidate_name,
       placement_start_date: placement_start_date,
       placement_finish_date: placement_finish_date,
+      school_address: school_address,
       school_start_time: school_start_time,
       school_finish_time: school_finish_time,
       school_dress_code: school_dress_code,

--- a/app/notify/notify_email/school_registration_confirmation.1b805620-1910-40b0-afe4-4ce9e5deebbf.md
+++ b/app/notify/notify_email/school_registration_confirmation.1b805620-1910-40b0-afe4-4ce9e5deebbf.md
@@ -9,4 +9,4 @@ You’ll receive confirmation emails when candidates have made a school experien
 ^ You should try to respond to requests within 10 working days
 
 ((school_experience_profile_link))
-((school_requests_and_bookings_link))
+((school_experience_dashboard_link))

--- a/app/notify/notify_email/school_registration_confirmation.rb
+++ b/app/notify/notify_email/school_registration_confirmation.rb
@@ -1,19 +1,14 @@
 class NotifyEmail::SchoolRegistrationConfirmation < Notify
   attr_accessor :school_name,
-    :school_admin_name,
     :school_experience_profile_link,
     :school_experience_dashboard_link
 
   def initialize(
     to:,
-    school_name:,
-    school_admin_name:,
     school_experience_profile_link:,
     school_experience_dashboard_link:
   )
 
-    self.school_name = school_name
-    self.school_admin_name = school_admin_name
     self.school_experience_profile_link = school_experience_profile_link
     self.school_experience_dashboard_link = school_experience_dashboard_link
     super(to: to)
@@ -27,8 +22,6 @@ private
 
   def personalisation
     {
-      school_name: school_name,
-      school_admin_name: school_admin_name,
       school_experience_profile_link: school_experience_profile_link,
       school_experience_dashboard_link: school_experience_dashboard_link
     }

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -6,6 +6,7 @@ describe NotifyEmail::CandidateBookingConfirmation do
     candidate_name: "Kearney Zzyzwicz",
     placement_start_date: "2022-01-01",
     placement_finish_date: "2022-02-01",
+    school_address: "123 Main Street, Springfield, M2 3JF",
     school_start_time: "08:40",
     school_finish_time: "15:30",
     school_dress_code: "Smart casual, elbow patches",

--- a/spec/notify/notify_email/school_registration_confirmation_spec.rb
+++ b/spec/notify/notify_email/school_registration_confirmation_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 describe NotifyEmail::SchoolRegistrationConfirmation do
   it_should_behave_like "email template", "1b805620-1910-40b0-afe4-4ce9e5deebbf",
-    school_name: "Springfield Elementary School",
-    school_admin_name: "Seymour Skinner",
     school_experience_profile_link: "https://se.gov.uk/12345",
     school_experience_dashboard_link: "https://se.gov.uk/12345/dashboard"
 end

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -78,4 +78,35 @@ shared_examples_for "email template" do |template_id, personalisation|
       end
     end
   end
+
+  describe 'Template' do
+    subject { described_class.new(to: to, **personalisation) }
+    let(:template_path) { [Rails.root, "app", "notify", "notify_email"] }
+
+    let(:template) do
+      File.read(
+        Dir.glob(
+          "#{File.join(template_path)}/*#{subject.send(:template_id)}.md"
+        ).first
+      )
+    end
+
+    specify "every initialization paramater should appear in the template" do
+      template_params = template
+        .scan(/\(\((\w+)\)\)/)
+        .flatten
+        .sort
+        .uniq
+        .map(&:to_s)
+
+      initialization_params = subject
+        .method(:initialize)
+        .parameters
+        .map(&:last)
+        .reject { |ip| ip == :to }
+        .map(&:to_s)
+
+      expect(initialization_params).to match_array(template_params)
+    end
+  end
 end


### PR DESCRIPTION
### Context

Add specs to ensure notify email class attributes match the associated templates. The tests highlighted a couple of minor discrepancies which are also fixed here.