### PR TITLE
Make health check password aware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 EXPOSE 3000
 ENTRYPOINT ["bundle", "exec"]
 CMD ["rails", "server" ]
-HEALTHCHECK CMD curl --fail http://localhost:3000/ || exit 1
+HEALTHCHECK CMD bin/check_health.sh || exit 1
 
 # Install node, leaving as few artifacts as possible
 RUN apt-get update && apt-get install apt-transport-https && \

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+protected
+
+  def http_basic_authenticate
+    authenticate_or_request_with_http_basic do |name, password|
+      name == ENV['SECURE_USERNAME'] && password == ENV['SECURE_PASSWORD']
+    end
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,10 @@ class PagesController < ApplicationController
     render template: sanitise_page
   end
 
+  def healthcheck
+    render plain: 'healthy'
+  end
+
 private
 
   def sanitise_page

--- a/bin/check_health.sh
+++ b/bin/check_health.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [[ -z "${SECURE_USERNAME}" ]]; then
+  exec curl --fail http://localhost:3000/
+else
+  exec curl --user $SECURE_USERNAME:$SECURE_PASSWORD --fail http://localhost:3000/
+fi

--- a/config/initializers/password_protection.rb
+++ b/config/initializers/password_protection.rb
@@ -1,6 +1,4 @@
 if ENV['SECURE_USERNAME'].present? && ENV['SECURE_PASSWORD'].present?
-  ApplicationController.http_basic_authenticate_with(
-    name: ENV['SECURE_USERNAME'],
-    password: ENV['SECURE_PASSWORD']
-  )
+  ApplicationController.before_action :http_basic_authenticate
+  PagesController.skip_before_action :http_basic_authenticate, only: :healthcheck
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "/robots933456.txt", to: "pages#healthcheck"
+  
   get "/pages/:page", to: "pages#show"
   root to: 'candidates/home#index'
 


### PR DESCRIPTION
### Context

1. Health checks within Docker fail if HTTP Basic Auth is configured, because they do not include the username/password. 
2. The Auth check from Azure raises a 404 because its an undefined endpoint.

### Changes proposed in this pull request

1. Use the username and password as part of the Docker internal health check
2. Add an endpoint for the Azure health check, which bypasses the username/password checks

