### PR TITLE
Adds email confirmation step

### DIFF
--- a/app/controllers/candidates/registrations/confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/confirmation_emails_controller.rb
@@ -1,0 +1,25 @@
+module Candidates
+  module Registrations
+    class ConfirmationEmailsController < RegistrationsController
+      def show
+        @email = params[:email]
+        @school_name = params[:school_name]
+        @resend_path = candidates_school_registrations_resend_confirmation_email_path \
+          email: @email,
+          school_name: @school_name,
+          uuid: params[:uuid]
+      end
+
+      def create
+        uuid = RegistrationStore.instance.store! current_registration
+
+        SendEmailConfirmationJob.perform_later uuid
+
+        redirect_to candidates_school_registrations_confirmation_email_path \
+          email: current_registration.email,
+          school_name: current_registration.school.name,
+          uuid: uuid
+      end
+    end
+  end
+end

--- a/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
@@ -1,0 +1,20 @@
+module Candidates
+  module Registrations
+    class ResendConfirmationEmailsController < RegistrationsController
+      def create
+        uuid = params[:uuid]
+
+        if RegistrationStore.instance.has_registration? uuid
+          SendEmailConfirmationJob.perform_later uuid
+
+          redirect_to candidates_school_registrations_confirmation_email_path \
+            email: params[:email],
+            school_name: params[:school_name],
+            uuid: uuid
+        else
+          render :session_expired
+        end
+      end
+    end
+  end
+end

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -15,6 +15,14 @@ module Candidates
           model.tap(&:flag_as_persisted!).attributes
       end
 
+      def email
+        account_check.email
+      end
+
+      def school
+        subject_preference.school
+      end
+
       # TODO add spec
       def account_check
         fetch AccountCheck

--- a/app/services/candidates/registrations/registration_store.rb
+++ b/app/services/candidates/registrations/registration_store.rb
@@ -34,6 +34,10 @@ module Candidates
         true
       end
 
+      def has_registration?(uuid)
+        @redis.exists namespace(uuid)
+      end
+
     private
 
       def delete(uuid)

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -84,6 +84,6 @@
       By submitting this notification you’re confirming, to the best of your knowledge, the details you’re providing are correct.
     </p>
     <p>GDPR STATEMENT AND CONTENT PATTERN HERE</p>
-    <%= button_to 'Accept and send', candidates_school_registrations_placement_request_path, class: 'govuk-button' %>
+    <%= button_to 'Accept and send', candidates_school_registrations_confirmation_email_path, class: 'govuk-button' %>
   </div>
 </div>

--- a/app/views/candidates/registrations/confirmation_emails/show.html.erb
+++ b/app/views/candidates/registrations/confirmation_emails/show.html.erb
@@ -1,0 +1,25 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-heading-l">
+      Confirm your placement request
+    </div>
+    <p>
+      Click the confirmation link in the email we’ve sent to the following email
+      address to confirm your request for a placement at <%= @school_name %>:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= @email %></li>
+    </ul>
+    <p>
+      If you can’t find the message in your inbox:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>check your spam and any other mailbox folders</li>
+    </ul>
+    <p>
+      If you can’t find or haven’t received the email and confirmation link
+      within the next 3 hours please click the following link to resend it:
+    </p>
+    <%= button_to 'Resend confirmation link', @resend_path, class: 'govuk-button' %>
+  </div>
+</div>

--- a/app/views/candidates/registrations/resend_confirmation_emails/session_expired.html.erb
+++ b/app/views/candidates/registrations/resend_confirmation_emails/session_expired.html.erb
@@ -6,6 +6,6 @@
     <p>
       Your session has expired.
     </p>
-    <%= link_to 'Restart your application', '/', class: 'govuk-link' %>
+    <%= link_to 'Restart your application', candidates_root_path, class: 'govuk-link' %>
   </div>
 </div>

--- a/app/views/candidates/registrations/resend_confirmation_emails/session_expired.html.erb
+++ b/app/views/candidates/registrations/resend_confirmation_emails/session_expired.html.erb
@@ -1,0 +1,11 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-heading-l">
+      Session expired
+    </div>
+    <p>
+      Your session has expired.
+    </p>
+    <%= link_to 'Restart your application', '/', class: 'govuk-link' %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
         resource :subject_preference, only: %i(new create edit update)
         resource :background_check, only: %i(new create edit update)
         resource :application_preview, only: %i(show)
+        resource :confirmation_email, only: %i(show create)
+        resource :resend_confirmation_email, only: %i(create)
         resource :placement_request, only: %i(show create)
       end
     end

--- a/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::ConfirmationEmailsController, type: :request do
+  include_context 'Stubbed candidates school'
+
+  let! :registration_session do
+    FactoryBot.build :registration_session
+  end
+
+  let! :uuid do
+    'some-uuid'
+  end
+
+  let! :registration_store do
+    double Candidates::Registrations::RegistrationStore, store!: uuid
+  end
+
+  before do
+    allow(Candidates::Registrations::RegistrationStore).to \
+      receive(:instance) { registration_store }
+    allow(Candidates::Registrations::RegistrationSession).to \
+      receive(:new) { registration_session }
+    allow(Candidates::Registrations::SendEmailConfirmationJob).to \
+      receive(:perform_later)
+  end
+
+  context '#create' do
+    context 'success' do
+      before do
+        post candidates_school_registrations_confirmation_email_path(school)
+      end
+
+      it 'stores the session' do
+        expect(registration_store).to have_received(:store!).with \
+          registration_session
+      end
+
+      it 'enqueues the confirmation email job' do
+        expect(Candidates::Registrations::SendEmailConfirmationJob).to \
+          have_received(:perform_later).with uuid
+      end
+
+      it 'redirects to the check your email page' do
+        expect(response).to redirect_to \
+          candidates_school_registrations_confirmation_email_path \
+            school,
+            email: registration_session.email,
+            school_name: registration_session.school.name,
+            uuid: uuid
+      end
+    end
+  end
+
+  context '#show' do
+    before do
+      get candidates_school_registrations_confirmation_email_path \
+        school,
+        email: 'test@test.com',
+        school_name: 'test school',
+        uuid: uuid
+    end
+
+    it 'assigns email for the view' do
+      expect(assigns(:email)).to eq 'test@test.com'
+    end
+
+    it 'assigns school name for the view' do
+      expect(assigns(:school_name)).to eq 'test school'
+    end
+
+    it 'assigns retry path for the view' do
+      expect(assigns(:resend_path)).to eq \
+        '/candidates/schools/11048/registrations/resend_confirmation_email?email=test%40test.com&school_name=test+school&uuid=some-uuid'
+    end
+  end
+end

--- a/spec/controllers/candidates/registrations/resend_confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/resend_confirmation_emails_controller_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::ResendConfirmationEmailsController, type: :request do
+  include_context 'Stubbed candidates school'
+
+  let! :registration_session do
+    FactoryBot.build :registration_session
+  end
+
+  let! :uuid do
+    Candidates::Registrations::RegistrationStore.instance.store! \
+      registration_session
+  end
+
+  before do
+    allow(Candidates::Registrations::SendEmailConfirmationJob).to \
+      receive :perform_later
+  end
+
+  context '#create' do
+    context 'registration not found' do
+      before do
+        post \
+          candidates_school_registrations_resend_confirmation_email_path \
+            registration_session.school,
+            uuid: '12345'
+      end
+
+      it 'shows the user the session expired page' do
+        expect(response).to render_template :session_expired
+      end
+    end
+
+    context 'registration found' do
+      before do
+        post \
+          candidates_school_registrations_resend_confirmation_email_path \
+            registration_session.school,
+            email: registration_session.email,
+            school_name: registration_session.school.name,
+            uuid: uuid
+      end
+
+      it 'resends the confirmation email' do
+        expect(Candidates::Registrations::SendEmailConfirmationJob).to \
+          have_received(:perform_later).with uuid
+      end
+
+      it 'redirects to confirmation email show' do
+        expect(response).to redirect_to \
+          candidates_school_registrations_confirmation_email_path(
+            registration_session.school,
+            email: registration_session.email,
+            school_name: registration_session.school.name,
+            uuid: uuid
+        )
+      end
+    end
+  end
+end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -32,8 +32,21 @@ feature 'Candidate Registrations', type: :feature do
     double Candidates::School, subjects: subjects, name: 'Test School'
   end
 
+  let :uuid do
+    'some-uuid'
+  end
+
+  let :registration_store do
+    double Candidates::Registrations::RegistrationStore, store!: uuid
+  end
+
   before do
     allow(Candidates::School).to receive(:find) { school }
+    allow(Candidates::Registrations::RegistrationStore).to \
+      receive(:instance) { registration_store }
+
+    allow(Candidates::Registrations::SendEmailConfirmationJob).to \
+      receive(:perform_later)
   end
 
   scenario 'Candidate Registraion Journey' do
@@ -155,8 +168,12 @@ feature 'Candidate Registrations', type: :feature do
     expect(page).to have_text "Teaching subject - second choice Mathematics"
     expect(page).to have_text "DBS check document Yes"
 
-    # Submit placement request form successfully
+    # Send email confirmation
     click_button 'Accept and send'
-    expect(page).to have_text 'Your placement request has been sent'
+    expect(page).to have_text \
+      "Click the confirmation link in the email we’ve sent to the following email address to confirm your request for a placement at Test School:\ntest@example.com"
+
+    # Visit email confirmation link
+    # expect(page).to have_text 'Your placement request has been sent'
   end
 end

--- a/spec/services/candidates/registrations/registration_store_spec.rb
+++ b/spec/services/candidates/registrations/registration_store_spec.rb
@@ -84,4 +84,22 @@ describe Candidates::Registrations::RegistrationStore do
       end
     end
   end
+
+  context '#has_registration?' do
+    let! :returned_uuid do
+      subject.store! session
+    end
+
+    context 'when registration does not exist' do
+      it 'returns false' do
+        expect(subject.has_registration?('bad-uuid')).to eq false
+      end
+    end
+
+    context 'when registration exists' do
+      it 'returns true' do
+        expect(subject.has_registration?(returned_uuid)).to eq true
+      end
+    end
+  end
 end

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -16,7 +16,7 @@ shared_context 'Stubbed candidates school' do
       id: school_urn,
       subjects: subjects,
       name: 'Test School',
-      to_param: school_urn
+      to_param: school_urn.to_s
   end
 
   let :allowed_subject_choices do


### PR DESCRIPTION
### Context
Adds controllers for sending & resending candidate email confirmation
emails.

### Changes proposed in this pull request
This pr adds the confirm your email step. `ConfirmationEmailsController#create` stores the `current_registration` in Redis and triggers the background job for sending the confirm your email notification.

### Guidance to review
Manual testing if so inclined.
Complete the wizard, expect to see `[ActiveJob] Enqueued Candidates::Registrations::SendEmailConfirmationJob ... with arguments: "m654W2ScKEpKK_Hltsm40g"` in the logs and the arguments to match the registration key in Redis.
