### PR TITLE
Enforce data cleansing script to use universal newlines

### DIFF
--- a/script/cleanse
+++ b/script/cleanse
@@ -9,4 +9,4 @@
 #
 # $./cleanse < edubasealldata20190220.csv > clean.csv
 
-STDOUT.puts(STDIN.read.scrub)
+STDOUT.puts(STDIN.read.scrub.encode(Encoding::UTF_8, universal_newline: true))


### PR DESCRIPTION
### Context

Simply enforce universal newline encoding as part of the data cleansing utility script
