### PR TITLE
Feature/add docker compose creation script

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ steps:
     displayName: 'Push Docker image'
   - task: CopyFiles@2
     inputs:
-      contents: 'compose-school-experience.sh'
+      contents: 'script/compose-school-experience.sh'
       targetFolder: $(Build.ArtifactStagingDirectory)
     displayName: 'Copy Docker Compose file to staging area'
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,3 +55,13 @@ steps:
       docker push $(dockerRegistry)/$(imageName):latest
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: 'Push Docker image'
+  - task: CopyFiles@2
+    inputs:
+      contents: 'compose-school-experience.sh'
+      targetFolder: $(Build.ArtifactStagingDirectory)
+    displayName: 'Copy Docker Compose file to staging area'
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: $(Build.ArtifactStagingDirectory)
+      artifactName: 'compose-school-experience.sh'
+    displayName: 'Publish the Docker Compose file'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,6 @@ steps:
     displayName: 'Copy Docker Compose file to staging area'
   - task: PublishBuildArtifacts@1
     inputs:
-      pathtoPublish: $(Build.ArtifactStagingDirectory)
-      artifactName: 'compose-school-experience.sh'
+      pathtoPublish: $(Build.ArtifactStagingDirectory)/script/compose-school-experience.sh
+      artifactName: 'compose-file'
     displayName: 'Publish the Docker Compose file'


### PR DESCRIPTION
### Context

The Docker Compose file is used by the release pipelines to do deployments. Rather than relying on the checkout of the source code for the cucumber tests, this explicitly makes the docker compose file a build artefact.

### Changes proposed in this pull request

Copy the Docker Compose file to the artefact staging directory and then publish.

### Guidance to review

Not much to review.

