### PR TITLE
Test page for verifying exception handling in production

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,11 @@ class PagesController < ApplicationController
     render plain: 'healthy'
   end
 
+  # FIXME this page should be removed
+  def fivehundred
+    raise "Test Exception Handler"
+  end
+
 private
 
   def sanitise_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   get "/healthcheck.txt", to: "pages#healthcheck"
+  get "/pages/fivehundred", to: "pages#fivehundred" #FIXME to remove
 
   get "/pages/:page", to: "pages#show"
   root to: 'candidates/home#index'


### PR DESCRIPTION
May help with testing Peter Yates work on error pages as well

To be removed in future

### Context

Currently we have no way of verifying 500 errors are handled correctly in production

### Changes proposed in this pull request

This adds an endpoint which always triggers an exception

### Guidance to review

This is intended as a temporary feature, to be removed in the future. There is a ticket filed in Jira to ensure this gets removed
