### PR TITLE
Feature/candidates registrations persist in postgres

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -4,10 +4,16 @@ class ApplicationJob < ActiveJob::Base
   # failure
   retry_on(StandardError, attempts: 3, wait: :exponentially_longer)
 
-  # Retry | Backoff
-  # 1     | 108 seconds
-  # 2     | 24 minutes
-  # 3     | 2 hours 15 minutes
-  # 4     | 8 hours 40 minutes
-  A_DECENT_AMOUNT_LONGER = ->(executions) { ((executions + 1)**6) * 2 }
+  RETRYS = [
+    1.minute,
+    10.minutes,
+    1.hour,
+    8.hours
+  ].freeze
+
+  MAX_RETRY = 8.hours
+
+  A_DECENT_AMOUNT_LONGER = ->(executions) do
+    RETRYS[executions - 1] || MAX_RETRY
+  end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,4 +3,11 @@ class ApplicationJob < ActiveJob::Base
   # cascade up to DelayJob which will deal with notifying in the event of
   # failure
   retry_on(StandardError, attempts: 3, wait: :exponentially_longer)
+
+  # Retry | Backoff
+  # 1     | 108 seconds
+  # 2     | 24 minutes
+  # 3     | 2 hours 15 minutes
+  # 4     | 8 hours 40 minutes
+  A_DECENT_AMOUNT_LONGER = ->(executions) { ((executions + 1)**6) * 2 }
 end

--- a/app/jobs/candidates/registrations/placement_request_job.rb
+++ b/app/jobs/candidates/registrations/placement_request_job.rb
@@ -1,0 +1,14 @@
+module Candidates
+  module Registrations
+    class PlacementRequestJob < ApplicationJob
+      queue_as :default
+
+      retry_on \
+        Notify::RetryableError, wait: :exponentially_longer, attempts: 5
+
+      def perform(uuid)
+        PlacementRequestAction.new(uuid).perform!
+      end
+    end
+  end
+end

--- a/app/jobs/candidates/registrations/placement_request_job.rb
+++ b/app/jobs/candidates/registrations/placement_request_job.rb
@@ -3,8 +3,7 @@ module Candidates
     class PlacementRequestJob < ApplicationJob
       queue_as :default
 
-      retry_on \
-        Notify::RetryableError, wait: :exponentially_longer, attempts: 5
+      retry_on Notify::RetryableError, wait: A_DECENT_AMOUNT_LONGER, attempts: 5
 
       def perform(uuid)
         PlacementRequestAction.new(uuid).perform!

--- a/app/jobs/candidates/registrations/send_email_confirmation_job.rb
+++ b/app/jobs/candidates/registrations/send_email_confirmation_job.rb
@@ -21,7 +21,7 @@ module Candidates
 
       def confirmation_link(uuid, registration_session)
         Rails.application.routes.url_helpers
-          .candidates_school_registrations_placement_request_url \
+          .candidates_school_registrations_placement_request_new_url \
             registration_session.subject_preference.school,
             uuid: uuid
       end

--- a/app/jobs/candidates/registrations/send_email_confirmation_job.rb
+++ b/app/jobs/candidates/registrations/send_email_confirmation_job.rb
@@ -3,8 +3,7 @@ module Candidates
     class SendEmailConfirmationJob < ApplicationJob
       queue_as :default
 
-      retry_on \
-        Notify::RetryableError, wait: :exponentially_longer, attempts: 5
+      retry_on Notify::RetryableError, wait: A_DECENT_AMOUNT_LONGER, attempts: 5
 
       def perform(uuid)
         registration_session = RegistrationStore.instance.retrieve! uuid

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -61,4 +61,9 @@ class Bookings::School < ApplicationRecord
   def to_param
     urn.to_s.presence
   end
+
+  def contact_email
+    # TODO
+    'CONTACT_EMAIL'
+  end
 end

--- a/app/services/candidates/registrations/placement_request_action.rb
+++ b/app/services/candidates/registrations/placement_request_action.rb
@@ -1,0 +1,45 @@
+module Candidates
+  module Registrations
+    class PlacementRequestAction
+      def initialize(uuid)
+        @uuid = uuid
+      end
+
+      def perform!
+        school_request_confirmation.despatch!
+        candidate_request_confirmation.despatch!
+        PlacementRequest.create_from_registration_session! registration_session
+      end
+
+    private
+
+      def school_request_confirmation
+        NotifyEmail::SchoolRequestConfirmation.from_application_preview \
+          school_contact_email,
+          application_preview
+      end
+
+      def candidate_request_confirmation
+        NotifyEmail::CandidateRequestConfirmation.from_application_preview \
+          candidate_email,
+          application_preview
+      end
+
+      def registration_session
+        @registration_session ||= RegistrationStore.instance.retrieve! @uuid
+      end
+
+      def application_preview
+        @application_preview ||= ApplicationPreview.new registration_session
+      end
+
+      def school_contact_email
+        registration_session.school.contact_email
+      end
+
+      def candidate_email
+        registration_session.email
+      end
+    end
+  end
+end

--- a/app/views/candidates/registrations/placement_requests/session_expired.html.erb
+++ b/app/views/candidates/registrations/placement_requests/session_expired.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-heading-l">
+      Session expired
+    </div>
+    <p>
+      Your session has expired.
+    </p>
+
+    <% link_text = local_assigns.fetch :message, 'Restart your application' %>
+    <%= link_to link_text, candidates_root_path, class: 'govuk-link' %>
+  </div>
+</div>

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -2,14 +2,14 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        Your placement request has been <%= @placement_request.status_in_words %>
+        Your placement request has been sent
       </h1>
     </div>
     <h3 class="govuk-heading-m">What happens next</h3>
     <p>
-      Your request for a school experience placement
-      <%= @placement_request.date_range_in_words %>
-      will be forwarded to <%= @placement_request.school_name %>.
+      Your request for a school experience placement for
+      <%= @application_preview.placement_availability %>
+      will be forwarded to <%= @application_preview.school %>.
     </p>
     <p class="govuk-inset-text">
       The school will be in touch with you shortly. For example, during term

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        Your placement request has been sent
+        Your placement request will be sent
       </h1>
     </div>
     <h3 class="govuk-heading-m">What happens next</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get "/pages/:page", to: "pages#show"
   root to: 'candidates/home#index'
 
+
   namespace :candidates do
     root to: 'home#index'
 
@@ -18,6 +19,8 @@ Rails.application.routes.draw do
         resource :confirmation_email, only: %i(show create)
         resource :resend_confirmation_email, only: %i(create)
         resource :placement_request, only: %i(show create)
+        # email confirmation link
+        get 'placement_request/new', to: 'placement_requests#create'
       end
     end
   end

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::PlacementRequestsController, type: :request do
+  include_context 'Stubbed candidates school'
+
+  let :uuid do
+    'some-uuid'
+  end
+
+  before do
+    allow(Candidates::Registrations::RegistrationStore).to \
+      receive(:instance) { registration_store }
+  end
+
+  context '#create' do
+    before do
+      allow(Candidates::Registrations::PlacementRequestJob).to \
+        receive(:perform_later) { true }
+
+      get \
+        "/candidates/schools/URN/registrations/placement_request/new?uuid=#{uuid}"
+    end
+
+    context 'uuid not found' do
+      let :registration_store do
+        double Candidates::Registrations::RegistrationStore, \
+          has_registration?: false
+      end
+
+      it 'renders the session expired view' do
+        expect(response).to render_template :session_expired
+      end
+    end
+
+    context 'uuid found' do
+      let :registration_store do
+        double Candidates::Registrations::RegistrationStore, \
+          has_registration?: true
+      end
+
+      it 'enqueues the placement request job' do
+        expect(Candidates::Registrations::PlacementRequestJob).to \
+          have_received(:perform_later).with uuid
+      end
+
+      it 'redirects to placement request show' do
+        expect(response).to redirect_to \
+          candidates_school_registrations_placement_request_path(
+            'URN',
+            uuid: uuid
+          )
+      end
+    end
+  end
+
+  context '#show' do
+    context 'uuid not found' do
+      let :registration_store do
+        double Candidates::Registrations::RegistrationStore
+      end
+
+      before do
+        allow(registration_store).to receive(:retrieve!) do
+          raise Candidates::Registrations::RegistrationStore::SessionNotFound
+        end
+
+        get \
+          "/candidates/schools/URN/registrations/placement_request?uuid=#{uuid}"
+      end
+
+      it 'renders the session expired view' do
+        expect(response).to render_template :session_expired
+      end
+    end
+
+    context 'uuid found' do
+      let :registration_session do
+        FactoryBot.build :registration_session
+      end
+
+      let :registration_store do
+        double Candidates::Registrations::RegistrationStore,
+          retrieve!: registration_session
+      end
+
+      before do
+        get \
+          "/candidates/schools/URN/registrations/placement_request?uuid=#{uuid}"
+      end
+
+      it 'renders the show template' do
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/jobs/candidates/registrations/placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/placement_request_job_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::PlacementRequestJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let :uuid do
+    'some-uuid'
+  end
+
+  let :placement_request_action do
+    double Candidates::Registrations::PlacementRequestAction, perform!: true
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :inline
+    allow(Candidates::Registrations::PlacementRequestAction).to \
+      receive(:new) { placement_request_action }
+  end
+
+  context '#perform' do
+    context 'no errors' do
+      before do
+        described_class.perform_later uuid
+      end
+
+      it 'calls PlacementRequestAction with the correct arguments' do
+        expect(Candidates::Registrations::PlacementRequestAction).to \
+          have_received(:new).with(uuid)
+
+        expect(placement_request_action).to have_received :perform!
+      end
+    end
+
+    context 'with errors' do
+      context 'non retryable' do
+        let :application_job_retry_limit do
+          3
+        end
+
+        let :expected_error do
+          double StandardError
+        end
+
+        before do
+          allow(placement_request_action).to receive :perform! do
+            raise 'Oh no!'
+          end
+
+          allow_any_instance_of(described_class).to receive :executions do
+            application_job_retry_limit
+          end
+        end
+
+        it 'lets the error propogate' do
+          expect { described_class.perform_later uuid }.to raise_error \
+            RuntimeError, 'Oh no!'
+        end
+      end
+
+      context 'retryable error' do
+        let :exponentially_longer do
+          3.seconds.from_now.to_f
+        end
+
+        before do
+          allow(placement_request_action).to receive :perform! do
+            raise Notify::RetryableError
+          end
+
+          allow(described_class.queue_adapter).to receive :enqueue_at
+
+          freeze_time # so we can easily compare 3.seconds.from_now
+
+          described_class.perform_later uuid
+        end
+
+        it 'reenqueues the job' do
+          expect(described_class.queue_adapter).to \
+            have_received(:enqueue_at).with \
+              an_instance_of(described_class), exponentially_longer
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/candidates/registrations/placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/placement_request_job_spec.rb
@@ -59,11 +59,11 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
 
       context 'retryable error' do
         let :number_of_executions do
-          4
+          2
         end
 
         let :a_decent_amount_longer do
-          31250.seconds.from_now.to_i
+          10.minutes.from_now.to_i
         end
 
         before do
@@ -77,7 +77,7 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
 
           allow(described_class.queue_adapter).to receive :enqueue_at
 
-          freeze_time # so we can easily compare 3.seconds.from_now
+          freeze_time # so we can easily compare a decent_amount_longer from now
 
           described_class.perform_later uuid
         end

--- a/spec/jobs/candidates/registrations/placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/placement_request_job_spec.rb
@@ -58,11 +58,19 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
       end
 
       context 'retryable error' do
-        let :exponentially_longer do
-          3.seconds.from_now.to_f
+        let :number_of_executions do
+          4
+        end
+
+        let :a_decent_amount_longer do
+          31250.seconds.from_now.to_i
         end
 
         before do
+          allow_any_instance_of(described_class).to receive(:executions) do
+            number_of_executions
+          end
+
           allow(placement_request_action).to receive :perform! do
             raise Notify::RetryableError
           end
@@ -77,7 +85,7 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
         it 'reenqueues the job' do
           expect(described_class.queue_adapter).to \
             have_received(:enqueue_at).with \
-              an_instance_of(described_class), exponentially_longer
+              an_instance_of(described_class), a_decent_amount_longer
         end
       end
     end

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -93,7 +93,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
         expect(NotifyEmail::CandidateMagicLink).to have_received(:new).with \
           to: 'test@example.com',
           school_name: 'Test School',
-          confirmation_link: 'http://example.com/candidates/schools/11048/registrations/placement_request?uuid=some-uuid'
+          confirmation_link: 'http://example.com/candidates/schools/11048/registrations/placement_request/new?uuid=some-uuid'
       end
 
       it 'sends the email' do

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -35,11 +35,19 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
   context '#perform' do
     context 'with errors' do
       context 'retryable error' do
-        let :exponentially_longer do
-          3.seconds.from_now.to_f
+        let :a_decent_amount_longer do
+          31250.seconds.from_now.to_i # ~8 hours 40mins
+        end
+
+        let :number_of_executions do
+          4
         end
 
         before do
+          allow_any_instance_of(described_class).to receive(:executions) do
+            number_of_executions
+          end
+
           allow(described_class.queue_adapter).to receive :enqueue_at
 
           allow(notification).to receive :despatch! do
@@ -54,7 +62,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
         it 'reenqueues the job' do
           expect(described_class.queue_adapter).to \
             have_received(:enqueue_at).with \
-              an_instance_of(described_class), exponentially_longer
+              an_instance_of(described_class), a_decent_amount_longer
         end
       end
 

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -36,7 +36,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
     context 'with errors' do
       context 'retryable error' do
         let :a_decent_amount_longer do
-          31250.seconds.from_now.to_i # ~8 hours 40mins
+          8.hours.from_now.to_i
         end
 
         let :number_of_executions do
@@ -54,7 +54,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
             raise Notify::RetryableError
           end
 
-          freeze_time # so we can easily compare 3.seconds.from_now
+          freeze_time # so we can easily compare a decent_amount_longer from now
 
           described_class.perform_later uuid
         end

--- a/spec/services/candidates/registrations/placement_request_action_spec.rb
+++ b/spec/services/candidates/registrations/placement_request_action_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::PlacementRequestAction do
+  include_context 'Stubbed candidates school'
+
+  let :uuid do
+    'some-uuid'
+  end
+
+  let :registration_session do
+    FactoryBot.build :registration_session
+  end
+
+  let :registration_store do
+    double Candidates::Registrations::RegistrationStore,
+      retrieve!: registration_session
+  end
+
+  let :application_preview do
+    double Candidates::Registrations::ApplicationPreview
+  end
+
+  let :school_request_confirmation do
+    double NotifyEmail::SchoolRequestConfirmation, despatch!: true
+  end
+
+  let :candidate_request_confirmation do
+    double NotifyEmail::CandidateRequestConfirmation, despatch!: true
+  end
+
+  subject { described_class.new uuid }
+
+  context '#perform' do
+    before do
+      allow(Candidates::Registrations::RegistrationStore).to \
+        receive(:instance) { registration_store }
+
+      allow(Candidates::Registrations::ApplicationPreview).to \
+        receive(:new) { application_preview }
+
+      allow(NotifyEmail::SchoolRequestConfirmation).to \
+        receive(:from_application_preview) { school_request_confirmation }
+
+      allow(NotifyEmail::CandidateRequestConfirmation).to \
+        receive(:from_application_preview) { candidate_request_confirmation }
+
+      allow(Candidates::Registrations::PlacementRequest).to \
+        receive :create_from_registration_session!
+    end
+
+    context 'school request notification fails' do
+      before do
+        allow(school_request_confirmation).to receive :despatch! do
+          raise 'Oh no!'
+        end
+      end
+
+      it 'doesnt persist the data to postgres' do
+        expect { subject.perform! }.to raise_error RuntimeError
+        expect(Candidates::Registrations::PlacementRequest).not_to \
+          have_received :create_from_registration_session!
+      end
+    end
+
+    context 'school request notification succeeds' do
+      context 'candidate notificaton fails' do
+        before do
+          allow(candidate_request_confirmation).to receive :despatch! do
+            raise 'Oh no!'
+          end
+        end
+
+        it 'doesnt persist the data to postgres' do
+          expect { subject.perform! }.to raise_error RuntimeError
+          expect(Candidates::Registrations::PlacementRequest).not_to \
+            have_received :create_from_registration_session!
+        end
+      end
+
+      context 'candidate notification succeeds' do
+        before do
+          subject.perform!
+        end
+
+        it 'attempts to retreive the correct session from the store' do
+          expect(registration_store).to have_received(:retrieve!).with uuid
+        end
+
+        it 'builds the application_preview correctly' do
+          expect(Candidates::Registrations::ApplicationPreview).to \
+            have_received(:new).with registration_session
+        end
+
+        it 'instantiates the school_request_confirmation correctly' do
+          expect(NotifyEmail::SchoolRequestConfirmation).to \
+            have_received(:from_application_preview)
+            .with(school.contact_email, application_preview)
+        end
+
+        it 'instantiates the candidate_request_confirmation correctly' do
+          expect(NotifyEmail::CandidateRequestConfirmation).to \
+            have_received(:from_application_preview)
+            .with(registration_session.email, application_preview)
+        end
+
+        it 'persists the registration in postgres' do
+          expect(Candidates::Registrations::PlacementRequest).to \
+            have_received(:create_from_registration_session!).with \
+              registration_session
+        end
+      end
+    end
+  end
+end

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -16,7 +16,8 @@ shared_context 'Stubbed candidates school' do
       id: school_urn,
       subjects: subjects,
       name: 'Test School',
-      to_param: school_urn.to_s
+      to_param: school_urn.to_s,
+      contact_email: 'test@test.com'
   end
 
   let :allowed_subject_choices do


### PR DESCRIPTION
### Context
We need to notify the candidate and the school once they have confirmed their email and completed the placement request registration wizard.

### Changes proposed in this pull request
Adds the final step to the registration wizard, notifies the candidate and the school when the once the candidates email has been confirmed.

### Guidance to review
Manual testing if so inclined.
Complete registration wizard,
open redis-cli, list keys, copy the UUID part from the relevant registration key eg `development:registrations:MMh9pJMb3X930IyT5trT3A`, 
visit `/candidates/schools/100048/registrations/placement_request/new?uuid=<YOUR-UUID>`
Expect to see 'Your placement request has been sent' with the dates and school you entered in the wizard.
Expect to see the job enqueued in the logs.