### PR TITLE
Renamed healthcheck endpoint

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  get "/robots933456.txt", to: "pages#healthcheck"
-  
+  get "/healthcheck.txt", to: "pages#healthcheck"
+
   get "/pages/:page", to: "pages#show"
   root to: 'candidates/home#index'
 


### PR DESCRIPTION
### Context

RobotsXXXX.txt was incorrectly identified as a healthcheck endpoint. The health check endpoint is still useful though since it bypasses the http basic auth.

### Changes proposed in this pull request

Change the route to just be '/healthcheck.txt'



