### PR TITLE
Pass host from request rather than set in config for each env

### DIFF
--- a/app/controllers/candidates/registrations/confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/confirmation_emails_controller.rb
@@ -13,7 +13,7 @@ module Candidates
       def create
         uuid = RegistrationStore.instance.store! current_registration
 
-        SendEmailConfirmationJob.perform_later uuid
+        SendEmailConfirmationJob.perform_later uuid, request.host
 
         redirect_to candidates_school_registrations_confirmation_email_path \
           email: current_registration.email,

--- a/app/jobs/candidates/registrations/send_email_confirmation_job.rb
+++ b/app/jobs/candidates/registrations/send_email_confirmation_job.rb
@@ -5,24 +5,25 @@ module Candidates
 
       retry_on Notify::RetryableError, wait: A_DECENT_AMOUNT_LONGER, attempts: 5
 
-      def perform(uuid)
+      def perform(uuid, host)
         registration_session = RegistrationStore.instance.retrieve! uuid
 
         notification = NotifyEmail::CandidateMagicLink.new \
           to: registration_session.account_check.email,
           school_name: registration_session.subject_preference.school_name,
-          confirmation_link: confirmation_link(uuid, registration_session)
+          confirmation_link: confirmation_link(uuid, registration_session, host)
 
         notification.despatch!
       end
 
     private
 
-      def confirmation_link(uuid, registration_session)
+      def confirmation_link(uuid, registration_session, host)
         Rails.application.routes.url_helpers
           .candidates_school_registrations_placement_request_new_url \
             registration_session.subject_preference.school,
-            uuid: uuid
+            uuid: uuid,
+            host: host
       end
     end
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,6 +74,4 @@ Rails.application.configure do
     Bullet.console = true
     Bullet.rails_logger = true
   end
-
-  Rails.application.routes.default_url_options = { host: 'http://localhost:5000' }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,8 +57,6 @@ Rails.application.configure do
     Bullet.raise = true
   end
 
-  Rails.application.routes.default_url_options = { host: 'example.com' }
-
   # Don't actually attempt to delivery emails during tests
   Notify.notification_class = NotifyFakeClient
 end

--- a/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
@@ -37,7 +37,7 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
 
       it 'enqueues the confirmation email job' do
         expect(Candidates::Registrations::SendEmailConfirmationJob).to \
-          have_received(:perform_later).with uuid
+          have_received(:perform_later).with uuid, 'www.example.com'
       end
 
       it 'redirects to the check your email page' do

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -12,6 +12,10 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
     'some-uuid'
   end
 
+  let :host do
+    'www.example.com'
+  end
+
   let :notification do
     double NotifyEmail::CandidateMagicLink, despatch!: true
   end
@@ -56,7 +60,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
 
           freeze_time # so we can easily compare a decent_amount_longer from now
 
-          described_class.perform_later uuid
+          described_class.perform_later uuid, host
         end
 
         it 'reenqueues the job' do
@@ -86,7 +90,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
         end
 
         it 'lets the error propogate' do
-          expect { described_class.perform_later uuid }.to raise_error \
+          expect { described_class.perform_later uuid, host }.to raise_error \
             Notifications::Client::RequestError
         end
       end
@@ -94,14 +98,14 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
 
     context 'without errors' do
       before do
-        described_class.perform_later uuid
+        described_class.perform_later uuid, host
       end
 
       it 'builds the email correctly' do
         expect(NotifyEmail::CandidateMagicLink).to have_received(:new).with \
           to: 'test@example.com',
           school_name: 'Test School',
-          confirmation_link: 'http://example.com/candidates/schools/11048/registrations/placement_request/new?uuid=some-uuid'
+          confirmation_link: 'http://www.example.com/candidates/schools/11048/registrations/placement_request/new?uuid=some-uuid'
       end
 
       it 'sends the email' do


### PR DESCRIPTION
### Context
Removes hardcoding the default host in initializers. We now pass it in as a parameter to the job that needs it.

### Changes proposed in this pull request
Remove setting default host in initializer, pass the request's host into the job that needs it.

### Guidance to review
Everything should work as before, urls in notification emails should still be correct
