### PR TITLE
Revert "Test page for verifying exception handling in production"

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,11 +7,6 @@ class PagesController < ApplicationController
     render plain: 'healthy'
   end
 
-  # FIXME this page should be removed
-  def fivehundred
-    raise "Test Exception Handler"
-  end
-
 private
 
   def sanitise_page

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   get "/healthcheck.txt", to: "pages#healthcheck"
-  get "/pages/fivehundred", to: "pages#fivehundred" #FIXME to remove
 
   get "/pages/:page", to: "pages#show"
   root to: 'candidates/home#index'


### PR DESCRIPTION
Reverts DFE-Digital/schools-experience#87

This will remove the temporary page for triggering exception handling on the servers