### PR TITLE
Upgraded shoulda-matchers to official release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
 
-  gem 'shoulda-matchers', '4.0.0.rc1'
+  gem 'shoulda-matchers', '~> 4.0'
   gem 'rails-controller-testing'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,7 +312,7 @@ GEM
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
-    shoulda-matchers (4.0.0.rc1)
+    shoulda-matchers (4.0.1)
       activesupport (>= 4.2.0)
     slack-notifier (2.3.2)
     spring (2.0.2)
@@ -391,7 +391,7 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   sassc-rails
   selenium-webdriver
-  shoulda-matchers (= 4.0.0.rc1)
+  shoulda-matchers (~> 4.0)
   slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)


### PR DESCRIPTION
### Context

This got missed by the round up pull request of gem updates because it was set to a specific version in the Gemfile

### Changes proposed in this pull request

Rather than use the dependabot PR, which changes the locked version - instead I've slackened the requirements to be anything in the 4.0 series.

### Guidance to review

