### PR TITLE
Feature/robots txt

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,16 @@
 class ApplicationController < ActionController::Base
+  CRAWLABLE_PATHS = %w{/ /candidates}.freeze
+  before_action :add_x_robots_tag
+
 protected
+
+  def add_x_robots_tag
+    headers["X-Robots-Tag"] = if request.path.in?(CRAWLABLE_PATHS)
+                                "all"
+                              else
+                                "none"
+                              end
+  end
 
   def http_basic_authenticate
     authenticate_or_request_with_http_basic do |name, password|

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /*
+Allow: /$

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
-Disallow: /*
 Allow: /$
+Disallow: /*

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe ApplicationController, type: :request do
+  describe 'X-Robots-Tag' do
+    let(:header) { 'X-Robots-Tag' }
+    let(:school) { create(:bookings_school) }
+
+    specify "should add 'X-Robots-Tag: all' to crawlable paths" do
+      described_class::CRAWLABLE_PATHS.each do |cp|
+        head cp
+        expect(response.headers[header]).to eql('all')
+      end
+    end
+
+    specify "should add 'X-Robots-Tag: none' to uncrawlable paths" do
+      [
+        "/healthcheck.txt",
+        candidates_schools_path,
+        candidates_school_path(school),
+        new_candidates_school_registrations_subject_preference_path(school),
+        new_candidates_school_registrations_account_check_path(school)
+
+      ].each do |cp|
+        head cp
+        expect(response.headers[header]).to eql('none')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The application, apart from the homepage(s) should not be indexable by search engines.

### Changes proposed in this pull request

Add `robots.txt` file to `/public` and set a `X-Robots-Tag` header to all responses via a `before_action`. The header's value is `none` for all pages except those defined in `ApplicationController::CRAWLABLE_PATHS`. 

### Guidance to review

General sense check