### PR TITLE
Remove Kaminari overrides from Cucumber features

### DIFF
--- a/features/candidates/schools/search/results/pagination.feature
+++ b/features/candidates/schools/search/results/pagination.feature
@@ -3,60 +3,55 @@ Feature: School search result pagination
     As a potential candidate
     I want to be able to browse through results by page
 
-    Background:
-        Given that the default results per page is set to 3
-
     Scenario: Pagination links are not displayed when there isn't a full page of results
-        Given there are 2 schools in 'London'
+        Given there are 6 schools in 'London'
         When I have searched for 'London' and am on the results page
         Then I should not see pagination links
 
     Scenario: Pagination links are displayed when there is more than one page of results
-        Given there are 10 schools in 'London'
+        Given there are 17 schools in 'London'
         When I have searched for 'London' and am on the results page
         Then I should see pagination links
 
     Scenario: Current page should not be a hyperlink
-        Given there are 6 schools in 'London'
+        Given there are 18 schools in 'London'
         When I have searched for 'London' and am on the results page
         Then pagination page 1 should not be a hyperlink
 
     Scenario: Other pages should be hyperlinks
-        Given there are 6 schools in 'London'
+        Given there are 18 schools in 'London'
         When I have searched for 'London' and am on the results page
         Then pagination page 2 should be a hyperlink
 
     Scenario: Next link
-        Given there are 6 schools in 'London'
+        Given there are 18 schools in 'London'
         When I have searched for 'London' and am on the results page
         Then there should be a 'Next' link in the pagination
 
     Scenario: Previous link
-        Given there are 6 schools in 'London'
+        Given there are 18 schools in 'London'
         And I have searched for 'London' and am on the results page
         When I navigate to the second page of results
         Then there should be a 'Previous' link in the pagination
 
     Scenario: Bottom-of-the-page navigation
-        Given that the default results per page is set to 15
-        And there are 18 schools in 'London'
+        Given there are 18 schools in 'London'
         When I have searched for 'London' and am on the results page
         Then there should be 2 sets of pagination links
 
     Scenario: Bottom-of-the-page on last page
-        Given that the default results per page is set to 15
-        And there are 18 schools in 'London'
+        Given there are 18 schools in 'London'
         When I have searched for 'London' and am on the results page
         And I navigate to the second page of results
         Then there should be 1 set of pagination links
 
     Scenario: Pagination description on page one
-        Given there are 6 schools in 'London'
+        Given there are 18 schools in 'London'
         When I have searched for 'London' and am on the results page
-        Then the pagination description should say 'Showing 1–3 of 6 results'
+        Then the pagination description should say 'Showing 1–15 of 18 results'
 
     Scenario: Pagination description on page two
-        Given there are 6 schools in 'London'
+        Given there are 18 schools in 'London'
         When I have searched for 'London' and am on the results page
         And I navigate to the second page of results
-        Then the pagination description should say 'Showing 4–6 of 6 results'
+        Then the pagination description should say 'Showing 16–18 of 18 results'

--- a/features/step_definitions/candidates/schools/pagination_steps.rb
+++ b/features/step_definitions/candidates/schools/pagination_steps.rb
@@ -1,9 +1,3 @@
-Given("that the default results per page is set to {int}") do |int|
-  Kaminari.configure do |c|
-    c.default_per_page = int
-  end
-end
-
 Given("there are {int} schools in {string}") do |count, town|
   FactoryBot.create_list(:bookings_school, count, name: town)
   expect(Bookings::School.count).to eql(count)
@@ -18,13 +12,13 @@ Then("I should not see pagination links") do
 end
 
 Then("pagination page {int} should not be a hyperlink") do |int|
-  within('nav.pagination') do
+  within('.pagination-info.higher > nav.pagination') do
     expect(page).to have_css('span.current', text: '1')
   end
 end
 
 Then("pagination page {int} should be a hyperlink") do |int|
-  within('nav.pagination') do
+  within('.pagination-info.higher > nav.pagination') do
     expect(page).to have_css('a', text: '2')
   end
 end
@@ -36,7 +30,7 @@ When("I navigate to the second page of results") do
 end
 
 Then("there should be a {string} link in the pagination") do |string|
-  within('nav.pagination') do
+  within('.pagination-info.higher > nav.pagination') do
     expect(page).to have_css('a', text: string)
   end
 end


### PR DESCRIPTION
### Context

In the CD environment where Cucumber runs on a different machine to the
application the overrides don't have any effect and tests fail. Just use
defaults for the moment at the expense of adding a few more test records

### Changes proposed in this pull request

Revert to use default page numbers by increasing the number of records used in the features
