### PR TITLE
Remove access needs fields

### DIFF
--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -39,9 +39,7 @@ module Candidates
         params.require(:candidates_registrations_placement_preference).permit \
           :date_start,
           :date_end,
-          :objectives,
-          :access_needs,
-          :access_needs_details
+          :objectives
       end
     end
   end

--- a/app/notify/notify_email/candidate_request_confirmation.8bd7e9b3-8c3f-4702-b642-1ccff32a264f.md
+++ b/app/notify/notify_email/candidate_request_confirmation.8bd7e9b3-8c3f-4702-b642-1ccff32a264f.md
@@ -20,7 +20,6 @@ Request details
 * School or college: ((school_name))
 * Placement availability: ((placement_start_date))-((placement_finish_date))
 * Placement outcome: ((placement_outcome))
-* Disability or access needs: ((candidate_disability_needs))
 * Degree stage: ((candidate_degree_stage))
 * Degree subject: ((candidate_degree_subject))
 * Teaching stage: ((candidate_teaching_stage))

--- a/app/notify/notify_email/candidate_request_confirmation.rb
+++ b/app/notify/notify_email/candidate_request_confirmation.rb
@@ -3,7 +3,6 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     :candidate_dbs_check_document,
     :candidate_degree_stage,
     :candidate_degree_subject,
-    :candidate_disability_needs,
     :candidate_email_address,
     :candidate_name,
     :candidate_phone_number,
@@ -21,7 +20,6 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     candidate_dbs_check_document:,
     candidate_degree_stage:,
     candidate_degree_subject:,
-    candidate_disability_needs:,
     candidate_email_address:,
     candidate_name:,
     candidate_phone_number:,
@@ -38,7 +36,6 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     self.candidate_dbs_check_document             =        candidate_dbs_check_document
     self.candidate_degree_stage                   =        candidate_degree_stage
     self.candidate_degree_subject                 =        candidate_degree_subject
-    self.candidate_disability_needs               =        candidate_disability_needs
     self.candidate_email_address                  =        candidate_email_address
     self.candidate_name                           =        candidate_name
     self.candidate_phone_number                   =        candidate_phone_number
@@ -59,7 +56,6 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
       candidate_address: application_preview.full_address,
       candidate_dbs_check_document: application_preview.dbs_check_document, candidate_degree_stage: application_preview.degree_stage,
       candidate_degree_subject: application_preview.degree_subject,
-      candidate_disability_needs: application_preview.access_needs,
       candidate_email_address: application_preview.email_address,
       candidate_name: application_preview.full_name,
       candidate_phone_number: application_preview.telephone_number,
@@ -85,7 +81,6 @@ private
       candidate_dbs_check_document: candidate_dbs_check_document,
       candidate_degree_stage: candidate_degree_stage,
       candidate_degree_subject: candidate_degree_subject,
-      candidate_disability_needs: candidate_disability_needs,
       candidate_email_address: candidate_email_address,
       candidate_name: candidate_name,
       candidate_phone_number: candidate_phone_number,

--- a/app/notify/notify_email/school_request_confirmation.dd4490f8-1d7b-455b-8502-47f57a65179a.md
+++ b/app/notify/notify_email/school_request_confirmation.dd4490f8-1d7b-455b-8502-47f57a65179a.md
@@ -19,7 +19,6 @@ Request details:
 School or college: ((school_name))
 Placement availability: ((placement_start_date))-((placement_finish_date))
 Placement outcome: ((placement_outcome))
-Disability or access needs: ((candidate_disability_needs))
 Degree stage: ((candidate_degree_stage))
 Degree subject: ((candidate_degree_subject))
 Teaching stage: ((candidate_teaching_stage))

--- a/app/notify/notify_email/school_request_confirmation.rb
+++ b/app/notify/notify_email/school_request_confirmation.rb
@@ -3,7 +3,6 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     :candidate_dbs_check_document,
     :candidate_degree_stage,
     :candidate_degree_subject,
-    :candidate_disability_needs,
     :candidate_email_address,
     :candidate_name,
     :candidate_phone_number,
@@ -22,7 +21,6 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     candidate_dbs_check_document:,
     candidate_degree_stage:,
     candidate_degree_subject:,
-    candidate_disability_needs:,
     candidate_email_address:,
     candidate_name:,
     candidate_phone_number:,
@@ -40,7 +38,6 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     self.candidate_dbs_check_document             =        candidate_dbs_check_document
     self.candidate_degree_stage                   =        candidate_degree_stage
     self.candidate_degree_subject                 =        candidate_degree_subject
-    self.candidate_disability_needs               =        candidate_disability_needs
     self.candidate_email_address                  =        candidate_email_address
     self.candidate_name                           =        candidate_name
     self.candidate_phone_number                   =        candidate_phone_number
@@ -62,7 +59,6 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
       candidate_address: application_preview.full_address,
       candidate_dbs_check_document: application_preview.dbs_check_document, candidate_degree_stage: application_preview.degree_stage,
       candidate_degree_subject: application_preview.degree_subject,
-      candidate_disability_needs: application_preview.access_needs,
       candidate_email_address: application_preview.email_address,
       candidate_name: application_preview.full_name,
       candidate_phone_number: application_preview.telephone_number,
@@ -89,7 +85,6 @@ private
       candidate_dbs_check_document: candidate_dbs_check_document,
       candidate_degree_stage: candidate_degree_stage,
       candidate_degree_subject: candidate_degree_subject,
-      candidate_disability_needs: candidate_disability_needs,
       candidate_email_address: candidate_email_address,
       candidate_name: candidate_name,
       candidate_phone_number: candidate_phone_number,

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -72,14 +72,6 @@ module Candidates
         placement_preference.objectives
       end
 
-      def access_needs
-        if placement_preference.access_needs
-          placement_preference.access_needs_details
-        else
-          'None'
-        end
-      end
-
       def teaching_subject_first_choice
         subject_first_choice
       end

--- a/app/services/candidates/registrations/behaviours/placement_preference.rb
+++ b/app/services/candidates/registrations/behaviours/placement_preference.rb
@@ -19,9 +19,6 @@ module Candidates
             if: -> { date_start_is_a_date? && date_end_is_a_date? }
           validates :objectives, presence: true
           validate  :objectives_not_too_long, if: -> { objectives.present? }
-          validates :access_needs, inclusion: { in: [true, false] }
-          validates :access_needs_details,
-            presence: true, if: -> { access_needs.present? }
         end
 
       private

--- a/app/services/candidates/registrations/placement_preference.rb
+++ b/app/services/candidates/registrations/placement_preference.rb
@@ -14,8 +14,6 @@ module Candidates
       attribute :date_start, :date
       attribute :date_end, :date
       attribute :objectives, :string
-      attribute :access_needs, :boolean
-      attribute :access_needs_details, :string
     end
   end
 end

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -42,11 +42,6 @@
         edit_candidates_school_registrations_placement_preference_path %>
 
       <%= summary_row \
-        'Disability or access needs',
-        @application_preview.access_needs,
-        edit_candidates_school_registrations_placement_preference_path %>
-
-      <%= summary_row \
         'Degree stage',
         @application_preview.degree_stage,
         edit_candidates_school_registrations_subject_preference_path %>

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -20,18 +20,6 @@
       %>
   </fieldset>
 
-  <fieldset class="govuk-fieldset disability-needs">
-    <%= f.radio_button_fieldset :access_needs do |field_set| %>
-      <span id="access-needs-hint" class="govuk-hint">
-        Tell us so we can make sure the school is able to cater for your requirements
-      </span>
-      <%= field_set.radio_input true do %>
-        <%= field_set.text_area :access_needs_details, rows: 5 %>
-      <% end %>
-      <%= field_set.radio_input false %>
-    <% end %>
-  </fieldset>
-
   <fieldset class="govuk-fieldset">
     <%= f.submit 'Continue' %>
   </fieldset>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,10 +4,6 @@ en:
 
   placement_preference_errors: &placement_preference_errors
     attributes:
-      access_needs:
-        inclusion: "Select an option"
-      access_needs_details:
-        blank: "Enter details"
       date_end:
         blank: "Enter an end date"
         is_not_a_date: "Enter a valid date"
@@ -84,7 +80,6 @@ en:
       candidates_registrations_placement_preference:
         date_start: "Start date"
         date_end: "End date"
-        access_needs: "Do you have any disability or access needs?"
       candidates_registrations_subject_preference:
         degree_stage: What stage are you at with your degree?
         teaching_stage: Which of the following teaching stages are you at?
@@ -112,10 +107,6 @@ en:
           false: "No"
       candidates_registrations_placement_preference:
         objectives: What do you want to get out of a placement?
-        access_needs_details: "Provide details"
-        access_needs:
-          true: "Yes"
-          false: "No"
       order: Sorted by
       query: Find what?
       location: Where?

--- a/db/migrate/20190225092622_remove_access_needs_and_access_needs_details_from_candidates_registrations_placmenet_requests.rb
+++ b/db/migrate/20190225092622_remove_access_needs_and_access_needs_details_from_candidates_registrations_placmenet_requests.rb
@@ -1,0 +1,6 @@
+class RemoveAccessNeedsAndAccessNeedsDetailsFromCandidatesRegistrationsPlacmenetRequests < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :candidates_registrations_placement_requests, :access_needs
+    remove_column :candidates_registrations_placement_requests, :access_needs_details
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_15_102428) do
+ActiveRecord::Schema.define(version: 2019_02_25_092622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,8 +80,6 @@ ActiveRecord::Schema.define(version: 2019_02_15_102428) do
     t.date "date_start", null: false
     t.date "date_end", null: false
     t.text "objectives", null: false
-    t.boolean "access_needs", null: false
-    t.text "access_needs_details"
     t.integer "urn", null: false
     t.string "degree_stage", null: false
     t.text "degree_stage_explaination"

--- a/features/candidates/registrations/request_school_experience_placement.feature
+++ b/features/candidates/registrations/request_school_experience_placement.feature
@@ -14,7 +14,6 @@ Feature: Request a school experience placement
             | Start date                                  | date          |         |
             | End date                                    | date          |         |
             | What do you want to get out of a placement? | textarea      |         |
-            | Do you have any disability or access needs? | radio buttons | Yes, No |
 
     Scenario: Word counting in placement objectives
         Given I am on the 'Request school experience placement' page for my school of choice
@@ -24,17 +23,6 @@ Feature: Request a school experience placement
         Given I am on the 'Request school experience placement' page for my school of choice
         When I enter 'The quick brown fox' into the 'What do you want to get out of a placement?' text area
         Then the 'placement objectives' word count should say 'You have 46 words remaining'
-
-    Scenario: Disability details
-        Given I am on the 'Request school experience placement' page for my school of choice
-        Then the 'Disability needs' section should have 'Yes' and 'No' radio buttons
-
-    @javascript @wip
-    Scenario: Revealing the 'Provide details' box
-        Given I am on the 'Request school experience placement' page for my school of choice
-        And there is no 'Provide details' text area
-        When I click the 'Yes' option in the 'Disability needs' section
-        Then a text area labelled 'Provide details' should have appeared
 
     Scenario: Submitting my data
         Given I am on the 'Request school experience placement' page for my school of choice

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -33,5 +33,4 @@ Given("I have filled in the form with accurate data") do
     And I fill in the date field "End date" with 27-02-2022
   )
   fill_in "What do you want to get out of a placement?", with: "I love teaching"
-  choose "No"
 end

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -71,8 +71,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
             candidates_registrations_placement_preference: {
               date_start: tomorrow,
               date_end: (tomorrow + 3.days),
-              objectives: 'Become a teacher',
-              access_needs: false
+              objectives: 'Become a teacher'
             }
           }
         end
@@ -82,8 +81,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
             Candidates::Registrations::PlacementPreference.new \
               date_start: tomorrow,
               date_end: (tomorrow + 3.days),
-              objectives: 'Become a teacher',
-              access_needs: false
+              objectives: 'Become a teacher'
         end
 
         it 'redirects to the next step' do
@@ -99,8 +97,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
       Candidates::Registrations::PlacementPreference.new \
         date_start: tomorrow,
         date_end: (tomorrow + 3.days),
-        objectives: 'Become a teacher',
-        access_needs: false
+        objectives: 'Become a teacher'
     end
 
     context '#edit' do
@@ -130,8 +127,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
             candidates_registrations_placement_preference: {
               date_start: nil,
               date_end: (tomorrow + 3.days),
-              objectives: 'Become a teacher',
-              access_needs: false
+              objectives: 'Become a teacher'
             }
           }
         end
@@ -151,8 +147,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
             candidates_registrations_placement_preference: {
               date_start: tomorrow,
               date_end: (tomorrow + 3.days),
-              objectives: 'I would like to become a teacher',
-              access_needs: false
+              objectives: 'I would like to become a teacher'
             }
           }
         end
@@ -162,8 +157,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
             Candidates::Registrations::PlacementPreference.new \
               date_start: tomorrow,
               date_end: (tomorrow + 3.days),
-              objectives: 'I would like to become a teacher',
-              access_needs: false
+              objectives: 'I would like to become a teacher'
         end
 
         it 'redirects to the application preview' do

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -28,8 +28,6 @@ FactoryBot.define do
              "date_start" => (current_time + 3.days),
              "date_end" => (current_time + 4.days),
              "objectives" => "test the software",
-             "access_needs" => false,
-             "access_needs_details" => "",
              "created_at" => current_time,
              "updated_at" => current_time
           },

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -73,7 +73,6 @@ feature 'Candidate Registrations', type: :feature do
     within all('.govuk-date-input')[1] do
       fill_in 'Day',   with: tomorrow.day
       fill_in 'Month', with: tomorrow.month
-      fill_in 'Year',  with: tomorrow.year
     end
 
     fill_in 'What do you want to get out of a placement?', with: 'I enjoy teaching'
@@ -94,7 +93,6 @@ feature 'Candidate Registrations', type: :feature do
     end
 
     fill_in 'What do you want to get out of a placement?', with: 'I enjoy teaching'
-    choose 'No'
     click_button 'Continue'
     expect(page.current_path).to eq \
       "/candidates/schools/#{school_urn}/registrations/contact_information/new"
@@ -155,7 +153,6 @@ feature 'Candidate Registrations', type: :feature do
     expect(page).to have_text \
       "Placement availability #{today_in_words} to #{tomorrow_in_words}"
     expect(page).to have_text "Placement outcome I enjoy teaching"
-    expect(page).to have_text "Disability or access needs None"
     expect(page).to have_text "Degree stage Graduate or postgraduate"
     expect(page).to have_text "Degree subject Physics"
     expect(page).to have_text "Teaching stage I want to become a teacher"

--- a/spec/models/candidates/registrations/placement_request_spec.rb
+++ b/spec/models/candidates/registrations/placement_request_spec.rb
@@ -4,8 +4,6 @@ describe Candidates::Registrations::PlacementRequest, type: :model do
   it { is_expected.to have_db_column(:date_start).of_type(:date).with_options null: false }
   it { is_expected.to have_db_column(:date_end).of_type(:date).with_options null: false }
   it { is_expected.to have_db_column(:objectives).of_type(:text).with_options null: false }
-  it { is_expected.to have_db_column(:access_needs).of_type(:boolean).with_options null: false }
-  it { is_expected.to have_db_column(:access_needs_details).of_type :text }
   it { is_expected.to have_db_column(:urn).of_type(:integer).with_options null: false }
   it { is_expected.to have_db_column(:degree_stage).of_type(:string).with_options null: false }
   it { is_expected.to have_db_column(:degree_stage_explaination).of_type :text }

--- a/spec/notify/notify_email/candidate_request_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_request_confirmation_spec.rb
@@ -7,7 +7,6 @@ describe NotifyEmail::CandidateRequestConfirmation do
     candidate_dbs_check_document: "Yes",
     candidate_degree_stage: "Postgraduate",
     candidate_degree_subject: "Sociology",
-    candidate_disability_needs: "None",
     candidate_email_address: "tony.hancock@bbc.co.uk",
     candidate_name: "Tony Hancock",
     candidate_phone_number: "01234 456 678",

--- a/spec/notify/notify_email/school_request_confirmation_spec.rb
+++ b/spec/notify/notify_email/school_request_confirmation_spec.rb
@@ -6,7 +6,6 @@ describe NotifyEmail::SchoolRequestConfirmation do
     candidate_dbs_check_document: "Yes",
     candidate_degree_stage: "Postgraduate",
     candidate_degree_subject: "Sociology",
-    candidate_disability_needs: "None",
     candidate_email_address: "milhouse.vh@gmail.com",
     candidate_name: "Milhouse van Houten",
     candidate_phone_number: "01234 456 678",

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -9,14 +9,6 @@ describe Candidates::Registrations::ApplicationPreview do
     placement_date_start + 7.days
   end
 
-  let :access_needs do
-    true
-  end
-
-  let :access_needs_details do
-    'Access needs'
-  end
-
   let :has_dbs_check do
     true
   end
@@ -42,9 +34,7 @@ describe Candidates::Registrations::ApplicationPreview do
     double Candidates::Registrations::PlacementPreference,
       date_start: placement_date_start,
       date_end: placement_date_end,
-      objectives: "test the software",
-      access_needs: access_needs,
-      access_needs_details: access_needs_details
+      objectives: "test the software"
   end
 
   let :subject_preference do
@@ -126,32 +116,6 @@ describe Candidates::Registrations::ApplicationPreview do
   context '#placement_outcome' do
     it 'returns the correct value' do
       expect(subject.placement_outcome).to eq "test the software"
-    end
-  end
-
-  context '#access_needs' do
-    context 'with access needs' do
-      let :access_needs do
-        true
-      end
-
-      let :access_needs_details do
-        'Access needs'
-      end
-
-      it 'returns the correct value' do
-        expect(subject.access_needs).to eq access_needs_details
-      end
-    end
-
-    context 'without access needs' do
-      let :access_needs do
-        false
-      end
-
-      it 'returns the correct value' do
-        expect(subject.access_needs).to eq "None"
-      end
     end
   end
 

--- a/spec/services/candidates/registrations/registration_as_placement_request_spec.rb
+++ b/spec/services/candidates/registrations/registration_as_placement_request_spec.rb
@@ -28,8 +28,6 @@ describe Candidates::Registrations::RegistrationAsPlacementRequest do
     "date_start" => (CURRENT_TIME + 3.days),
     "date_end" => (CURRENT_TIME + 4.days),
     "objectives" => "test the software",
-    "access_needs" => false,
-    "access_needs_details" => "",
     "degree_stage" => "I don't have a degree and am not studying for one",
     "degree_stage_explaination" => "",
     "degree_subject" => "Not applicable",

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -145,10 +145,6 @@ shared_examples_for "email template from application preview" do |school_admin_i
         expect(subject.candidate_degree_stage).to eql(ap.degree_stage)
       end
 
-      specify 'candidate_disability_needs is correctly-assigned' do
-        expect(subject.candidate_disability_needs).to eql(ap.access_needs)
-      end
-
       specify 'candidate_email_address is correctly-assigned' do
         expect(subject.candidate_email_address).to eql(ap.email_address)
       end

--- a/spec/support/placement_preference_shared_examples.rb
+++ b/spec/support/placement_preference_shared_examples.rb
@@ -7,7 +7,6 @@ shared_examples 'a placement preference' do
     it { is_expected.to respond_to :date_start }
     it { is_expected.to respond_to :date_end }
     it { is_expected.to respond_to :objectives }
-    it { is_expected.to respond_to :access_needs }
   end
 
   context 'validations' do
@@ -105,30 +104,6 @@ shared_examples 'a placement preference' do
       it 'adds an error to objectives' do
         expect(placement_preference.errors[:objectives]).to eq \
           ["Please use 50 words or fewer"]
-      end
-    end
-
-    context 'when access_needs are not a boolean' do
-      let :placement_preference do
-        described_class.new
-      end
-
-      it 'adds an error to access_needs' do
-        expect(placement_preference.errors[:access_needs]).to eq \
-          ['Select an option']
-      end
-    end
-
-    context 'when access_needs are present' do
-      context 'when access_needs_details are not present' do
-        let :placement_preference do
-          described_class.new access_needs: true
-        end
-
-        it 'adds an error to access_needs_details' do
-          expect(placement_preference.errors[:access_needs_details]).to eq \
-            ["Enter details"]
-        end
       end
     end
   end


### PR DESCRIPTION
Removes access needs fields across the candidate journey now they've
been taken out of the prototype.

### Context
Updates app to reflect changes in the prototype

### Changes proposed in this pull request
Removes access_needs and access_needs_details

### Guidance to review
Everything should work as before but now without access needs fields

