### PR TITLE
Feature/google analytics

### DIFF
--- a/app/helpers/google_analytics_helper.rb
+++ b/app/helpers/google_analytics_helper.rb
@@ -1,6 +1,6 @@
 module GoogleAnalyticsHelper
   def google_analytics_enabled?
-    ENV.has_key?('GA_TRACKING_ID')
+    ENV['GA_TRACKING_ID'].present?
   end
 
   def google_analytics_tracking_id

--- a/app/helpers/google_analytics_helper.rb
+++ b/app/helpers/google_analytics_helper.rb
@@ -1,0 +1,9 @@
+module GoogleAnalyticsHelper
+  def google_analytics_enabled?
+    ENV.has_key?('GA_TRACKING_ID')
+  end
+
+  def google_analytics_tracking_id
+    ENV.fetch('GA_TRACKING_ID')
+  end
+end

--- a/app/views/application/_google_analytics.html.erb
+++ b/app/views/application/_google_analytics.html.erb
@@ -1,0 +1,8 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=<%= google_analytics_tracking_id %>"></script>
+<script>
+   window.dataLayer = window.dataLayer || [];
+   function gtag(){dataLayer.push(arguments);}
+   gtag("js", new Date());
+   gtag("config", "<%= google_analytics_tracking_id %>");
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,8 @@
     <%= stylesheet_link_tag 'application', media: 'all' %>
   </head>
 
+  <%= render partial: 'google_analytics' if google_analytics_enabled? %>
+
   <body class="govuk-template__body ">
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
+    <%= render partial: 'google_analytics' if google_analytics_enabled? %>
     <title>DfE School Experience</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -16,8 +17,6 @@
     <%= favicon_link_tag 'govuk-apple-touch-icon-180x180.png', rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
   </head>
-
-  <%= render partial: 'google_analytics' if google_analytics_enabled? %>
 
   <body class="govuk-template__body ">
     <script>

--- a/spec/helpers/google_analytics_helper_spec.rb
+++ b/spec/helpers/google_analytics_helper_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe GoogleAnalyticsHelper, type: :helper do
+  let(:tracking_id_key) { "GA_TRACKING_ID" }
+  let(:tracking_id) { "AAAAABBBBBCCCCCDDDDDEEEEE" }
+
+  describe '#google_analytics_enabled?' do
+    context 'when GA_TRACKING_ID is present' do
+      before do
+        allow(ENV).to(
+          receive(:has_key?)
+            .with(tracking_id_key)
+            .and_return(true)
+        )
+      end
+
+      specify { expect(google_analytics_enabled?).to be true }
+    end
+
+    context 'when GA_TRACKING_ID is not present' do
+      specify { expect(google_analytics_enabled?).to be false }
+    end
+  end
+
+  describe '#google_analytics_tracking_id' do
+    context 'when GA_TRACKING_ID is present' do
+      before do
+        allow(ENV).to(
+          receive(:fetch)
+            .with(tracking_id_key)
+            .and_return(tracking_id)
+        )
+      end
+
+      specify { expect(google_analytics_tracking_id).to eql(tracking_id) }
+    end
+
+    context 'when GA_TRACKING_ID is not present' do
+      specify do
+        expect { google_analytics_tracking_id }.to raise_error(KeyError)
+      end
+    end
+  end
+end

--- a/spec/helpers/google_analytics_helper_spec.rb
+++ b/spec/helpers/google_analytics_helper_spec.rb
@@ -7,11 +7,7 @@ describe GoogleAnalyticsHelper, type: :helper do
   describe '#google_analytics_enabled?' do
     context 'when GA_TRACKING_ID is present' do
       before do
-        allow(ENV).to(
-          receive(:has_key?)
-            .with(tracking_id_key)
-            .and_return(true)
-        )
+        allow(ENV).to(receive(:[]).and_return(tracking_id_key))
       end
 
       specify { expect(google_analytics_enabled?).to be true }

--- a/spec/requests/google_analytics/presence_spec.rb
+++ b/spec/requests/google_analytics/presence_spec.rb
@@ -13,11 +13,7 @@ describe "candidates/home/index.html.erb", type: :request do
 
   context 'When GA_TRACKING_ID is present in the environment' do
     before do
-      allow(ENV).to(
-        receive(:has_key?)
-          .with(tracking_id_key)
-          .and_return(true)
-      )
+      allow(ENV).to(receive(:[]).and_return(tracking_id_key))
       allow(ENV).to(
         receive(:fetch)
           .with(tracking_id_key)

--- a/spec/requests/google_analytics/presence_spec.rb
+++ b/spec/requests/google_analytics/presence_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe "candidates/home/index.html.erb", type: :request do
+  let(:tracking_id_key) { "GA_TRACKING_ID" }
+  let(:tracking_id) { "AAAAABBBBBCCCCCDDDDDEEEEE" }
+
+  let(:ga_identifiers) do
+    [
+      '<script async src="https://www.googletagmanager.com/gtag/js?id=AAAAABBBBBCCCCCDDDDDEEEEE"></script>',
+      'gtag("config", "AAAAABBBBBCCCCCDDDDDEEEEE");'
+    ]
+  end
+
+  context 'When GA_TRACKING_ID is present in the environment' do
+    before do
+      allow(ENV).to(
+        receive(:has_key?)
+          .with(tracking_id_key)
+          .and_return(true)
+      )
+      allow(ENV).to(
+        receive(:fetch)
+          .with(tracking_id_key)
+          .and_return(tracking_id)
+      )
+    end
+
+    specify "google analytics partial should be present" do
+      get '/'
+
+      expect(response.body).to include(*ga_identifiers)
+    end
+  end
+
+  context "When GA_TRACKING_ID is not present in the environment" do
+    before do
+      allow(ENV).to(
+        receive(:has_key?)
+          .with(tracking_id_key)
+          .and_return(false)
+      )
+    end
+
+    specify "google analytics partial should not be present" do
+      get '/'
+
+      expect(response.body).not_to include(*ga_identifiers)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Google Analytics will provide us with a valuable set of metrics on how visitors find and use the web application, this PR enables it.

### Changes proposed in this pull request

Add Google Analytics' global tracking snippet as a partial that we can enable and configure by setting the `GA_TRACKING_ID` environment variable. If the variable is not present nothing extra will be rendered.

### Guidance to review

Make sure everything looks sensible and secure.