### PR TITLE
Se 445 replace placement start and end

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: 385644fadb99afce688dbb6e046d959734203d78
+  revision: 41c0636020bb68d5514b35c84748bf061175c1c0
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,4 +23,5 @@ $govuk-grid-widths: (
 @import "school-search" ;
 @import "pagination";
 @import "application-preview";
+@import "placement-preference";
 @import "stimulus/*" ;

--- a/app/assets/stylesheets/placement-preference.scss
+++ b/app/assets/stylesheets/placement-preference.scss
@@ -1,14 +1,13 @@
 #placement-preference {
   form {
     label.govuk-heading-m {
-      margin-top: 30px;
       .govuk-hint {
         color: #0b0c0c;
       }
     }
     span.govuk-hint {
       &:first-child {
-        margin-top: 15px;
+        @include govuk-responsive-margin(3, "top");
       }
     }
   }

--- a/app/assets/stylesheets/placement-preference.scss
+++ b/app/assets/stylesheets/placement-preference.scss
@@ -1,0 +1,15 @@
+#placement-preference {
+  form {
+    label.govuk-heading-m {
+      margin-top: 30px;
+      .govuk-hint {
+        color: #0b0c0c;
+      }
+    }
+    span.govuk-hint {
+      &:first-child {
+        margin-top: 15px;
+      }
+    }
+  }
+}

--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -37,8 +37,7 @@ module Candidates
 
       def placement_preference_params
         params.require(:candidates_registrations_placement_preference).permit \
-          :date_start,
-          :date_end,
+          :availability,
           :objectives
       end
     end

--- a/app/notify/notify_email/candidate_request_confirmation.8bd7e9b3-8c3f-4702-b642-1ccff32a264f.md
+++ b/app/notify/notify_email/candidate_request_confirmation.8bd7e9b3-8c3f-4702-b642-1ccff32a264f.md
@@ -1,6 +1,6 @@
 Dear ((candidate_name))
 
-You've requested a placement from ((placement_start_date))-((placement_finish_date)) at ((school_name)).
+You've requested a placement at ((school_name)).
 
 ^ The school will be in touch with you shortly. For example, during term time this could typically mean within two weeks.
 
@@ -18,7 +18,7 @@ Personal details
 Request details
 
 * School or college: ((school_name))
-* Placement availability: ((placement_start_date))-((placement_finish_date))
+* Placement availability: ((placement_availability))
 * Placement outcome: ((placement_outcome))
 * Degree stage: ((candidate_degree_stage))
 * Degree subject: ((candidate_degree_subject))

--- a/app/notify/notify_email/candidate_request_confirmation.rb
+++ b/app/notify/notify_email/candidate_request_confirmation.rb
@@ -9,9 +9,8 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     :candidate_teaching_stage,
     :candidate_teaching_subject_first_choice,
     :candidate_teaching_subject_second_choice,
-    :placement_finish_date,
     :placement_outcome,
-    :placement_start_date,
+    :placement_availability,
     :school_name
 
   def initialize(
@@ -26,9 +25,8 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     candidate_teaching_stage:,
     candidate_teaching_subject_first_choice:,
     candidate_teaching_subject_second_choice:,
-    placement_finish_date:,
     placement_outcome:,
-    placement_start_date:,
+    placement_availability:,
     school_name:
   )
 
@@ -42,9 +40,8 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     self.candidate_teaching_stage                 =        candidate_teaching_stage
     self.candidate_teaching_subject_first_choice  =        candidate_teaching_subject_first_choice
     self.candidate_teaching_subject_second_choice =        candidate_teaching_subject_second_choice
-    self.placement_finish_date                    =        placement_finish_date
     self.placement_outcome                        =        placement_outcome
-    self.placement_start_date                     =        placement_start_date
+    self.placement_availability                   =        placement_availability
     self.school_name                              =        school_name
 
     super(to: to)
@@ -62,9 +59,8 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
       candidate_teaching_stage: application_preview.teaching_stage,
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
-      placement_finish_date: application_preview.placement_date_end,
       placement_outcome: application_preview.placement_outcome,
-      placement_start_date: application_preview.placement_date_start,
+      placement_availability: application_preview.placement_availability,
       school_name: application_preview.school
     )
   end
@@ -87,9 +83,8 @@ private
       candidate_teaching_stage: candidate_teaching_stage,
       candidate_teaching_subject_first_choice: candidate_teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: candidate_teaching_subject_second_choice,
-      placement_finish_date: placement_finish_date,
       placement_outcome: placement_outcome,
-      placement_start_date: placement_start_date,
+      placement_availability: placement_availability,
       school_name: school_name
     }
   end

--- a/app/notify/notify_email/school_request_confirmation.dd4490f8-1d7b-455b-8502-47f57a65179a.md
+++ b/app/notify/notify_email/school_request_confirmation.dd4490f8-1d7b-455b-8502-47f57a65179a.md
@@ -1,6 +1,6 @@
 Dear ((school_admin_name)),
 
-((candidate_name)) has sent you a request for school experience from ((placement_start_date)) to ((placement_finish_date)) at ((school_name)).
+((candidate_name)) has sent you a request for school experience at ((school_name)).
 
 # ((candidate_name)) request details
 
@@ -17,7 +17,7 @@ Request details
 Request details:
 
 School or college: ((school_name))
-Placement availability: ((placement_start_date))-((placement_finish_date))
+Placement availability: ((placement_availability))
 Placement outcome: ((placement_outcome))
 Degree stage: ((candidate_degree_stage))
 Degree subject: ((candidate_degree_subject))

--- a/app/notify/notify_email/school_request_confirmation.rb
+++ b/app/notify/notify_email/school_request_confirmation.rb
@@ -9,9 +9,8 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     :candidate_teaching_stage,
     :candidate_teaching_subject_first_choice,
     :candidate_teaching_subject_second_choice,
-    :placement_finish_date,
     :placement_outcome,
-    :placement_start_date,
+    :placement_availability,
     :school_name,
     :school_admin_name
 
@@ -27,9 +26,8 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     candidate_teaching_stage:,
     candidate_teaching_subject_first_choice:,
     candidate_teaching_subject_second_choice:,
-    placement_finish_date:,
     placement_outcome:,
-    placement_start_date:,
+    placement_availability:,
     school_name:,
     school_admin_name:
   )
@@ -44,9 +42,8 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     self.candidate_teaching_stage                 =        candidate_teaching_stage
     self.candidate_teaching_subject_first_choice  =        candidate_teaching_subject_first_choice
     self.candidate_teaching_subject_second_choice =        candidate_teaching_subject_second_choice
-    self.placement_finish_date                    =        placement_finish_date
     self.placement_outcome                        =        placement_outcome
-    self.placement_start_date                     =        placement_start_date
+    self.placement_availability                   =        placement_availability
     self.school_name                              =        school_name
     self.school_admin_name                        =        school_admin_name
 
@@ -57,7 +54,8 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     NotifyEmail::SchoolRequestConfirmation.new(
       to: to,
       candidate_address: application_preview.full_address,
-      candidate_dbs_check_document: application_preview.dbs_check_document, candidate_degree_stage: application_preview.degree_stage,
+      candidate_dbs_check_document: application_preview.dbs_check_document,
+      candidate_degree_stage: application_preview.degree_stage,
       candidate_degree_subject: application_preview.degree_subject,
       candidate_email_address: application_preview.email_address,
       candidate_name: application_preview.full_name,
@@ -65,9 +63,8 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
       candidate_teaching_stage: application_preview.teaching_stage,
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
-      placement_finish_date: application_preview.placement_date_end,
       placement_outcome: application_preview.placement_outcome,
-      placement_start_date: application_preview.placement_date_start,
+      placement_availability: application_preview.placement_availability,
       school_name: application_preview.school,
       school_admin_name: "PLACEHOLDER FOR SCHOOL ADMIN"
     )
@@ -91,9 +88,8 @@ private
       candidate_teaching_stage: candidate_teaching_stage,
       candidate_teaching_subject_first_choice: candidate_teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: candidate_teaching_subject_second_choice,
-      placement_finish_date: placement_finish_date,
       placement_outcome: placement_outcome,
-      placement_start_date: placement_start_date,
+      placement_availability: placement_availability,
       school_name: school_name,
       school_admin_name: school_admin_name
     }

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -57,15 +57,7 @@ module Candidates
       end
 
       def placement_availability
-        "#{placement_date_start} to #{placement_date_end}"
-      end
-
-      def placement_date_start
-        date_in_words(placement_preference.date_start)
-      end
-
-      def placement_date_end
-        date_in_words(placement_preference.date_end)
+        placement_preference.availability
       end
 
       def placement_outcome
@@ -86,12 +78,6 @@ module Candidates
         else
           'No'
         end
-      end
-
-    private
-
-      def date_in_words(date)
-        date.strftime '%d %B %Y'
       end
     end
   end

--- a/app/services/candidates/registrations/behaviours/placement_preference.rb
+++ b/app/services/candidates/registrations/behaviours/placement_preference.rb
@@ -4,80 +4,36 @@ module Candidates
       module PlacementPreference
         extend ActiveSupport::Concern
 
-        MAX_WORDS_FOR_OBJECTIVE = 50
+        MAX_WORDS_FOR_AVAILABILITY = 149
+        MAX_WORDS_FOR_OBJECTIVE = 149
 
         included do
-          validates :date_start, presence: true
-          validate  :date_start_is_a_date,
-            if: -> { date_start.present? }
-          validates :date_end, presence: true
-          validate  :date_end_is_a_date,
-            if: -> { date_end.present? }
-          validate  :date_start_is_not_in_the_past,
-            if: -> { date_start_is_a_date? }
-          validate  :date_end_not_before_date_start,
-            if: -> { date_start_is_a_date? && date_end_is_a_date? }
+          validates :availability, presence: true
+          validate :availability_not_too_long, if: -> { availability.present? }
           validates :objectives, presence: true
           validate  :objectives_not_too_long, if: -> { objectives.present? }
         end
 
       private
 
-        def date_start_is_a_date
-          unless date_start_is_a_date?
-            errors.add :date_start, :is_not_a_date
+        def availability_not_too_long
+          if availability_too_long?
+            errors.add :availability, :use_fewer_words
           end
         end
 
-        def date_start_is_a_date?
-          is_a_date? date_start
-        end
-
-        def date_end_is_a_date
-          unless date_end_is_a_date?
-            errors.add :date_end, :is_not_a_date
-          end
-        end
-
-        def date_end_is_a_date?
-          is_a_date? date_end
-        end
-
-        def is_a_date?(maybe_date)
-          Date.parse maybe_date.to_s
-          true
-        rescue ArgumentError
-          false
-        end
-
-        def date_start_is_not_in_the_past
-          if date_start_is_in_the_past?
-            errors.add :date_start, :should_not_be_in_past
-          end
-        end
-
-        def date_start_is_in_the_past?
-          date_start < Date.today
-        end
-
-        def date_end_not_before_date_start
-          unless date_end_not_before_date_start?
-            errors.add :date_end, :should_not_be_before_date_start
-          end
-        end
-
-        def date_end_not_before_date_start?
-          date_end > date_start
+        def availability_too_long?
+          availability.scan(/\s/).size > MAX_WORDS_FOR_AVAILABILITY
         end
 
         def objectives_not_too_long
           if objectives_too_long?
-            errors.add :objectives, :use_fifty_words_or_fewer
+            errors.add :objectives, :use_fewer_words
           end
         end
 
         def objectives_too_long?
-          objectives.scan(/\w/).size > MAX_WORDS_FOR_OBJECTIVE
+          objectives.scan(/\s/).size > MAX_WORDS_FOR_OBJECTIVE
         end
       end
     end

--- a/app/services/candidates/registrations/placement_preference.rb
+++ b/app/services/candidates/registrations/placement_preference.rb
@@ -1,18 +1,9 @@
 module Candidates
   module Registrations
     class PlacementPreference < RegistrationStep
-      # This allows us to parse multi-part date parameters like an ActiveRecord object.
-      include ActiveRecord::AttributeAssignment
-      class ActiveModel::Type::Date
-        def default_timezone
-          :utc
-        end
-      end
-
       include Behaviours::PlacementPreference
 
-      attribute :date_start, :date
-      attribute :date_end, :date
+      attribute :availability, :string
       attribute :objectives, :string
     end
   end

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -1,26 +1,21 @@
-<h1 class="govuk-heading-l">Request school experience placement</h1>
-<p>Tell us a few details so we can forward your requirements to the school.</p>
+<div class="govuk-grid-row" id="placement-preference">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Request school experience placement</h1>
+    <p>Tell us a few details so we can forward your placement requirements to the school.</p>
 
-<%= form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>
-  <%= GovukElementsErrorsHelper.error_summary placement_preference, 'There is a problem', '' %>
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-      <h1 class="govuk-fieldset__heading">When would you be available for a placement?</h1>
-    </legend>
-    <%= f.date_field :date_start %>
-    <%= f.date_field :date_end %>
-  </fieldset>
-
-  <fieldset id="placement-objectives-container" class="govuk-fieldset">
-    <%=
-      f.text_area_with_maxwords \
-        :objectives,
-        rows: 5,
-        maxwords: { count: 150 }
-      %>
-  </fieldset>
-
-  <fieldset class="govuk-fieldset">
-    <%= f.submit 'Continue' %>
-  </fieldset>
-<% end %>
+    <%= form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>
+      <%= GovukElementsErrorsHelper.error_summary placement_preference, 'There is a problem', '' %>
+      <%= f.text_area_with_maxwords \
+          :availability,
+          rows: 5,
+          maxwords: { count: 150 },
+          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } %>
+      <%= f.text_area_with_maxwords \
+          :objectives,
+          rows: 5,
+          maxwords: { count: 150 },
+          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } %>
+      <%= f.submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -7,9 +7,8 @@
     </div>
     <h3 class="govuk-heading-m">What happens next</h3>
     <p>
-      Your request for a school experience placement for
-      <%= @application_preview.placement_availability %>
-      will be forwarded to <%= @application_preview.school %>.
+      Your request for a school experience placement will be forwarded to
+      <%= @application_preview.school %>.
     </p>
     <p class="govuk-inset-text">
       The school will be in touch with you shortly. For example, during term

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,17 +4,12 @@ en:
 
   placement_preference_errors: &placement_preference_errors
     attributes:
-      date_end:
-        blank: "Enter an end date"
-        is_not_a_date: "Enter a valid date"
-        should_not_be_before_date_start: "End date must not be earlier than start date"
-      date_start:
-        blank: "Enter a start date"
-        is_not_a_date: "Enter a valid date"
-        should_not_be_in_past: "Must not be in the past"
+      availability:
+        blank: "Enter your availability"
+        use_fewer_words: "Please use 150 words or fewer"
       objectives:
         blank: "Enter what you want to get out of a placement"
-        use_fifty_words_or_fewer: "Please use 50 words or fewer"
+        use_fewer_words: "Please use 150 words or fewer"
 
   subject_preference_errors: &subject_preference_errors
     attributes:
@@ -77,9 +72,6 @@ en:
       subject: Subject
       candidates_registrations_background_check:
         has_dbs_check: Do you have a DBS certificate?
-      candidates_registrations_placement_preference:
-        date_start: "Start date"
-        date_end: "End date"
       candidates_registrations_subject_preference:
         degree_stage: What stage are you at with your degree?
         teaching_stage: Which of the following teaching stages are you at?
@@ -87,6 +79,19 @@ en:
       phases: Select all that apply
       max_fee: Schools may charge
       subjects: Select all that apply
+      candidates_registrations_placement_preference:
+        availability:
+          - Tell us about your availability. For example, when you'll be
+            available for placements or any particular days or periods when you
+            won't.
+          - The school will contact you to arrange the exact date of your
+            placement and will use this information to offer you the best dates
+            it has available.
+          - Depending on availability and time of year, schools may not always
+            be able to offer you the exact dates you’re looking for.
+        objectives:
+          - Provide a short explanation about what you want to gain from your placement.
+          - This will help the school see if it can offer you the kind of placement you’re looking for.
 
     label:
       candidates_registrations_contact_information:
@@ -104,7 +109,8 @@ en:
           true: "Yes"
           false: "No"
       candidates_registrations_placement_preference:
-        objectives: What do you want to get out of a placement?
+        availability: When are you available for placements?
+        objectives: What do you want to get out of your placement?
       order: Sorted by
       query: Find what?
       location: Where?

--- a/db/migrate/20190225114124_add_availability_to_placement_requests.rb
+++ b/db/migrate/20190225114124_add_availability_to_placement_requests.rb
@@ -1,0 +1,5 @@
+class AddAvailabilityToPlacementRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :candidates_registrations_placement_requests, :availability, :text, null: false
+  end
+end

--- a/db/migrate/20190226120359_remove_date_start_and_date_end_from_candidates_registrations_placement_requests.rb
+++ b/db/migrate/20190226120359_remove_date_start_and_date_end_from_candidates_registrations_placement_requests.rb
@@ -1,0 +1,6 @@
+class RemoveDateStartAndDateEndFromCandidatesRegistrationsPlacementRequests < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :candidates_registrations_placement_requests, :date_start, :date
+    remove_column :candidates_registrations_placement_requests, :date_end, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_25_092622) do
+ActiveRecord::Schema.define(version: 2019_02_26_120359) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,8 +77,6 @@ ActiveRecord::Schema.define(version: 2019_02_25_092622) do
   end
 
   create_table "candidates_registrations_placement_requests", force: :cascade do |t|
-    t.date "date_start", null: false
-    t.date "date_end", null: false
     t.text "objectives", null: false
     t.integer "urn", null: false
     t.string "degree_stage", null: false
@@ -90,6 +88,7 @@ ActiveRecord::Schema.define(version: 2019_02_25_092622) do
     t.boolean "has_dbs_check", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "availability", null: false
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/features/candidates/registrations/request_school_experience_placement.feature
+++ b/features/candidates/registrations/request_school_experience_placement.feature
@@ -10,10 +10,9 @@ Feature: Request a school experience placement
     Scenario: Form contents
         Given I am on the 'Request school experience placement' page for my school of choice
         Then I should see a form with the following fields:
-            | Label                                       | Type          | Options |
-            | Start date                                  | date          |         |
-            | End date                                    | date          |         |
-            | What do you want to get out of a placement? | textarea      |         |
+            | Label                                          | Type          | Options |
+            | When are you available for placements?         | textarea      |         |
+            | What do you want to get out of your placement? | textarea      |         |
 
     Scenario: Word counting in placement objectives
         Given I am on the 'Request school experience placement' page for my school of choice
@@ -21,7 +20,7 @@ Feature: Request a school experience placement
 
     Scenario: Updating the word count
         Given I am on the 'Request school experience placement' page for my school of choice
-        When I enter 'The quick brown fox' into the 'What do you want to get out of a placement?' text area
+        When I enter 'The quick brown fox' into the 'What do you want to get out of your placement?' text area
         Then the 'placement objectives' word count should say 'You have 46 words remaining'
 
     Scenario: Submitting my data

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -12,7 +12,6 @@ Then("the {string} section should have {string} and {string} radio buttons") do 
   end
 end
 
-
 When("I click the {string} option in the {string} section") do |option, section|
   within(".#{section.parameterize}") do
     expect(choose(option)).to be_checked
@@ -28,9 +27,6 @@ Then("a text area labelled {string} should have appeared") do |string|
 end
 
 Given("I have filled in the form with accurate data") do
-  steps %(
-    When I fill in the date field "Start date" with 20-02-2022
-    And I fill in the date field "End date" with 27-02-2022
-  )
-  fill_in "What do you want to get out of a placement?", with: "I love teaching"
+  fill_in "When are you available for placements?", with: "Anytime!"
+  fill_in "What do you want to get out of your placement?", with: "I love teaching"
 end

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -74,12 +74,13 @@ Given("I choose {string} from the {string} radio buttons") do |option, field|
   end
 end
 
+LABEL_SELECTORS = %w(.govuk-label legend label).freeze
 def get_form_group(page, label_text)
-  if page.has_css?(".govuk-label", text: label_text)
-    page.find(".govuk-label", text: label_text).ancestor('div.govuk-form-group')
-  else
-    page.find("legend", text: label_text).ancestor('div.govuk-form-group')
+  selector = LABEL_SELECTORS.detect do |selector|
+    page.has_css?(selector, text: label_text)
   end
+  label = page.find(selector, text: label_text)
+  label.ancestor('div.govuk-form-group')
 end
 
 def ensure_date_field_exists(form_group)

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -51,7 +51,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
         let :placement_preference_params do
           {
             candidates_registrations_placement_preference: {
-              date_start: tomorrow
+              availability: ''
             }
           }
         end
@@ -69,8 +69,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
         let :placement_preference_params do
           {
             candidates_registrations_placement_preference: {
-              date_start: tomorrow,
-              date_end: (tomorrow + 3.days),
+              availability: 'Every second Friday',
               objectives: 'Become a teacher'
             }
           }
@@ -79,8 +78,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
         it 'stores the placement_preference details in the session' do
           expect(registration_session).to have_received(:save).with \
             Candidates::Registrations::PlacementPreference.new \
-              date_start: tomorrow,
-              date_end: (tomorrow + 3.days),
+              availability: 'Every second Friday',
               objectives: 'Become a teacher'
         end
 
@@ -95,8 +93,6 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
   context 'with existing placement_preference in session' do
     let :existing_placement_preference do
       Candidates::Registrations::PlacementPreference.new \
-        date_start: tomorrow,
-        date_end: (tomorrow + 3.days),
         objectives: 'Become a teacher'
     end
 
@@ -125,8 +121,6 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
         let :placement_preference_params do
           {
             candidates_registrations_placement_preference: {
-              date_start: nil,
-              date_end: (tomorrow + 3.days),
               objectives: 'Become a teacher'
             }
           }
@@ -145,8 +139,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
         let :placement_preference_params do
           {
             candidates_registrations_placement_preference: {
-              date_start: tomorrow,
-              date_end: (tomorrow + 3.days),
+              availability: 'Every second Friday',
               objectives: 'I would like to become a teacher'
             }
           }
@@ -155,8 +148,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
         it 'updates the session with the new details' do
           expect(registration_session).to have_received(:save).with \
             Candidates::Registrations::PlacementPreference.new \
-              date_start: tomorrow,
-              date_end: (tomorrow + 3.days),
+              availability: 'Every second Friday',
               objectives: 'I would like to become a teacher'
         end
 

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -25,8 +25,7 @@ FactoryBot.define do
             "updated_at" => current_time
           },
            "candidates_registrations_placement_preference" => {
-             "date_start" => (current_time + 3.days),
-             "date_end" => (current_time + 4.days),
+             "availability" => "Every third Tuesday",
              "objectives" => "test the software",
              "created_at" => current_time,
              "updated_at" => current_time

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -64,35 +64,13 @@ feature 'Candidate Registrations', type: :feature do
     expect(page).to have_text 'Request school experience placement'
 
     # Submit registrations/placement_preference form with errors
-    within all('.govuk-date-input')[0] do
-      fill_in 'Day',   with: today.day
-      fill_in 'Month', with: today.month
-      fill_in 'Year',  with: today.year
-    end
-
-    within all('.govuk-date-input')[1] do
-      fill_in 'Day',   with: tomorrow.day
-      fill_in 'Month', with: tomorrow.month
-    end
-
-    fill_in 'What do you want to get out of a placement?', with: 'I enjoy teaching'
+    fill_in 'What do you want to get out of your placement?', with: 'I enjoy teaching'
     click_button 'Continue'
     expect(page).to have_text 'There is a problem'
 
     # Submit registrations/placement_preference form successfully
-    within all('.govuk-date-input')[0] do
-      fill_in 'Day',   with: today.day
-      fill_in 'Month', with: today.month
-      fill_in 'Year',  with: today.year
-    end
-
-    within all('.govuk-date-input')[1] do
-      fill_in 'Day',   with: tomorrow.day
-      fill_in 'Month', with: tomorrow.month
-      fill_in 'Year',  with: tomorrow.year
-    end
-
-    fill_in 'What do you want to get out of a placement?', with: 'I enjoy teaching'
+    fill_in 'When are you available for placements?', with: 'From Epiphany to Whitsunday'
+    fill_in 'What do you want to get out of your placement?', with: 'I enjoy teaching'
     click_button 'Continue'
     expect(page.current_path).to eq \
       "/candidates/schools/#{school_urn}/registrations/contact_information/new"
@@ -150,8 +128,7 @@ feature 'Candidate Registrations', type: :feature do
     expect(page).to have_text 'UK telephone number 01234567890'
     expect(page).to have_text 'Email address test@example.com'
     expect(page).to have_text "School or college #{school.name}"
-    expect(page).to have_text \
-      "Placement availability #{today_in_words} to #{tomorrow_in_words}"
+    expect(page).to have_text 'Placement availability From Epiphany to Whitsunday'
     expect(page).to have_text "Placement outcome I enjoy teaching"
     expect(page).to have_text "Degree stage Graduate or postgraduate"
     expect(page).to have_text "Degree subject Physics"
@@ -169,8 +146,7 @@ feature 'Candidate Registrations', type: :feature do
     visit \
       "/candidates/schools/#{school_urn}/registrations/placement_request/new?uuid=#{uuid}"
 
-    save_page
     expect(page).to have_text \
-      "Your request for a school experience placement for #{today_in_words} to #{tomorrow_in_words} will be forwarded to Test School."
+      "Your request for a school experience placement will be forwarded to Test School."
   end
 end

--- a/spec/models/candidates/registrations/placement_request_spec.rb
+++ b/spec/models/candidates/registrations/placement_request_spec.rb
@@ -1,8 +1,7 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::PlacementRequest, type: :model do
-  it { is_expected.to have_db_column(:date_start).of_type(:date).with_options null: false }
-  it { is_expected.to have_db_column(:date_end).of_type(:date).with_options null: false }
+  it { is_expected.to have_db_column(:availability).of_type(:text).with_options null: false }
   it { is_expected.to have_db_column(:objectives).of_type(:text).with_options null: false }
   it { is_expected.to have_db_column(:urn).of_type(:integer).with_options null: false }
   it { is_expected.to have_db_column(:degree_stage).of_type(:string).with_options null: false }
@@ -24,8 +23,8 @@ describe Candidates::Registrations::PlacementRequest, type: :model do
           "registration" => {
             "candidates_registrations_background_check" => {},
             "candidates_registrations_contact_information" => {},
-             "candidates_registrations_placement_preference" => {},
-             "candidates_registrations_subject_preference" => {}
+            "candidates_registrations_placement_preference" => {},
+            "candidates_registrations_subject_preference" => {}
           }
       end
 

--- a/spec/notify/notify_email/candidate_request_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_request_confirmation_spec.rb
@@ -13,9 +13,8 @@ describe NotifyEmail::CandidateRequestConfirmation do
     candidate_teaching_stage: "I want to become a teacher",
     candidate_teaching_subject_first_choice: "Sociology",
     candidate_teaching_subject_second_choice: "Philosophy",
-    placement_finish_date: "2020-01-14",
-    placement_outcome: "I enjoy teaching",
-    placement_start_date: "2020-01-07"
+    placement_availability: "Mid lent",
+    placement_outcome: "I enjoy teaching"
 
   it_should_behave_like "email template from application preview", false
 end

--- a/spec/notify/notify_email/school_request_confirmation_spec.rb
+++ b/spec/notify/notify_email/school_request_confirmation_spec.rb
@@ -12,9 +12,8 @@ describe NotifyEmail::SchoolRequestConfirmation do
     candidate_teaching_stage: "I want to become a teacher",
     candidate_teaching_subject_first_choice: "Sociology",
     candidate_teaching_subject_second_choice: "Philosophy",
-    placement_finish_date: "2020-01-14",
     placement_outcome: "I enjoy teaching",
-    placement_start_date: "2020-01-07",
+    placement_availability: "Late Smarch",
     school_name: "Springfield Elementary School",
     school_admin_name: "Seymour Skinner"
 

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::ApplicationPreview do
-  let! :placement_date_start do
-    Date.tomorrow
-  end
-
-  let! :placement_date_end do
-    placement_date_start + 7.days
-  end
-
   let :has_dbs_check do
     true
   end
@@ -32,9 +24,8 @@ describe Candidates::Registrations::ApplicationPreview do
 
   let :placement_preference do
     double Candidates::Registrations::PlacementPreference,
-      date_start: placement_date_start,
-      date_end: placement_date_end,
-      objectives: "test the software"
+      objectives: "test the software",
+      availability: 'From Epiphany to Whitsunday'
   end
 
   let :subject_preference do
@@ -91,25 +82,9 @@ describe Candidates::Registrations::ApplicationPreview do
     end
   end
 
-  context '#placement_date_start' do
-    it 'returns the correct value' do
-      expect(subject.placement_date_start).to eq \
-        placement_date_start.strftime('%d %B %Y')
-    end
-  end
-
-  context '#placement_date_end' do
-    it 'returns the correct value' do
-      expect(subject.placement_date_end).to eq \
-        placement_date_end.strftime('%d %B %Y')
-    end
-  end
-
   context '#placement_availability' do
     it 'returns the correct value' do
-      expect(subject.placement_availability).to eq \
-        placement_date_start.strftime('%d %B %Y') + ' to ' +
-        placement_date_end.strftime('%d %B %Y')
+      expect(subject.placement_availability).to eq 'From Epiphany to Whitsunday'
     end
   end
 

--- a/spec/services/candidates/registrations/registration_as_placement_request_spec.rb
+++ b/spec/services/candidates/registrations/registration_as_placement_request_spec.rb
@@ -1,13 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::RegistrationAsPlacementRequest do
-  # It's a date not a time,
-  # it just makes comparisions with date_end/date_start easier and we don't
-  # care too much about the registration_session's updated/created_at timestamps
-  CURRENT_TIME = Date.today
-
   let :session do
-    FactoryBot.build :registration_session, current_time: CURRENT_TIME
+    FactoryBot.build :registration_session
   end
 
   subject { described_class.new session }
@@ -25,8 +20,7 @@ describe Candidates::Registrations::RegistrationAsPlacementRequest do
 
   EXPECTED_ATTRIBUTES = {
     "has_dbs_check" => true,
-    "date_start" => (CURRENT_TIME + 3.days),
-    "date_end" => (CURRENT_TIME + 4.days),
+    "availability" => "Every third Tuesday",
     "objectives" => "test the software",
     "degree_stage" => "I don't have a degree and am not studying for one",
     "degree_stage_explaination" => "",

--- a/spec/services/candidates/registrations/registration_store_spec.rb
+++ b/spec/services/candidates/registrations/registration_store_spec.rb
@@ -52,11 +52,6 @@ describe Candidates::Registrations::RegistrationStore do
       expect(returned).to eq session
     end
 
-    it 'preserves dates when deserializing' do
-      expect(returned.placement_preference.date_start).to eq \
-        session.placement_preference.date_start
-    end
-
     it 'preserves date times when deserializing' do
       expect(returned.placement_preference.created_at.to_i).to \
         eq session.placement_preference.created_at.to_i

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -169,16 +169,12 @@ shared_examples_for "email template from application preview" do |school_admin_i
         expect(subject.candidate_teaching_subject_second_choice).to eql(ap.teaching_subject_second_choice)
       end
 
-      specify 'placement_finish_date is correctly-assigned' do
-        expect(subject.placement_finish_date).to eql(ap.placement_date_end)
-      end
-
       specify 'placement_outcome is correctly-assigned' do
         expect(subject.placement_outcome).to eql(ap.placement_outcome)
       end
 
-      specify 'placement_start_date is correctly-assigned' do
-        expect(subject.placement_start_date).to eql(ap.placement_date_start)
+      specify 'placement_availability is correctly-assigned' do
+        expect(subject.placement_availability).to eql(ap.placement_availability)
       end
 
       specify 'school_name is correctly-assigned' do

--- a/spec/support/placement_preference_shared_examples.rb
+++ b/spec/support/placement_preference_shared_examples.rb
@@ -4,8 +4,7 @@ shared_examples 'a placement preference' do
   end
 
   context 'attributes' do
-    it { is_expected.to respond_to :date_start }
-    it { is_expected.to respond_to :date_end }
+    it { is_expected.to respond_to :availability }
     it { is_expected.to respond_to :objectives }
   end
 
@@ -14,73 +13,26 @@ shared_examples 'a placement preference' do
       placement_preference.validate
     end
 
-    context 'when date_start is not present' do
+    context 'when availability are not present' do
       let :placement_preference do
         described_class.new
       end
 
-      it 'adds an error to date_start' do
-        expect(placement_preference.errors[:date_start]).to eq \
-          ["Enter a start date"]
+      it 'adds an error to availability' do
+        expect(placement_preference.errors[:availability]).to eq \
+          ["Enter your availability"]
       end
     end
 
-    context 'when date_start is not a date' do
-      let :placement_preference do
-        described_class.new date_start: 'Im not a date'
-      end
-
-      it 'adds an error to date_start' do
-        expect(placement_preference.errors[:date_start]).to eq \
-          ["Enter a start date"]
-      end
-    end
-
-    context 'when date_end is not present' do
-      let :placement_preference do
-        described_class.new
-      end
-
-      it 'adds an error to date_end' do
-        expect(placement_preference.errors[:date_end]).to eq \
-          ["Enter an end date"]
-      end
-    end
-
-    context 'when date_end is not a date' do
-      let :placement_preference do
-        described_class.new date_end: 'Im not a date'
-      end
-
-      it 'adds an error to date_end' do
-        expect(placement_preference.errors[:date_end]).to eq \
-          ["Enter an end date"]
-      end
-    end
-
-    context 'when date_end is before date_start' do
+    context 'when availability are too long' do
       let :placement_preference do
         described_class.new \
-          date_start: today,
-          date_end: (today - 3.days)
+          availability: 151.times.map { 'word' }.join(' ')
       end
 
-      it 'adds an error to date_end' do
-        expect(placement_preference.errors[:date_end]).to eq \
-          ["End date must not be earlier than start date"]
-      end
-    end
-
-    context 'when date_start is in the past' do
-      let :placement_preference do
-        described_class.new \
-          date_start: 3.days.ago,
-          date_end: today
-      end
-
-      it 'adds an error to date_start' do
-        expect(placement_preference.errors[:date_start]).to eq \
-          ["Must not be in the past"]
+      it 'adds an error to availability' do
+        expect(placement_preference.errors[:availability]).to eq \
+          ["Please use 150 words or fewer"]
       end
     end
 
@@ -98,12 +50,12 @@ shared_examples 'a placement preference' do
     context 'when objectives are too long' do
       let :placement_preference do
         described_class.new \
-          objectives: 51.times.map { 'word' }.join(' ')
+          objectives: 151.times.map { 'word' }.join(' ')
       end
 
       it 'adds an error to objectives' do
         expect(placement_preference.errors[:objectives]).to eq \
-          ["Please use 50 words or fewer"]
+          ["Please use 150 words or fewer"]
       end
     end
   end


### PR DESCRIPTION
### Context
Start and end dates have been removed from the prototype and replaced with a free text field

### Changes proposed in this pull request
Removes start and end dates across the candidate journey, replace them with start and end date

### Guidance to review
Journey should work as before, except now you enter availability rather than start and end dates
