### PR TITLE
Set Rails' default test cache to null_store

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 #  config.action_mailer.delivery_method = :test
 
   # set the cache to use RAM
-  config.cache_store = :memory_store, { size: 2.megabytes }
+  config.cache_store = :null_store
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/services/bookings/school_search_spec.rb
+++ b/spec/services/bookings/school_search_spec.rb
@@ -10,7 +10,10 @@ describe Bookings::SchoolSearch do
 
   describe '#geolocation' do
     let(:location) { 'Springfield' }
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
     before do
+      allow(Rails).to receive(:cache).and_return(memory_store)
       allow(Geocoder).to receive(:search).and_return(manchester_coordinates)
     end
 


### PR DESCRIPTION
### Context

Setting the default cache to `:memory_store` could have some unforeseen consequences later on

### Changes proposed in this pull request

Change the default to `:null_store` which will require it to be explicitly set wherever we interact with the cache in tests.
