### PR TITLE
Adds privacy policy acceptance checkbox

### DIFF
--- a/app/assets/stylesheets/application-preview.scss
+++ b/app/assets/stylesheets/application-preview.scss
@@ -5,5 +5,8 @@
         margin-top: 60px;
       }
     }
+    .govuk-summary-list__key {
+      word-break: break-word;
+    }
   }
 }

--- a/app/controllers/candidates/registrations/application_previews_controller.rb
+++ b/app/controllers/candidates/registrations/application_previews_controller.rb
@@ -3,6 +3,7 @@ module Candidates
     class ApplicationPreviewsController < RegistrationsController
       def show
         @application_preview = ApplicationPreview.new current_registration
+        @privacy_policy = PrivacyPolicy.new
       end
     end
   end

--- a/app/controllers/candidates/registrations/confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/confirmation_emails_controller.rb
@@ -24,9 +24,8 @@ module Candidates
           @application_preview = ApplicationPreview.new current_registration
           render 'candidates/registrations/application_previews/show'
         end
-
-        rescue RegistrationSession::NotCompletedError
-          redirect_to candidates_school_registrations_application_preview_path
+      rescue RegistrationSession::NotCompletedError
+        redirect_to candidates_school_registrations_application_preview_path
       end
 
     private

--- a/app/controllers/candidates/registrations/confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/confirmation_emails_controller.rb
@@ -8,17 +8,32 @@ module Candidates
       end
 
       def create
-        current_registration.flag_as_pending_email_confirmation!
+        @privacy_policy = PrivacyPolicy.new privacy_policy_params
 
-        RegistrationStore.instance.store! current_registration
+        if @privacy_policy.accepted?
+          current_registration.flag_as_pending_email_confirmation!
 
-        SendEmailConfirmationJob.perform_later \
-          current_registration.uuid,
-          request.host
+          RegistrationStore.instance.store! current_registration
 
-        redirect_to candidates_school_registrations_confirmation_email_path
-      rescue RegistrationSession::NotCompletedError
-        redirect_to candidates_school_registrations_application_preview_path
+          SendEmailConfirmationJob.perform_later \
+            current_registration.uuid,
+            request.host
+
+          redirect_to candidates_school_registrations_confirmation_email_path
+        else
+          @application_preview = ApplicationPreview.new current_registration
+          render 'candidates/registrations/application_previews/show'
+        end
+
+        rescue RegistrationSession::NotCompletedError
+          redirect_to candidates_school_registrations_application_preview_path
+      end
+
+    private
+
+      def privacy_policy_params
+        params.require(:candidates_registrations_privacy_policy).permit \
+          :acceptance
       end
     end
   end

--- a/app/helpers/candidates/registrations_helper.rb
+++ b/app/helpers/candidates/registrations_helper.rb
@@ -3,6 +3,7 @@ module Candidates::RegistrationsHelper
     action = change_path ? link_to('Change', change_path) : nil
 
     render \
-      partial: "list_row", locals: { key: key, value: value, action: action }
+      partial: "candidates/registrations/application_previews/list_row",
+      locals: { key: key, value: value, action: action }
   end
 end

--- a/app/services/candidates/registrations/privacy_policy.rb
+++ b/app/services/candidates/registrations/privacy_policy.rb
@@ -1,0 +1,14 @@
+module Candidates
+  module Registrations
+    class PrivacyPolicy
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :acceptance, :boolean
+
+      validates :acceptance, acceptance: true
+
+      alias_method :accepted?, :valid?
+    end
+  end
+end

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -68,7 +68,7 @@
         edit_candidates_school_registrations_subject_preference_path %>
 
       <%= summary_row \
-        'DBS check document',
+        'DBS certificate',
         @application_preview.dbs_check_document,
         edit_candidates_school_registrations_background_check_path %>
 
@@ -76,10 +76,11 @@
   </div>
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m">Send your placement request</h2>
-    <p class="govuk-body">
-      By submitting this notification you’re confirming, to the best of your knowledge, the details you’re providing are correct.
-    </p>
-    <p>GDPR STATEMENT AND CONTENT PATTERN HERE</p>
-    <%= button_to 'Accept and send', candidates_school_registrations_confirmation_email_path, class: 'govuk-button' %>
+    <%= form_for @privacy_policy, url: candidates_school_registrations_confirmation_email_path do |f| %>
+      <div class="govuk-form-group">
+        <%= f.check_box_input :acceptance %>
+      </div>
+      <%= f.submit 'Accept and send', class: 'govuk-button' %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,8 @@ en:
       candidates_registrations_placement_preference:
         availability: When are you available for placements?
         objectives: What do you want to get out of your placement?
+      candidates_registrations_privacy_policy:
+        acceptance_html: 'By checking this box and sending this request you’re confirming, to the best of your knowledge, the details you’re providing are correct and you accept our <a href="#" class="govuk-link">privacy policy</a>'
       order: Sorted by
       query: Find what?
       location: Where?

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -135,9 +135,17 @@ feature 'Candidate Registrations', type: :feature do
     expect(page).to have_text "Teaching stage I want to become a teacher"
     expect(page).to have_text "Teaching subject - first choice Physics"
     expect(page).to have_text "Teaching subject - second choice Mathematics"
-    expect(page).to have_text "DBS check document Yes"
+    expect(page).to have_text "DBS certificate Yes"
 
-    # Send email confirmation
+    # Submit email confirmation form with errors
+    click_button 'Accept and send'
+    expect(page).to have_text 'must be accepted'
+    expect(page).not_to have_text \
+      "Click the confirmation link in the email we’ve sent to the following email address to confirm your request for a placement at Test School:\ntest@example.com"
+
+    # Submit email confirmation form successfully
+    check \
+      "By checking this box and sending this request you’re confirming, to the best of your knowledge, the details you’re providing are correct and you accept our privacy policy"
     click_button 'Accept and send'
     expect(page).to have_text \
       "Click the confirmation link in the email we’ve sent to the following email address to confirm your request for a placement at Test School:\ntest@example.com"

--- a/spec/services/candidates/registrations/privacy_policy_spec.rb
+++ b/spec/services/candidates/registrations/privacy_policy_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::PrivacyPolicy, type: :model do
+  context 'attributes' do
+    it { is_expected.to respond_to :acceptance }
+  end
+
+  context 'validations' do
+    it { is_expected.to validate_acceptance_of :acceptance }
+  end
+end


### PR DESCRIPTION
### Context
The prototype has added a checkbox for the user to confirm that they accept
the privacy policy.

### Changes proposed in this pull request
Adds the accept privacy policy checkbox.

### Guidance to review
Manual testing steps: complete the candidate registration wizard, expect to need to check that you accept the privacy policy to continue.
