### PR TITLE
Use .govuk-heading-m for degree subject label

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: 41c0636020bb68d5514b35c84748bf061175c1c0
+  revision: 1a14e6e784eebfa19168695ce447bb6e40a00a36
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)

--- a/app/views/candidates/registrations/subject_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/subject_preferences/_form.html.erb
@@ -23,7 +23,10 @@
       :to_s,
       :to_s,
       { prompt: 'Select' },
-      { class: 'govuk-select' } %>
+      {
+        class: 'govuk-select',
+        label_options: { class: 'govuk-heading-m' }
+      } %>
   </div>
 
   <%= f.radio_button_fieldset :teaching_stage do |fieldset| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,8 @@ en:
       phases: Select all that apply
       max_fee: Schools may charge
       subjects: Select all that apply
+      candidates_registrations_subject_preference:
+        degree_subject: Select the nearest or equivalent subject.
       candidates_registrations_placement_preference:
         availability:
           - Tell us about your availability. For example, when you'll be


### PR DESCRIPTION
### Context
Prototype now has .govuk-heading-m on the tell us your your degree subject label.

### Changes proposed in this pull request
Adds .govuk-heading label, bumps form builder version so collection_selects support label_options, also adds a hint for this field.

### Guidance to review
candidates/schools/<urn>/registrations/subject_preference/new
The 'If you have or are studying for a degree, tell us your your degree subject' label should be embiggend
