### PR TITLE
Scope registration sessions by school urn

### DIFF
--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -7,7 +7,11 @@ module Candidates
     end
 
     def current_registration
-      @current_registration ||= Registrations::RegistrationSession.new(session)
+      @current_registration ||= school_session.current_registration
+    end
+
+    def school_session
+      @school_session ||= Registrations::SchoolSession.new current_urn, session
     end
 
     def current_urn

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -4,10 +4,8 @@
 module Candidates
   module Registrations
     class RegistrationSession
-      NAMESPACE = 'registration'.freeze
-
       def initialize(session)
-        @registration_session = session[NAMESPACE] ||= {}
+        @registration_session = session
       end
 
       def save(model)
@@ -46,7 +44,7 @@ module Candidates
       end
 
       def to_h
-        { NAMESPACE => @registration_session }
+        @registration_session
       end
 
       def to_json

--- a/app/services/candidates/registrations/school_session.rb
+++ b/app/services/candidates/registrations/school_session.rb
@@ -1,0 +1,15 @@
+# Wrapper around Rails session
+# Namespaces registration sessions under the current school urn
+module Candidates
+  module Registrations
+    class SchoolSession
+      def initialize(urn, session)
+        @school_session = session["schools/#{urn}/registrations"] ||= {}
+      end
+
+      def current_registration
+        @current_registration ||= RegistrationSession.new @school_session
+      end
+    end
+  end
+end

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -6,41 +6,39 @@ FactoryBot.define do
 
     initialize_with do
       new \
-        "registration" => {
-          "candidates_registrations_contact_information" => {
-            "full_name" => 'Testy McTest',
-            "email" => 'test@example.com',
-            "building" => "Test building",
-            "street" => "Test street",
-            "town_or_city" => "Test town",
-            "county" => "Testshire",
-            "postcode" => "TE57 1NG",
-            "phone" => "01234567890",
-            "created_at" => current_time,
-            "updated_at" => current_time
-          },
-          "candidates_registrations_background_check" => {
-            "has_dbs_check" => true,
-            "created_at" => current_time,
-            "updated_at" => current_time
-          },
-           "candidates_registrations_placement_preference" => {
-             "availability" => "Every third Tuesday",
-             "objectives" => "test the software",
-             "created_at" => current_time,
-             "updated_at" => current_time
-          },
-           "candidates_registrations_subject_preference" => {
-             "degree_stage" => "I don't have a degree and am not studying for one",
-             "degree_stage_explaination" => "",
-             "degree_subject" => "Not applicable",
-             "teaching_stage" => "I'm thinking about teaching and want to find out more",
-             "subject_first_choice" => "Architecture",
-             "subject_second_choice" => "Mathematics",
-             "urn" => 11048,
-             "created_at" => current_time,
-             "updated_at" => current_time
-          }
+        "candidates_registrations_contact_information" => {
+          "full_name" => 'Testy McTest',
+          "email" => 'test@example.com',
+          "building" => "Test building",
+          "street" => "Test street",
+          "town_or_city" => "Test town",
+          "county" => "Testshire",
+          "postcode" => "TE57 1NG",
+          "phone" => "01234567890",
+          "created_at" => current_time,
+          "updated_at" => current_time
+        },
+        "candidates_registrations_background_check" => {
+          "has_dbs_check" => true,
+          "created_at" => current_time,
+          "updated_at" => current_time
+        },
+         "candidates_registrations_placement_preference" => {
+           "availability" => "Every third Tuesday",
+           "objectives" => "test the software",
+           "created_at" => current_time,
+           "updated_at" => current_time
+        },
+         "candidates_registrations_subject_preference" => {
+           "degree_stage" => "I don't have a degree and am not studying for one",
+           "degree_stage_explaination" => "",
+           "degree_subject" => "Not applicable",
+           "teaching_stage" => "I'm thinking about teaching and want to find out more",
+           "subject_first_choice" => "Architecture",
+           "subject_second_choice" => "Mathematics",
+           "urn" => 11048,
+           "created_at" => current_time,
+           "updated_at" => current_time
         }
     end
   end

--- a/spec/models/candidates/registrations/placement_request_spec.rb
+++ b/spec/models/candidates/registrations/placement_request_spec.rb
@@ -20,12 +20,10 @@ describe Candidates::Registrations::PlacementRequest, type: :model do
     context 'invalid session' do
       let :invalid_session do
         Candidates::Registrations::RegistrationSession.new \
-          "registration" => {
-            "candidates_registrations_background_check" => {},
-            "candidates_registrations_contact_information" => {},
-            "candidates_registrations_placement_preference" => {},
-            "candidates_registrations_subject_preference" => {}
-          }
+          "candidates_registrations_background_check" => {},
+          "candidates_registrations_contact_information" => {},
+          "candidates_registrations_placement_preference" => {},
+          "candidates_registrations_subject_preference" => {}
       end
 
       it 'raises a validation error' do

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -20,24 +20,24 @@ describe Candidates::Registrations::RegistrationSession do
       end
 
       it 'adds the registration key to the session' do
-        expect(session['registration']).to eq({})
+        expect(session).to eq({})
       end
     end
 
     context 'when registration key is set' do
       let :session do
-        { 'registration' => { 'some' => 'information' } }
+        { 'some' => 'information' }
       end
 
       it "doesn't over write the registration key" do
-        expect(session['registration']).to eq 'some' => 'information'
+        expect(session).to eq 'some' => 'information'
       end
     end
   end
 
   context '#save' do
     let :session do
-      { 'registration' => { 'some' => 'information' } }
+      { 'some' => 'information' }
     end
 
     let :model do
@@ -50,7 +50,7 @@ describe Candidates::Registrations::RegistrationSession do
 
     it 'stores the models attributes under the correct key' do
       expect(
-        session['registration']['candidates_registrations_background_check']
+        session['candidates_registrations_background_check']
       ).to eq \
         'has_dbs_check' => true,
         'created_at' => date,
@@ -58,17 +58,15 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     it 'doesnt over write other keys' do
-      expect(session['registration']['some']).to eq 'information'
+      expect(session['some']).to eq 'information'
     end
   end
 
   context '#fetch' do
     let :session do
       {
-        'registration' => {
-          'candidates_registrations_background_check' => {
-            'has_dbs_check' => true
-          }
+        'candidates_registrations_background_check' => {
+          'has_dbs_check' => true
         }
       }
     end

--- a/spec/services/candidates/registrations/school_session_spec.rb
+++ b/spec/services/candidates/registrations/school_session_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::SchoolSession do
+  let :school_urn_1 do
+    100001
+  end
+
+  let :school_urn_2 do
+    100002
+  end
+
+  let :contact_information_1 do
+    FactoryBot.build :contact_information
+  end
+
+  let :contact_information_2 do
+    FactoryBot.build :contact_information, full_name: 'Someone Else'
+  end
+
+  let :session do
+    {}
+  end
+
+  context '#current_registration' do
+    context '1 school' do
+      subject do
+        described_class.new school_urn_1, session
+      end
+
+      before do
+        subject.current_registration.save contact_information_1
+      end
+
+      it 'returns the current_registration' do
+        expect(subject.current_registration.contact_information).to eq \
+          contact_information_1
+      end
+
+      it 'stores the registration in the session' do
+        expect(session).to eq "schools/#{school_urn_1}/registrations" => {
+          contact_information_1.model_name.param_key => contact_information_1.attributes
+        }
+      end
+    end
+
+    context 'multiple schools' do
+      let :school_session_1 do
+        described_class.new school_urn_1, session
+      end
+
+      let :school_session_2 do
+        described_class.new school_urn_2, session
+      end
+
+      before do
+        school_session_1.current_registration.save contact_information_1
+        school_session_2.current_registration.save contact_information_2
+      end
+
+      it 'returns the correct current_registration for each school session' do
+        expect(school_session_1.current_registration.contact_information).to eq \
+          contact_information_1
+
+        expect(school_session_2.current_registration.contact_information).to eq \
+          contact_information_2
+      end
+
+      it 'stores the registratiosn for each school seperatley' do
+        expect(session).to eq \
+          "schools/#{school_urn_1}/registrations" => {
+            contact_information_1.model_name.param_key => contact_information_1.attributes
+          },
+          "schools/#{school_urn_2}/registrations" => {
+            contact_information_2.model_name.param_key => contact_information_2.attributes
+          }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously if a user performed two simulations registrations for
different schools in separate windows the first registration session
would be overwritten by the second. This commit fixes that issue by
scoping the session by school urn.
School session is not needed for registration store as the store
generates a uuid for each registration session.

### Context
We want to support a candidate registering for two (or more) schools without the details for the first school being overwritten by the later.

### Changes proposed in this pull request
Scopes the registration session by school urn

### Guidance to review
Manual testing steps if desired:
Open two browser windows and complete the registration for two different schools. Once on the application preview screen reload the page in both windows, the details should remain correct (on master the details in the first window would be overwritten by the details in the second)
