### PR TITLE
Feature/add pending step definitions for search features

### DIFF
--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -1,0 +1,28 @@
+module Candidates::ResultsHelper
+  # This helper is a replacement for (and is heavily influenced by)
+  # page_entries_info as provided by Kaminari. However, Instead of attempting
+  # to build a subquery itself (which fails due to our reliance on calculated
+  # columns) it uses the `#total_count` method provided by the supplied
+  # Bookings::SchoolSearch object
+  def school_results_info(school_search)
+    entry_name = school_search.total_count > 1 ? "results" : "result"
+
+    if school_search.results.total_pages < 2
+      t(
+        'helpers.page_entries_info.one_page.display_entries',
+        entry_name: entry_name,
+        count: school_search.total_count
+      )
+    else
+      t(
+        'helpers.page_entries_info.more_pages.display_entries',
+        entry_name: entry_name,
+        first: school_search.results.offset_value + 1,
+        last: [
+          school_search.results.offset_value + school_search.results.limit_value,
+          school_search.total_count
+        ].min,
+        total: school_search.total_count)
+    end.html_safe
+  end
+end

--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -22,7 +22,8 @@ module Candidates::ResultsHelper
           school_search.results.offset_value + school_search.results.limit_value,
           school_search.total_count
         ].min,
-        total: school_search.total_count)
+        total: school_search.total_count
+      )
     end.html_safe
   end
 end

--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -3,7 +3,7 @@ module Candidates::ResultsHelper
   # page_entries_info as provided by Kaminari. However, Instead of attempting
   # to build a subquery itself (which fails due to our reliance on calculated
   # columns) it uses the `#total_count` method provided by the supplied
-  # Bookings::SchoolSearch object
+  # Candidates:::SchoolSearch object
   def school_results_info(school_search)
     entry_name = "result".pluralize(school_search.total_count)
 

--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -5,7 +5,7 @@ module Candidates::ResultsHelper
   # columns) it uses the `#total_count` method provided by the supplied
   # Bookings::SchoolSearch object
   def school_results_info(school_search)
-    entry_name = school_search.total_count > 1 ? "results" : "result"
+    entry_name = "result".pluralize(school_search.total_count)
 
     if school_search.results.total_pages < 2
       t(

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -69,6 +69,10 @@ module Candidates
       school_search.results
     end
 
+    def total_count
+      school_search.total_count
+    end
+
     def valid_search?
       query.present? ||
         (location.present? && distance.present?) ||

--- a/app/models/concerns/geographic_search.rb
+++ b/app/models/concerns/geographic_search.rb
@@ -16,21 +16,27 @@ module GeographicSearch
     # @param [String] column The name of the geographic column, defaults
     #   to 'coordinates'
     # @return [School::ActiveRecord_Relation] All matching records
-    scope :close_to, ->(point, radius: 10, column: 'coordinates') do
+    scope :close_to, ->(point, radius: 10, column: 'coordinates', include_distance: true) do
       if point.present?
-        select(
-          [
-            arel_table[Arel.star],
-            "st_distance(%<source>s, '%<destination>s', false) as distance" % {
-              source: column,
-              destination: point
-            }
-          ]
-        ).where("st_dwithin(%<column>s, '%<coordinates>s', %<radius>d)" % {
+        query = where("st_dwithin(%<column>s, '%<coordinates>s', %<radius>d)" % {
           column: column,
           coordinates: point,
           radius: Conversions::Distance::Miles::ToMetres.convert(radius)
         })
+
+        if include_distance
+          return query.select(
+            [
+              arel_table[Arel.star],
+              "st_distance(%<source>s, '%<destination>s', false) as distance" % {
+                source: column,
+                destination: point
+              }
+            ]
+          )
+        end
+
+        query
       else
         all
       end

--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -54,7 +54,7 @@ private
   end
 
   def parse_location(location)
-    if location.is_a?(Hash) || location.is_a?(OpenStruct)
+    if location.is_a?(Hash)
       extract_coords(location) || raise(InvalidCoordinatesError)
     elsif location.present?
       geolocate(location)

--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -25,13 +25,14 @@ class Bookings::SchoolSearch
   # amend the +ActiveRecord::Relation+ if no param is provided, meaning
   # they can be safely chained
   def results
+    Rails.logger.debug("sorting by '#{order_by(@requested_order)}'")
     Bookings::School
       .close_to(@point, radius: @radius)
       .that_provide(@subjects)
       .at_phases(@phases)
       .costing_upto(@max_fee)
       .search(@query)
-      .order(order_by(@requested_order))
+      .reorder(order_by(@requested_order))
       .page(@page)
       .includes(%i{subjects phases school_type})
   end

--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -26,14 +26,11 @@ class Bookings::SchoolSearch
     base_query
       .includes(%i{subjects phases school_type})
       .reorder(order_by(@requested_order))
-      .close_to(@point, radius: @radius)
       .page(@page)
   end
 
   def total_count
-    base_query
-      .close_to(@point, radius: @radius, include_distance: false)
-      .count
+    base_query(include_distance: false).count
   end
 
   class InvalidCoordinatesError < ArgumentError
@@ -47,8 +44,9 @@ private
   # Note, all of the scopes provided by +Bookings::School+ will not
   # amend the +ActiveRecord::Relation+ if no param is provided, meaning
   # they can be safely chained
-  def base_query
+  def base_query(include_distance: true)
     Bookings::School
+      .close_to(@point, radius: @radius, include_distance: include_distance)
       .that_provide(@subjects)
       .at_phases(@phases)
       .costing_upto(@max_fee)

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -30,7 +30,7 @@
 
         <div class="pagination-info higher">
           <div class="pagination-slice">
-            <%= page_entries_info @search.results, entry_name: 'result' %>
+            <%= school_results_info @search %>
           </div>
 
           <%= paginate @search.results %>

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -59,7 +59,7 @@
 
         <ul id="results">
             <% @search.results.each_with_index do |result, index| %>
-            <li class="school-result">
+            <li class="school-result" data-school-urn="<%= result.urn %>">
                 <strong class="name"><%= link_to result.name, candidates_school_path(result) %></strong>
                 <ul>
                     <li><strong>Address:</strong> <%= format_school_address result %></li>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ variables:
   SECRET_KEY_BASE: stubbed
   REDIS_IMAGE: redis:5-alpine
   REDIS_URL: redis://redis:6379/1
+  CUCUMBER_PROFILE: continuous_integration
 
 steps:
   - script: docker login $(dockerRegistry) -u $(dockerId) -p $pswd
@@ -35,7 +36,7 @@ steps:
     displayName: Create Testing databases, import schema and fixtures
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rspec
     displayName: Run the Specs
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true $(dockerRegistry)/$(imageName):$(imageTag) cucumber
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true $(dockerRegistry)/$(imageName):$(imageTag) cucumber --profile=$(CUCUMBER_PROFILE)
     displayName: Run the Cucumber features
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) brakeman --no-pager
     displayName: Run the Brakeman security scan

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -7,3 +7,4 @@ std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'pretty'} --tags 'not @wip'"
 default: <%= std_opts %> features
 wip: --tags @wip:3 --wip features
 rerun: <%= rerun_opts %> --format rerun --out rerun.txt --strict --tags 'not @wip'
+continuous_integration: <%= std_opts %> --tags 'not (@wip or @javascript)' features

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -13,3 +13,9 @@ Geocoder.configure(
 
   units: :miles
 )
+
+# hardcode geocoder to return a specific single result when we're in the servertest
+# environment
+if Rails.env.eql?('servertest')
+  require Rails.root.join("lib", "servertest", "geocoder")
+end

--- a/features/candidates/registrations/request_school_experience_placement.feature
+++ b/features/candidates/registrations/request_school_experience_placement.feature
@@ -15,14 +15,16 @@ Feature: Request a school experience placement
             | End date                                    | date          |         |
             | What do you want to get out of a placement? | textarea      |         |
 
+    @javascript
     Scenario: Word counting in placement objectives
         Given I am on the 'Request school experience placement' page for my school of choice
-        Then the 'placement objectives' word count should say 'You have 50 words remaining'
+        Then the 'What do you want to get out of a placement?' word count should say 'You have 150 words remaining'
 
+    @javascript
     Scenario: Updating the word count
         Given I am on the 'Request school experience placement' page for my school of choice
         When I enter 'The quick brown fox' into the 'What do you want to get out of a placement?' text area
-        Then the 'placement objectives' word count should say 'You have 46 words remaining'
+        Then the 'What do you want to get out of a placement?' word count should say 'You have 146 words remaining'
 
     Scenario: Submitting my data
         Given I am on the 'Request school experience placement' page for my school of choice

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -10,10 +10,10 @@ Feature: Schools search page sorting
             | Rochdale School   | 10  | Rochdale   |
             | Burnley School    | 20  | Burnley    |
 
-    @javascript @not_cd
+    @javascript
     Scenario: Sorting by distance
         Given I have searched for 'School' and provided 'Bury' for my location
-        When I sort the results by distance
+        When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
 
     @javascript

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -3,12 +3,21 @@ Feature: Schools search page sorting
     As a potential candidate
     I want to be able to sort results by various criteria
 
+    Background:
+        Given there there are schools with the following attributes:
+            | Name     | Fee | Location   |
+            | School 1 | 30  | Manchester |
+            | School 2 | 10  | Rochdale   |
+            | School 3 | 20  | Burnley    |
+
+    @javascript
     Scenario: Sorting by distance
         Given I have searched for 'Manchester' and provided my location
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
 
+    @javascript
     Scenario: Sorting by fee
-        Given I have searched for 'Manchester' and am on the results page
+        Given I have searched for 'School' and am on the results page
         When I select 'Fee' in the 'Sorted by' select box
         Then the results should be sorted by fee, lowest to highest

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -5,15 +5,15 @@ Feature: Schools search page sorting
 
     Background:
         Given there there are schools with the following attributes:
-            | Name     | Fee | Location   |
-            | School 1 | 30  | Manchester |
-            | School 2 | 10  | Rochdale   |
-            | School 3 | 20  | Burnley    |
+            | Name              | Fee | Location   |
+            | Manchester School | 30  | Manchester |
+            | Rochdale School   | 10  | Rochdale   |
+            | Burnley School    | 20  | Burnley    |
 
-    @javascript
+    @javascript @not_cd
     Scenario: Sorting by distance
-        Given I have searched for 'Manchester' and provided my location
-        When I select 'Distance' in the 'Sorted by' select box
+        Given I have searched for 'School' and provided 'Bury' for my location
+        When I sort the results by distance
         Then the results should be sorted by distance, nearest to furthest
 
     @javascript

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -1,5 +1,7 @@
-Then("the {string} word count should say {string}") do |string, string2|
-  pending "awaiting patch to form builder enabling counts"
+Then("the {string} word count should say {string}") do |label_text, expectation|
+  within(page.find("label", text: label_text).ancestor('div.govuk-form-group')) do
+    expect(page).to have_css("span.govuk-character-count__message", text: expectation)
+  end
 end
 
 When("I enter {string} into the {string} text area") do |value, label|

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -35,15 +35,6 @@ Given("I have searched for {string} and am on the results page") do |string|
   expect(path_with_query).to eql(path)
 end
 
-Given("I have searched for {string} and provided my location") do |string|
-  pending "candidate providing location not implemented just yet"
-  path = candidates_schools_path(query: string)
-  visit(path)
-  path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
-  expect(path_with_query).to eql(path)
-end
-
-
 Given("there are {int} results") do |quantity|
   expect(page).to have_css('ul > li.school-result', count: quantity)
 end

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -86,7 +86,6 @@ Given("there are some subjects") do
 end
 
 Then("it should have checkboxes for all subjects") do
-  pending "these are currently hardcoded"
   within('#search-filter') do
     @subjects.each do |subject|
       expect(page).to have_field(subject.name, type: 'checkbox')
@@ -97,19 +96,4 @@ end
 When("I select {string} in the {string} select box") do |option, label_text|
   label = page.find('label', text: label_text)
   select(option, from: label[:for])
-end
-
-Then("the results should be sorted by distance, nearest to furthest") do
-  pending "sorting not yet implemented"
-  # should be ol, results will always be ordered by something?
-  # below is pseudocode
-  within('ul#results') do
-    actual = page.all('li.school-result .name').map(&:text).map(&:name)
-    expected = Bookings::School.close_to(@point, radius: 20).reorder('distance asc')
-    expect(expected).to eql(actual)
-  end
-end
-
-Then("the results should be sorted by fee, lowest to highest") do
-  pending "sorting not yet implemented"
 end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -1,0 +1,39 @@
+Given("there there are schools with the following attributes:") do |table|
+  def locate(place)
+    {
+      "Manchester" => Bookings::School::GEOFACTORY.point(-2.241, 53.481),
+      "Rochdale" => Bookings::School::GEOFACTORY.point(-2.150, 53.615),
+      "Burnley" => Bookings::School::GEOFACTORY.point(-2.243, 53.788)
+    }[place]
+  end
+
+  @schools = table.hashes.each.with_object([]) do |attributes, schools|
+    schools << FactoryBot.create(
+      :bookings_school,
+      name: attributes["Name"],
+      fee: attributes["Fee"].to_i,
+      coordinates: locate(attributes["Location"])
+    )
+  end
+
+  expect(Bookings::School.count).to eql(table.rows.length)
+end
+
+Then("the results should be sorted by distance, nearest to furthest") do
+  pending "sorting not yet implemented"
+  # should be ol, results will always be ordered by something?
+  # below is pseudocode
+  within('ul#results') do
+    actual = page.all('li.school-result .name').map(&:text).map(&:name)
+    expected = Bookings::School.close_to(@point, radius: 20).reorder('distance asc')
+    expect(expected).to eql(actual)
+  end
+end
+
+Then("the results should be sorted by fee, lowest to highest") do
+  expect(
+    page
+      .all('#search-results > ul > li')
+      .map{ |ele| ele['data-school-urn'].to_i }
+  ).to eql(@schools.sort_by(&:fee).map(&:urn))
+end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -30,7 +30,7 @@ Then("the results should be sorted by fee, lowest to highest") do
 end
 
 Given("I have searched for {string} and provided {string} for my location") do |query, location|
-  path = candidates_schools_path(query: query, location: location, radius: 50)
+  path = candidates_schools_path(query: query, location: location, distance: 25)
   visit(path)
 
   path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
@@ -50,18 +50,4 @@ Then("the results should be sorted by distance, nearest to furthest") do
       .all('#search-results > ul > li')
       .map{ |ele| ele['data-school-urn'].to_i }
   ).to eql(urns_in_distance_order)
-end
-
-When("I sort the results by distance") do
-  RSpec::Mocks.with_temporary_scope do
-
-    bury_coordinates = [
-      OpenStruct.new(data: { "lat" => "53.596", "lon" => "-2.29" })
-    ]
-
-    allow(Geocoder).to receive(:search).and_return(bury_coordinates)
-
-    label = page.find('label', text: 'Sorted by')
-    select('Distance', from: label[:for])
-  end
 end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -1,5 +1,3 @@
-require 'cucumber/rspec/doubles'
-
 Given("there there are schools with the following attributes:") do |table|
   def locate(place)
     {

--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -1,0 +1,5 @@
+exceptions = {except: %w{schema_migrations spatial_ref_sys}}
+
+DatabaseCleaner.clean_with(:truncation, exceptions)
+DatabaseCleaner.strategy = :truncation, exceptions
+Cucumber::Rails::Database.javascript_strategy = :truncation, exceptions

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -29,18 +29,6 @@ require 'selenium/webdriver'
 #
 ActionController::Base.allow_rescue = false
 
-# Remove/comment out the lines below if your app doesn't have a database.
-# For some databases (like MongoDB and CouchDB) you may need to use :truncation instead.
-begin
-  DatabaseCleaner.strategy = :transaction
-rescue NameError
-  raise "You need to add database_cleaner to your Gemfile (in the :test group) if you wish to use it."
-end
-
-if ENV['CUC_DB_CLEANER'] == 'false'
-  Cucumber::Rails::Database.autorun_database_cleaner = false
-end
-
 # You may also want to configure DatabaseCleaner to use different strategies for certain features and scenarios.
 # See the DatabaseCleaner documentation for details. Example:
 #
@@ -59,9 +47,6 @@ end
 # Possible values are :truncation and :transaction
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
-
-DatabaseCleaner.strategy = :truncation
-Cucumber::Rails::Database.javascript_strategy = :truncation
 
 # Browser configuration
 

--- a/features/support/geocoder.rb
+++ b/features/support/geocoder.rb
@@ -1,0 +1,5 @@
+module Geocoder
+  def self.search(*args)
+    [ OpenStruct.new(data: { "lat" => "53.596", "lon" => "-2.29" }) ]
+  end
+end

--- a/features/support/geocoder.rb
+++ b/features/support/geocoder.rb
@@ -1,6 +1,1 @@
-module Geocoder
-  def self.search(*args)
-    # A point in Bury, Greater Manchester
-    [ OpenStruct.new(data: { "lat" => "53.596", "lon" => "-2.29" }) ]
-  end
-end
+require Rails.root.join("lib", "servertest", "geocoder")

--- a/features/support/geocoder.rb
+++ b/features/support/geocoder.rb
@@ -1,5 +1,6 @@
 module Geocoder
   def self.search(*args)
+    # A point in Bury, Greater Manchester
     [ OpenStruct.new(data: { "lat" => "53.596", "lon" => "-2.29" }) ]
   end
 end

--- a/lib/servertest/geocoder.rb
+++ b/lib/servertest/geocoder.rb
@@ -1,0 +1,6 @@
+module Geocoder
+  def self.search(*_args)
+    # A point in Bury, Greater Manchester
+    [OpenStruct.new(data: { "lat" => "53.596", "lon" => "-2.29" })]
+  end
+end

--- a/spec/helpers/candidates/results_helper_spec.rb
+++ b/spec/helpers/candidates/results_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Candidates::ResultsHelper, type: :helper do
+  let(:search) { Candidates::SchoolSearch.new(query: 'School') }
+
+  subject { school_results_info(search) }
+
+  describe '#school_results_info' do
+    context 'When there are no results' do
+      specify { expect(subject).to eql('No results found') }
+    end
+
+    context 'When there fewer than one page of results' do
+      let!(:schools) { create_list(:bookings_school, 5) }
+      specify { expect(subject).to eql('Displaying all 5 results') }
+    end
+
+    context 'When there are more than one page of results' do
+      let!(:schools) { create_list(:bookings_school, 18) }
+      specify { expect(subject).to eql("Showing 1&ndash;15 of 18 results") }
+    end
+  end
+end

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -141,6 +141,14 @@ RSpec.describe Candidates::SchoolSearch do
     end
   end
 
+  context '.total_count' do
+    subject { described_class.new(query: 'Test School') }
+
+    it 'returns array of Schools' do
+      expect(subject.total_count).to be_kind_of Integer
+    end
+  end
+
   context '.valid_search?' do
     context 'with query' do
       subject { described_class.new(query: 'Test School') }

--- a/spec/models/concerns/geographic_search_spec.rb
+++ b/spec/models/concerns/geographic_search_spec.rb
@@ -47,6 +47,24 @@ describe 'Concerns' do
           expect(subject.close_to(mcr_centre, radius: 1.2)).not_to include(leeds_station)
         end
       end
+
+      context 'include_distance: true' do
+        specify 'should return records with a included distance attribute' do
+          expect(subject.close_to(mcr_centre, radius: 50)).to all(respond_to(:distance))
+        end
+
+        specify 'all distances should be floating point numbers' do
+          expect(subject.close_to(mcr_centre, radius: 50).map(&:distance)).to all(be_a(Float))
+        end
+      end
+
+      context 'include_distance: false' do
+        specify 'should return records without an included distance attribute' do
+          subject.close_to(mcr_centre, radius: 50, include_distance: false).each do |result|
+            expect(result).not_to respond_to(:distance)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/services/bookings/school_search_spec.rb
+++ b/spec/services/bookings/school_search_spec.rb
@@ -334,7 +334,7 @@ describe Bookings::SchoolSearch do
         end
 
         specify 'schools should be ordered alphabetically by name' do
-          expect(subject.map(&:name)).to eql([cardiff, bath].map(&:name))
+          expect(subject.map(&:name)).to eql([bath, cardiff].map(&:name))
         end
       end
 

--- a/spec/services/bookings/school_search_spec.rb
+++ b/spec/services/bookings/school_search_spec.rb
@@ -353,4 +353,18 @@ describe Bookings::SchoolSearch do
       end
     end
   end
+
+  describe '#total_count' do
+    let!(:matching_schools) do
+      create_list(:bookings_school, 8)
+    end
+
+    let!(:non_matching_school) do
+      create(:bookings_school, name: "Non-matching establishment")
+    end
+
+    specify 'total count should match the number of matching schools' do
+      expect(Bookings::SchoolSearch.new("school").total_count).to eql(matching_schools.length)
+    end
+  end
 end


### PR DESCRIPTION
### Context

This PR is intended to make all the tests green by implementing missing step definitions for Cucumber scenarios that were awaiting other functionality.

### Changes proposed in this pull request

* Split `Bookings::SchoolSearch`'s query functionality into `#results` and `#total_count` to aid the paginator and prevent it from attempting (and failing) to create a subquery to do the count separately. This failed because the `order_by` clause was attempting to order by columns which don't exist in the newly-optimised subquery.
* Allow `.close_to` scope to take additional argument `include_distance` which defaults to `true`, again to support the pagination helpers
* Split out and rewrite the `DatabaseCleaner` config. Now it should work repeatedly without clearing out the `spatial_ref_sys` and `schema_migrations` tables
* Add the step definitions for `@javascript`-tagged scenarios
* Change the `azure-pipelines.yml` to not run `@javascript` pipelines in CI by creating a new profile called `continuous_integration`
* Hard-code the `Geocoder` response when running via Cucumber

### Guidance to review

Ensure everything looks sensible and new functionality is covered by tests.
