### PR TITLE
Moves magic link uuid from params to session.

### DIFF
--- a/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
@@ -2,15 +2,12 @@ module Candidates
   module Registrations
     class ResendConfirmationEmailsController < RegistrationsController
       def create
-        uuid = params[:uuid]
+        if current_registration.pending_email_confirmation?
+          SendEmailConfirmationJob.perform_later \
+            current_registration.uuid,
+            request.host
 
-        if RegistrationStore.instance.has_registration? uuid
-          SendEmailConfirmationJob.perform_later uuid
-
-          redirect_to candidates_school_registrations_confirmation_email_path \
-            email: params[:email],
-            school_name: params[:school_name],
-            uuid: uuid
+          redirect_to candidates_school_registrations_confirmation_email_path
         else
           render :session_expired
         end

--- a/app/services/candidates/registrations/registration_store.rb
+++ b/app/services/candidates/registrations/registration_store.rb
@@ -13,9 +13,10 @@ module Candidates
       end
 
       def store!(registration_session)
-        uuid = SecureRandom.urlsafe_base64
-        @redis.set namespace(uuid), serialize(registration_session), ex: @ttl
-        uuid
+        @redis.set \
+          namespace(registration_session.uuid),
+          serialize(registration_session),
+          ex: @ttl
       end
 
       def retrieve!(uuid)

--- a/spec/services/candidates/registrations/registration_store_spec.rb
+++ b/spec/services/candidates/registrations/registration_store_spec.rb
@@ -28,10 +28,6 @@ describe Candidates::Registrations::RegistrationStore do
     it 'stores the key with the correct ttl' do
       expect(redis.ttl("test:registrations:sekret")).to eq 86400
     end
-
-    it 'returns the uuid' do
-      expect(returned_uuid).to eq 'sekret'
-    end
   end
 
   context '#get!' do
@@ -94,7 +90,7 @@ describe Candidates::Registrations::RegistrationStore do
 
     context 'when registration exists' do
       it 'returns true' do
-        expect(subject.has_registration?(returned_uuid)).to eq true
+        expect(subject.has_registration?(session.uuid)).to eq true
       end
     end
   end


### PR DESCRIPTION
There was an issue with redirecting to confirmation_emails#show with the
uuid in the url such that the user could skip straight to
placement_requests/new?uuid=<uuid> without having to click the link in
the email. This PR fixes the issue by storing the uuid in the session
when redirecting to confirmation_emails#show.

The instances of RegistrationSession are now responsible for generating
a uuid rather than the RegistrationStore. The store now asks the session
for it's uuid.

### Context
We want to ensure candidates controller the email address confirmation emails are sent to.

### Changes proposed in this pull request
Stores 'magiclink' uuid in the session rather than in the params.
Moves responsibility for generating the uuid to the registration session

### Guidance to review
Manual review steps if desired:
Completed candidate registration up to confirm email step. Expect not to see the uuid in the url. Click resend confirmation email, expect not to see the uuid in the url. Visit the link in the confirmation email expect to be redirected to placement request show.