### PR TITLE
Only queue placement_request_job if not already queued

### DIFF
--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -5,6 +5,7 @@ module Candidates
   module Registrations
     class RegistrationSession
       PENDING_EMAIL_CONFIRMATION_STATUS = 'pending_email_confirmation'.freeze
+      COMPLETED_STATUS = 'completed'.freeze
 
       def initialize(session)
         @registration_session = session
@@ -27,6 +28,16 @@ module Candidates
 
       def pending_email_confirmation?
         @registration_session['status'] == PENDING_EMAIL_CONFIRMATION_STATUS
+      end
+
+      def flag_as_completed!
+        raise NotCompletedError unless all_steps_completed?
+
+        @registration_session['status'] = COMPLETED_STATUS
+      end
+
+      def completed?
+        @registration_session['status'] == COMPLETED_STATUS
       end
 
       # TODO add spec

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -7,24 +7,38 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
     'some-uuid'
   end
 
+  let :registration_store do
+    double Candidates::Registrations::RegistrationStore,
+      retrieve!: registration_session,
+      store!: 1
+  end
+
   before do
     allow(Candidates::Registrations::RegistrationStore).to \
       receive(:instance) { registration_store }
   end
 
   context '#create' do
-    before do
-      allow(Candidates::Registrations::PlacementRequestJob).to \
-        receive(:perform_later) { true }
-
-      get \
-        "/candidates/schools/URN/registrations/placement_request/new?uuid=#{uuid}"
-    end
-
     context 'uuid not found' do
-      let :registration_store do
-        double Candidates::Registrations::RegistrationStore, \
-          has_registration?: false
+      let :registration_session do
+        nil
+      end
+
+      before do
+        allow(Candidates::Registrations::PlacementRequestJob).to \
+          receive(:perform_later) { true }
+
+        allow(registration_store).to receive(:retrieve!) do
+          raise Candidates::Registrations::RegistrationStore::SessionNotFound
+        end
+
+        get \
+          "/candidates/schools/URN/registrations/placement_request/new?uuid=#{uuid}"
+      end
+
+      it "doesn't queue a PlacementRequestJob" do
+        expect(Candidates::Registrations::PlacementRequestJob).not_to \
+          have_received :perform_later
       end
 
       it 'renders the session expired view' do
@@ -33,30 +47,72 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
     end
 
     context 'uuid found' do
-      let :registration_store do
-        double Candidates::Registrations::RegistrationStore, \
-          has_registration?: true
+      before do
+        allow(Candidates::Registrations::PlacementRequestJob).to \
+          receive(:perform_later) { true }
+
+        get \
+          "/candidates/schools/URN/registrations/placement_request/new?uuid=#{uuid}"
       end
 
-      it 'enqueues the placement request job' do
-        expect(Candidates::Registrations::PlacementRequestJob).to \
-          have_received(:perform_later).with uuid
-      end
-
-      it 'redirects to placement request show' do
-        expect(response).to redirect_to \
-          candidates_school_registrations_placement_request_path(
-            'URN',
+      context 'registration job already enqueued' do
+        let :registration_session do
+          double Candidates::Registrations::RegistrationSession,
+            completed?: true,
             uuid: uuid
-          )
+        end
+
+        it "doesn't queue a PlacementRequestJob" do
+          expect(Candidates::Registrations::PlacementRequestJob).not_to \
+            have_received :perform_later
+        end
+
+        it 'redirects to placement request show' do
+          expect(response).to redirect_to \
+            candidates_school_registrations_placement_request_path(
+              'URN',
+              uuid: uuid
+            )
+        end
+      end
+
+      context 'registration job not already enqueued' do
+        let :registration_session do
+          double Candidates::Registrations::RegistrationSession,
+            completed?: false,
+            flag_as_completed!: true,
+            uuid: uuid
+        end
+
+        it 'marks the registration as completed' do
+          expect(registration_session).to have_received :flag_as_completed!
+        end
+
+        it 're-stores the updated registration in the registration_store' do
+          expect(registration_store).to have_received(:store!).with \
+            registration_session
+        end
+
+        it 'enqueues the placement request job' do
+          expect(Candidates::Registrations::PlacementRequestJob).to \
+            have_received(:perform_later).with uuid
+        end
+
+        it 'redirects to placement request show' do
+          expect(response).to redirect_to \
+            candidates_school_registrations_placement_request_path(
+              'URN',
+              uuid: uuid
+            )
+        end
       end
     end
   end
 
   context '#show' do
     context 'uuid not found' do
-      let :registration_store do
-        double Candidates::Registrations::RegistrationStore
+      let :registration_session do
+        nil
       end
 
       before do
@@ -76,11 +132,6 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
     context 'uuid found' do
       let :registration_session do
         FactoryBot.build :registration_session
-      end
-
-      let :registration_store do
-        double Candidates::Registrations::RegistrationStore,
-          retrieve!: registration_session
       end
 
       before do

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -151,4 +151,59 @@ describe Candidates::Registrations::RegistrationSession do
       expect(returned_model.has_dbs_check).to be true
     end
   end
+
+  context '#completed?' do
+    context 'not completed' do
+      let :session do
+        {}
+      end
+
+      it 'returns false' do
+        expect(described_class.new(session).completed?).to be false
+      end
+    end
+
+    context 'completed' do
+      let :session do
+        { 'status' => 'completed' }
+      end
+
+      it 'returns true' do
+        expect(described_class.new(session).completed?).to be true
+      end
+    end
+  end
+
+  context '#flag_as_completed!' do
+    context 'when not completed' do
+      let :registration_session do
+        described_class.new({})
+      end
+
+      it 'raises an error' do
+        expect { registration_session.flag_as_completed! }.to raise_error \
+          described_class::NotCompletedError
+      end
+
+      it "doesn't mark the session as completed" do
+        expect(registration_session).not_to be_completed
+      end
+    end
+
+    context 'when completed' do
+      include_context 'Stubbed candidates school'
+
+      let :registration_session do
+        FactoryBot.build :registration_session
+      end
+
+      before do
+        registration_session.flag_as_completed!
+      end
+
+      it 'marks the registration_session as completed' do
+        expect(registration_session).to be_completed
+      end
+    end
+  end
 end


### PR DESCRIPTION
This commit prevents additional visits to the email confirmation url
form queuing placement request jobs.

### Context
If users revisited the confirm email address link in their email we would send a second placement request email to the school, which we want to avoid.

### Changes proposed in this pull request
Marks the registration_session as completed on the first visit, only enqueues non completed jobs 

### Guidance to review
Manual review steps:
Complete candidate registration wizard, revisit the confirm email address url, expect additional placement request jobs not to be queued.
