### PR TITLE
Handles candidate skipping a step.

### DIFF
--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -1,5 +1,10 @@
 module Candidates
   class RegistrationsController < ApplicationController
+    rescue_from Registrations::RegistrationSession::StepNotFound do |error|
+      Rails.logger.warn "Step not found: #{error.inspect}"
+      redirect_to public_send error.step_path
+    end
+
   private
 
     def persist(model)

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -4,6 +4,8 @@
 module Candidates
   module Registrations
     class RegistrationSession
+      class NotCompletedError < StandardError; end
+
       PENDING_EMAIL_CONFIRMATION_STATUS = 'pending_email_confirmation'.freeze
 
       def initialize(session)
@@ -57,6 +59,8 @@ module Candidates
 
       def fetch(klass)
         klass.new @registration_session.fetch(klass.model_name.param_key)
+      rescue KeyError => e
+        raise StepNotFound, e.key
       end
 
       def to_h
@@ -74,8 +78,6 @@ module Candidates
 
     private
 
-      class NotCompletedError < StandardError; end
-
       def all_steps_completed?
         [
           background_check,
@@ -83,7 +85,7 @@ module Candidates
           placement_preference,
           subject_preference
         ].all?(&:valid?)
-      rescue KeyError
+      rescue StepNotFound
         false
       end
     end

--- a/app/services/candidates/registrations/registration_session/step_not_found.rb
+++ b/app/services/candidates/registrations/registration_session/step_not_found.rb
@@ -1,0 +1,14 @@
+module Candidates
+  module Registrations
+    class RegistrationSession
+      class StepNotFound < StandardError
+        alias_method :key, :message
+
+        def step_path
+          model_path_name = key.split('_').insert(1, 'school').join('_')
+          ['new', model_path_name, 'path'].join('_')
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/candidates/registrations/application_previews_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/application_previews_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::ApplicationPreviewsController, type: :request do
+  include_context 'Stubbed candidates school'
+
+  let! :uncompleted_registration_session do
+    Candidates::Registrations::RegistrationSession.new({})
+  end
+
+  let! :completed_registration_session do
+    FactoryBot.build :registration_session
+  end
+
+  context '#show' do
+    before do
+      allow(Candidates::Registrations::RegistrationSession).to receive :new do
+        registration_session
+      end
+
+      get '/candidates/schools/urn/registrations/application_preview'
+    end
+
+    context 'candidate skipped ahead' do
+      let :registration_session do
+        uncompleted_registration_session
+      end
+
+      it 'redirects to the first missing step' do
+        expect(response).to redirect_to \
+          '/candidates/schools/urn/registrations/contact_information/new'
+      end
+    end
+
+    context 'candidate has not skipped ahead' do
+      let :registration_session do
+        completed_registration_session
+      end
+
+      it 'renders the show template' do
+        expect(response).to render_template :show
+      end
+    end
+  end
+end

--- a/spec/services/candidates/registrations/registration_session/step_not_found_spec.rb
+++ b/spec/services/candidates/registrations/registration_session/step_not_found_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::RegistrationSession::StepNotFound do
+  context '#step_path' do
+    let :model do
+      FactoryBot.build :contact_information
+    end
+
+    subject do
+      described_class.new model.model_name.param_key
+    end
+
+    it 'returns the path to build the correct model' do
+      expect(subject.step_path).to eq \
+        'new_candidates_school_registrations_contact_information_path'
+    end
+  end
+end


### PR DESCRIPTION
RegistrationSession now reraises a custom exception when a step's key is
not found. We rescue this error and redirect to the appropriate step's
new action.

### Context
If the user directly navigates to the application preview screen url (or a later stage) without completing some of the previous steps the app will throw an error when trying to fetch the missing attributes.

### Changes proposed in this pull request
Throw a custom exception, rescue that in the controller and redirect the user to the appropriate missing step.

### Guidance to review
Skip ahead to application preview screen, expect to be redirected to any steps you have missed.

