### PR TITLE
Fix missing error border on textarea with errors

### DIFF
--- a/app/assets/stylesheets/placement-preference.scss
+++ b/app/assets/stylesheets/placement-preference.scss
@@ -10,5 +10,8 @@
         @include govuk-responsive-margin(3, "top");
       }
     }
+    textarea.govuk-input--error {
+      @extend .govuk-textarea--error;
+    }
   }
 }


### PR DESCRIPTION
The form builder adds .govuk-input--error rather than
.govuk-textarea--error to textareas with error. However the javascript
that provides the maxwords behaviour removes .govuk-textarea--error from
textareas on page load (it adds this class when the word count is too
high and removes it once the word count is low enough). The textarea's
normal border overrules .govuk-input--error border (stylesheet is
arranged alphabetically) so we need to add this styling with heigher
specificity.

### Context

### Changes proposed in this pull request

### Guidance to review
Manual testing steps: Start candidate wizard, don't enter anything in one or both of the textareas, submit the form, textareas should have a red error border.

