### PR TITLE
Se 488/se 297 candidate registration validation messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem 'dotenv-rails'
 gem "font-awesome-rails"
 gem 'kaminari'
 
+gem 'phonelib'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
     pg_search (2.1.4)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
+    phonelib (0.6.29)
     powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -384,6 +385,7 @@ DEPENDENCIES
   notifications-ruby-client
   pg (>= 0.18, < 2.0)
   pg_search
+  phonelib
   pry-byebug
   pry-rails
   puma (~> 3.11)

--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -18,6 +18,7 @@ module Candidates
       validates :county, presence: true
       validates :postcode, presence: true
       validates :phone, presence: true
+      validates :phone, phone: true, if: :phone
     end
   end
 end

--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -13,9 +13,6 @@ module Candidates
       validates :full_name, presence: true
       validates :email, presence: true
       validates :building, presence: true
-      validates :street, presence: true
-      validates :town_or_city, presence: true
-      validates :county, presence: true
       validates :postcode, presence: true
       validates :phone, presence: true
       validates :phone, phone: true, if: :phone

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -1,7 +1,9 @@
 <div class="govuk-grid-row" id="application-preview">
+  <%= form_for @privacy_policy, url: candidates_school_registrations_confirmation_email_path do |f| %>
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Check your answers before requesting your placement</h1>
     <p>A copy of the following details will be emailed to you once you've sent your placement request.</p>
+    <%= GovukElementsErrorsHelper.error_summary @privacy_policy, 'There is a problem', '' %>
     <dl class="govuk-summary-list">
 
       <h2 class="govuk-heading-m">Personal details</h2>
@@ -76,11 +78,10 @@
   </div>
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m">Send your placement request</h2>
-    <%= form_for @privacy_policy, url: candidates_school_registrations_confirmation_email_path do |f| %>
       <div class="govuk-form-group">
         <%= f.check_box_input :acceptance %>
       </div>
       <%= f.submit 'Accept and send', class: 'govuk-button' %>
-    <% end %>
   </div>
+  <% end %>
 </div>

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -10,20 +10,20 @@
         <%= form_for contact_information, url: candidates_school_registrations_contact_information_path do |f| %>
           <%= GovukElementsErrorsHelper.error_summary contact_information, 'There is a problem', '' %>
 
-          <%= f.text_field :full_name %>
-          <%= f.telephone_field :phone %>
-          <%= f.email_field :email %>
+          <%= f.text_field :full_name, autocomplete: 'on' %>
+          <%= f.telephone_field :phone, autocomplete: 'on' %>
+          <%= f.email_field :email, autocomplete: 'on' %>
 
           <h2 class="govuk-heading-m">Address</h2>
-          <%= f.text_field :building %>
+          <%= f.text_field :building, autocomplete: 'on' %>
           <% if f.object.errors[:street].any? %>
-            <%= f.text_field :street %>
+            <%= f.text_field :street, autocomplete: 'on' %>
           <% else %>
-            <%= f.text_field :street, label_options: { class: 'govuk-visually-hidden' } %>
+            <%= f.text_field :street, autocomplete: 'on', label_options: { class: 'govuk-visually-hidden' } %>
           <% end %>
-          <%= f.text_field :town_or_city, class: 'govuk-!-width-two-thirds' %>
-          <%= f.text_field :county, class: 'govuk-!-width-two-thirds' %>
-          <%= f.text_field :postcode, class: 'govuk-input govuk-input--width-10' %>
+          <%= f.text_field :town_or_city, autocomplete: 'on', class: 'govuk-!-width-two-thirds' %>
+          <%= f.text_field :county, autocomplete: 'on', class: 'govuk-!-width-two-thirds' %>
+          <%= f.text_field :postcode, autocomplete: 'on', class: 'govuk-input govuk-input--width-10' %>
 
           <%= f.submit 'Continue' %>
         <% end %>

--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,0 +1,1 @@
+Phonelib.default_country = 'GB'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,7 @@ en:
             full_name:
               blank: "Enter your full name"
             phone:
-              blank: "Enter a telephone number"
+              invalid: "Enter a valid telephone number"
             postcode:
               blank: "Enter a postcode"
             street:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,11 @@ en:
         candidates/registrations/placement_preference:
           <<: *placement_preference_errors
 
+        candidates/registrations/privacy_policy:
+          attributes:
+            acceptance:
+              accepted: "You need to confirm your details are correct and accept our privacy policy to continue"
+
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,25 +6,27 @@ en:
     attributes:
       availability:
         blank: "Enter your availability"
-        use_fewer_words: "Please use 150 words or fewer"
+        use_fewer_words: "Use 150 words or fewer"
       objectives:
         blank: "Enter what you want to get out of a placement"
-        use_fewer_words: "Please use 150 words or fewer"
+        use_fewer_words: "Use 150 words or fewer"
 
   subject_preference_errors: &subject_preference_errors
     attributes:
       degree_stage:
-        blank: "Select a stage"
+        blank: "Select a degree stage"
       degree_stage_explaination:
         blank: "Enter an explaination"
       degree_subject:
         blank: "Select a subject"
+        inclusion: "Select 'Not applicable' if you don't have a degree or are not studying for one"
+        exclusion: "Select a subject if you have a degree or are studying for one"
       subject_first_choice:
         blank: "Select a subject"
       subject_second_choice:
         blank: "Select a subject"
       teaching_stage:
-        blank: "Select a stage"
+        blank: "Select a teaching stage"
 
   activemodel:
     errors:
@@ -40,21 +42,22 @@ en:
         candidates/registrations/contact_information:
           attributes:
             building:
-              blank: "Enter a building"
+              blank: "Enter your building"
             county:
-              blank: "Enter a county"
+              blank: "Enter your county"
             email:
-              blank: "Enter an email address"
+              blank: "Enter your email address"
             full_name:
               blank: "Enter your full name"
             phone:
+              blank: "Enter your telephone number"
               invalid: "Enter a valid telephone number"
             postcode:
-              blank: "Enter a postcode"
+              blank: "Enter your postcode"
             street:
-              blank: "Enter a street"
+              blank: "Enter your street"
             town_or_city:
-              blank: "Enter a town or city"
+              blank: "Enter your town or city"
 
         candidates/registrations/placement_preference:
           <<: *placement_preference_errors

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -139,7 +139,7 @@ feature 'Candidate Registrations', type: :feature do
 
     # Submit email confirmation form with errors
     click_button 'Accept and send'
-    expect(page).to have_text 'must be accepted'
+    expect(page).to have_text 'You need to confirm your details are correct and accept our privacy policy to continue'
     expect(page).not_to have_text \
       "Click the confirmation link in the email we’ve sent to the following email address to confirm your request for a placement at Test School:\ntest@example.com"
 

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -23,7 +23,7 @@ describe Candidates::Registrations::ContactInformation, type: :model do
 
     context 'phone is present' do
       VALID_NUMBERS = ['01434 634996', '+441434634996', '01234567890'].freeze
-      INVALID_NUMBERS = ['7', 'q', '+4414346349'].freeze
+      INVALID_NUMBERS = ['7', 'q', '+4414346349', ' ', '   '].freeze
 
       context 'valid numbers' do
         VALID_NUMBERS.each do |number|
@@ -42,8 +42,8 @@ describe Candidates::Registrations::ContactInformation, type: :model do
           before { subject.validate }
 
           it "doesn't permit #{number}" do
-            expect(subject.errors[:phone]).to eq \
-              ["Enter a valid telephone number"]
+            expect(subject.errors[:phone]).to include \
+              "Enter a valid telephone number"
           end
         end
       end

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -23,5 +23,33 @@ describe Candidates::Registrations::ContactInformation, type: :model do
     it { is_expected.to validate_presence_of :county }
     it { is_expected.to validate_presence_of :postcode }
     it { is_expected.to validate_presence_of :phone }
+
+    context 'phone is present' do
+      VALID_NUMBERS = ['01434 634996', '+441434634996', '01234567890'].freeze
+      INVALID_NUMBERS = ['7', 'q', '+4414346349'].freeze
+
+      context 'valid numbers' do
+        VALID_NUMBERS.each do |number|
+          subject { described_class.new phone: number }
+          before { subject.validate }
+
+          it "permits #{number}" do
+            expect(subject.errors[:phone]).to be_empty
+          end
+        end
+      end
+
+      context 'invalid numbers' do
+        INVALID_NUMBERS.each do |number|
+          subject { described_class.new phone: number }
+          before { subject.validate }
+
+          it "doesn't permit #{number}" do
+            expect(subject.errors[:phone]).to eq \
+              ["Enter a valid telephone number"]
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -18,9 +18,6 @@ describe Candidates::Registrations::ContactInformation, type: :model do
     it { is_expected.to validate_presence_of :full_name }
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_presence_of :building }
-    it { is_expected.to validate_presence_of :street }
-    it { is_expected.to validate_presence_of :town_or_city }
-    it { is_expected.to validate_presence_of :county }
     it { is_expected.to validate_presence_of :postcode }
     it { is_expected.to validate_presence_of :phone }
 

--- a/spec/support/placement_preference_shared_examples.rb
+++ b/spec/support/placement_preference_shared_examples.rb
@@ -32,7 +32,7 @@ shared_examples 'a placement preference' do
 
       it 'adds an error to availability' do
         expect(placement_preference.errors[:availability]).to eq \
-          ["Please use 150 words or fewer"]
+          ["Use 150 words or fewer"]
       end
     end
 
@@ -55,7 +55,7 @@ shared_examples 'a placement preference' do
 
       it 'adds an error to objectives' do
         expect(placement_preference.errors[:objectives]).to eq \
-          ["Please use 150 words or fewer"]
+          ["Use 150 words or fewer"]
       end
     end
   end


### PR DESCRIPTION
### Context
Some minor fixes that needed doing. 

### Changes proposed in this pull request
Fixes up some validation messages, adds autocomplete attribute to address fields, adds a phone number validator.

### Guidance to review
Manual testing steps, if required:
Error messages should seem reasonable, invalid phone numbers should not be accepted on candidate contact information form, valid UK phone numbers should be accepted.
