### PR TITLE
Populate new form with session attributes

### DIFF
--- a/app/controllers/candidates/registrations/background_checks_controller.rb
+++ b/app/controllers/candidates/registrations/background_checks_controller.rb
@@ -2,7 +2,7 @@ module Candidates
   module Registrations
     class BackgroundChecksController < RegistrationsController
       def new
-        @background_check = BackgroundCheck.new
+        @background_check = BackgroundCheck.new attributes_from_session
       end
 
       def create
@@ -36,6 +36,10 @@ module Candidates
       def background_check_params
         params.require(:candidates_registrations_background_check).permit \
           :has_dbs_check
+      end
+
+      def attributes_from_session
+        current_registration.background_check_attributes.except 'created_at'
       end
     end
   end

--- a/app/controllers/candidates/registrations/contact_informations_controller.rb
+++ b/app/controllers/candidates/registrations/contact_informations_controller.rb
@@ -2,7 +2,7 @@ module Candidates
   module Registrations
     class ContactInformationsController < RegistrationsController
       def new
-        @contact_information = ContactInformation.new
+        @contact_information = ContactInformation.new attributes_from_session
       end
 
       def create
@@ -43,6 +43,10 @@ module Candidates
           :county,
           :postcode,
           :phone
+      end
+
+      def attributes_from_session
+        current_registration.contact_information_attributes.except 'created_at'
       end
     end
   end

--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -2,7 +2,7 @@ module Candidates
   module Registrations
     class PlacementPreferencesController < RegistrationsController
       def new
-        @placement_preference = PlacementPreference.new
+        @placement_preference = PlacementPreference.new attributes_from_session
       end
 
       def create
@@ -39,6 +39,10 @@ module Candidates
         params.require(:candidates_registrations_placement_preference).permit \
           :availability,
           :objectives
+      end
+
+      def attributes_from_session
+        current_registration.placement_preference_attributes.except 'created_at'
       end
     end
   end

--- a/app/controllers/candidates/registrations/subject_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/subject_preferences_controller.rb
@@ -2,7 +2,8 @@ module Candidates
   module Registrations
     class SubjectPreferencesController < RegistrationsController
       def new
-        @subject_preference = SubjectPreference.new urn: current_urn
+        @subject_preference = SubjectPreference.new \
+          attributes_from_session.merge(urn: current_urn)
       end
 
       def create
@@ -43,6 +44,10 @@ module Candidates
           :teaching_stage,
           :subject_first_choice,
           :subject_second_choice
+      end
+
+      def attributes_from_session
+        current_registration.subject_preference_attributes.except 'created_at'
       end
     end
   end

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -55,23 +55,43 @@ module Candidates
         fetch BackgroundCheck
       end
 
+      def background_check_attributes
+        fetch_attributes BackgroundCheck
+      end
+
       # TODO add specs for these
       def contact_information
         fetch ContactInformation
+      end
+
+      def contact_information_attributes
+        fetch_attributes ContactInformation
       end
 
       def placement_preference
         fetch PlacementPreference
       end
 
+      def placement_preference_attributes
+        fetch_attributes PlacementPreference
+      end
+
       def subject_preference
         fetch SubjectPreference
+      end
+
+      def subject_preference_attributes
+        fetch_attributes SubjectPreference
       end
 
       def fetch(klass)
         klass.new @registration_session.fetch(klass.model_name.param_key)
       rescue KeyError => e
         raise StepNotFound, e.key
+      end
+
+      def fetch_attributes(klass)
+        @registration_session.fetch(klass.model_name.param_key, {})
       end
 
       def to_h

--- a/features/candidates/registrations/wizard.feature
+++ b/features/candidates/registrations/wizard.feature
@@ -1,0 +1,19 @@
+Feature: Persisting registration information on navigating away
+  So I can keep my place in the wizard
+  As a potential candidate
+  I want to be able to regain my place on a partially completed wizard
+
+  Background:
+    Given I'm applying for a school
+
+  Scenario: Returning to the wizard
+      Given I have completed the placement preference form
+      And I have completed the contact information form
+      And I have completed the subject preference form
+      And I have completed the background check form
+      And I have navigated away from the wizard
+      When I come back to the wizard
+      Then the placement preference form should populated with the details I've entered so far
+      And  the contact information form should populated with the details I've entered so far
+      And  the subject preference form should populated with the details I've entered so far
+      And  the background check form should populated with the details I've entered so far

--- a/features/step_definitions/candidates/registrations/wizard_steps.rb
+++ b/features/step_definitions/candidates/registrations/wizard_steps.rb
@@ -1,0 +1,88 @@
+Given("I'm applying for a school") do
+  @school = FactoryBot.create(:bookings_school)
+  @school.subjects.create! name: 'Physics'
+  @school.subjects.create! name: 'Mathematics'
+end
+
+Given("I have completed the placement preference form") do
+  visit path_for 'request school experience placement', school: @school
+  fill_in 'When are you available for placements?', with: 'From Epiphany to Whitsunday'
+  fill_in 'What do you want to get out of your placement?', with: 'I enjoy teaching'
+  click_button 'Continue'
+end
+
+Given("I have completed the contact information form") do
+  visit path_for 'enter your contact details', school: @school
+  fill_in 'Full name', with: 'testy mctest'
+  fill_in 'Email address', with: 'test@example.com'
+  fill_in 'Building', with: 'Test house'
+  fill_in 'Street', with: 'Test street'
+  fill_in 'Town or city', with: 'Test Town'
+  fill_in 'County', with: 'Testshire'
+  fill_in 'Postcode', with: 'TE57 1NG'
+  fill_in 'UK telephone number', with: '01234567890'
+  click_button 'Continue'
+end
+
+Given("I have completed the subject preference form") do
+  visit path_for 'candidate subjects', school: @school
+  make_inputs_opaque if opaquify_inputs?
+  choose 'Graduate or postgraduate'
+  select 'Physics', from: 'If you have or are studying for a degree, tell us about your degree subject'
+  choose 'I want to become a teacher'
+  select 'Physics', from: 'First choice'
+  select 'Mathematics', from: 'Second choice'
+  click_button 'Continue'
+end
+
+Given("I have completed the background check form") do
+  visit path_for 'background checks', school: @school
+  make_inputs_opaque if opaquify_inputs?
+  choose 'Yes'
+  click_button 'Continue'
+end
+
+Given("I have navigated away from the wizard") do
+  visit '/'
+end
+
+When("I come back to the wizard") do
+  visit path_for 'request school experience placement', school: @school
+end
+
+Then("the placement preference form should populated with the details I've entered so far") do
+  visit path_for 'request school experience placement', school: @school
+  expect(find_field('When are you available for placements?').value).to eq \
+   'From Epiphany to Whitsunday'
+  expect(find_field('What do you want to get out of your placement?').value).to eq \
+   'I enjoy teaching'
+end
+
+Then("the contact information form should populated with the details I've entered so far") do
+  visit path_for 'enter your contact details', school: @school
+  expect(find_field('Full name').value).to eq 'testy mctest'
+  expect(find_field('Email address').value).to eq 'test@example.com'
+  expect(find_field('Building').value).to eq 'Test house'
+  expect(find_field('Street').value).to eq 'Test street'
+  expect(find_field('Town or city').value).to eq 'Test Town'
+  expect(find_field('County').value).to eq 'Testshire'
+  expect(find_field('Postcode').value).to eq 'TE57 1NG'
+  expect(find_field('UK telephone number').value).to eq '01234567890'
+end
+
+Then("the subject preference form should populated with the details I've entered so far") do
+  visit path_for 'candidate subjects', school: @school
+  make_inputs_opaque if opaquify_inputs?
+  expect(find_field('Graduate or postgraduate')).to be_checked
+  expect(find_field('If you have or are studying for a degree, tell us about your degree subject').value).to eq \
+   'Physics'
+  expect(find_field('I want to become a teacher')).to be_checked
+  expect(find_field('First choice').value).to eq 'Physics'
+  expect(find_field('Second choice').value).to eq 'Mathematics'
+end
+
+Then("the background check form should populated with the details I've entered so far") do
+  visit path_for 'background checks', school: @school
+  make_inputs_opaque if opaquify_inputs?
+  expect(find_field('Yes')).to be_checked
+end

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -8,7 +8,8 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
   let :registration_session do
     double Candidates::Registrations::RegistrationSession,
       save: true,
-      background_check: existing_background_check
+      background_check: existing_background_check,
+      background_check_attributes: background_check_attributes
   end
 
   before do
@@ -21,6 +22,10 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
   context 'without existing background_check in session' do
     let :existing_background_check do
       nil
+    end
+
+    let :background_check_attributes do
+      {}
     end
 
     context '#new' do
@@ -80,6 +85,24 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
     let :existing_background_check do
       Candidates::Registrations::BackgroundCheck.new \
         has_dbs_check: true
+    end
+
+    let :background_check_attributes do
+      existing_background_check.attributes
+    end
+
+    context '#new' do
+      before do
+        get '/candidates/schools/11048/registrations/background_check/new'
+      end
+
+      it 'populates the new form with values from the session' do
+        expect(assigns(:background_check)).to eq existing_background_check
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template :new
+      end
     end
 
     context '#edit' do

--- a/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
@@ -4,7 +4,8 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
   let :registration_session do
     double Candidates::Registrations::RegistrationSession,
       contact_information: existing_contact_information,
-      save: true
+      save: true,
+      contact_information_attributes: contact_information_attributes
   end
 
   before do
@@ -14,6 +15,10 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
 
   let :contact_information do
     FactoryBot.build :contact_information
+  end
+
+  let :contact_information_attributes do
+    {}
   end
 
   context 'without existing contact information in the session' do
@@ -80,6 +85,24 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
   context 'with existing contact information in session' do
     let :existing_contact_information do
       contact_information
+    end
+
+    let :contact_information_attributes do
+      existing_contact_information.attributes
+    end
+
+    context '#new' do
+      before do
+        get '/candidates/schools/11048/registrations/contact_information/new'
+      end
+
+      it 'populates the form with the values from the session' do
+        expect(assigns(:contact_information)).to eq existing_contact_information
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template :new
+      end
     end
 
     context '#edit' do

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -12,7 +12,8 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
   let :registration_session do
     double Candidates::Registrations::RegistrationSession,
       save: true,
-      placement_preference: existing_placement_preference
+      placement_preference: existing_placement_preference,
+      placement_preference_attributes: placement_preference_attributes
   end
 
   before do
@@ -25,6 +26,10 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
   context 'without existing placement_preference in session' do
     let :existing_placement_preference do
       nil
+    end
+
+    let :placement_preference_attributes do
+      {}
     end
 
     context '#new' do
@@ -94,6 +99,25 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
     let :existing_placement_preference do
       Candidates::Registrations::PlacementPreference.new \
         objectives: 'Become a teacher'
+    end
+
+    let :placement_preference_attributes do
+      existing_placement_preference.attributes
+    end
+
+    context '#new' do
+      before do
+        get '/candidates/schools/11048/registrations/placement_preference/new'
+      end
+
+      it 'populates the new form with values from the session' do
+        expect(assigns(:placement_preference)).to eq \
+          existing_placement_preference
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template :new
+      end
     end
 
     context '#edit' do

--- a/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
@@ -8,7 +8,8 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
   let :registration_session do
     double Candidates::Registrations::RegistrationSession,
       save: true,
-      subject_preference: existing_subject_preference
+      subject_preference: existing_subject_preference,
+      subject_preference_attributes: subject_preference_attributes
   end
 
   let :subjects do
@@ -34,6 +35,10 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
   context 'without existing subject_preference in session' do
     let :existing_subject_preference do
       nil
+    end
+
+    let :subject_preference_attributes do
+      {}
     end
 
     context '#new' do
@@ -117,6 +122,24 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
         subject_first_choice: "Astronomy",
         subject_second_choice: "History",
         urn: 11048
+    end
+
+    let :subject_preference_attributes do
+      existing_subject_preference.attributes
+    end
+
+    context '#new' do
+      before do
+        get '/candidates/schools/11048/registrations/subject_preference/new'
+      end
+
+      it 'populates the new form with values from the session' do
+        expect(assigns(:subject_preference)).to eq existing_subject_preference
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template :new
+      end
     end
 
     context '#edit' do


### PR DESCRIPTION
### Context
We want to support candidates leaving the wizard part way through and picking up where they left off.

### Changes proposed in this pull request
Populate the new forms with the information from the session. 

### Guidance to review
Manual testing steps:
Complete some steps on the candidate wizard for a school. Navigate away. Navigate back to the school's show view and restart the wizard. Expect the forms to be populated with the details you've entered so far. Complete the wizard up to the check your answers screen. Edit some answers, expect submitting the edit form to still redirect you back to the check your answers screen