### PR TITLE
Upgraded GovUK Frontend to 2.8.0

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
-    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
+    <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1, viewport-fit=cover' %>
     <%= tag :meta, property: 'og:image', content: image_url('govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
     <%= favicon_link_tag 'favicon.ico' %>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,9 +2712,9 @@ globule@^1.0.0:
     minimatch "~3.0.2"
 
 govuk-frontend@^2.5:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.7.0.tgz#6a12baf514426653220dd3cdef55b1e1d97f52a6"
-  integrity sha512-IZvho72ExUAOmMOZHbE7s//HdtpSoO1aLn3fcXTnuIUi20UTsz6j+5i1Ztyqr4KUEb8OB/jNMYt4kuYyJnEMRQ==
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.8.0.tgz#e4cecf7365ca38d65ed514867d11ff3a35b1c361"
+  integrity sha512-yGjvE9HlIRUb5IxpF19h+IMIX8ATlCsyXLIY/KTvCRnHMMOd0RNlTtHyhD7YMP3k1yP+mqlyoQYcNH9XC8Qwqw==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"


### PR DESCRIPTION
### Context

There's been a new release of the GovUK Frontend.

### Changes proposed in this pull request

Upgraded to the 2.8.0 release of GovUK Frontend

Also updated the viewport meta tag to match the new recommendation

### Guidance to review

Does CI pass, do the screens look correct
