### PR TITLE
Only compile assets at beginning of test runs

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -52,7 +52,7 @@ development:
 
 test:
   <<: *default
-  compile: true
+  compile: false
 
   # Compile test packs to a separate directory
   public_output_path: packs-test

--- a/features/support/assets.rb
+++ b/features/support/assets.rb
@@ -1,0 +1,3 @@
+AfterConfiguration do
+  Webpacker.compile
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,6 +71,10 @@ RSpec.configure do |config|
     ])
   end
 
+  config.before :suite do
+    Webpacker.compile
+  end
+
   config.after :suite do
     Redis.current.keys("test:*").each { |k| Redis.current.del k }
   end


### PR DESCRIPTION
The @javascript tagged Cucumber scenarios were delayed by a couple of seconds by Webpacker compiling prior to running each one. Now the assets will be compiled once at the beginning instead.

Now we are disabling the automatic compilation in the test environment and manually performing the compile before we start both the Cucumber and RSpec suites.

The [AfterConfiguration hook](https://docs.cucumber.io/cucumber/api/#hooks) runs after support has been loaded but before any features are run. It runs only once.