### PR TITLE
Removed 'find what' option

### DIFF
--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -60,41 +60,26 @@
 }
 
 .school-search-form {
-  .school-search-form__search-field {
+  .school-search-form__location-field {
     @include govuk-grid-column(one-third, $at: desktop, $class: false) ;
   }
 
-  .school-search-form__location-field {
-    @include govuk-grid-column(two-thirds, $class: false) ;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 0;
-    padding-right: 0;
-  }
-
   .school-search-form__distance-field {
-    @include govuk-grid-column(one-third, $class: false) ;
-    margin-left: 0;
-    margin-right: 0;
-    padding-left: 0;
-    padding-right: 0;
+    @include govuk-grid-column(one-third, $at: desktop, $class: false) ;
 
     select {
       width: 100%;
     }
   }
 
-  .school-search-form__location-pair {
-    @include govuk-grid-column(one-half, $at: desktop, $class: false) ;
-  }
-
   .school-search-form__submit {
-    @include govuk-grid-column(two-twelths, $at: desktop, $class: false) ;
+    @include govuk-grid-column(one-third, $at: desktop, $class: false) ;
 
     .govuk-button {
       width: 100%;
 
       @include govuk-media-query($from: desktop) {
+        width: auto;
         margin-top: govuk-spacing(6);
       }
     }

--- a/app/assets/stylesheets/stimulus/grab-location.scss
+++ b/app/assets/stylesheets/stimulus/grab-location.scss
@@ -3,10 +3,14 @@ div[data-controller="grab-location"] {
     @extend .govuk-link ;
     float: right;
     line-height: 20px ;
+    text-decoration: none;
 
     @include govuk-media-query($from: tablet) {
       line-height: 25px;
-      margin-right: 6px;
+    }
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 

--- a/app/views/candidates/schools/_form.html.erb
+++ b/app/views/candidates/schools/_form.html.erb
@@ -1,53 +1,53 @@
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-        <div id="search-form">
-            <%= form_for @search, as: '', method: :get do |f| %>
-                <fieldset class="govuk-fieldset">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                        <h1 class="govuk-fieldset__heading">
-                            Find school experience placements
-                        </h1>
-                    </legend>
+  <div class="govuk-grid-column-full">
+    <div id="search-form">
+      <%= form_for @search, as: '', method: :get do |f| %>
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">
+              Find school experience placements
+            </h1>
+          </legend>
 
-                    <p class="govuk-hint">
-                      Search by location, postcode, school type and subject or
-                      any combination of these
-                    </p>
+          <p class="govuk-hint">
+            Search by location, postcode, school type and subject or
+            any combination of these
+          </p>
 
-                    <div class="govuk-grid-row school-search-form">
-                        <div class="school-search-form__search-field">
-                            <%= f.search_field :query, placeholder: 'For example, maths, special school' %>
-                        </div>
+          <div class="govuk-grid-row school-search-form">
+            <div class="school-search-form__search-field">
+              <%= f.search_field :query, placeholder: 'For example, maths, special school' %>
+            </div>
 
-                        <div class="school-search-form__location-pair">
-                            <div class="school-search-form__location-field"
-                                data-controller="grab-location">
+            <div class="school-search-form__location-pair">
+              <div class="school-search-form__location-field"
+                    data-controller="grab-location">
 
-                                <%= f.search_field :location,
-                                        placeholder: 'For example, Manchester, M1 3BD',
-                                        data: {
-                                            action: "focus->grab-location#clearLocationInfo",
-                                            target: "grab-location.location"
-                                        } %>
-                                <%= f.hidden_field :latitude, data: { target: 'grab-location.latitude' } %>
-                                <%= f.hidden_field :longitude, data: { target: 'grab-location.longitude' } %>
-                            </div>
+                <%= f.search_field :location,
+                      placeholder: 'For example, Manchester, M1 3BD',
+                      data: {
+                        action: "focus->grab-location#clearLocationInfo",
+                        target: "grab-location.location"
+                      } %>
+                      <%= f.hidden_field :latitude, data: { target: 'grab-location.latitude' } %>
+                      <%= f.hidden_field :longitude, data: { target: 'grab-location.longitude' } %>
+              </div>
 
-                            <div class="school-search-form__distance-field">
-                                <%= f.collection_select :distance,
-                                    Candidates::SchoolSearch.distances, :first, :last,
-                                    include_blank: 'distance' %>
-                            </div>
-                        </div>
+              <div class="school-search-form__distance-field">
+                <%= f.collection_select :distance,
+                      Candidates::SchoolSearch.distances, :first, :last,
+                      include_blank: 'distance' %>
+              </div>
+            </div>
 
-                        <div class="school-search-form__submit">
-                            <div class="govuk-form-group">
-                                <%= f.submit 'Find', name: nil %>
-                            </div>
-                        </div>
-                    </div>
-                </fieldset>
-            <% end %>
-        </div>
+            <div class="school-search-form__submit">
+              <div class="govuk-form-group">
+                <%= f.submit 'Find', name: nil %>
+              </div>
+            </div>
+          </div>
+        </fieldset>
+      <% end %>
     </div>
+  </div>
 </div>

--- a/app/views/candidates/schools/_form.html.erb
+++ b/app/views/candidates/schools/_form.html.erb
@@ -15,29 +15,23 @@
           </p>
 
           <div class="govuk-grid-row school-search-form">
-            <div class="school-search-form__search-field">
-              <%= f.search_field :query, placeholder: 'For example, maths, special school' %>
+            <div class="school-search-form__location-field"
+                  data-controller="grab-location">
+
+              <%= f.search_field :location,
+                    placeholder: 'e.g. Manchester, M1 3BD',
+                    data: {
+                      action: "focus->grab-location#clearLocationInfo",
+                      target: "grab-location.location"
+                    } %>
+              <%= f.hidden_field :latitude, data: { target: 'grab-location.latitude' } %>
+              <%= f.hidden_field :longitude, data: { target: 'grab-location.longitude' } %>
             </div>
 
-            <div class="school-search-form__location-pair">
-              <div class="school-search-form__location-field"
-                    data-controller="grab-location">
-
-                <%= f.search_field :location,
-                      placeholder: 'For example, Manchester, M1 3BD',
-                      data: {
-                        action: "focus->grab-location#clearLocationInfo",
-                        target: "grab-location.location"
-                      } %>
-                      <%= f.hidden_field :latitude, data: { target: 'grab-location.latitude' } %>
-                      <%= f.hidden_field :longitude, data: { target: 'grab-location.longitude' } %>
-              </div>
-
-              <div class="school-search-form__distance-field">
-                <%= f.collection_select :distance,
-                      Candidates::SchoolSearch.distances, :first, :last,
-                      include_blank: 'distance' %>
-              </div>
+            <div class="school-search-form__distance-field">
+              <%= f.collection_select :distance,
+                    Candidates::SchoolSearch.distances, :first, :last,
+                    include_blank: 'distance' %>
             </div>
 
             <div class="school-search-form__submit">

--- a/features/step_definitions/candidates/schools/search_steps.rb
+++ b/features/step_definitions/candidates/schools/search_steps.rb
@@ -6,7 +6,7 @@ end
 
 Then("it should have a blank search field") do
   within(@form) do
-    field = page.find_field('Find what?', type: 'search')
+    field = page.find_field('Where?', type: 'search')
     expect(field.text).to be_blank
   end
 end


### PR DESCRIPTION
### Context

It has been decided to remove the 'Find What' field from the search schools page

### Changes proposed in this pull request

Removed the Find What field, and changed the layout of the remaining fields to split into 3 equal columns

### Guidance to review

View the page in both mobile and desktop, and check the search still works
