### PR TITLE
Feature/improve cucumber opaquify with multiple drivers

### DIFF
--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -24,7 +24,7 @@ class Bookings::SchoolSearch
 
   def results
     base_query
-      .includes(%i{subjects phases school_type})
+      .includes(%i{subjects phases})
       .reorder(order_by(@requested_order))
       .page(@page)
   end

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -78,9 +78,11 @@ end
 
 Then("it should have checkboxes for all subjects") do
   within('#search-filter') do
-    @subjects.each do |subject|
-      expect(page).to have_field(subject.name, type: 'checkbox')
-    end
+    form_group = page
+      .find('.govuk-label', text: 'Placement subjects')
+      .ancestor('div.govuk-form-group')
+
+    ensure_check_boxes_exist(form_group, @subjects.map(&:name))
   end
 end
 


### PR DESCRIPTION
Even though the "it should have checkboxes for all subjects" isn't a `@javascript` scenario, when run with a `Capybara::Selenium::Driver` it fails because the GOV.UK Design System makes the inputs transparent.

The `ensure_check_boxes_exist` method automatically fixes this by 'opaquifying' them. This PR fixes at least one of the cucumber failures currently occurring on CD.