### PR TITLE
Feature/attempt to fix sorting by distance features on cd

### DIFF
--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -3,27 +3,36 @@ Feature: Schools search page sorting
     As a potential candidate
     I want to be able to sort results by various criteria
 
-    Background:
+
+    @javascript
+    Scenario: Sorting by distance
         Given there there are schools with the following attributes:
             | Name              | Fee | Location   |
             | Manchester School | 30  | Manchester |
             | Rochdale School   | 10  | Rochdale   |
             | Burnley School    | 20  | Burnley    |
-
-    @javascript
-    Scenario: Sorting by distance
-        Given I have searched for 'School' and provided 'Bury' for my location
+        And I have searched for 'School' and provided 'Bury' for my location
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
 
     @javascript
     Scenario: Sorting by fee
-        Given I have searched for 'School' and am on the results page
+        Given there there are schools with the following attributes:
+            | Name              | Fee | Location   |
+            | Manchester School | 30  | Manchester |
+            | Rochdale School   | 10  | Rochdale   |
+            | Burnley School    | 20  | Burnley    |
+        And I have searched for 'School' and am on the results page
         When I select 'Fee' in the 'Sorted by' select box
         Then the results should be sorted by fee, lowest to highest
 
     @javascript
     Scenario: Sorting by relevance
-        Given I have searched for 'School' and am on the results page
+        Given there there are schools with the following attributes:
+            | Name                       | Fee | Location    |
+            | Manton School              | 30  | Manton      |
+            | Mansfield School           | 10  | Mansfield   |
+            | Manningtree Primary School | 20  | Manningtree |
+        And I have searched for 'Man' and am on the results page
         When I select 'Relevance' in the 'Sorted by' select box
         Then the results should be sorted by relevance, highest to lowest

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -21,7 +21,7 @@ Feature: Schools search page sorting
         Given I have searched for 'School' and am on the results page
         When I select 'Fee' in the 'Sorted by' select box
         Then the results should be sorted by fee, lowest to highest
-        
+
     @javascript
     Scenario: Sorting by relevance
         Given I have searched for 'School' and am on the results page

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -87,6 +87,5 @@ Then("it should have checkboxes for all subjects") do
 end
 
 When("I select {string} in the {string} select box") do |option, label_text|
-  label = page.find('label', text: label_text)
-  select(option, from: label[:for])
+  select(option, from: label_text)
 end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -51,15 +51,15 @@ Then("the results should be sorted by distance, nearest to furthest") do
 end
 
 Then("the results should be sorted by relevance, highest to lowest") do
-  urns_in_distance_order = [
-    @schools.detect { |s| s.name == "Manchester School" },
-    @schools.detect { |s| s.name == "Rochdale School" },
-    @schools.detect { |s| s.name == "Burnley School" }
+  urns_in_relevance_order = [
+    @schools.detect { |s| s.name == "Manton School" },
+    @schools.detect { |s| s.name == "Mansfield School" },
+    @schools.detect { |s| s.name == "Manningtree Primary School" }
   ].map(&:urn)
 
   expect(
     page
       .all('#search-results > ul > li')
       .map{ |ele| ele['data-school-urn'].to_i }
-  ).to eql(urns_in_distance_order)
+  ).to eql(urns_in_relevance_order)
 end

--- a/lib/servertest/geocoder.rb
+++ b/lib/servertest/geocoder.rb
@@ -1,6 +1,6 @@
 module Geocoder
   def self.search(*_args)
     # A point in Bury, Greater Manchester
-    [Geocoder::Result::Test.new("latitude" => 53.596, "longitude" => -2.29)]
+    [Geocoder::Result::Test.new(latitude: 53.596, longitude: -2.29)]
   end
 end


### PR DESCRIPTION
### Context

Builds are failing on CD due to the sorting by distance feature. It reports `label` cannot be found.

### Changes proposed in this pull request

The important bit of this PR is the change to `result_steps.rb` (15461fe) where `select` is now used directly rather than in a two step process.

The remainder is minor refactoring/rewording and stylistic changes.

### Guidance to review

Ensure it looks sensible