### PR TITLE
Hide degree subject if no degree selected

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: 13b5465f1a848eb4baafa07894fe9e54ee201e94
+  revision: d34f0649effd1833b4d3629a58dd4eb057787cde
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)

--- a/app/javascript/controllers/subject_preference_form_controller.js
+++ b/app/javascript/controllers/subject_preference_form_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ 'degreeSubjectContainer', 'degreeSubject', 'degreeStagesContainer' ]
+
+  connect() {
+    const radioButtons = this.degreeStagesContainerTarget.querySelectorAll('input[type="radio"]')
+    const checked = Array.from(radioButtons).find(r => r.checked)
+    if (checked) { this.toggleDegreeSubjectContainer(checked) }
+  }
+
+  degreeStageSelected(e) {
+    this.toggleDegreeSubjectContainer(e.target)
+  }
+
+  toggleDegreeSubjectContainer(radioButton) {
+    const requiresSubject = JSON.parse(radioButton.dataset.requiresSubject)
+    const options = this.degreeSubjectTarget.options
+    const valueForNoDegree = this.degreeSubjectTarget.dataset.valueForNoDegree
+    const optionForNoDegree = Array.from(options).find(o => o.value == valueForNoDegree)
+
+    this.degreeSubjectContainerTarget.hidden = !requiresSubject
+    optionForNoDegree.hidden = requiresSubject
+    if ( !requiresSubject ) {
+      optionForNoDegree.selected = 'selected'
+    } else {
+      optionForNoDegree.selected = false
+    }
+  }
+}

--- a/app/services/candidates/registrations/behaviours/subject_preference.rb
+++ b/app/services/candidates/registrations/behaviours/subject_preference.rb
@@ -7,6 +7,7 @@ module Candidates
         OPTIONS_CONFIG = YAML.load_file "#{Rails.root}/config/candidate_form_options.yml"
         NOT_APPLYING_FOR_DEGREE = "I don't have a degree and am not studying for one".freeze
         DEGREE_STAGE_REQUIRING_EXPLANATION = 'Other'.freeze
+        NO_DEGREE_SUBJECT = 'Not applicable'.freeze
 
         included do
           validates :urn, presence: true
@@ -15,8 +16,8 @@ module Candidates
           validates :degree_stage_explaination, presence: true, if: :degree_stage_explaination_required?
           validates :degree_subject, presence: true
           validates :degree_subject, inclusion: { in: :available_degree_subjects }, if: -> { degree_subject.present? }
-          validates :degree_subject, inclusion: ['Not applicable'], if: -> { degree_stage.present? && !applying_for_degree? }
-          validates :degree_subject, exclusion: ['Not applicable'], if: -> { degree_stage.present? && applying_for_degree? }
+          validates :degree_subject, inclusion: [NO_DEGREE_SUBJECT], if: -> { degree_stage.present? && !degree_stage_requires_subject? }
+          validates :degree_subject, exclusion: [NO_DEGREE_SUBJECT], if: -> { degree_stage.present? && degree_stage_requires_subject? }
           validates :teaching_stage, presence: true
           validates :teaching_stage, inclusion: { in: :available_teaching_stages }, if: -> { teaching_stage.present? }
           validates :subject_first_choice, presence: true
@@ -53,10 +54,18 @@ module Candidates
           some_degree_stage == DEGREE_STAGE_REQUIRING_EXPLANATION
         end
 
+        def requires_subject_for_degree_stage?(some_degree_stage)
+          some_degree_stage != NOT_APPLYING_FOR_DEGREE
+        end
+
+        def no_degree_subject
+          NO_DEGREE_SUBJECT
+        end
+
       private
 
-        def applying_for_degree?
-          degree_stage != NOT_APPLYING_FOR_DEGREE
+        def degree_stage_requires_subject?
+          requires_subject_for_degree_stage? degree_stage
         end
 
         def degree_stage_explaination_required?

--- a/app/views/candidates/registrations/subject_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/subject_preferences/_form.html.erb
@@ -1,30 +1,42 @@
 <h1 class="govuk-heading-l">We need some more details</h1>
 <p>The following will be used to help schools offer you school experience placements.</p>
 
-<%= form_for subject_preference, url: candidates_school_registrations_subject_preference_path do |f| %>
+<%= form_for subject_preference, url: candidates_school_registrations_subject_preference_path, data: { controller: 'subject-preference-form' } do |f| %>
   <%= GovukElementsErrorsHelper.error_summary subject_preference, 'There is a problem', '' %>
 
-  <%= f.radio_button_fieldset :degree_stage do |fieldset| %>
-    <% f.object.available_degree_stages.each do |degree_stage| %>
-      <% if f.object.requires_explanation_for_degree_stage? degree_stage %>
-        <%= fieldset.radio_input degree_stage do %>
-          <%= fieldset.text_area :degree_stage_explaination %>
+  <div data-target="subject-preference-form.degreeStagesContainer">
+    <%= f.radio_button_fieldset :degree_stage do |fieldset| %>
+      <% f.object.available_degree_stages.each do |degree_stage| %>
+        <% if f.object.requires_explanation_for_degree_stage? degree_stage %>
+          <%= fieldset.radio_input degree_stage, data: {
+            action: 'click->subject-preference-form#degreeStageSelected',
+            requires_subject: f.object.requires_subject_for_degree_stage?(degree_stage)
+          } do %>
+            <%= fieldset.text_area :degree_stage_explaination %>
+          <% end %>
+        <% else %>
+          <%= fieldset.radio_input degree_stage, data: {
+            action: 'click->subject-preference-form#degreeStageSelected',
+            requires_subject: f.object.requires_subject_for_degree_stage?(degree_stage)
+          } %>
         <% end %>
-      <% else %>
-        <%= fieldset.radio_input degree_stage %>
       <% end %>
     <% end %>
-  <% end %>
+  </div>
 
-  <div class="govuk-form-group">
+  <div data-target="subject-preference-form.degreeSubjectContainer">
     <%= f.collection_select \
       :degree_subject,
       subject_preference.available_degree_subjects,
       :to_s,
       :to_s,
-      { prompt: 'Select' },
+      { include_blank: 'Select' },
       {
         class: 'govuk-select',
+        data: {
+          target: 'subject-preference-form.degreeSubject',
+          value_for_no_degree: subject_preference.no_degree_subject
+        },
         label_options: { class: 'govuk-heading-m' }
       } %>
   </div>

--- a/features/candidates/registrations/subject_preferences.feature
+++ b/features/candidates/registrations/subject_preferences.feature
@@ -31,3 +31,15 @@ Feature: Entering candidate contact details
         And I make my degree and teaching preference selections
         When I submit the form
         Then I should be on the 'background checks' page for my school of choice
+
+    @javascript
+    Scenario: Hiding degree subject choice when candidate has no degree
+        Given I am on the 'candidate subjects' page for my school of choice
+        When I choose 'I don\'t have a degree and am not studying for one' as my degree stage
+        Then I should not see any subject choices
+
+    @javascript
+    Scenario: Showing degree subject choice when candidate has a degree
+        Given I am on the 'candidate subjects' page for my school of choice
+        When I choose 'Final year' as my degree stage
+        Then I should see some subject choices

--- a/features/step_definitions/candidates/registrations/subject_preferences_steps.rb
+++ b/features/step_definitions/candidates/registrations/subject_preferences_steps.rb
@@ -5,3 +5,17 @@ Given("I make my degree and teaching preference selections") do
   select 'Physics', from: 'First choice'
   select 'Mathematics', from: 'Second choice'
 end
+
+When("I choose {string} as my degree stage") do |string|
+  choose string
+end
+
+Then("I should not see any subject choices") do
+  expect(page).not_to have_field \
+    'If you have or are studying for a degree, tell us about your degree subject'
+end
+
+Then("I should see some subject choices") do
+  expect(page).to have_field \
+    'If you have or are studying for a degree, tell us about your degree subject'
+end

--- a/spec/support/subject_preference_shared_examples.rb
+++ b/spec/support/subject_preference_shared_examples.rb
@@ -96,4 +96,30 @@ shared_examples 'a subject preference' do
       expect(Candidates::School).to have_received(:find).with(school_urn)
     end
   end
+
+  context '#requires_subject_for_degree_stage?' do
+    let :result do
+      described_class.new.requires_subject_for_degree_stage? stage
+    end
+
+    context 'when degree stage does not require subject' do
+      let :stage do
+        "I don't have a degree and am not studying for one"
+      end
+
+      it 'returns false' do
+        expect(result).to be false
+      end
+    end
+
+    context 'when degree stage requires subject' do
+      let :stage do
+        "Graduate or postgraduate"
+      end
+
+      it 'returns true' do
+        expect(result).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context
If the candidate selects they don't have a degree and aren't studying for one, then we want to select 'Not applicable' for the degree subject and hide the select box (there are existing validations in case the candidate has javascript disabled)

### Changes proposed in this pull request
Hide the degree subject select if no degree is selected as the degree stage.

### Guidance to review
Complete the candidate wizard up to the subject preference screen. Select no degree as degree stage  and submit the form without selecting anything else, expect there to be no validation error on degree subject. When the form rerenders expect the degree subject select to still be hidden. Chose a different degree stage, expect the degree subject select to re appear.
