### PR TITLE
Replace direct jump to results with actual search

### DIFF
--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -28,11 +28,11 @@ Then("the results should be sorted by fee, lowest to highest") do
 end
 
 Given("I have searched for {string} and provided {string} for my location") do |query, location|
-  path = candidates_schools_path(query: query, location: location, distance: 25)
-  visit(path)
-
-  path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
-  expect(path_with_query).to eql(path)
+  visit(candidates_schools_path)
+  fill_in "Find what?", with: query
+  fill_in "Where?", with: location
+  select "25", from: "Distance"
+  click_button "Find"
 end
 
 Then("the results should be sorted by distance, nearest to furthest") do


### PR DESCRIPTION
### Context

The previous attempt (#151) was not successful, it failed at the same point. Upon directly-navigating to the results page by building the search string and jumping right to it, the select box for filtering isn't present on the page.

### Changes proposed in this pull request

Now, instead of jumping we're filling in and submitting the search page.

### Guidance to review

Ensure it's sensible. Please chip in if you have any other suggestions for making this work in CD 😕
