### PR TITLE
Feature/make geolocation safe from bad cache values

### DIFF
--- a/features/support/cache.rb
+++ b/features/support/cache.rb
@@ -1,0 +1,3 @@
+AfterConfiguration do
+  Rails.cache.clear
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,7 +67,7 @@ RSpec.configure do |config|
   # Prevent unintended API access from Geocoder
   config.before :each do
     allow(Geocoder).to receive(:search).and_return([
-      OpenStruct.new(latitude: 53.4794892, longitude: -2.2451148)
+      Geocoder::Result::Test.new(latitude: 53.4794892, longitude: -2.2451148)
     ])
   end
 


### PR DESCRIPTION
### Context

Invalid cached values were causing failures in CD

### Changes proposed in this pull request

In addition to checking the validity of newly retrieved (via Geocoder) results we also check the validity of those returned from the cache. If invalid objects are retrieved an error message is written to the log and the entry is purged.

Also, the entire Rails cache is purged before running the Cucumber suite.

### Guidance to review

Make sure the changes are sensible
