### PR TITLE
Remove reference to 'Find what?' which was removed

### DIFF
--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -11,7 +11,7 @@ Feature: Schools search page sorting
             | Manchester School | 30  | Manchester |
             | Rochdale School   | 10  | Rochdale   |
             | Burnley School    | 20  | Burnley    |
-        And I have searched for 'School' and provided 'Bury' for my location
+        And I have provided 'Bury' as my location
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
 

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -27,9 +27,8 @@ Then("the results should be sorted by fee, lowest to highest") do
   ).to eql(@schools.sort_by(&:fee).map(&:urn))
 end
 
-Given("I have searched for {string} and provided {string} for my location") do |query, location|
+Given("I have provided {string} as my location") do |location|
   visit(candidates_schools_path)
-  fill_in "Find what?", with: query
   fill_in "Where?", with: location
   select "25", from: "Distance"
   click_button "Find"


### PR DESCRIPTION
### Context

Failure caused in CD by removed field still being referred to by the Cucumber tests,

### Changes proposed in this pull request

Remove the reference