### PR TITLE
Use Bing maps for geocoding look ups

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,18 +1,34 @@
-Geocoder.configure(
-  # street address geocoding service (default :nominatim)
-  # lookup: :yandex,
+#Geocoder.configure(
+#
+#  if ENV['BING_MAPS_KEY'].present?
+#    lookup:
+#    api_key: ENV[[]]
+#  end
+#
+#  # street address geocoding service (default :nominatim)
+#  # lookup: :yandex,
+#
+#  # IP address geocoding service (default :ipinfo_io)
+#  # ip_lookup: :maxmind,
+#
+#  # to use an API key:
+#  # api_key: "...",
+#
+#  # geocoding service request timeout, in seconds (default 3):
+#  # timeout: 5,
+#
+#  units: :miles
+#)
 
-  # IP address geocoding service (default :ipinfo_io)
-  # ip_lookup: :maxmind,
-
-  # to use an API key:
-  # api_key: "...",
-
-  # geocoding service request timeout, in seconds (default 3):
-  # timeout: 5,
-
-  units: :miles
-)
+if ENV['BING_MAPS_KEY'].present?
+  Geocoder.configure(
+    lookup: :bing,
+    api_key: ENV['BING_MAPS_KEY'],
+    units: :miles
+  )
+else
+  Geocoder.configure(units: :miles)
+end
 
 # hardcode geocoder to return a specific single result when we're in the servertest
 # environment


### PR DESCRIPTION
### Context

We should be using Bing Maps to geocode locations

### Changes proposed in this pull request

Configure Geocoder to use bing maps when the BING_MAPS_KEY environment variable is set, otherwise fallback to using OpenStreetmap


