### PR TITLE
Add selenium running against Chrome to the CI pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,9 +40,9 @@ steps:
     displayName: Run the Cucumber features
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) brakeman --no-pager
     displayName: Run the Brakeman security scan
-  - script: docker run --rm --link postgres:postgres --link redis:redis -e DATABASE_URL="$(WEB_URL)" -e REDIS_URL -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:schema:load
+  - script: docker run --rm --link postgres:postgres --link redis:redis -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:schema:load
     displayName: Create Smoketest database and import schema
-  - script: docker run -d --name=smoketest --health-interval=4s --link postgres:postgres --link redis:redis -e DATABASE_URL="$(WEB_URL)" -e REDIS_URL -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag)
+  - script: docker run -d --name=smoketest --health-interval=4s --link postgres:postgres --link redis:redis -e RAILS_ENV=servertest -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag)
     displayName: Spin up app
   - script: sleep 15 # ugly but gives the web app time to boot
     displayName: Pause to allow app to boot
@@ -50,6 +50,10 @@ steps:
     displayName: Check app reports as Healthy
   - script: docker run --rm --link postgres:postgres --link redis:redis -e DATABASE_URL -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) govuk-lint-ruby app lib spec
     displayName: Run the GovUK Lint check
+  - script: docker run --name=selenium -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-chrome
+    displayName: Launch Selenium Chrome
+  - script: docker run --rm --link postgres:postgres --link=redis:redis --link selenium:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
+    displayName: Run Cucumber via Selenium Chrome
   - script: |
       docker push $(dockerRegistry)/$(imageName):$(imageTag)
       docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(dockerRegistry)/$(imageName):latest

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -126,12 +126,12 @@ end
 
 if ENV['SELENIUM_HUB_HOSTNAME'].present?
   Capybara.run_server = false
-  Capybara.javascript_driver = :chrome
-  Capybara.default_driver = :selenium_remote
   Capybara.register_driver :selenium_remote do |app|
     Capybara::Selenium::Driver.new(app,
         :browser => :remote,
         :url => "http://#{ENV['SELENIUM_HUB_HOSTNAME']}:4444/wd/hub",
         :desired_capabilities => :chrome)
   end
+  Capybara.javascript_driver = :selenium_remote
+  Capybara.default_driver = :selenium_remote
 end


### PR DESCRIPTION
### Context

Currently we have tests which are passing in CI but failing when run against a real server in CD

### Changes proposed in this pull request

To improve the quality of the testing in CI we now run the Cucumber tests against Chrome in CI as well

1. Changed Smoke test to run server in servertest rails environment
2. Run Selenium tests against the smoketest webserver
3. Run Cucumber Javascript tests against remote driver when one is configured

### Guidance to review

Does CI still pass - looking for review from both Peter Yates and Peter Fry