### PR TITLE
Re-enable Bullet in the test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :test
 
   config.after_initialize do
-    Bullet.enable = false
+    Bullet.enable = true
     Bullet.raise = true
   end
 


### PR DESCRIPTION
### Context

Bullet was previously failing while running tests due to a n+1 error.

It appears that this problem was independently-resolved in e128e5e09d95

### Changes proposed in this pull request

Re-enable bullet in the `test` env.

### Guidance to review

Ensure bullet is re-enabled, tests pass and n+1 issue in `Bookings::SchoolSearch` is resolved.