### PR TITLE
Flag up to the user when we cannot retrieve their location

### DIFF
--- a/app/javascript/controllers/grab_location_controller.js
+++ b/app/javascript/controllers/grab_location_controller.js
@@ -81,8 +81,9 @@ export default class extends Controller {
           this.setCoords(position.coords) ;
           this.hideSpinner()
         },
-        () => {
+        (err) => {
           this.hideSpinner()
+          window.alert("Your location is not available") ;
         }
       ) ;
     }


### PR DESCRIPTION
### Context

@rjlynch pointed out that GeoLocation lookups were failing on his mobile phone. After some investigation, this only affects non-https sites and is an in built restriction in Safari.

This in turn highlighted that the code was assuming a failure to retrieve Geolocation was because the user denied the permission, hence understood what happened. This is not always the case (see non-HTTPS) so instead an alert is shown to the user in the event of failed geolocation lookup

### Changes proposed in this pull request

notify the user of a failed Geolocation lookup

### Guidance to review

Test again on mobile, compare with the running copy at https://schoolexperience.education.gov.uk - that should pass because its on HTTPS