### PR TITLE
Lock to Ruby to 2.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5.3
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \


### PR DESCRIPTION
Gemfile is currently locked to a specific Ruby version. Either we slacken that
requirement or increase strictness of Dockerfile.

Since 2.5.4 has been released with known problems with Puma, and since 2.5.5
which fixes the issue, is not yet available in the Docker registry - I'm locking
to a specific version and taking the view that changing versions is something
which should be a code change by the developers.

