### PR TITLE
Allow setting the GovUK Notify API Key from an Env Var

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -1,7 +1,7 @@
 class Notify
   attr_accessor :notify_client, :to
 
-  API_KEY = Rails.application.credentials[:notify_api_key].freeze
+  API_KEY = ENV['NOTIFY_API_KEY'].presence || Rails.application.credentials[:notify_api_key].freeze
 
   class RetryableError < ArgumentError; end
 


### PR DESCRIPTION
This allows for overriding the key used where necessary

### Context

Different environments, or local development environments may require different API keys

### Changes proposed in this pull request

This allows the API key to be set from an Environment variable as per 12 Factor guidance

### Guidance to review

