### PR TITLE
Allow overriding school notifications address

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -65,8 +65,7 @@ class Bookings::School < ApplicationRecord
   end
 
   def contact_email
-    # TODO
-    'CONTACT_EMAIL'
+    ENV['STUBBED_SCHOOL_EMAIL'].presence
   end
 
   def private_beta?


### PR DESCRIPTION
### Context

Current school address is stubbed to an invalid value

### Changes proposed in this pull request

Allow replacing this with an Environment Variable as a temporary solution

