### PR TITLE
Se 596 surface school availability on school profile

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -22,6 +22,10 @@ module Candidates::SchoolHelper
     safe_join school.phases.map(&:name), ', '
   end
 
+  def format_school_availability(school)
+    simple_format school.try(:availability_info) || 'Not specified'
+  end
+
   def describe_current_search(search)
     if search.latitude.present? && search.longitude.present?
       "near me"

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -71,6 +71,4 @@ class Bookings::School < ApplicationRecord
   def private_beta?
     false # FIXME this should check if they're in the Private Beta program
   end
-
-  def availability_text; end
 end

--- a/app/models/candidates/school_stub.rb
+++ b/app/models/candidates/school_stub.rb
@@ -9,7 +9,7 @@ class Candidates::SchoolStub
   end
 
   def respond_to_missing?(method, _include_private = false)
-    @school.respond_to?(method, false) || @fallback.keys?(method.to_s)
+    @school.respond_to?(method, false) || @fallback.key?(method.to_s)
   end
 
   def method_missing(method, *args, &block)

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -43,7 +43,7 @@
       
       <p>
         <b>Availability:</b>
-        <%= @school.availability_text.presence || 'Not specified' %>
+        <%= format_school_availability @school %>
       </p>
       
       <p>

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -80,6 +80,14 @@
     <p class="govuk-body">
       <%= format_school_address @school %>.
     </p>
+
+    <h3 class="govuk-heading-m">
+      Availability
+    </h3>
+
+    <div class="govuk-body">
+      <%= format_school_availability @school %>
+    </div>
     
     <h3 class="govuk-heading-s">
       DBS check required

--- a/demo-school.yml
+++ b/demo-school.yml
@@ -28,4 +28,5 @@ times: 8am to 5pm
 parking: Limited on-site parking arranged as part of placement. Local paid-for on-street parking around school site for £3 per day
 accessibility: Ramp access and disabled parking available on site
 training_offered: Yes. We offer training opportunities for a a mainstream ITT programme.
+availability_info: '17th to 21st June 2019'
 


### PR DESCRIPTION
### Context
Need to display the school availability on the school profile, if we have it.

### Changes proposed in this pull request
Use the new method name that's backed by a db column. Otherwise fallback to 'Not specified'.

### Guidance to review
Visit a school's show page, expect to see availability information, if the school has any
