### PR TITLE
Drop relevance and fee sort

### DIFF
--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -36,6 +36,7 @@ module Candidates
 
     def initialize(*args)
       @distance = 3
+      @order = 'distance'
 
       super
     end

--- a/app/services/bookings/school_search.rb
+++ b/app/services/bookings/school_search.rb
@@ -2,9 +2,8 @@ class Bookings::SchoolSearch
   attr_accessor :query, :point, :radius, :subjects, :phases, :max_fee, :page, :requested_order
 
   AVAILABLE_ORDERS = [
-    %w{relevance Relevance},
     %w{distance Distance},
-    %w{fee Fee}
+    %w{name Name}
   ].freeze
 
   def self.available_orders
@@ -109,12 +108,8 @@ private
       # Bookings::School so we can't use hash syntax
       # as Rails will complain
       'distance asc'
-    elsif requested_order == 'fee'
-      { fee: 'asc' }
-    elsif requested_order == 'name'
+    else
       { name: 'asc' }
-    else # revert to pg_search's rank which is default
-      {}
     end
   end
 end

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -16,23 +16,12 @@ Feature: Schools search page sorting
         Then the results should be sorted by distance, nearest to furthest
 
     @javascript
-    Scenario: Sorting by fee
-        Given there there are schools with the following attributes:
-            | Name              | Fee | Location   |
-            | Manchester School | 30  | Manchester |
-            | Rochdale School   | 10  | Rochdale   |
-            | Burnley School    | 20  | Burnley    |
-        And I have searched for 'School' and am on the results page
-        When I select 'Fee' in the 'Sorted by' select box
-        Then the results should be sorted by fee, lowest to highest
-
-    @javascript
-    Scenario: Sorting by relevance
+    Scenario: Sorting by name
         Given there there are schools with the following attributes:
             | Name                       | Fee | Location    |
             | Manton School              | 30  | Manton      |
             | Mansfield School           | 10  | Mansfield   |
             | Manningtree Primary School | 20  | Manningtree |
         And I have searched for 'Man' and am on the results page
-        When I select 'Relevance' in the 'Sorted by' select box
-        Then the results should be sorted by relevance, highest to lowest
+        When I select 'Name' in the 'Sorted by' select box
+        Then the results should be sorted by name, lowest to highest

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -19,14 +19,6 @@ Given("there there are schools with the following attributes:") do |table|
   expect(Bookings::School.count).to eql(table.rows.length)
 end
 
-Then("the results should be sorted by fee, lowest to highest") do
-  expect(
-    page
-      .all('#search-results > ul > li')
-      .map{ |ele| ele['data-school-urn'].to_i }
-  ).to eql(@schools.sort_by(&:fee).map(&:urn))
-end
-
 Given("I have provided {string} as my location") do |location|
   visit(candidates_schools_path)
   fill_in "Where?", with: location
@@ -49,16 +41,17 @@ Then("the results should be sorted by distance, nearest to furthest") do
   ).to eql(urns_in_distance_order)
 end
 
-Then("the results should be sorted by relevance, highest to lowest") do
-  urns_in_relevance_order = [
-    @schools.detect { |s| s.name == "Manton School" },
+Then("the results should be sorted by name, lowest to highest") do
+  # proximity from Man
+  urns_in_name_order = [
+    @schools.detect { |s| s.name == "Manningtree Primary School" },
     @schools.detect { |s| s.name == "Mansfield School" },
-    @schools.detect { |s| s.name == "Manningtree Primary School" }
+    @schools.detect { |s| s.name == "Manton School" }
   ].map(&:urn)
 
   expect(
     page
       .all('#search-results > ul > li')
       .map{ |ele| ele['data-school-urn'].to_i }
-  ).to eql(urns_in_relevance_order)
+  ).to eql(urns_in_name_order)
 end

--- a/spec/services/bookings/school_search_spec.rb
+++ b/spec/services/bookings/school_search_spec.rb
@@ -323,34 +323,6 @@ describe Bookings::SchoolSearch do
         end
       end
 
-      context 'Fee ordering' do
-        let!(:reasonable) { create(:bookings_school, name: "Reasonable", fee: 15) }
-        let!(:cheap) { create(:bookings_school, name: "Cheap", fee: 0) }
-        let!(:expensive) { create(:bookings_school, name: "Expensive", fee: 30) }
-
-        subject do
-          Bookings::SchoolSearch.new('', requested_order: 'fee').results
-        end
-
-        specify 'schools should be ordered by fee, low to high' do
-          expect(subject.map(&:name)).to eql([cheap, reasonable, expensive].map(&:name))
-        end
-      end
-
-      context 'Search relevance ordering' do
-        let!(:bath) { create(:bookings_school, name: "Bath High School") }
-        let!(:coventry) { create(:bookings_school, name: "Coventry Academy") }
-        let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive") }
-
-        subject do
-          Bookings::SchoolSearch.new('Cardiff High').results
-        end
-
-        specify 'schools should be ordered alphabetically by name' do
-          expect(subject.map(&:name)).to eql([bath, cardiff].map(&:name))
-        end
-      end
-
       context 'Sorting by name' do
         let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive") }
         let!(:bath) { create(:bookings_school, name: "Bath High School") }


### PR DESCRIPTION
### Context

Relevance sort is no longer needed. Fee sorting is currently awaiting refinement of Fee information

### Changes proposed in this pull request

1. Remove Fee and Relevance sorting options from both RSpec and Cucumber tests

### Guidance to review

