### PR TITLE
Scrub pii from params

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,14 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [
+  :password,
+  :full_name,
+  :email,
+  :building,
+  :street,
+  :town_or_city,
+  :county,
+  :postcode,
+  :phone
+]


### PR DESCRIPTION
Add params from candidate contact_information controller to filter
parameters list

### Context
We don't want to store candidates personally identifiably information in the logs

### Changes proposed in this pull request
Add pii attributes to the params filter

### Guidance to review
Tail the logs, submit the candidate's contact information step, expect the params to be replaced with [FILTERED] in the logs

