### PR TITLE
Removed incorrrect footer text from final screen of Application process

### DIFF
--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -17,8 +17,5 @@
     <p>
       We'll also send you an email to confirm you've requested a placement.
     </p>
-    <h3 class="govuk-heading-m">View and request more placements</h3>
-    <%= link_to 'View and request more placements', '#', class: 'govuk-link' %>
-    <%= link_to 'Sign out', '#', class: 'govuk-link' %>
   </div>
 </div>


### PR DESCRIPTION
### Context

Footer text on the final screen, after the Candidate has confirmed their email, includes references to Sign Out, etc.

### Changes proposed in this pull request

Remove these

### Guidance to review

