### PR TITLE
Update School-Request-Confirmation email to clarify formatting

### DIFF
--- a/app/notify/notify_email/school_request_confirmation.3da1cb35-efd2-4aa6-8416-27efc5611d06.md
+++ b/app/notify/notify_email/school_request_confirmation.3da1cb35-efd2-4aa6-8416-27efc5611d06.md
@@ -1,4 +1,4 @@
-Dear ((school_admin_name)),
+Hello,
 
 ((candidate_name)) has sent you a request for school experience at ((school_name)).
 
@@ -8,20 +8,19 @@ Dear ((school_admin_name)),
 
 Personal details:
 
-Full name: ((candidate_name))
-Address: ((candidate_address))
-UK telephone number: ((candidate_phone_number))
-Email address: ((candidate_email_address))
-Request details
+* Full name: ((candidate_name))
+* Address: ((candidate_address))
+* UK telephone number: ((candidate_phone_number))
+* Email address: ((candidate_email_address))
 
 Request details:
 
-School or college: ((school_name))
-Placement availability: ((placement_availability))
-Placement outcome: ((placement_outcome))
-Degree stage: ((candidate_degree_stage))
-Degree subject: ((candidate_degree_subject))
-Teaching stage: ((candidate_teaching_stage))
-Teaching subject – first choice: ((candidate_teaching_subject_first_choice))
-Teaching subject – second choice: ((candidate_teaching_subject_second_choice))
-DBS Check Document: ((candidate_dbs_check_document))
+* School or college: ((school_name))
+* Placement availability: ((placement_availability))
+* Placement outcome: ((placement_outcome))
+* Degree stage: ((candidate_degree_stage))
+* Degree subject: ((candidate_degree_subject))
+* Teaching stage: ((candidate_teaching_stage))
+* Teaching subject – first choice: ((candidate_teaching_subject_first_choice))
+* Teaching subject – second choice: ((candidate_teaching_subject_second_choice))
+* DBS Check Document: ((candidate_dbs_check_document))

--- a/app/notify/notify_email/school_request_confirmation.rb
+++ b/app/notify/notify_email/school_request_confirmation.rb
@@ -11,8 +11,7 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     :candidate_teaching_subject_second_choice,
     :placement_outcome,
     :placement_availability,
-    :school_name,
-    :school_admin_name
+    :school_name
 
   def initialize(
     to:,
@@ -28,8 +27,7 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     candidate_teaching_subject_second_choice:,
     placement_outcome:,
     placement_availability:,
-    school_name:,
-    school_admin_name:
+    school_name:
   )
 
     self.candidate_address                        =        candidate_address
@@ -45,7 +43,6 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
     self.placement_outcome                        =        placement_outcome
     self.placement_availability                   =        placement_availability
     self.school_name                              =        school_name
-    self.school_admin_name                        =        school_admin_name
 
     super(to: to)
   end
@@ -65,8 +62,7 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
       placement_outcome: application_preview.placement_outcome,
       placement_availability: application_preview.placement_availability,
-      school_name: application_preview.school,
-      school_admin_name: "PLACEHOLDER FOR SCHOOL ADMIN"
+      school_name: application_preview.school
     )
   end
 
@@ -90,8 +86,7 @@ private
       candidate_teaching_subject_second_choice: candidate_teaching_subject_second_choice,
       placement_outcome: placement_outcome,
       placement_availability: placement_availability,
-      school_name: school_name,
-      school_admin_name: school_admin_name
+      school_name: school_name
     }
   end
 end

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -36,11 +36,11 @@ module Candidates
 
       def full_address
         [
-          building,
-          street,
-          town_or_city,
-          county,
-          postcode
+          building.presence,
+          street.presence,
+          town_or_city.presence,
+          county.presence,
+          postcode.presence
         ].compact.join(', ')
       end
 

--- a/spec/notify/notify_email/school_request_confirmation_spec.rb
+++ b/spec/notify/notify_email/school_request_confirmation_spec.rb
@@ -14,8 +14,7 @@ describe NotifyEmail::SchoolRequestConfirmation do
     candidate_teaching_subject_second_choice: "Philosophy",
     placement_outcome: "I enjoy teaching",
     placement_availability: "Late Smarch",
-    school_name: "Springfield Elementary School",
-    school_admin_name: "Seymour Skinner"
+    school_name: "Springfield Elementary School"
 
   it_should_behave_like "email template from application preview", true
 end

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -112,7 +112,7 @@ shared_examples_for "email template" do |template_id, personalisation|
 end
 
 
-shared_examples_for "email template from application preview" do |school_admin_included|
+shared_examples_for "email template from application preview" do
   describe ".from_application_preview" do
     before do
       stub_const(
@@ -179,12 +179,6 @@ shared_examples_for "email template from application preview" do |school_admin_i
 
       specify 'school_name is correctly-assigned' do
         expect(subject.school_name).to eql(ap.school)
-      end
-
-      if school_admin_included
-        specify 'school_admin_name is correctly-assigned' do
-          expect(subject.school_admin_name).to match(/PLACEHOLDER/)
-        end
       end
     end
   end


### PR DESCRIPTION
Also avoid duplicate comma's in address lines

### Context

There are a couple of minor issues with the School Request Confirmation email
1. There's a duplicate 'Placement details' line
2. The information is bulleted on the Candidates email which is much clearer
3. There are duplicate comma's for blank address lines

### Changes proposed in this pull request

1. Removed duplicate line
2. Added Bullets to information
3. Remove blank lines from formatted address

### Guidance to review

