### PR TITLE
Remove session info from redis after persisting in postgres

### DIFF
--- a/app/services/candidates/registrations/placement_request_action.rb
+++ b/app/services/candidates/registrations/placement_request_action.rb
@@ -10,6 +10,8 @@ module Candidates
         candidate_request_confirmation.despatch!
         Bookings::PlacementRequest.create_from_registration_session! \
           registration_session
+
+        RegistrationStore.instance.delete! registration_session.uuid
       end
 
     private

--- a/spec/services/candidates/registrations/placement_request_action_spec.rb
+++ b/spec/services/candidates/registrations/placement_request_action_spec.rb
@@ -13,7 +13,8 @@ describe Candidates::Registrations::PlacementRequestAction do
 
   let :registration_store do
     double Candidates::Registrations::RegistrationStore,
-      retrieve!: registration_session
+      retrieve!: registration_session,
+      delete!: true
   end
 
   let :application_preview do
@@ -75,6 +76,11 @@ describe Candidates::Registrations::PlacementRequestAction do
           expect(Bookings::PlacementRequest).not_to \
             have_received :create_from_registration_session!
         end
+
+        it 'doesnt remove the registration_session from redis' do
+          expect(registration_store).not_to have_received(:delete!).with \
+            registration_session.uuid
+        end
       end
 
       context 'candidate notification succeeds' do
@@ -107,6 +113,11 @@ describe Candidates::Registrations::PlacementRequestAction do
           expect(Bookings::PlacementRequest).to \
             have_received(:create_from_registration_session!).with \
               registration_session
+        end
+
+        it 'removes the registration_session from redis' do
+          expect(registration_store).to have_received(:delete!).with \
+            registration_session.uuid
         end
       end
     end


### PR DESCRIPTION
### Context
We want to clear the pii from redis once we no longer need it rather than rely on redis' key expirey 

### Changes proposed in this pull request
Delete the registration session from redis once we've persisted the registration information in postgres.

### Guidance to review
Monitor redis, complete the wizard, get to the placement request step, expect redis to have received del with the correct uuid. Refresh the placement request sent screen, expect to see session expired as we've removed it from redis.
