### PR TITLE
Show "Not specified" if no school subject info available

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -15,7 +15,11 @@ module Candidates::SchoolHelper
       ERB::Util.h(subj)
     end
 
-    safe_subjects.to_sentence.html_safe
+    if safe_subjects.empty?
+      'Not specified'
+    else
+      safe_subjects.to_sentence.html_safe
+    end
   end
 
   def format_school_phases(school)

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -26,23 +26,37 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
 
   context '.format_school_subjects' do
     before do
-      @school = OpenStruct.new(
-        subjects: [
-          OpenStruct.new(id: 1, name: 'First'),
-          OpenStruct.new(id: 2, name: 'Second'),
-          OpenStruct.new(id: 3, name: 'Third')
-        ]
-      )
+      @school = OpenStruct.new(subjects: subjects)
 
       @formatted = format_school_subjects(@school)
     end
 
-    it 'should be html_safe' do
-      expect(@formatted.html_safe?).to be true
+    context 'without subjects' do
+      let :subjects do
+        []
+      end
+
+      it 'should return "Not specified"' do
+        expect(@formatted).to eq 'Not specified'
+      end
     end
 
-    it 'should turn them into a sentence' do
-      expect(@formatted).to eq "First, Second, and Third"
+    context 'with subjects' do
+      let :subjects do
+        [
+          OpenStruct.new(id: 1, name: 'First'),
+          OpenStruct.new(id: 2, name: 'Second'),
+          OpenStruct.new(id: 3, name: 'Third')
+        ]
+      end
+
+      it 'should be html_safe' do
+        expect(@formatted.html_safe?).to be true
+      end
+
+      it 'should turn them into a sentence' do
+        expect(@formatted).to eq "First, Second, and Third"
+      end
     end
   end
 


### PR DESCRIPTION
### Context
Not all schools have given us subject information. We currently show nothing on school index and school show pages if the school has no subjects.

### Changes proposed in this pull request
So 'Not specified' if we don't have any subject information.

### Guidance to review
Visit school index page, perform a search. If a school has subjects expect to see the list of subjects, if the school has no subjects expect to see 'Not specified'. Click on 'View school details', if the schools has subjects expect to see them listed, if it doesn't expect to see 'Not specified'
