### PR TITLE
Add the 'sentry-raven' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ gem 'kaminari'
 
 gem 'phonelib'
 
+gem 'sentry-raven'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]


### PR DESCRIPTION
### Context

There is a desire to use Sentry to monitor errors etc.

### Changes proposed in this pull request

Add the 'sentry-raven' gem.

### Guidance to review

To start using Sentry with Ruby we would need to follow

https://docs.sentry.io/clients/ruby/

