### PR TITLE
Adds privacy policy and cookie policy pages

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,6 +12,8 @@ private
   def sanitise_page
     case params[:page]
     when 'home' then 'pages/home'
+    when 'privacy_policy' then 'pages/privacy_policy'
+    when 'cookies_policy' then 'pages/cookies_policy'
     else
       raise ActiveRecord::RecordNotFound
     end

--- a/app/helpers/back_to_top_helper.rb
+++ b/app/helpers/back_to_top_helper.rb
@@ -1,0 +1,12 @@
+module BackToTopHelper
+  def back_to_top_link
+    link_to '#', class: 'govuk-link govuk-link--no-visited-state back-to-top' do
+      <<-HTML.squish.html_safe
+      <svg class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
+        <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
+      </svg>
+      Back to top
+      HTML
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,6 +72,19 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
 
+            <h2 class="govuk-visually-hidden">
+              Support links
+            </h2>
+
+            <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to 'Cookies', '/pages/cookies_policy', class: 'govuk-footer__link' %>
+              </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to 'Privacy Policy', '/pages/privacy_policy', class: 'govuk-footer__link' %>
+              </li>
+            </ul>
+
             <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
               <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
               />

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -1,0 +1,174 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Cookies</h1>
+    <section>
+      <p>
+        This site puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          measure how you use the website so it can be updated and improved based on your needs
+        </li>
+        <li>
+          remember the notifications you’ve seen so we don’t show them to you again
+        </li>
+      </ul>
+      <p>
+        <%= link_to 'Find out more about how to manage cookies', 'https://ico.org.uk/your-data-matters/online/cookies/' %>
+      </p>
+    </section>
+    <section>
+      <h2 class="govuk-heading-m">How cookies are used on this site</h2>
+      <section>
+        <h3 class="govuk-heading-s">Measuring website usage (Google Analytics)</h3>
+        <p>
+          We use Google Analytics software (Universal Analytics) to collect information about how you use this site. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example, improving site search.
+        </p>
+        <p>
+          Google Analytics stores information about:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the pages you visit on this site</li>
+          <li>how long you spend on each page</li>
+          <li>how you got to the site</li>
+          <li>what you click on while you’re visiting the site</li>
+        </ul>
+        <p>
+          We do not store this information with your personal information (for example, your name or address) so this information can’t be used to identify who you are.
+        </p>
+        <p>
+          We do not allow Google to use or share our analytics data.
+        </p>
+      </section>
+      <section>
+        <table class="govuk-table">
+          <caption class="govuk-table__caption">
+            Google Analytics sets the following cookies
+          </caption>
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">
+                Name
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Purpose
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Expires
+              </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong>_ga</strong>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                Helps count how many people visit this site by tracking if you’ve visited before
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                2 years
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong>_gid</strong>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                Helps count how many people visit this site by tracking if you’ve visited before
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                24 hours
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong>_gat</strong>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                Used to manage the rate at which page view requests are made
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                10 minutes
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          You can opt out of <%= link_to 'Google Analytics cookies', 'https://tools.google.com/dlpage/gaoptout' %>
+        </p>
+      </section>
+      <section>
+        <h3 class="govuk-heading-m">Our cookie message</h3>
+        <p>
+          You may see a pop-up welcome message when you first visit the service. We’ll store a cookie so your computer knows you’ve seen it and knows not to show it again.
+        </p>
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">
+                Name
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Purpose
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Expires
+              </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong>seen_cookie_message</strong>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                Saves a cookie to let us know you’ve seen our cookie message
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                14 days
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h3 class="govuk-heading-m">Session Cookie</h3>
+        <p>
+          Used to identify the user's current session.
+        </p>
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">
+                Name
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Purpose
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Expires
+              </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong>schoolex-session</strong>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                Used to identify the user's current session with the School Experience Service
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                14 days
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+
+    <br>
+    <%= back_to_top_link %>
+  </div>
+</div>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,0 +1,196 @@
+<div class="govuk-grid-row">
+  <div class="gov-grid-column-full">
+    <h1 class="govuk-heading-l">Privacy notice for the School Experience Service</h1>
+    <section>
+      <h2 class="govuk-heading-m">
+        Who we are
+      </h2>
+      <p>
+        This work is being carried out by Education Standards which is a part of the Department for Education (DfE). DfE has engaged the private companies Engine Group and Teleperformance UK (TPUK) to help provide and improve the service.
+      </p>
+      <p>
+        For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of School Experience Service.
+      </p>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        How we'll use your information
+      </h2>
+      <p>
+        We receive your personal data from when you fill in and submit an online request for a school experience. This data is passed onto staff, who work at / for schools and manage school experience at the school you've selected, for processing and review.
+      </p>
+      <p>
+        As part of the service we'll use the contact information you've provided to send out notifications, reminders and feedback questionnaires relating to the School Experience Service.
+      </p>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        The nature of your personal data we'll be using
+      </h2>
+      <p>
+        Personal data will be collected when you fill in and submit a webform. The fields required on the webform ask for personal information such as:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          name
+        </li>
+        <li>
+          email address
+        </li>
+        <li>
+          address
+        </li>
+        <li>
+          telephone number
+        </li>
+        <li>
+          degree subject
+        </li>
+        <li>
+          stage of degree
+        </li>
+        <li>
+          degree class (predicted / achieved)
+        </li>
+        <li>
+          teaching subject preferences
+        </li>
+        <li>
+          IP address
+        </li>
+      </ul>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        Why our use of your personal data is lawful
+      </h2>
+      <p>
+        In order to lawfully use your personal data, we need to meet 1 (or more) conditions in the data protection legislation. For the purpose of this project, your consent forms the basis of this as stated under GDPR Article 6 (1)(a).
+      </p>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        Who we'll make your personal data available to
+      </h2>
+      <p>
+        We sometimes need to make your personal data available to other organisations. These might include contracted partners (who we've employed to process your personal data on our behalf) and / or other organisations (with whom we need to share your personal data for specific purposes).
+      </p>
+      <p>
+        Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with Engine Group, who have been contracted by DfE to manage the delivery of the digital service and TPUK, who have been contracted by DfE to support the administration of the service.
+      </p>
+
+      <section>
+        <h2 class="govuk-heading-s">The private company Engine Group uses your data:</h2>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            for user research - to help develop the School Experience Service, where you've shared your name, email address and / or telephone number for this purpose
+          </li>
+          <li>
+            for security purposes - to protect the School Experience Service, parts of the IP addresses of website visitors are collected (for example, to block continuous direct denial of service attacks from an IP address range)
+          </li>
+          <li>
+            for communication purposes - to help you use the School Experience Service and receive updates the email addresses of individuals requesting school experience are collected
+          </li>
+        </ul>
+      </section>
+
+      <section>
+        <h2 class="govuk-heading-s">The private company TPUK uses your data:</h2>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            to cancel, amend and manage booking requests on your behalf
+          </li>
+        </ul>
+      </section>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        How long we'll keep your personal data
+      </h2>
+      <p>
+        DfE, Engine Group or TPUK will only keep your personal data for as long as we need it for the purposes of their work, after which it will be securely destroyed. If this is longer than 6 years your data will be deleted.
+      </p>
+      <p>
+        Please note, under Data Protection legislation and in compliance with the relevant data processing conditions, personal data can be kept for longer periods of time when processed purely for archiving purposes in the public interest, statistical purposes and historical or scientific research.
+      </p>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        Your data protection rights
+      </h2>
+      <p>
+        Under certain circumstances, you have the right to:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          ask us for access to the personal data we hold about you
+        </li>
+        <li>
+          have your personal data rectified if it's inaccurate or incomplete
+        </li>
+        <li>
+          request the deletion or removal of personal data where there's no compelling reason for its continued processing
+        </li>
+        <li>
+          restrict our processing of your personal data (ie permitting its storage but no further processing)
+        </li>
+        <li>
+          object to direct marketing (including profiling) and processing for statistical purposes and historical or scientific research
+        </li>
+        <li>
+          not be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you
+        </li>
+      </ul>
+
+      <p>
+        If you need to contact us regarding any of the above use the details on DfE's <%= link_to "Contact the Department for Education (DfE)", 'https://www.gov.uk/contact-dfe' %> page.
+      </p>
+
+      <p>
+        Further information about your data protection rights can be found on the on the <%= link_to "Information Commissioner’s Office (ICO)", "https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" %> website.
+      </p>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        Withdrawal of consent and the right to lodge a complaint
+      </h2>
+      <p>
+        Where we're processing your personal data with your consent, you have the right to withdraw that consent.
+      </p>
+      <p>
+        If you change your mind or you are unhappy with our use of your personal data please email us at <%= mail_to 'organise.schoolexperience@education.gov.uk' %>.
+      </p>
+      <p>
+        Alternatively, you have the right to raise any concerns via the <%= link_to "Information Commissioner’s Office (ICO)", 'https://ico.org.uk/concerns/' %> website.
+      </p>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        Last updated
+      </h2>
+      <p>
+        We may need to update this privacy notice periodically and recommend you revisit this information from time to time. This version was last updated on 6 March 2019.
+      </p>
+    </section>
+
+    <section>
+      <h2 class="govuk-heading-m">
+        Contact Information
+      </h2>
+      <p>
+        If you have any questions about how your personal information will be used either email us at <%= mail_to 'organise.schoolexperience@education.gov.uk' %> or contact the DfE Data Protection Officer (DPO) via DfE's <%= link_to 'Contact the Department for Education (DfE)', 'https://www.gov.uk/contact-dfe' %> page.
+      </p>
+    </section>
+
+    <br>
+    <%= back_to_top_link %>
+  </div>
+</div>


### PR DESCRIPTION
### Context
We need to display our cookie and privacy policy

### Changes proposed in this pull request
Adds links to the cookie and privacy policy to the footer, adds cookie and privacy pages from the prototype.

### Guidance to review
Text should match the prototype's cookie and privacy policy pages. Layout should look ok, links to the policies in the footer should work.