### PR TITLE
Added custom error handler for Redis connection issues

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,7 +91,15 @@ Rails.application.configure do
 
   # Use Redis for Session and cache if REDIS_URL or REDIS_CACHE_URL is set
   config.cache_store = :redis_cache_store, {
-    url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL'].presence
+    url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL'].presence,
+    error_handler: -> (method:, returning:, exception:) do
+      ExceptionNotifier.notify_exception(
+        exception,
+        data: {
+          returning: returning.inspect
+        }
+      )
+    end
   }
   config.session_store :cache_store, key: 'schoolex-session'
 


### PR DESCRIPTION
### Context

We are getting unexplained `InvalidAuthenticityToken` errors on both Staging and Research sites. Working hypthesis is this is caused by flakiness in the Redis connection, which is used to hold Session data, and in turn holds the AuthenticityToken.

This scenario should result in errors being recorded in the Logs. It does not.

Further investigation of the default error handler in ActiveSupport::RedisCacheStore leads me to think there is a coding error in the default handler, where errors are only logged when there is access to the logger, but that is never set.

This explains the silent failure, and makes sense if the flaky Redis hypothesis is correct.

### Changes proposed in this pull request

In order to gain further information, and aid in to solving the issue I've added a custom error for Redis connection issues, which logs connection errors the same as other Exceptions within the app.

### Guidance to review

Does the code look sane, does CI pass