### PR TITLE
Enable force_ssl

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
     displayName: Run the Brakeman security scan
   - script: docker run --rm --link postgres:postgres --link redis:redis -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:schema:load
     displayName: Create Smoketest database and import schema
-  - script: docker run -d --name=smoketest --health-interval=4s --link postgres:postgres --link redis:redis -e RAILS_ENV=servertest -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag)
+  - script: docker run -d --name=smoketest --health-interval=4s --link postgres:postgres --link redis:redis -e RAILS_ENV=servertest -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e SECRET_KEY_BASE=stubbed -e SKIP_FORCE_SSL=true $(dockerRegistry)/$(imageName):$(imageTag)
     displayName: Spin up app
   - script: sleep 15 # ugly but gives the web app time to boot
     displayName: Pause to allow app to boot

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,4 +98,6 @@ Rails.application.configure do
   config.active_job.queue_adapter = :delayed_job
 
   config.x.phase_two.enabled = ENV["PHASE_TWO"].present?
+
+  config.force_ssl = true
 end

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -7,4 +7,7 @@ Rails.application.configure do
 
   # Don't actually attempt to delivery emails in Staging environment
   Notify.notification_class = NotifyFakeClient
+
+  # default to true but allow overriding in CI
+  config.force_ssl = !ENV['SKIP_FORCE_SSL'].present?
 end


### PR DESCRIPTION
### Context

Currently URLs in Emails are http:// instead of https:// - this is because the application is actually served over http, and the TLS terminates at the proxy.

### Changes proposed in this pull request

Set the force_ssl option, this will make cookies https only, and force URLs to all be HTTPS. Resulting in correct URLs in the emails.

### Guidance to review

