### PR TITLE
fix privacy policy link on registration preview

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,13 +7,15 @@ class PagesController < ApplicationController
     render plain: 'healthy'
   end
 
+  def privacy_policy; end
+
+  def cookies_policy; end
+
 private
 
   def sanitise_page
     case params[:page]
     when 'home' then 'pages/home'
-    when 'privacy_policy' then 'pages/privacy_policy'
-    when 'cookies_policy' then 'pages/cookies_policy'
     else
       raise ActiveRecord::RecordNotFound
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,10 +78,10 @@
 
             <ul class="govuk-footer__inline-list">
               <li class="govuk-footer__inline-list-item">
-                <%= link_to 'Cookies', '/pages/cookies_policy', class: 'govuk-footer__link' %>
+                <%= link_to 'Cookies', cookies_policy_path, class: 'govuk-footer__link' %>
               </li>
               <li class="govuk-footer__inline-list-item">
-                <%= link_to 'Privacy Policy', '/pages/privacy_policy', class: 'govuk-footer__link' %>
+                <%= link_to 'Privacy Policy', privacy_policy_path, class: 'govuk-footer__link' %>
               </li>
             </ul>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,7 @@ en:
         availability: Is there anything schools need to know about your availability for placements?
         objectives: What do you want to get out of your placement?
       candidates_registrations_privacy_policy:
-        acceptance_html: 'By checking this box and sending this request you’re confirming, to the best of your knowledge, the details you’re providing are correct and you accept our <a href="#" class="govuk-link">privacy policy</a>'
+        acceptance_html: 'By checking this box and sending this request you’re confirming, to the best of your knowledge, the details you’re providing are correct and you accept our <a href="/pages/privacy_policy" class="govuk-link">privacy policy</a>'
       order: Sorted by
       query: Find what?
       location: Where?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,7 +109,7 @@ en:
         availability: Is there anything schools need to know about your availability for placements?
         objectives: What do you want to get out of your placement?
       candidates_registrations_privacy_policy:
-        acceptance_html: 'By checking this box and sending this request you’re confirming, to the best of your knowledge, the details you’re providing are correct and you accept our <a href="/pages/privacy_policy" class="govuk-link">privacy policy</a>'
+        acceptance_html: 'By checking this box and sending this request you’re confirming, to the best of your knowledge, the details you’re providing are correct and you accept our <a href="/privacy_policy" class="govuk-link">privacy policy</a>'
       order: Sorted by
       query: Find what?
       location: Where?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
   get "/pages/:page", to: "pages#show"
   root to: 'candidates/home#index'
 
+  get '/privacy_policy', to: 'pages#privacy_policy'
+  get '/cookies_policy', to: 'pages#cookies_policy'
+
   if Rails.application.config.x.phase_two.enabled
     namespace :schools do
       resource :dashboard, only: :show


### PR DESCRIPTION
### Context
Privacy policy link was not working on application preview page

### Changes proposed in this pull request
Fixes the link

### Guidance to review
Complete the wizard up to application preview page, click the privacy policy link, expect link to take you to the privacy policy

