### PR TITLE
Bugfix/maintain location when searching by current location

### DIFF
--- a/app/views/candidates/registrations/application_previews/_list_row.html.erb
+++ b/app/views/candidates/registrations/application_previews/_list_row.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-summary-list__row">
+<div class="govuk-summary-list__row <%= key.parameterize %>">
   <dt class="govuk-summary-list__key">
     <%= key %>
   </dt>

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -22,6 +22,8 @@
           <%= f.hidden_field :query %>
           <%= f.hidden_field :location %>
           <%= f.hidden_field :distance %>
+          <%= f.hidden_field :latitude %>
+          <%= f.hidden_field :longitude %>
 
           <%= f.collection_check_boxes :phases, Candidates::School.phases, :first, :last %>
 

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -87,7 +87,7 @@
           <h3 class="govuk-heading-l">
             <%= school.name %>
             <%- if school.respond_to? :distance -%>
-            <span class="govuk-caption-m">
+            <span class="govuk-caption-m distance">
               <%= pluralize Conversions::Distance::Metres::ToMiles.convert(school.distance), 'mile' %>
               away
             </span>

--- a/app/views/candidates/schools/_results.html.erb
+++ b/app/views/candidates/schools/_results.html.erb
@@ -40,7 +40,7 @@
       <div>
         <%= school_search_phase_filter_description @search %>
       </div>
-      
+
       <div>
         <%= school_search_subject_filter_description @search %>
       </div>
@@ -62,6 +62,8 @@
         <%= f.hidden_field :query %>
         <%= f.hidden_field :location %>
         <%= f.hidden_field :distance %>
+        <%= f.hidden_field :latitude %>
+        <%= f.hidden_field :longitude %>
         <% for phase_id in f.object.phases %>
           <%= f.hidden_field :phases, multiple: true, value: phase_id, id: nil %>
         <% end %>

--- a/features/candidates/schools/search/results/filtering.feature
+++ b/features/candidates/schools/search/results/filtering.feature
@@ -20,3 +20,15 @@ Feature: Filtering school search results
         Then I should see a 'Placement subjects' filter on the left
         And it should have the hint text 'Select all that apply'
         And it should have checkboxes for all subjects
+
+    @javascript
+    Scenario: Filtering while searching by current location
+        Given there there are schools with the following attributes:
+            | Name              | Phase     | Location   |
+            | Manchester School | Secondary | Manchester |
+            | Rochdale School   | Secondary | Rochdale   |
+            | Burnley School    | Primary   | Burnley    |
+        And I have provided a point in 'Bury' as my location
+        And there are both 'Primary' and 'Secondary' schools in the results
+        When I check the 'Secondary' filter box
+        Then only 'Secondary' schools should remain in the results

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -6,10 +6,10 @@ Feature: Schools search page sorting
     @javascript
     Scenario: Sorting by distance when searching by a specified location
         Given there there are schools with the following attributes:
-            | Name              | Fee | Location   |
-            | Manchester School | 30  | Manchester |
-            | Rochdale School   | 10  | Rochdale   |
-            | Burnley School    | 20  | Burnley    |
+            | Name              | Location   |
+            | Manchester School | Manchester |
+            | Rochdale School   | Rochdale   |
+            | Burnley School    | Burnley    |
         And I have provided 'Bury' as my location
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
@@ -17,10 +17,10 @@ Feature: Schools search page sorting
     @javascript
     Scenario: Sorting by distance when searching by current location
         Given there there are schools with the following attributes:
-            | Name              | Fee | Location   |
-            | Manchester School | 30  | Manchester |
-            | Rochdale School   | 10  | Rochdale   |
-            | Burnley School    | 20  | Burnley    |
+            | Name              | Location   |
+            | Manchester School | Manchester |
+            | Rochdale School   | Rochdale   |
+            | Burnley School    | Burnley    |
         And I have provided a point in 'Bury' as my location
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
@@ -28,10 +28,10 @@ Feature: Schools search page sorting
     @javascript
     Scenario: Sorting by name
         Given there there are schools with the following attributes:
-            | Name                       | Fee | Location    |
-            | Manton School              | 30  | Manton      |
-            | Mansfield School           | 10  | Mansfield   |
-            | Manningtree Primary School | 20  | Manningtree |
+            | Name                       | Location    |
+            | Manton School              | Manton      |
+            | Mansfield School           | Mansfield   |
+            | Manningtree Primary School | Manningtree |
         And I have searched for 'Man' and am on the results page
         When I select 'Name' in the 'Sorted by' select box
         Then the results should be sorted by name, lowest to highest

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -3,15 +3,25 @@ Feature: Schools search page sorting
     As a potential candidate
     I want to be able to sort results by various criteria
 
-
     @javascript
-    Scenario: Sorting by distance
+    Scenario: Sorting by distance when searching by a specified location
         Given there there are schools with the following attributes:
             | Name              | Fee | Location   |
             | Manchester School | 30  | Manchester |
             | Rochdale School   | 10  | Rochdale   |
             | Burnley School    | 20  | Burnley    |
         And I have provided 'Bury' as my location
+        When I select 'Distance' in the 'Sorted by' select box
+        Then the results should be sorted by distance, nearest to furthest
+
+    @javascript
+    Scenario: Sorting by distance when searching by current location
+        Given there there are schools with the following attributes:
+            | Name              | Fee | Location   |
+            | Manchester School | 30  | Manchester |
+            | Rochdale School   | 10  | Rochdale   |
+            | Burnley School    | 20  | Burnley    |
+        And I have provided a point in 'Bury' as my location
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
 

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -11,6 +11,7 @@ Feature: Schools search page sorting
             | Rochdale School   | Rochdale   |
             | Burnley School    | Burnley    |
         And I have provided 'Bury' as my location
+        And I have changed the sort order to 'Name'
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
 
@@ -22,8 +23,21 @@ Feature: Schools search page sorting
             | Rochdale School   | Rochdale   |
             | Burnley School    | Burnley    |
         And I have provided a point in 'Bury' as my location
+        And I have changed the sort order to 'Name'
         When I select 'Distance' in the 'Sorted by' select box
         Then the results should be sorted by distance, nearest to furthest
+
+    @javascript
+    Scenario: When sorted by distance the mileage should increase
+        Given there there are schools with the following attributes:
+            | Name              | Location   |
+            | Manchester School | Manchester |
+            | Rochdale School   | Rochdale   |
+            | Burnley School    | Burnley    |
+        And I have provided a point in 'Bury' as my location
+        And I have changed the sort order to 'Name'
+        When I select 'Distance' in the 'Sorted by' select box
+        Then the distance should be ordered from low to high
 
     @javascript
     Scenario: Sorting by name
@@ -33,5 +47,6 @@ Feature: Schools search page sorting
             | Mansfield School           | Mansfield   |
             | Manningtree Primary School | Manningtree |
         And I have searched for 'Man' and am on the results page
+        And the sort order has defaulted to 'Distance'
         When I select 'Name' in the 'Sorted by' select box
         Then the results should be sorted by name, lowest to highest

--- a/features/step_definitions/candidates/schools/filtering_steps.rb
+++ b/features/step_definitions/candidates/schools/filtering_steps.rb
@@ -1,0 +1,18 @@
+Given("there are both {string} and {string} schools in the results") do |phase1, phase2|
+  expect(all_education_phases_from_page(page)).to match_array([phase1, phase2])
+end
+
+When("I check the {string} filter box") do |string|
+  check string
+end
+
+Then("only {string} schools should remain in the results") do |phase|
+  expect(all_education_phases_from_page(page)).to match_array([phase])
+end
+
+def all_education_phases_from_page(page)
+  page
+    .all(".govuk-summary-list__row.education-phases > dd.govuk-summary-list__value")
+    .map(&:text)
+    .uniq
+end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -72,3 +72,21 @@ Then("the results should be sorted by name, lowest to highest") do
       .map{ |ele| ele['data-school-urn'].to_i }
   ).to eql(urns_in_name_order)
 end
+
+Given("I have changed the sort order to {string}") do |sort_by|
+  select(sort_by, from: 'Sorted by')
+end
+
+Given("the sort order has defaulted to {string}") do |string|
+  expect(page.find("select#order").value).to eql(string.downcase)
+end
+
+Then("the distance should be ordered from low to high") do
+  distances = page
+    .all(".distance")
+    .map(&:text)
+    .map { |distance| distance.split(" ").first }
+    .map(&:to_f)
+
+  expect(distances).to eql(distances.sort)
+end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -11,7 +11,6 @@ Given("there there are schools with the following attributes:") do |table|
     schools << FactoryBot.create(
       :bookings_school,
       name: attributes["Name"],
-      fee: attributes["Fee"].to_i,
       phases: Bookings::Phase.where(name: attributes["Phase"]),
       coordinates: locate(attributes["Location"])
     )

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -12,6 +12,7 @@ Given("there there are schools with the following attributes:") do |table|
       :bookings_school,
       name: attributes["Name"],
       fee: attributes["Fee"].to_i,
+      phases: Bookings::Phase.where(name: attributes["Phase"]),
       coordinates: locate(attributes["Location"])
     )
   end
@@ -20,10 +21,27 @@ Given("there there are schools with the following attributes:") do |table|
 end
 
 Given("I have provided {string} as my location") do |location|
-  visit(candidates_schools_path)
-  fill_in "Where?", with: location
-  select "25", from: "Distance"
-  click_button "Find"
+  path = candidates_schools_path(location: location, distance: 25)
+  visit(path)
+  path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
+  expect(path_with_query).to eql(path)
+end
+
+Given("I have provided a point in {string} as my location") do |centre|
+  points = {
+    "Bury" => {
+      "latitude" => 53.593,
+      "longitude" => -2.289
+    }
+  }
+
+  point = points[centre]
+  fail "No point found for #{centre}" unless point.present?
+
+  path = candidates_schools_path(latitude: point["latitude"], longitude: point["longitude"], distance: 25)
+  visit(path)
+  path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
+  expect(path_with_query).to eql(path)
 end
 
 Then("the results should be sorted by distance, nearest to furthest") do


### PR DESCRIPTION
### Context

When searching by current location _then_ applying filters or sorting, the location was lost.

### Changes proposed in this pull request

Add the appropriate hidden fields to the sort and filter forms to maintain the location

### Guidance to review

Ensure the bug is fixed, one for @mahmoodc
