### PR TITLE
Set reconnection for RedisCacheStore and Redis.current

### DIFF
--- a/app/services/candidates/registrations/registration_store.rb
+++ b/app/services/candidates/registrations/registration_store.rb
@@ -9,6 +9,9 @@ module Candidates
       def initialize
         @namespace = 'registrations'.freeze
         @ttl = 1.day.to_i
+
+        # Note this is using the same connection as was created during boot
+        # so no need for reconnection params here
         @redis = Redis.current
       end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,6 +92,7 @@ Rails.application.configure do
   # Use Redis for Session and cache if REDIS_URL or REDIS_CACHE_URL is set
   config.cache_store = :redis_cache_store, {
     url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL'].presence,
+    reconnect_attempts: 1,
     error_handler: -> (method:, returning:, exception:) do
       ExceptionNotifier.notify_exception(
         exception,

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,4 +1,11 @@
 # Test the Redis connection on boot
-unless ENV['SKIP_REDIS'].present? || Redis.current.ping == "PONG"
-  raise "Could not connect to Redis"
+unless ENV['SKIP_REDIS'].present?
+  Redis.current = Redis.new(
+    connect_timeout: 20, # Default is 5s but logic is we're better being slower booting than failing to boot
+    reconnect_attempts: 1 # Allow for connection failure since Azure networking to Redis is showing some unreliability
+  )
+
+  unless Redis.current.ping == "PONG"
+    raise "Could not connect to Redis"
+  end
 end


### PR DESCRIPTION
### Context

We've been encountering some dropped connections between the App and Redis.

### Changes proposed in this pull request

Set a single reconnect attempt to see if this resolves the issue, this can be
incremented later if it continues to be an issue.

### Guidance to review

