### PR TITLE
Add pid tag to production logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
+  config.log_tags = [:request_id, lambda { |_| "PID:#{Process.pid}" }]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
### Context

Difficult to see source of log messages in multi-webserver environments

### Changes proposed in this pull request

Add the PID to the production log

### Guidance to review

Ensure it's sensible and works
