### PR TITLE
Se 626 anchor links placement summary screen

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: b1d26c2bc489957aca7750a663ed371364ad2504
+  revision: 6067fd7920a59b6057ead9b8a9828e276403a117
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -11,22 +11,30 @@
       <%= summary_row \
         'Full name',
         @application_preview.full_name,
-        edit_candidates_school_registrations_contact_information_path %>
+        edit_candidates_school_registrations_contact_information_path(
+          anchor: 'candidates_registrations_contact_information_full_name_container'
+        ) %>
 
       <%= summary_row \
         'Address',
         @application_preview.full_address,
-        edit_candidates_school_registrations_contact_information_path %>
+        edit_candidates_school_registrations_contact_information_path(
+          anchor: 'candidates_registrations_contact_information_building_container'
+        ) %>
 
       <%= summary_row \
         'UK telephone number',
         @application_preview.telephone_number,
-        edit_candidates_school_registrations_contact_information_path %>
+        edit_candidates_school_registrations_contact_information_path(
+          anchor: 'candidates_registrations_contact_information_phone_container'
+        ) %>
 
       <%= summary_row \
         'Email address',
         @application_preview.email_address,
-        edit_candidates_school_registrations_contact_information_path %>
+        edit_candidates_school_registrations_contact_information_path(
+          anchor: 'candidates_registrations_contact_information_email_container'
+        ) %>
 
       <h2 class="govuk-heading-m">Request details</h2>
 
@@ -37,42 +45,58 @@
       <%= summary_row \
         'Placement availability',
         @application_preview.placement_availability,
-        edit_candidates_school_registrations_placement_preference_path %>
+        edit_candidates_school_registrations_placement_preference_path(
+          anchor: 'candidates_registrations_placement_preference_availability_container'
+        ) %>
 
       <%= summary_row \
         'Placement outcome',
         @application_preview.placement_outcome,
-        edit_candidates_school_registrations_placement_preference_path %>
+        edit_candidates_school_registrations_placement_preference_path(
+          anchor: 'candidates_registrations_placement_preference_objectives_container'
+        ) %>
 
       <%= summary_row \
         'Degree stage',
         @application_preview.degree_stage,
-        edit_candidates_school_registrations_subject_preference_path %>
+        edit_candidates_school_registrations_subject_preference_path(
+          anchor: 'candidates_registrations_subject_preference_degree_stage_container'
+        ) %>
 
       <%= summary_row \
         'Degree subject',
         @application_preview.degree_subject,
-        edit_candidates_school_registrations_subject_preference_path %>
+        edit_candidates_school_registrations_subject_preference_path(
+          anchor: 'candidates_registrations_subject_preference_degree_stage_container'
+        ) %>
 
       <%= summary_row \
         'Teaching stage',
         @application_preview.teaching_stage,
-        edit_candidates_school_registrations_subject_preference_path %>
+        edit_candidates_school_registrations_subject_preference_path(
+          anchor: 'candidates_registrations_subject_preference_teaching_stage_container'
+        ) %>
 
       <%= summary_row \
         'Teaching subject - first choice',
         @application_preview.teaching_subject_first_choice,
-        edit_candidates_school_registrations_subject_preference_path %>
+        edit_candidates_school_registrations_subject_preference_path(
+          anchor: 'candidates_registrations_subject_preference_subject_first_choice_container'
+        ) %>
 
       <%= summary_row \
         'Teaching subject - second choice',
         @application_preview.teaching_subject_second_choice,
-        edit_candidates_school_registrations_subject_preference_path %>
+        edit_candidates_school_registrations_subject_preference_path(
+          anchor: 'candidates_registrations_subject_preference_subject_second_choice_container'
+        ) %>
 
       <%= summary_row \
         'DBS certificate',
         @application_preview.dbs_check_document,
-        edit_candidates_school_registrations_background_check_path %>
+        edit_candidates_school_registrations_background_check_path(
+          anchor: 'candidates_registrations_background_check_has_dbs_check_container'
+        ) %>
 
     </dl>
   </div>


### PR DESCRIPTION
### Context
In order to make the edit application links more useful they should jump to the field in question rather than just the page.

### Changes proposed in this pull request
Links directly to the fields

### Guidance to review
Complete the wizard up to the application preview. Click edit next to the fields, expect to be taken straight to the fields. Submit a form with errors expect the links in the summary to still take you directly to the fields.
