### PR TITLE
Added Keep Alive settings for Redis

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,6 +93,7 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, {
     url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL'].presence,
     reconnect_attempts: 1,
+    tcp_keepalive: 60,
     error_handler: -> (method:, returning:, exception:) do
       ExceptionNotifier.notify_exception(
         exception,

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -2,6 +2,7 @@
 unless ENV['SKIP_REDIS'].present?
   Redis.current = Redis.new(
     connect_timeout: 20, # Default is 5s but logic is we're better being slower booting than failing to boot
+    tcp_keepalive: 60, # Turn keep alive on, ping after 40 seconds, try twice, 10 seconds apart, before giving up - then fall through to reconnect attemp
     reconnect_attempts: 1 # Allow for connection failure since Azure networking to Redis is showing some unreliability
   )
 


### PR DESCRIPTION
### Context

We are getting dropped connections to Redis so use Keep Alive to reduce frequency of dropped connections

### Changes proposed in this pull request

Configuration is based off Redis source and the following document.

Redis gem when given an integer calculates its own keep alive socket settings,
see

https://github.com/redis/redis-rb/blob/master/lib/redis/client.rb#L477

Value of 60 seconds is chosen based off understanding of the Keep Alive values
documented at the link below

http://man7.org/linux/man-pages/man7/tcp.7.html

see
* TCP_KEEPCNT
* TCP_KEEPIDLE
* TCP_KEEPINTVL


