### PR TITLE
Remove query from Bookings::School and specs

### DIFF
--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -62,7 +62,7 @@ private
       .that_provide(subjects)
       .at_phases(phases)
       .costing_upto(max_fee)
-      .search(query)
+      .distinct
   end
 
   def parse_location(location)


### PR DESCRIPTION
### Context

As we're no longer using it in the front end it makes no sense for it to be represented in the service object and associated tests.

### Changes proposed in this pull request

Remove the query param from `Bookings::SchoolSearch`.

The scope powering it, `.search_by_name` and `.search` remain in the FullTextSearch concern and are available to the model should they be needed again.

### Guidance to review

Ensure everything looks sensible.

