### PR TITLE
Call html_safe on titles

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,9 @@
 module ApplicationHelper
   def page_title
-    [
+    safe_join([
       content_for(:page_title).presence,
       'DfE School Experience'
-    ].compact.join ' | '
+    ].compact, ' | ')
   end
 
   def page_title=(title)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <%= render partial: 'google_analytics' if google_analytics_enabled? %>
-    <title><%= page_title %></title>
+    <title><%= page_title.html_safe %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template ">
   <head>
     <%= render partial: 'google_analytics' if google_analytics_enabled? %>
-    <title><%= page_title.html_safe %></title>
+    <title><%= page_title %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>


### PR DESCRIPTION
Apostrophes in school names are being escaped in the
page title. This commit calls html_safe on the page
title, which isnt ideal, but Ive tested by adding script
tags into school names and the script isnt executed
when rendered from the title.

Open to any better suggestions on this

### Context
See above
### Changes proposed in this pull request
Call html_safe in page title
### Guidance to review
Visit schools show for a school with an apostrophe in it's name, eg urn 144046, expect the page title to be displayed correctly. Update the school name to have some script tags in, expect them not to be executed.
