### PR TITLE
De-emphasized resend link

### DIFF
--- a/app/assets/stylesheets/global-styles.scss
+++ b/app/assets/stylesheets/global-styles.scss
@@ -50,3 +50,22 @@ dl.govuk-summary-list {
     }
   }
 }
+
+.govuk-button--secondary {
+  $govuk-button-secondary-colour: govuk-colour("grey-1");
+  $govuk-button-secondary-hover-colour: darken($govuk-button-secondary-colour, 5%);
+  $govuk-button-secondary-shadow-colour: darken($govuk-button-secondary-colour, 15%);
+  $button-shadow-size: $govuk-border-width-form-element;
+
+  background-color: $govuk-button-secondary-colour;
+  box-shadow: 0 $button-shadow-size 0 $govuk-button-secondary-shadow-colour; // s0
+
+  @include govuk-if-ie8 {
+    border-bottom: $button-shadow-size solid $govuk-button-secondary-shadow-colour;
+  }
+
+  &:hover,
+  &:focus {
+    background-color: $govuk-button-secondary-hover-colour;
+  }
+}

--- a/app/views/candidates/registrations/confirmation_emails/show.html.erb
+++ b/app/views/candidates/registrations/confirmation_emails/show.html.erb
@@ -22,6 +22,6 @@
       If you can’t find or haven’t received the email and confirmation link
       within the next 3 hours please click the following link to resend it:
     </p>
-    <%= button_to 'Resend confirmation link', @resend_path, class: 'govuk-button' %>
+    <%= button_to 'Resend confirmation link', @resend_path, class: 'govuk-button govuk-button--secondary' %>
   </div>
 </div>


### PR DESCRIPTION
Note chose grey-1 instead of grey-2 to avoid contrast issues for users with
accessibility needs.

Easy change later if designers disagree.

