### PR TITLE
Se 621 confirmation url

### DIFF
--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -20,6 +20,7 @@ module Candidates
         end
 
         redirect_to candidates_school_registrations_placement_request_path \
+          registration_session.school,
           uuid: registration_session.uuid
       rescue RegistrationStore::SessionNotFound
         render :session_expired

--- a/app/jobs/candidates/registrations/send_email_confirmation_job.rb
+++ b/app/jobs/candidates/registrations/send_email_confirmation_job.rb
@@ -11,19 +11,17 @@ module Candidates
         notification = NotifyEmail::CandidateMagicLink.new \
           to: registration_session.email,
           school_name: registration_session.school.name,
-          confirmation_link: confirmation_link(uuid, registration_session, host)
+          confirmation_link: confirmation_link(uuid, host)
 
         notification.despatch!
       end
 
     private
 
-      def confirmation_link(uuid, registration_session, host)
-        Rails.application.routes.url_helpers
-          .candidates_school_registrations_placement_request_new_url \
-            registration_session.school,
-            uuid: uuid,
-            host: host
+      def confirmation_link(uuid, host)
+        Rails.application.routes.url_helpers.candidates_confirm_url \
+          uuid: uuid,
+          host: host
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     get "splash", to: "home#splash"
 
     # email confirmation link
-    get 'confirm', to: 'registrations/placement_requests#create'
+    get 'confirm/:uuid', to: 'registrations/placement_requests#create', as: :confirm
 
     resources :schools, only: %i{index show} do
       namespace :registrations do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
     root to: 'home#index'
     get "splash", to: "home#splash"
 
+    # email confirmation link
+    get 'confirm', to: 'registrations/placement_requests#create'
+
     resources :schools, only: %i{index show} do
       namespace :registrations do
         resource :placement_preference, only: %i(new create edit update)
@@ -24,8 +27,6 @@ Rails.application.routes.draw do
         resource :confirmation_email, only: %i(show create)
         resource :resend_confirmation_email, only: %i(create)
         resource :placement_request, only: %i(show create)
-        # email confirmation link
-        get 'placement_request/new', to: 'placement_requests#create'
       end
     end
   end

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -22,7 +22,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
   context '#create' do
     context 'uuid not found' do
       before do
-        get "/candidates/confirm?uuid=bad-uuid"
+        get "/candidates/confirm/bad-uuid"
       end
 
       it "doesn't queue a PlacementRequestJob" do
@@ -37,12 +37,12 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
 
     context 'uuid found' do
       before do
-        get "/candidates/confirm?uuid=#{uuid}"
+        get "/candidates/confirm/#{uuid}"
       end
 
       context 'registration job already enqueued' do
         before do
-          get "/candidates/confirm?uuid=#{uuid}"
+          get "/candidates/confirm/#{uuid}"
         end
 
         it "doesn't requeue a PlacementRequestJob" do

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -32,8 +32,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
           raise Candidates::Registrations::RegistrationStore::SessionNotFound
         end
 
-        get \
-          "/candidates/schools/URN/registrations/placement_request/new?uuid=#{uuid}"
+        get "/candidates/confirm?uuid=#{uuid}"
       end
 
       it "doesn't queue a PlacementRequestJob" do
@@ -51,15 +50,15 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
         allow(Candidates::Registrations::PlacementRequestJob).to \
           receive(:perform_later) { true }
 
-        get \
-          "/candidates/schools/URN/registrations/placement_request/new?uuid=#{uuid}"
+        get "/candidates/confirm?uuid=#{uuid}"
       end
 
       context 'registration job already enqueued' do
         let :registration_session do
           double Candidates::Registrations::RegistrationSession,
             completed?: true,
-            uuid: uuid
+            uuid: uuid,
+            school: school
         end
 
         it "doesn't queue a PlacementRequestJob" do
@@ -70,7 +69,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
         it 'redirects to placement request show' do
           expect(response).to redirect_to \
             candidates_school_registrations_placement_request_path(
-              'URN',
+              school,
               uuid: uuid
             )
         end
@@ -81,7 +80,8 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
           double Candidates::Registrations::RegistrationSession,
             completed?: false,
             flag_as_completed!: true,
-            uuid: uuid
+            uuid: uuid,
+            school: school
         end
 
         it 'marks the registration as completed' do
@@ -101,7 +101,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
         it 'redirects to placement request show' do
           expect(response).to redirect_to \
             candidates_school_registrations_placement_request_path(
-              'URN',
+              school,
               uuid: uuid
             )
         end

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -3,36 +3,26 @@ require 'rails_helper'
 describe Candidates::Registrations::PlacementRequestsController, type: :request do
   include_context 'Stubbed candidates school'
 
-  let :uuid do
-    'some-uuid'
+  let :registration_session do
+    FactoryBot.build :registration_session, urn: school.urn
   end
 
-  let :registration_store do
-    double Candidates::Registrations::RegistrationStore,
-      retrieve!: registration_session,
-      store!: 1
+  let :uuid do
+    registration_session.uuid
   end
 
   before do
-    allow(Candidates::Registrations::RegistrationStore).to \
-      receive(:instance) { registration_store }
+    Candidates::Registrations::RegistrationStore.instance.store! \
+      registration_session
+
+    allow(Candidates::Registrations::PlacementRequestJob).to \
+      receive(:perform_later) { true }
   end
 
   context '#create' do
     context 'uuid not found' do
-      let :registration_session do
-        nil
-      end
-
       before do
-        allow(Candidates::Registrations::PlacementRequestJob).to \
-          receive(:perform_later) { true }
-
-        allow(registration_store).to receive(:retrieve!) do
-          raise Candidates::Registrations::RegistrationStore::SessionNotFound
-        end
-
-        get "/candidates/confirm?uuid=#{uuid}"
+        get "/candidates/confirm?uuid=bad-uuid"
       end
 
       it "doesn't queue a PlacementRequestJob" do
@@ -47,23 +37,17 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
 
     context 'uuid found' do
       before do
-        allow(Candidates::Registrations::PlacementRequestJob).to \
-          receive(:perform_later) { true }
-
         get "/candidates/confirm?uuid=#{uuid}"
       end
 
       context 'registration job already enqueued' do
-        let :registration_session do
-          double Candidates::Registrations::RegistrationSession,
-            completed?: true,
-            uuid: uuid,
-            school: school
+        before do
+          get "/candidates/confirm?uuid=#{uuid}"
         end
 
-        it "doesn't queue a PlacementRequestJob" do
-          expect(Candidates::Registrations::PlacementRequestJob).not_to \
-            have_received :perform_later
+        it "doesn't requeue a PlacementRequestJob" do
+          expect(Candidates::Registrations::PlacementRequestJob).to \
+            have_received(:perform_later).exactly(:once)
         end
 
         it 'redirects to placement request show' do
@@ -76,21 +60,12 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       end
 
       context 'registration job not already enqueued' do
-        let :registration_session do
-          double Candidates::Registrations::RegistrationSession,
-            completed?: false,
-            flag_as_completed!: true,
-            uuid: uuid,
-            school: school
+        let :stored_registration_session do
+          Candidates::Registrations::RegistrationStore.instance.retrieve! uuid
         end
 
-        it 'marks the registration as completed' do
-          expect(registration_session).to have_received :flag_as_completed!
-        end
-
-        it 're-stores the updated registration in the registration_store' do
-          expect(registration_store).to have_received(:store!).with \
-            registration_session
+        it 'marks the registration as completed and re-stores it in redis' do
+          expect(stored_registration_session).to be_completed
         end
 
         it 'enqueues the placement request job' do
@@ -111,17 +86,9 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
 
   context '#show' do
     context 'uuid not found' do
-      let :registration_session do
-        nil
-      end
-
       before do
-        allow(registration_store).to receive(:retrieve!) do
-          raise Candidates::Registrations::RegistrationStore::SessionNotFound
-        end
-
         get \
-          "/candidates/schools/URN/registrations/placement_request?uuid=#{uuid}"
+          "/candidates/schools/URN/registrations/placement_request?uuid=bad-uuid"
       end
 
       it 'renders the session expired view' do
@@ -130,10 +97,6 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
     end
 
     context 'uuid found' do
-      let :registration_session do
-        FactoryBot.build :registration_session
-      end
-
       before do
         get \
           "/candidates/schools/URN/registrations/placement_request?uuid=#{uuid}"

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :registration_session, class: Candidates::Registrations::RegistrationSession do
     transient do
       current_time { DateTime.current }
+      urn { 11048 }
     end
 
     initialize_with do
@@ -36,7 +37,7 @@ FactoryBot.define do
            "teaching_stage" => "I’m very sure and think I’ll apply",
            "subject_first_choice" => "Maths",
            "subject_second_choice" => "Physics",
-           "urn" => 11048,
+           "urn" => urn,
            "created_at" => current_time,
            "updated_at" => current_time
         }

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -144,7 +144,7 @@ feature 'Candidate Registrations', type: :feature do
       "Click the confirmation link in the email we’ve sent to the following email address to confirm your request for a placement at Test School:\ntest@example.com"
 
     # Click email confirmation link
-    visit "/candidates/confirm?uuid=#{uuid}"
+    visit "/candidates/confirm/#{uuid}"
 
     expect(page).to have_text \
       "Your request for a school experience placement will be forwarded to Test School."

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -144,8 +144,7 @@ feature 'Candidate Registrations', type: :feature do
       "Click the confirmation link in the email we’ve sent to the following email address to confirm your request for a placement at Test School:\ntest@example.com"
 
     # Click email confirmation link
-    visit \
-      "/candidates/schools/#{school_urn}/registrations/placement_request/new?uuid=#{uuid}"
+    visit "/candidates/confirm?uuid=#{uuid}"
 
     expect(page).to have_text \
       "Your request for a school experience placement will be forwarded to Test School."

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -105,7 +105,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
         expect(NotifyEmail::CandidateMagicLink).to have_received(:new).with \
           to: 'test@example.com',
           school_name: 'Test School',
-          confirmation_link: 'http://www.example.com/candidates/confirm?uuid=some-uuid'
+          confirmation_link: 'http://www.example.com/candidates/confirm/some-uuid'
       end
 
       it 'sends the email' do

--- a/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
+++ b/spec/jobs/candidates/registrations/send_email_confirmation_job_spec.rb
@@ -105,7 +105,7 @@ describe Candidates::Registrations::SendEmailConfirmationJob, type: :job do
         expect(NotifyEmail::CandidateMagicLink).to have_received(:new).with \
           to: 'test@example.com',
           school_name: 'Test School',
-          confirmation_link: 'http://www.example.com/candidates/schools/11048/registrations/placement_request/new?uuid=some-uuid'
+          confirmation_link: 'http://www.example.com/candidates/confirm?uuid=some-uuid'
       end
 
       it 'sends the email' do

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -8,7 +8,8 @@ shared_context 'Stubbed candidates school' do
       id: school_urn,
       name: 'Test School',
       to_param: school_urn.to_s,
-      contact_email: 'test@test.com'
+      contact_email: 'test@test.com',
+      urn: school_urn
   end
 
   let :allowed_subject_choices do


### PR DESCRIPTION
### Context
We want a shorter confirmation url

### Changes proposed in this pull request
Shortens confirmation url.
Removes stubbing of redis in placement_request controller specs

### Guidance to review
Complete wizard, you should get a shorter email confirmation url, confirmation url should work as before.
