### PR TITLE
Show matched location in Search title if available

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -37,6 +37,8 @@ module Candidates::SchoolHelper
   def describe_current_search(search)
     if search.latitude.present? && search.longitude.present?
       "near me"
+    elsif search.location_name.present?
+      "near #{search.location_name}"
     elsif search.location.to_s.present?
       "near #{search.location.to_s.humanize}"
     else

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -1,5 +1,6 @@
 class Bookings::SchoolSearch < ApplicationRecord
   attr_accessor :requested_order
+  attr_reader :location_name
 
   AVAILABLE_ORDERS = [
     %w{distance Distance},
@@ -100,6 +101,7 @@ private
 
     fail InvalidGeocoderResultError unless valid_geocoder_result?(result)
 
+    @location_name = result.name
     extract_coords(latitude: result.latitude, longitude: result.longitude)
   end
 

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -22,6 +22,8 @@ module Candidates
     attr_accessor :query, :location, :order, :latitude, :longitude, :page
     attr_reader :distance, :max_fee
 
+    delegate :location_name, to: :school_search
+
     class << self
       delegate :available_orders, to: Bookings::SchoolSearch
 

--- a/lib/servertest/geocoder.rb
+++ b/lib/servertest/geocoder.rb
@@ -1,6 +1,6 @@
 module Geocoder
   def self.search(*_args)
     # A point in Bury, Greater Manchester
-    [Geocoder::Result::Test.new('latitude' => 53.596, 'longitude' => -2.29)]
+    [Geocoder::Result::Test.new('latitude' => 53.596, 'longitude' => -2.29, 'name' => 'Manchester, UK')]
   end
 end

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -82,13 +82,14 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
     end
   end
 
-  context '.current_search' do
+  context '.describe_current_search' do
     context 'with coordinates search' do
       subject do
         double('Coords search',
           latitude: '1',
           longitude: '2',
           location: '',
+          location_name: nil,
           query: '')
       end
 
@@ -98,16 +99,34 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
     end
 
     context 'with location search' do
-      subject do
-        double('Location search',
-          latitude: '',
-          longitude: '',
-          location: 'Manchester',
-          query: '')
+      context 'and name supplied by search' do
+        subject do
+          double('Location search',
+            latitude: '',
+            longitude: '',
+            location: 'Manchester',
+            location_name: 'Manchester, United Kingdom',
+            query: '')
+        end
+
+        it('should say near Manchester') do
+          expect(describe_current_search(subject)).to match(/near Manchester, United Kingdom/)
+        end
       end
 
-      it('should say near Manchester') do
-        expect(describe_current_search(subject)).to match(/near Manchester/i)
+      context 'without name supplied by search' do
+        subject do
+          double('Location search',
+            latitude: '',
+            longitude: '',
+            location: 'Manchester',
+            location_name: nil,
+            query: '')
+        end
+
+        it('should say near Manchester') do
+          expect(describe_current_search(subject)).to match(/near Manchester$/)
+        end
       end
     end
 
@@ -117,6 +136,7 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
           latitude: '',
           longitude: '',
           location: '',
+          location_name: nil,
           query: 'special school')
       end
 

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe Bookings::SchoolSearch do
   let(:manchester_coordinates) {
     [
-      Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242),
-      Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229)
+      Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK'),
+      Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229, name: 'Manchester, UK')
     ]
   }
 


### PR DESCRIPTION
### Context

Currently we tell the user the results are for the location they typed in. In reality they are for the location Geocoder found matching the location they typed in. 

### Changes proposed in this pull request

1. For clarity show the Geocoder matched location instead



