### PR TITLE
adding IE Selenium driver options

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -108,7 +108,10 @@ Capybara.register_driver :firefox_headless do |app|
 end
 
 Capybara.register_driver :ie do |app|
-  Capybara::Selenium::Driver.new(app, browser: :internet_explorer)
+  options = Selenium::WebDriver::IE::Options.new
+  options.require_window_focus = true
+  options.ignore_protected_mode_settings = true
+  Capybara::Selenium::Driver.new(app, browser: :internet_explorer, options: options)
 end
 
 if (driver = ENV['CUC_DRIVER']) && driver.present?


### PR DESCRIPTION
### Context

The IE functional tests currently run very slowly and different steps experience timeouts.

This might be to do with slow typing by the driver but to be honest the causes seem unclear etc.

https://stackoverflow.com/questions/27985300/selenium-webdriver-typing-very-slow-in-text-field-on-ie-browser/27985398

### Changes proposed in this pull request

Implement 'require window focus' and 'ignore protected mode settings' as IE driver options.

### Guidance to review

The previous IE tests were timing out and resulted in the maximum step duration being reached (15 mins). The pass rate was as follows

```
2019-03-24T14:28:43.1174777Z 55 scenarios (18 failed, 37 passed)
2019-03-24T14:28:43.1175631Z 201 steps (17 failed, 26 skipped, 158 passed)
```
with the changes the tests complete in c. 10 mins and have close to 100% pass rate (3 failing steps)

```
2019-03-24T14:46:34.3814957Z 61 scenarios (3 failed, 58 passed)
2019-03-24T14:46:34.3815187Z 222 steps (3 failed, 219 passed)
```

The functional tests can now be run independently via new release job, the results above were correspond to Release 7 of the Functional Tests job.