### PR TITLE
make select width consistent

### DIFF
--- a/app/views/candidates/registrations/subject_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/subject_preferences/_form.html.erb
@@ -35,7 +35,7 @@
         :to_s,
         { include_blank: 'Select' },
         {
-          class: 'govuk-select',
+          class: 'govuk-select govuk-!-width-one-half',
           data: {
             target: 'subject-preference-form.degreeSubject',
             value_for_no_degree: subject_preference.no_degree_subject
@@ -64,7 +64,7 @@
           :to_s,
           :to_s,
           { prompt: 'Select' },
-          { class: 'govuk-select' } %>
+          { class: 'govuk-select govuk-!-width-one-half' } %>
       </div>
 
       <div class="govuk-form-group">
@@ -73,7 +73,8 @@
           subject_preference.second_subject_choices,
           :to_s,
           :to_s,
-          { class: 'govuk-select' } %>
+          {},
+          { class: 'govuk-select govuk-!-width-one-half' } %>
       </div>
     </fieldset>
 


### PR DESCRIPTION
### Context
The subject select boxes on the candidate wizard were different widths

### Changes proposed in this pull request
Fix the select boxes to be the same width

### Guidance to review
Complete the wizard up to subject preferences, the select boxes for teaching subjects should be the same width.
