### PR TITLE
Only show single error if phone number is blank

### DIFF
--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -15,7 +15,7 @@ module Candidates
       validates :building, presence: true
       validates :postcode, presence: true
       validates :phone, presence: true
-      validates :phone, phone: true, if: :phone
+      validates :phone, phone: true, if: -> { phone.present? }
     end
   end
 end

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -23,7 +23,8 @@ describe Candidates::Registrations::ContactInformation, type: :model do
 
     context 'phone is present' do
       VALID_NUMBERS = ['01434 634996', '+441434634996', '01234567890'].freeze
-      INVALID_NUMBERS = ['7', 'q', '+4414346349', ' ', '   '].freeze
+      INVALID_NUMBERS = ['7', 'q', '+4414346349'].freeze
+      BLANK_NUMBERS = ['', ' ', '   '].freeze
 
       context 'valid numbers' do
         VALID_NUMBERS.each do |number|
@@ -42,8 +43,18 @@ describe Candidates::Registrations::ContactInformation, type: :model do
           before { subject.validate }
 
           it "doesn't permit #{number}" do
-            expect(subject.errors[:phone]).to include \
-              "Enter a valid telephone number"
+            expect(subject.errors[:phone]).to eq ["Enter a valid telephone number"]
+          end
+        end
+      end
+
+      context 'blank number' do
+        BLANK_NUMBERS.each do |number|
+          subject { described_class.new phone: number }
+          before { subject.validate }
+
+          it "doesn't permit #{number}" do
+            expect(subject.errors[:phone]).to eq ["Enter your telephone number"]
           end
         end
       end


### PR DESCRIPTION
### Context
If the candidate enters a blank phone number we were showing both the invalid and blank error messages

### Changes proposed in this pull request
Only show the blank error message if the phone number is blank

### Guidance to review
Complete the candidate wizard up to entering a contact phone number, don't enter a number, submit the form, expect to only see a single validation error for phone number.
