### PR TITLE
Handle Javascript failure of loading map in IE

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,7 +413,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.5.3p105
+   ruby 2.5.5p157
 
 BUNDLED WITH
    1.17.3

--- a/app/assets/stylesheets/stimulus/map.scss
+++ b/app/assets/stylesheets/stimulus/map.scss
@@ -27,6 +27,8 @@
   }
 }
 
+/*
 body.js-enabled .embedded-map img.embedded-map__nojs-img {
   display: none;
 }
+*/


### PR DESCRIPTION
### Context

Bing have made a change to their maps which breaks IE

### Changes proposed in this pull request

Always show the Image map as a fall back for when the map is not showing in IE

### Guidance to review

