### PR TITLE
Use correct protocol when redirecting to canonical domain

### DIFF
--- a/config/initializers/canonical_redirect.rb
+++ b/config/initializers/canonical_redirect.rb
@@ -4,7 +4,7 @@ if ENV['CANONICAL_DOMAIN'].present? || Rails.env.test? || Rails.env.servertest?
 
     # If request via old domain pointing directly to Rails app
     r302 %r{.*},
-      lambda { |match, rack_env| "http://#{ENV['CANONICAL_DOMAIN']}/pages/migration" },
+      lambda { |match, rack_env| "#{protocol}//#{ENV['CANONICAL_DOMAIN']}/pages/migration" },
       if: Proc.new { |rack_env|
         ENV['CANONICAL_DOMAIN'].present? &&
           ENV['OLD_SEP_DOMAIN'].present? &&
@@ -12,7 +12,7 @@ if ENV['CANONICAL_DOMAIN'].present? || Rails.env.test? || Rails.env.servertest?
       }
 
     r302 %r{(.*)},
-      lambda { |match, rack_env| "http://#{ENV['CANONICAL_DOMAIN']}#{match[1]}" },
+      lambda { |match, rack_env| "#{protocol}//#{ENV['CANONICAL_DOMAIN']}#{match[1]}" },
       if: Proc.new { |rack_env|
         ENV['CANONICAL_DOMAIN'].present? &&
           rack_env['HTTP_HOST'] != ENV['CANONICAL_DOMAIN']

--- a/config/initializers/canonical_redirect.rb
+++ b/config/initializers/canonical_redirect.rb
@@ -1,10 +1,10 @@
 if ENV['CANONICAL_DOMAIN'].present? || Rails.env.test? || Rails.env.servertest?
   Rails.application.config.middleware.insert(0, Rack::Rewrite) do
-    protocol = Rails.application.config.force_ssl ? "https" : "http"
+    proto = Rails.application.config.force_ssl ? "https" : "http"
 
     # If request via old domain pointing directly to Rails app
     r302 %r{.*},
-      lambda { |match, rack_env| "#{protocol}//#{ENV['CANONICAL_DOMAIN']}/pages/migration" },
+      lambda { |match, rack_env| "#{proto}://#{ENV['CANONICAL_DOMAIN']}/pages/migration" },
       if: Proc.new { |rack_env|
         ENV['CANONICAL_DOMAIN'].present? &&
           ENV['OLD_SEP_DOMAIN'].present? &&
@@ -12,7 +12,7 @@ if ENV['CANONICAL_DOMAIN'].present? || Rails.env.test? || Rails.env.servertest?
       }
 
     r302 %r{(.*)},
-      lambda { |match, rack_env| "#{protocol}//#{ENV['CANONICAL_DOMAIN']}#{match[1]}" },
+      lambda { |match, rack_env| "#{proto}://#{ENV['CANONICAL_DOMAIN']}#{match[1]}" },
       if: Proc.new { |rack_env|
         ENV['CANONICAL_DOMAIN'].present? &&
           rack_env['HTTP_HOST'] != ENV['CANONICAL_DOMAIN']


### PR DESCRIPTION
### Context

Mistake made in development meant we were always redirecting to HTTP

### Changes proposed in this pull request

Redirect to the protocol the request was made over, which should always be https in production

### Guidance to review

