### PR TITLE
Feature/allow schools to be disabled and omitted from search results

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -38,6 +38,8 @@ class Bookings::School < ApplicationRecord
     class_name: "Bookings::SchoolType",
     foreign_key: :bookings_school_type_id
 
+  scope :enabled, -> { where(enabled: true) }
+
   scope :that_provide, ->(subject_ids) do
     if subject_ids.present?
       left_outer_joins(:bookings_schools_subjects)

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -63,6 +63,7 @@ private
       .that_provide(subjects)
       .at_phases(phases)
       .costing_upto(max_fee)
+      .enabled
       .distinct
   end
 

--- a/db/migrate/20190325160501_add_enabled_flag_to_bookings_schools.rb
+++ b/db/migrate/20190325160501_add_enabled_flag_to_bookings_schools.rb
@@ -1,0 +1,5 @@
+class AddEnabledFlagToBookingsSchools < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_schools, :enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_18_121139) do
+ActiveRecord::Schema.define(version: 2019_03_25_160501) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2019_03_18_121139) do
     t.text "primary_key_stage_info"
     t.text "availability_info"
     t.string "teacher_training_website"
+    t.boolean "enabled", default: true, null: false
     t.index ["coordinates"], name: "index_bookings_schools_on_coordinates", using: :gist
     t.index ["name"], name: "index_bookings_schools_on_name"
     t.index ["urn"], name: "index_bookings_schools_on_urn", unique: true

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
     sequence(:postcode) { |n| "M#{n} 2JF" }
     association :school_type, factory: :bookings_school_type
 
+    trait :disabled do
+      enabled { false }
+    end
+
     trait :full_address do
       sequence(:address_2) { |n| "#{n} Something area" }
       sequence(:address_3) { |n| "#{n} Something area" }

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 describe Bookings::SchoolSearch do
+  let(:point_in_manchester) { Bookings::School::GEOFACTORY.point(-2.241, 53.481) }
+  let(:point_in_leeds) { Bookings::School::GEOFACTORY.point(-1.548, 53.794) }
+
   let(:manchester_coordinates) {
     [
       Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK'),

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -110,6 +110,21 @@ describe Bookings::School, type: :model do
       it { is_expected.to respond_to(:close_to) }
     end
 
+    context 'Enabled' do
+      let!(:enabled_school) { create(:bookings_school) }
+      let!(:disabled_school) { create(:bookings_school, :disabled) }
+
+      it { is_expected.to respond_to(:enabled) }
+
+      specify 'should return enabled schools' do
+        expect(subject.enabled).to include(enabled_school)
+      end
+
+      specify 'should not return non-enabled schools' do
+        expect(subject.enabled).not_to include(disabled_school)
+      end
+    end
+
     context 'Filtering' do
       let!(:school_a) { create(:bookings_school) }
       let!(:school_b) { create(:bookings_school) }


### PR DESCRIPTION
### Context

There is a possibility that certain schools will be inundated with requests and may want to temporarily close the process.

### Changes proposed in this pull request

Add an `enabled` flag to `Bookings::School` that defaults to `true`. Only schools with the flag enabled will be returned in searches.

### Guidance to review

Sense check.
