### PR TITLE
Revert "Add Sentry"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ gem "font-awesome-rails"
 gem 'kaminari'
 
 gem 'phonelib'
-gem 'sentry-raven'
 
 gem 'rack-rewrite'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,8 +136,6 @@ GEM
     factory_bot_rails (5.0.1)
       factory_bot (~> 5.0.0)
       railties (>= 4.2.0)
-    faraday (0.15.4)
-      multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
@@ -197,7 +195,6 @@ GEM
     msgpack (1.2.6)
     multi_json (1.13.1)
     multi_test (0.1.2)
-    multipart-post (2.0.0)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -319,8 +316,6 @@ GEM
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
-    sentry-raven (2.9.0)
-      faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (4.0.1)
       activesupport (>= 4.2.0)
     slack-notifier (2.3.2)
@@ -402,7 +397,6 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   sassc-rails
   selenium-webdriver
-  sentry-raven
   shoulda-matchers (~> 4.0)
   slack-notifier
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,8 +22,6 @@ protected
 
   def session_expired(exception)
     ExceptionNotifier.notify_exception(exception)
-    Raven.capture_exception(exception)
-
     render 'shared/session_expired'
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,8 +101,6 @@ Rails.application.configure do
           returning: returning.inspect
         }
       )
-
-      Raven.capture_exception(exception)
     end
   }
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,0 @@
-Raven.configure do |config|
-  config.excluded_exceptions -= ['ActionController::InvalidAuthenticityToken']
-end


### PR DESCRIPTION
Reverts DFE-Digital/schools-experience#228

Currently Sentry is swallowing our exceptions and the developers don't all have access to Sentry.

Reverting this until we understand the interaction between this and ExceptionNotifier better.