### PR TITLE
Set protocol to https for urls in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,4 +113,6 @@ Rails.application.configure do
   config.x.phase_two.enabled = ENV["PHASE_TWO"].present?
 
   config.force_ssl = true
+
+  Rails.application.routes.default_url_options = { protocol: 'https' }
 end


### PR DESCRIPTION
### Context
We want urls we send in notifications to use https

### Changes proposed in this pull request
Use https in urls sent in notifications

### Guidance to review
Start the app in production env, expect urls sent in notification to use https
