### PR TITLE
Add validation for contact_email field

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -14,6 +14,11 @@ class Bookings::School < ApplicationRecord
 
   validates :teacher_training_website, allow_nil: true, website: true
 
+  validates :contact_email, format: {
+    with: URI::MailTo::EMAIL_REGEXP,
+    message: "isn't a valid email address"
+  }
+
   has_many :bookings_schools_subjects,
     class_name: "Bookings::SchoolsSubject",
     inverse_of: :bookings_school,

--- a/db/migrate/20190326112400_make_bookings_schools_contact_email_not_null.rb
+++ b/db/migrate/20190326112400_make_bookings_schools_contact_email_not_null.rb
@@ -1,0 +1,9 @@
+class MakeBookingsSchoolsContactEmailNotNull < ActiveRecord::Migration[5.2]
+  def down
+    change_column :bookings_schools, :contact_email, :string, limit: 64
+  end
+
+  def up
+    change_column :bookings_schools, :contact_email, :string, limit: 64, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_18_121139) do
+ActiveRecord::Schema.define(version: 2019_03_26_112400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2019_03_18_121139) do
     t.string "county"
     t.string "postcode", null: false
     t.integer "bookings_school_type_id", null: false
-    t.string "contact_email", limit: 64
+    t.string "contact_email", limit: 64, null: false
     t.text "placement_info"
     t.boolean "teacher_training_provider", default: false, null: false
     t.text "teacher_training_info"

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     sequence(:address_1) { |n| "#{n} Something Street" }
     sequence(:postcode) { |n| "M#{n} 2JF" }
     association :school_type, factory: :bookings_school_type
+    sequence(:contact_email) { |n| "admin#{n}@school.org" }
 
     trait :full_address do
       sequence(:address_2) { |n| "#{n} Something area" }

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -41,6 +41,32 @@ describe Bookings::School, type: :model do
 
     include_examples "websites", :website
     include_examples "websites", :teacher_training_website
+
+    context 'contact_email' do
+      valid_addresses = %w{hello@bbc.co.uk hi.there@bbc.com}
+      invalid_addresses = [
+        "www.bbc.co.uk",
+        "0161 123 4567",
+        "address including whitespace@something.org",
+        "this@does@not.work.com",
+        "@twitter_handle2",
+        "trailing@",
+        "nodomain@.com",
+        "trailingdot@somewhere."
+      ]
+
+      context 'valid' do
+        valid_addresses.each do |valid_address|
+          it { should allow_value(valid_address).for(:contact_email) }
+        end
+      end
+
+      context 'invalid' do
+        invalid_addresses.each do |invalid_address|
+          it { should_not allow_value(invalid_address).for(:contact_email) }
+        end
+      end
+    end
   end
 
   describe 'Relationships' do


### PR DESCRIPTION
### Context

There was no email validation, now there is

### Changes proposed in this pull request

Add email format validation to the `Bookings::School` model. Format check uses the regexp provided by `URI::MailTo::EMAIL_REGEXP`.

### Guidance to review

Ensure it looks sensible and tests make sense. We could simplify this by _just_ checking for a single `@` etc but the supplied regexp looks suitable to me.

