### PR TITLE
Validate format of candidate email

### DIFF
--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -12,6 +12,7 @@ module Candidates
 
       validates :full_name, presence: true
       validates :email, presence: true
+      validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
       validates :building, presence: true
       validates :postcode, presence: true
       validates :phone, presence: true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
               blank: "Enter your county"
             email:
               blank: "Enter your email address"
+              invalid: "Enter a valid email address"
             full_name:
               blank: "Enter your full name"
             phone:

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -21,6 +21,45 @@ describe Candidates::Registrations::ContactInformation, type: :model do
     it { is_expected.to validate_presence_of :postcode }
     it { is_expected.to validate_presence_of :phone }
 
+    context 'email is present' do
+      VALID_EMAILS = ['test@example.com', 'testymctest@gmail.com'].freeze
+      INVALID_EMAILS = ['test.com', 'test@@test.com', 'FFFF'].freeze
+      BLANK_EMAILS = ['', ' ', '   '].freeze
+
+      context 'valid emails' do
+        VALID_EMAILS.each do |email|
+          subject { described_class.new email: email }
+          before { subject.validate }
+
+          it "permits #{email}" do
+            expect(subject.errors[:email]).to be_empty
+          end
+        end
+      end
+
+      context 'invalid emails' do
+        INVALID_EMAILS.each do |email|
+          subject { described_class.new email: email }
+          before { subject.validate }
+
+          it "doesn't permit #{email}" do
+            expect(subject.errors[:email]).to eq ['Enter a valid email address']
+          end
+        end
+      end
+
+      context 'blank emails' do
+        BLANK_EMAILS.each do |email|
+          subject { described_class.new email: email }
+          before { subject.validate }
+
+          it "doesn't permit #{email}" do
+            expect(subject.errors[:email]).to eq ['Enter your email address']
+          end
+        end
+      end
+    end
+
     context 'phone is present' do
       VALID_NUMBERS = ['01434 634996', '+441434634996', '01234567890'].freeze
       INVALID_NUMBERS = ['7', 'q', '+4414346349'].freeze


### PR DESCRIPTION
### Context
Over looked validating format of candidate emails 🤦‍♂️, as the input field's type is email and the form wont submit if it's incorrect but we want this for completion.

### Changes proposed in this pull request
Add validation of candidate email

### Guidance to review
Should look correct
