### PR TITLE
Don't attempt to resend emails if reg completed

### DIFF
--- a/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
@@ -2,15 +2,23 @@ module Candidates
   module Registrations
     class ResendConfirmationEmailsController < RegistrationsController
       def create
-        if current_registration.pending_email_confirmation?
+        registration_session = RegistrationStore.instance.retrieve! current_registration.uuid
+
+        if registration_session.pending_email_confirmation?
           SendEmailConfirmationJob.perform_later \
-            current_registration.uuid,
+            registration_session.uuid,
             request.host
 
           redirect_to candidates_school_registrations_confirmation_email_path
         else
           render 'shared/session_expired'
         end
+      rescue RegistrationStore::SessionNotFound => e
+        ExceptionNotifier.notify_exception(e, data: {
+          action: 'ResendConfirmationEmailsController#create',
+          uuid: current_registration.uuid
+        })
+        render 'shared/session_expired'
       end
     end
   end


### PR DESCRIPTION
Fixes a bug where a user could click resend confirmation email after
they had completed the wizard and been purged from redis, causing the
background job to error when attempting to retrieve the session from
redis.

This issue was caused due to the user's session not refelecting the
state in redis.

Fix: We need to fetch the the registration session from redis in the
controller and handle any errors there, rendering the session expired
template.

Test: Complete the wizard, keeping the resend confirmation email page
open. After having confirmed your email click resend confirmation email,
expect to show session expired page.

### Context

### Changes proposed in this pull request

### Guidance to review

