### PR TITLE
Feature/make availability info more visible

### DIFF
--- a/app/assets/stylesheets/global-styles.scss
+++ b/app/assets/stylesheets/global-styles.scss
@@ -69,3 +69,9 @@ dl.govuk-summary-list {
     background-color: $govuk-button-secondary-hover-colour;
   }
 }
+
+section.govuk-se-warning {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background-color: lighten(govuk-colour("yellow"), 25%);
+}

--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -1,6 +1,8 @@
 module Candidates
   module Registrations
     class PlacementPreferencesController < RegistrationsController
+      before_action :set_school
+
       def new
         @placement_preference = PlacementPreference.new attributes_from_session
       end
@@ -34,6 +36,11 @@ module Candidates
       end
 
     private
+
+      def set_school
+        # FIXME modify to use current_registration.school
+        @school = Candidates::School.find(params[:school_id])
+      end
 
       def placement_preference_params
         params.require(:candidates_registrations_placement_preference).permit \

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -27,7 +27,7 @@ module Candidates::SchoolHelper
   end
 
   def format_school_availability(school)
-    simple_format school.try(:availability_info) || 'Not specified'
+    simple_format school.try(:availability_info) || 'No information supplied'
   end
 
   def format_phases(school)

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -30,6 +30,22 @@
           <p>
             Depending on availability and time of year, schools may not always be able to offer you the exact dates you’re looking for.
           </p>
+
+          <%- if @school.availability_info.present? -%>
+            <section class="govuk-se-warning">
+
+              <div class="govuk-warning-text">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                  <span class="govuk-warning-text__assistive">Warning</span>
+                  The school has provided the following information
+                </strong>
+              </div>
+
+              <%= format_school_availability(@school) %>
+            </section>
+          <%- end -%>
+
       <% end %>
 
       <%= f.text_area_with_maxwords \

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -100,16 +100,14 @@
         </dd>
       </div>
 
-      <%- if @school.availability_info.present? -%>
       <div id="school-availability-info" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Placement availability
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= simple_format(@school.availability_info) %>
+          <%= format_school_availability(@school) %>
         </dd>
       </div>
-      <%- end -%>
 
       <%- if @school.teacher_training_provider? -%>
       <div id="school-teacher-training-info" class="govuk-summary-list__row">

--- a/features/candidates/registrations/request_school_experience_placement.feature
+++ b/features/candidates/registrations/request_school_experience_placement.feature
@@ -14,6 +14,16 @@ Feature: Request a school experience placement
             | Is there anything schools need to know about your availability for school experience? | textarea |         |
             | What do you want to get out of your school experience?                                | textarea |         |
 
+    Scenario: Displaying a warning if the school has availability information
+        Given my school has availability information set
+        When I am on the 'Request school experience placement' page for my school of choice
+        Then I should see a warning containing the availability information
+
+    Scenario: No warning should be displayed if the availability information is absent
+        Given my school has availability no information set
+        When I am on the 'Request school experience placement' page for my school of choice
+        Then I should see no warning containing the availability information
+
     @javascript
     Scenario: Word counting in placement objectives
         Given I am on the 'Request school experience placement' page for my school of choice

--- a/features/candidates/schools/show/full_school_details.feature
+++ b/features/candidates/schools/show/full_school_details.feature
@@ -66,6 +66,11 @@ Feature: School show page (enhanced data)
         When I am on the profile page for the chosen school
         Then I should see availability information in the sidebar
 
+    Scenario: Placement availability (sidebar)
+        Given the chosen school has no availability information
+        When I am on the profile page for the chosen school
+        Then the availability information in the sidebar should read 'No information supplied'
+
     Scenario: Teacher training offered (sidebar)
         Given the chosen school offers teacher training and has the following info
             """

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -32,3 +32,23 @@ Given("I have filled in the form with accurate data") do
   fill_in "Is there anything schools need to know about your availability for school experience?", with: "Anytime!"
   fill_in "What do you want to get out of your school experience?", with: "I love teaching"
 end
+
+Given("my school has availability information set") do
+  @availability_info = "Tuesday afternoons only"
+  @school = FactoryBot.create(:bookings_school, availability_info: @availability_info)
+end
+
+Then("I should see a warning containing the availability information") do
+  within('section.govuk-se-warning') do
+    expect(page).to have_content("The school has provided the following information")
+    expect(page).to have_content(@availability_info)
+  end
+end
+
+Given("my school has availability no information set") do
+  # do nothing
+end
+
+Then("I should see no warning containing the availability information") do
+  expect(page).not_to have_css('section.govuk-se-warning')
+end

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -158,3 +158,14 @@ end
 Then("the placement information section should not be visible") do
   expect(page).not_to have_css("#school-placement-info")
 end
+
+Given("the chosen school has no availability information") do
+  @school.update_attributes(availability_info: nil)
+  expect(@school.availability_info).to be_nil
+end
+
+Then("the availability information in the sidebar should read {string}") do |string|
+  within("#school-availability-info") do
+    expect(page).to have_css('dd', text: string)
+  end
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -6,7 +6,7 @@ Given("I am on the {string} page") do |string|
 end
 
 Given("I am on the {string} page for my school of choice") do |string|
-  @school = FactoryBot.create(:bookings_school)
+  @school ||= FactoryBot.create(:bookings_school)
   path_for(string, school: @school).tap do |p|
     visit(p)
     expect(page.current_path).to eql(p)

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::PlacementPreferencesController, type: :request do
+  include_context 'Stubbed candidates school'
+
   let! :date do
     DateTime.now
   end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -22,7 +22,7 @@ feature 'Candidate Registrations', type: :feature do
   end
 
   let :school do
-    double Candidates::School, name: 'Test School'
+    double Candidates::School, name: 'Test School', availability_info: 'Tuesdays only'
   end
 
   let :uuid do

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -4,10 +4,8 @@ shared_context 'Stubbed candidates school' do
   end
 
   let :school do
-    double Bookings::School, \
-      id: school_urn,
+    create :bookings_school, \
       name: 'Test School',
-      to_param: school_urn.to_s,
       contact_email: 'test@test.com',
       urn: school_urn
   end


### PR DESCRIPTION
### Context

Some bookings were not respecting the availability dates specified by the school

### Changes proposed in this pull request

This change makes two changes to attempt to address the issue

1. Display 'Placement availability' as 'No information specified' if it's absent, rather than just omitting the section
2. Add a warning to the 'Request school experience' page if placement availability is present that reiterates the school's placement availability. This box is yellow to attract more attention

### Guidance to review

Ensure changes make sense and look ok.
