### PR TITLE
Se 760 subject choice limiting

### DIFF
--- a/app/services/candidates/registrations/behaviours/subject_preference.rb
+++ b/app/services/candidates/registrations/behaviours/subject_preference.rb
@@ -35,7 +35,7 @@ module Candidates
         end
 
         def available_subject_choices
-          @available_subject_choices ||= Candidates::School.subjects.map(&:last)
+          @available_subject_choices ||= get_available_subject_choices
         end
 
         def second_subject_choices
@@ -75,6 +75,18 @@ module Candidates
 
         def degree_stage_explaination_required?
           requires_explanation_for_degree_stage? degree_stage
+        end
+
+        def get_available_subject_choices
+          if school.subjects.any?
+            school.subjects.pluck(:name)
+          else
+            all_available_subject_choices
+          end
+        end
+
+        def all_available_subject_choices
+          Candidates::School.subjects.map(&:last)
         end
       end
     end

--- a/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::SubjectPreferencesController, type: :request do
+  include_context 'Stubbed candidates school'
+
   let! :date do
     DateTime.now
   end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 feature 'Candidate Registrations', type: :feature do
+  include_context 'Stubbed candidates school'
+
   let! :today do
     Date.today
   end
@@ -15,14 +17,6 @@ feature 'Candidate Registrations', type: :feature do
 
   let! :tomorrow_in_words do
     tomorrow.strftime '%d %B %Y'
-  end
-
-  let! :school_urn do
-    11048
-  end
-
-  let :school do
-    double Candidates::School, name: 'Test School'
   end
 
   let :uuid do

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -4,10 +4,9 @@ shared_context 'Stubbed candidates school' do
   end
 
   let :school do
-    double Bookings::School, \
-      id: school_urn,
+    FactoryBot.build_stubbed \
+      :bookings_school,
       name: 'Test School',
-      to_param: school_urn.to_s,
       contact_email: 'test@test.com',
       urn: school_urn
   end

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -4,7 +4,7 @@ shared_context 'Stubbed candidates school' do
   end
 
   let :school do
-    FactoryBot.build_stubbed \
+    FactoryBot.create \
       :bookings_school,
       name: 'Test School',
       contact_email: 'test@test.com',

--- a/spec/support/subject_preference_shared_examples.rb
+++ b/spec/support/subject_preference_shared_examples.rb
@@ -87,9 +87,22 @@ shared_examples 'a subject preference' do
   end
 
   context '#available_subject_choices' do
-    it "returns the list of subjects from it's school" do
-      expect(subject.available_subject_choices).to \
-        eq Candidates::School.subjects.map(&:last)
+    context 'when the school has subjects' do
+      before do
+        school.subjects << FactoryBot.build_list(:bookings_subject, 8)
+      end
+
+      it "returns the list of subjects from it's school" do
+        expect(subject.available_subject_choices).to \
+          eq school.subjects.pluck(:name)
+      end
+    end
+
+    context "when the school doesn't have subjects" do
+      it 'returns the list of all subjects' do
+        expect(subject.available_subject_choices).to \
+          eq Candidates::School.subjects.map(&:last)
+      end
     end
   end
 


### PR DESCRIPTION
    Populate subject choice with schools subjects if it has any

    If the school has provided us with a list of subjects during enrichment
    we'll show that list, if the school has not we'll default to showing all
    available subjects.

    Testing:
    Find a school which has it's own subjects, eg urn 142541,
    complete the wizard up to the "We need some more details" screen
    expect the list of subjects in the what subject do you want to teach selects to
    match the schools' subject.

    Find a school which has no subjects, eg urn 138304,
    complete the wizard up to the "We need some more details" screen
    expect the list of subjects in the what subject do you want to teach selects to
    show all subjects.

