### PR TITLE
Feature/prevent searches with no location

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -1,5 +1,7 @@
 class Candidates::SchoolsController < ApplicationController
   def index
+    redirect_to new_candidates_school_search_path unless location_present?
+
     @search = Candidates::SchoolSearch.new(search_params)
   end
 
@@ -8,6 +10,12 @@ class Candidates::SchoolsController < ApplicationController
   end
 
 private
+
+  def location_present?
+    search_params[:location].present? || (
+      search_params[:latitude].present? && search_params[:latitude].present?
+    )
+  end
 
   def search_params
     params.permit(

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -21,6 +21,7 @@
 
               <%= f.search_field :location,
                     placeholder: 'Such as Manchester, M1 3BD',
+                    required: true,
                     data: {
                       action: "focus->grab-location#clearLocationInfo",
                       target: "grab-location.location"

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -42,10 +42,10 @@ Feature: Schools search page sorting
     @javascript
     Scenario: Sorting by name
         Given there there are schools with the following attributes:
-            | Name                       | Location    |
-            | Manton School              | Manton      |
-            | Mansfield School           | Mansfield   |
-            | Manningtree Primary School | Manningtree |
+            | Name                       | Location   |
+            | Manton School              | Manchester |
+            | Mansfield School           | Rochdale   |
+            | Manningtree Primary School | Burnley    |
         And I have searched for 'Man' and am on the results page
         And the sort order has defaulted to 'Distance'
         When I select 'Name' in the 'Sorted by' select box

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -29,7 +29,7 @@ Given("there are some schools with a range of fees containing the word {string}"
 end
 
 Given("I have searched for {string} and am on the results page") do |string|
-  path = candidates_schools_path(query: string)
+  path = candidates_schools_path(location: string, distance: 100)
   visit(path)
   path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
   expect(path_with_query).to eql(path)

--- a/features/step_definitions/candidates/schools/search_steps.rb
+++ b/features/step_definitions/candidates/schools/search_steps.rb
@@ -7,6 +7,7 @@ end
 Then("it should have a blank search field") do
   within(@form) do
     field = page.find_field('Where?', type: 'search')
+    expect(field['required']).to eql('required')
     expect(field.text).to be_blank
   end
 end

--- a/features/step_definitions/candidates/schools/search_steps.rb
+++ b/features/step_definitions/candidates/schools/search_steps.rb
@@ -7,7 +7,7 @@ end
 Then("it should have a blank search field") do
   within(@form) do
     field = page.find_field('Where?', type: 'search')
-    expect(field['required']).to eql('required')
+    expect(field['required']).to be_present
     expect(field.text).to be_blank
   end
 end

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -1,18 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Candidates::SchoolsController, type: :request do
-  context "GET #index" do
-    before { get candidates_schools_path }
-
-    it "returns http success" do
-      expect(response).to have_http_status(:success)
-    end
-
-    it "excludes the search results" do
-      expect(response.body).to_not match(/experience near/i)
-    end
-  end
-
   context "GET #index with search params" do
     let(:query_params) {
       {
@@ -40,6 +28,46 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       expect(assigns(:search).subjects).to eq([2, 3])
       expect(assigns(:search).max_fee).to eq('30')
       expect(assigns(:search).order).to eq('Name')
+    end
+
+    context 'when location and coordinates are blank' do
+      let(:query_params) do
+        {
+          query: 'Something',
+          location: '',
+          latitude: '',
+          longitude: '',
+          distance: '10',
+          phases: %w{1},
+          subjects: %w{2 3},
+          max_fee: '30',
+          order: 'Name'
+        }
+      end
+
+      it 'redirects to the search page' do
+        expect(subject).to redirect_to(new_candidates_school_search_path)
+      end
+
+      context 'when coordinates are blank and location is present' do
+        let(:query_params_with_location) do
+          query_params.merge(location: 'Rochdale')
+        end
+
+        before { get candidates_schools_path(query_params_with_location) }
+
+        specify { expect(response).to have_http_status(:success) }
+      end
+
+      context 'when coordinates are present and location is blank' do
+        let(:query_params_with_coordinates) do
+          query_params.merge(latitude: 53.479, longitude: -245)
+        end
+
+        before { get candidates_schools_path(query_params_with_coordinates) }
+
+        specify { expect(response).to have_http_status(:success) }
+      end
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,7 +68,7 @@ RSpec.configure do |config|
   # Prevent unintended API access from Geocoder
   config.before :each do
     allow(Geocoder).to receive(:search).and_return([
-      Geocoder::Result::Test.new(latitude: 53.4794892, longitude: -2.2451148)
+      Geocoder::Result::Test.new(name: 'Bury', latitude: 53.4794892, longitude: -2.2451148)
     ])
   end
 

--- a/spec/views/candidates/school_searches/new.html.erb_spec.rb
+++ b/spec/views/candidates/school_searches/new.html.erb_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "candidates/school_searches/new.html.erb", type: :view do
     expect(rendered).to have_css('label', text: 'Where?')
     expect(rendered).to have_css('label', text: 'Distance')
 
-    expect(rendered).to have_css('input#location')
+    expect(rendered).to have_css("input#location[required='required']")
     expect(rendered).to have_css('select#distance')
 
     expect(rendered).to have_button('Find')


### PR DESCRIPTION
### Context

Searches with no location provided were yielding _all_ of the results

### Changes proposed in this pull request

Now, if location **and** coordinates are omitted, the results page will redirect back to the search form. There is also a `required` attribute on the location input on the search form

### Guidance to review

Make sure it works and the redirect makes sense.
