### PR TITLE
Fixed case of page titles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Get School Experience", root_path, class: 'govuk-header__link govuk-header__link--service-name' %>
+          <%= link_to "Get school experience", root_path, class: 'govuk-header__link govuk-header__link--service-name' %>
         </div>
       </div>
     </header>


### PR DESCRIPTION
### Context

Page title should only have the first letter of Get school experience capitalised

### Changes proposed in this pull request

Changed capitalisation

### Guidance to review

