### PR TITLE
Fix crash caused by missing distance param

### DIFF
--- a/app/models/concerns/geographic_search.rb
+++ b/app/models/concerns/geographic_search.rb
@@ -3,6 +3,7 @@ require 'active_support/concern'
 module GeographicSearch
   extend ActiveSupport::Concern
   GEOFACTORY = RGeo::Geographic.spherical_factory(srid: 4326)
+  DEFAULT_RADIUS = 10
 
   included do
     # Returns records that fall within a radius of a point using PostGIS
@@ -16,12 +17,12 @@ module GeographicSearch
     # @param [String] column The name of the geographic column, defaults
     #   to 'coordinates'
     # @return [School::ActiveRecord_Relation] All matching records
-    scope :close_to, ->(point, radius: 10, column: 'coordinates', include_distance: true) do
+    scope :close_to, ->(point, radius: DEFAULT_RADIUS, column: 'coordinates', include_distance: true) do
       if point.present?
         query = where("st_dwithin(%<column>s, '%<coordinates>s', %<radius>d)" % {
           column: column,
           coordinates: point,
-          radius: Conversions::Distance::Miles::ToMetres.convert(radius)
+          radius: Conversions::Distance::Miles::ToMetres.convert(radius || DEFAULT_RADIUS)
         })
 
         if include_distance

--- a/spec/models/concerns/geographic_search_spec.rb
+++ b/spec/models/concerns/geographic_search_spec.rb
@@ -32,6 +32,18 @@ describe 'Concerns' do
         expect(subject.close_to(leeds_centre)).not_to include(mcr_victoria, mcr_piccadilly)
       end
 
+      context 'should use default value when supplied a nil radius' do
+        before do
+          allow(Conversions::Distance::Miles::ToMetres).to receive(:convert).and_return(50)
+        end
+
+        before { subject.close_to(mcr_piccadilly, radius: nil) }
+
+        specify 'should use the specified default value when nil supplied' do
+          expect(Conversions::Distance::Miles::ToMetres).to have_received(:convert).with(subject::DEFAULT_RADIUS)
+        end
+      end
+
       context 'custom radius' do
         specify 'should return records that fall inside a custom radius of a point' do
           expect(subject.close_to(mcr_centre, radius: 50)).to include(leeds_station)


### PR DESCRIPTION
When distance param is supplied in the URL but has no value (eg
`&longitude=&distance`) Rails was passing nil into the scope
explicitely, causing it not to revert to the default value set in the
database.

Now there is a `DEFAULT_RADIUS` constant defined in the module to ensure a
value is present

