### PR TITLE
Disabled the find-my-location field on Internet Explorer

### DIFF
--- a/app/javascript/controllers/grab_location_controller.js
+++ b/app/javascript/controllers/grab_location_controller.js
@@ -8,10 +8,18 @@ export default class extends Controller {
   spinIcon = 'fa-spin' ;
 
   connect() {
-    if ("geolocation" in navigator) {
+    if (this.enableGeolocation()) {
       this.addLocationLink() ;
       this.toggleCoordsState() ;
     }
+  }
+
+  isIE() {
+    return (!!window.MSInputMethodContext && !!document.documentMode) ;
+  }
+
+  enableGeolocation() {
+    return (("geolocation" in navigator) && !this.isIE()) ;
   }
 
   clearLocationInfo() {
@@ -79,7 +87,7 @@ export default class extends Controller {
 
     this.showSpinner() ;
 
-    if ("geolocation" in navigator) {
+    if (this.enableGeolocation()) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
           this.setCoords(position.coords) ;


### PR DESCRIPTION
### Context

Whilst Internet Explorer implements the navigator.geolocation feature. It
doesn't implement it fully, missing the 'failed to get location' callback.
This means if the user disables the prompt, then we never receive a message to
say the browser has stopped searching for the location.

Since the feature is an optional enhancement, IE only partially implements this
feature, and the use case for supporting it under IE is very niche, I am
instead just disabling the feature under Internet Explorer.

### Changes proposed in this pull request

1. Don't show 'find my location' on IE

### Guidance to review

Test both IE and Edge in VMs
1. both are in the Win10 + Edge VM on modern.ie
2. puma on your own computer probably needs starting with --binding=0.0.0.0
3. local computer can be accessed from within the VM at http://10.0.2.2:3000/

