### PR TITLE
Remove the blank 'distance' value from search form

### DIFF
--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -32,8 +32,7 @@
 
             <div class="school-search-form__distance-field">
               <%= f.collection_select :distance,
-                    Candidates::SchoolSearch.distances, :first, :last,
-                    include_blank: 'distance' %>
+                    Candidates::SchoolSearch.distances, :first, :last %>
             </div>
 
             <div class="school-search-form__submit">


### PR DESCRIPTION
### Context

There is a blank 'distance' option in the drop down of available distances.
This doesn't make sense from a UI stand point and is problematic from a
technical standpoint.

### Changes proposed in this pull request

Remove the 'distance' option from the drop down

### Guidance to review

Does it still work