### PR TITLE
Feature/enhance no results page

### DIFF
--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -63,8 +63,11 @@
       margin-bottom: govuk-spacing(1) ;
     }
 
-    p.nearby-info {
+    .nearby-info {
       margin-bottom: 0rem;
+      p:last-child {
+        margin-bottom: 0rem;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -53,6 +53,20 @@
       }
     }
   }
+
+  .expanded-search-radius {
+    padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) govuk-spacing(6);
+    margin: govuk-spacing(4) 0 govuk-spacing(6);
+    border-left: 5px solid govuk-colour('red');
+
+    h3 {
+      margin-bottom: govuk-spacing(1) ;
+    }
+
+    p.nearby-info {
+      margin-bottom: 0rem;
+    }
+  }
 }
 
 .filter-list fieldset legend span.govuk-label {

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -1,8 +1,17 @@
 class Candidates::SchoolsController < ApplicationController
+  EXPANDED_SEARCH_RADIUS = 50
+
   def index
     redirect_to new_candidates_school_search_path unless location_present?
 
     @search = Candidates::SchoolSearch.new(search_params)
+
+    if @search.results.empty?
+      @expanded_search_radius = true
+      @search = Candidates::SchoolSearch.new(
+        search_params.merge(distance: EXPANDED_SEARCH_RADIUS)
+      )
+    end
   end
 
   def show

--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -26,4 +26,8 @@ module Candidates::ResultsHelper
       )
     end.html_safe
   end
+
+  def expanded_search_radius_header_text
+    "0 results found within #{pluralize(params[:distance], 'mile')}"
+  end
 end

--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -30,4 +30,15 @@ module Candidates::ResultsHelper
   def expanded_search_radius_header_text
     "0 results found within #{pluralize(params[:distance], 'mile')}"
   end
+
+  def expanded_search_nearby_info_text
+    if @search.results.empty?
+      "There aren't any results within %<expanded_radius>s of your location, try a %<link>s" % {
+        expanded_radius: pluralize(Candidates::SchoolsController::EXPANDED_SEARCH_RADIUS, "mile"),
+        link: link_to('new search', new_candidates_school_search_path)
+      }
+    else
+      "However, we did find the following schools nearby:"
+    end.html_safe
+  end
 end

--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -33,12 +33,19 @@ module Candidates::ResultsHelper
 
   def expanded_search_nearby_info_text
     if @search.results.empty?
-      "There aren't any results within %<expanded_radius>s of your location, try a %<link>s" % {
-        expanded_radius: pluralize(Candidates::SchoolsController::EXPANDED_SEARCH_RADIUS, "mile"),
-        link: link_to('new search', new_candidates_school_search_path)
-      }
+      capture do
+        concat(tag.p { 'Not all schools in your area have signed up to use this website.' })
+
+        concat(tag.p do
+          <<~FIND_OUT_MORE
+            To find out about arranging school experience with schools who are
+            not yet on this website visit #{link_to('Get into teaching', 'https://getintoteaching.education.gov.uk/school-experience/arranging-school-experience-independently')}.
+          FIND_OUT_MORE
+          .html_safe
+        end)
+      end
     else
-      "However, we did find the following schools nearby:"
-    end.html_safe
+      tag.p { 'However, we did find the following schools nearby:' }.html_safe
+    end
   end
 end

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -82,6 +82,16 @@
     <hr />
 
     <ul id="results">
+      <%- if @expanded_search_radius -%>
+      <li class="expanded-search-radius">
+        <h3 class="govuk-heading-l"><%= expanded_search_radius_header_text %></h3>
+
+        <p class="nearby-info">
+          However, we did find the following schools nearby:
+        </p>
+      </li>
+      <%- end -%>
+
       <% @search.results.each_with_index do |school, index| %>
       <li data-school-urn="<%= school.urn %>">
         <article class="school-result">

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -87,7 +87,7 @@
         <h3 class="govuk-heading-l"><%= expanded_search_radius_header_text %></h3>
 
         <p class="nearby-info">
-          However, we did find the following schools nearby:
+          <%= expanded_search_nearby_info_text %>
         </p>
       </li>
       <%- end -%>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -86,9 +86,9 @@
       <li class="expanded-search-radius">
         <h3 class="govuk-heading-l"><%= expanded_search_radius_header_text %></h3>
 
-        <p class="nearby-info">
+        <div class="nearby-info">
           <%= expanded_search_nearby_info_text %>
-        </p>
+        </div>
       </li>
       <%- end -%>
 

--- a/features/candidates/schools/search/results/no_results.feature
+++ b/features/candidates/schools/search/results/no_results.feature
@@ -1,0 +1,9 @@
+Feature: Schools search page contents
+    To keep me informed when my search yields no results
+    As a potential candidate
+    I want to see a clear and concise error message
+
+    Scenario: No results in expanded area
+        Given there are no schools in or around my search location
+        When I search for schools within 5 miles
+        Then the results page should include a warning that no results were found

--- a/features/candidates/schools/search/results/no_results.feature
+++ b/features/candidates/schools/search/results/no_results.feature
@@ -7,3 +7,4 @@ Feature: Schools search page contents
         Given there are no schools in or around my search location
         When I search for schools within 5 miles
         Then the results page should include a warning that no results were found
+        And there should be a link to Get into teaching

--- a/features/candidates/schools/search/results/results.feature
+++ b/features/candidates/schools/search/results/results.feature
@@ -16,3 +16,10 @@ Feature: Schools search page contents
             | Fees        |
             | School type |
             | Subjects    |
+
+    Scenario: No closeby results
+        Given there are no schools near my search location
+        But there are some schools just outside it
+        When I search for schools within 5 miles
+        Then the results page should include a warning that my search radius was expanded
+        And the results from further out are displayed

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -131,3 +131,14 @@ end
 Then("the results from further out are displayed") do
   expect(page).to have_css('article.school-result', count: Bookings::School.count)
 end
+
+Given("there are no schools in or around my search location") do
+  # do nothing
+end
+
+Then("the results page should include a warning that no results were found") do
+  within('#results li.expanded-search-radius') do
+    expect(page).to have_css('h3', text: '0 results found within 5 miles')
+    expect(page).to have_content("There aren't any results within 50 miles of your location")
+  end
+end

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -139,6 +139,13 @@ end
 Then("the results page should include a warning that no results were found") do
   within('#results li.expanded-search-radius') do
     expect(page).to have_css('h3', text: '0 results found within 5 miles')
-    expect(page).to have_content("There aren't any results within 50 miles of your location")
+    expect(page).to have_content("Not all schools in your area have signed up to use this website.")
+    expect(page).to have_content("To find out about arranging school experience with schools who are not yet on this website visit")
+  end
+end
+
+Then("there should be a link to Get into teaching") do
+  within('#results li.expanded-search-radius') do
+    expect(page).to have_link("Get into teaching", href: 'https://getintoteaching.education.gov.uk/school-experience/arranging-school-experience-independently')
   end
 end

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -23,11 +23,14 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       expect(assigns(:search).location).to eq('Manchester')
       expect(assigns(:search).latitude).to eq('53.481')
       expect(assigns(:search).longitude).to eq('-2.241')
-      expect(assigns(:search).distance).to eq(10)
       expect(assigns(:search).phases).to eq([1])
       expect(assigns(:search).subjects).to eq([2, 3])
       expect(assigns(:search).max_fee).to eq('30')
       expect(assigns(:search).order).to eq('Name')
+
+      # note, this search will yield no results so the search radius will
+      # automatically be expanded from 10 to the value at EXPANDED_SEARCH_RADIUS
+      expect(assigns(:search).distance).to eq(Candidates::SchoolsController::EXPANDED_SEARCH_RADIUS)
     end
 
     context 'when location and coordinates are blank' do


### PR DESCRIPTION
### Context

Searches that yield no results are a bit of a dead end for candidates

### Changes proposed in this pull request

If a search yields no results, expand the search to the `EXPANDED_SEARCH_RADIUS` (currently set to 50 miles) and display the results beneath a _warning_ entry that explains no schools were found by the original search.

Note, some of the text hasn't yet been finalised, awaiting @fredbrenton's input on that

### Guidance to review

Ensure implementation matches design, looks sensible etc.

![Screenshot 2019-03-29 at 14 45 32](https://user-images.githubusercontent.com/128088/55248270-5b528f80-5241-11e9-9303-2947d4c520bd.png)

