### PR TITLE
Feature/notify later

### DIFF
--- a/app/jobs/notify_job.rb
+++ b/app/jobs/notify_job.rb
@@ -2,10 +2,10 @@ class NotifyJob < ApplicationJob
   queue_as :default
 
   def perform(klass, to, personalisation)
-    klass.constantize.new(
-      to: to,
-      **JSON.parse(personalisation).symbolize_keys
-    )
+    klass
+      .constantize
+      .new(to: to, **JSON.parse(personalisation).symbolize_keys)
+      .despatch!
   end
 
   def self.perform_later(notification)

--- a/app/jobs/notify_job.rb
+++ b/app/jobs/notify_job.rb
@@ -1,0 +1,18 @@
+class NotifyJob < ApplicationJob
+  queue_as :default
+
+  def perform(klass, to, personalisation)
+    klass.constantize.new(
+      to: to,
+      **JSON.parse(personalisation).symbolize_keys
+    )
+  end
+
+  def self.perform_later(notification)
+    super(
+      notification.class.to_s,
+      notification.to,
+      notification.send(:personalisation).to_json
+    )
+  end
+end

--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -24,12 +24,16 @@ class Notify
     begin
       notify_client.send_email(
         template_id: template_id,
-        email_address: @to,
+        email_address: to,
         personalisation: personalisation
       )
     rescue Notifications::Client::ServerError => e
       raise RetryableError, e.message
     end
+  end
+
+  def despatch_later!
+    NotifyJob.perform_later(self)
   end
 
 private

--- a/spec/jobs/notify_job_spec.rb
+++ b/spec/jobs/notify_job_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe NotifyJob do
+  before { ActiveJob::Base.queue_adapter = :test }
+  let(:personalisation) do
+    {
+      school_name: "A School",
+      confirmation_link: "ABC123"
+    }
+  end
+
+  context '#perform_later' do
+    let(:email) do
+      NotifyEmail::CandidateMagicLink.new({ to: 'test@test.org' }.merge(personalisation))
+    end
+
+    before { NotifyJob.perform_later(email) }
+
+    specify 'should enqueue the job properly' do
+      expect { NotifyJob.perform_later(email) }.to have_enqueued_job.with(
+        "NotifyEmail::CandidateMagicLink",
+        "test@test.org",
+        personalisation.to_json
+      )
+    end
+  end
+
+  context '#perform_now' do
+    subject {
+      described_class.new.perform(
+        "NotifyEmail::CandidateMagicLink",
+        "test@test.com",
+        personalisation.to_json
+      )
+    }
+
+    specify 'should send an email' do
+      expect(subject[:delivered_at]).not_to be_nil
+      expect(subject[:template_id]).to eql('a06fe38a-5f7f-4c68-8612-6aae9495a8ab')
+      expect(subject[:personalisation]).to eql(personalisation)
+    end
+  end
+end

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -77,6 +77,20 @@ shared_examples_for "email template" do |template_id, personalisation|
         end
       end
     end
+
+    describe '#despatch_later!' do
+      specify { expect(subject).to respond_to(:despatch_later!) }
+
+      before do
+        allow(NotifyJob).to receive(:perform_later).and_return(true)
+      end
+
+      before { subject.despatch_later! }
+
+      specify 'should call @notify_client.send_email with correct args' do
+        expect(NotifyJob).to have_received(:perform_later).with(subject)
+      end
+    end
   end
 
   describe 'Template' do


### PR DESCRIPTION
### Context

All notify emails are currently sent immediately via `#despatch!`. This could potentially cause problems when the response from Notify is slow or Notify isn't responding.

### Changes proposed in this pull request

Add a `#despatch_later!` method to the `Notify` class that queues a `NotifyJob` via `#perform_later`. Enqueuing the job means the UI won't be left hanging while awaiting a response.

### Guidance to review

Ensure choices look sane and the approach is valid
