### PR TITLE
Adds postcode validation to candidate wizard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,8 @@ gem 'phonelib'
 
 gem 'rack-rewrite'
 
+gem 'uk_postcode'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    uk_postcode (2.1.3)
     unicode-display_width (1.4.1)
     uniform_notifier (1.12.1)
     web-console (3.7.0)
@@ -403,6 +404,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
+  uk_postcode
   web-console (>= 3.3.0)
   webpacker
 

--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -1,8 +1,6 @@
 module Candidates
   module Registrations
     class ContactInformation < RegistrationStep
-      POSTCODE_REGEXP = /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/.freeze
-
       attribute :full_name
       attribute :email
       attribute :building
@@ -17,9 +15,21 @@ module Candidates
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
       validates :building, presence: true
       validates :postcode, presence: true
-      validates :postcode, format: { with: POSTCODE_REGEXP }, if: -> { postcode.present? }
+      validate :postcode_is_valid, if: -> { postcode.present? }
       validates :phone, presence: true
       validates :phone, phone: true, if: -> { phone.present? }
+
+    private
+
+      def postcode_is_valid
+        unless postcode_is_valid?
+          errors.add :postcode, :invalid
+        end
+      end
+
+      def postcode_is_valid?
+        UKPostcode.parse(postcode).full_valid?
+      end
     end
   end
 end

--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -1,6 +1,8 @@
 module Candidates
   module Registrations
     class ContactInformation < RegistrationStep
+      POSTCODE_REGEXP = /([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/.freeze
+
       attribute :full_name
       attribute :email
       attribute :building
@@ -15,6 +17,7 @@ module Candidates
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
       validates :building, presence: true
       validates :postcode, presence: true
+      validates :postcode, format: { with: POSTCODE_REGEXP }, if: -> { postcode.present? }
       validates :phone, presence: true
       validates :phone, phone: true, if: -> { phone.present? }
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,7 @@ en:
               invalid: "Enter a valid telephone number"
             postcode:
               blank: "Enter your postcode"
+              invalid: 'Enter a valid postcode'
             street:
               blank: "Enter your street"
             town_or_city:

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -98,5 +98,45 @@ describe Candidates::Registrations::ContactInformation, type: :model do
         end
       end
     end
+
+    context 'postcode is present' do
+      VALID_POSTCODES = [
+        'DN55 1PT',
+        'CR2 6XH',
+        'B33 8TH',
+        'M1 1AE',
+        'W1A 0AX',
+        'EC1A 1BB',
+        'ch63 7ns'
+      ].freeze
+
+      INVALID_POSTCODES = [
+        'horses',
+        'N0T AP057C0D3',
+        'B3333 1BB'
+      ].freeze
+
+      context 'valid postcodes' do
+        VALID_POSTCODES.each do |postcode|
+          subject { described_class.new postcode: postcode }
+          before { subject.validate }
+
+          it "permits #{postcode}" do
+            expect(subject.errors[:postcode]).to be_empty
+          end
+        end
+      end
+
+      context 'invalid postcodes' do
+        INVALID_POSTCODES.each do |postcode|
+          subject { described_class.new postcode: postcode }
+          before { subject.validate }
+
+          it "permits #{postcode}" do
+            expect(subject.errors[:postcode]).to eq ['Enter a valid postcode']
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -113,7 +113,8 @@ describe Candidates::Registrations::ContactInformation, type: :model do
       INVALID_POSTCODES = [
         'horses',
         'N0T AP057C0D3',
-        'B3333 1BB'
+        'B3333 1BB',
+        'CH3',
       ].freeze
 
       BLANK_POSTCODES = ['', ' ', '  '].freeze

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -116,6 +116,8 @@ describe Candidates::Registrations::ContactInformation, type: :model do
         'B3333 1BB'
       ].freeze
 
+      BLANK_POSTCODES = ['', ' ', '  '].freeze
+
       context 'valid postcodes' do
         VALID_POSTCODES.each do |postcode|
           subject { described_class.new postcode: postcode }
@@ -134,6 +136,17 @@ describe Candidates::Registrations::ContactInformation, type: :model do
 
           it "permits #{postcode}" do
             expect(subject.errors[:postcode]).to eq ['Enter a valid postcode']
+          end
+        end
+      end
+
+      context 'blank postcodes' do
+        BLANK_POSTCODES.each do |postcode|
+          subject { described_class.new postcode: postcode }
+          before { subject.validate }
+
+          it "permits #{postcode}" do
+            expect(subject.errors[:postcode]).to eq ['Enter your postcode']
           end
         end
       end


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Adds postcode validation to candidates contact information

### Guidance to review
Complete the wizard up to the candidate contact information step. Expect only to be able to supply valid postcodes

REGEX taken from top answer here: https://stackoverflow.com/questions/164979/uk-postcode-regex-comprehensive
