### PR TITLE
Only try to add subjects if they don't exist

### DIFF
--- a/lib/data/school_enhancer.rb
+++ b/lib/data/school_enhancer.rb
@@ -44,7 +44,8 @@ class SchoolEnhancer
           teacher_training_website: cleanup_website(urn, row['itt_website'])
         )
           if row['secondary_subjects'].present?
-            school.subjects << extract_secondary_subjects(row['secondary_subjects'])
+            extract_secondary_subjects(row['secondary_subjects'])
+              .each { |s| school.subjects << s unless s.in?(school.subjects) }
           end
 
           puts "#{i} of #{total} #{school.urn} - #{school.name} enhanced"


### PR DESCRIPTION
### Context

Re-running the enrichment/enhancement task is problematic if schools re-define their subjects

### Changes proposed in this pull request

Now new subjects are only added if they aren't already present.

### Guidance to review

Ensure it looks sane.