### PR TITLE
Feature/fix ie and screenshots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,7 @@ group :test do
 
   gem 'shoulda-matchers', '~> 4.0'
   gem 'rails-controller-testing'
+  gem 'capybara-screenshot'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
+    capybara-screenshot (1.0.22)
+      capybara (>= 1.0, < 4)
+      launchy
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (2.1.1)
@@ -173,6 +176,8 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -369,6 +374,7 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (>= 2.15)
+  capybara-screenshot
   chromedriver-helper
   cucumber-rails
   database_cleaner

--- a/features/step_definitions/candidates/landing_page_steps.rb
+++ b/features/step_definitions/candidates/landing_page_steps.rb
@@ -27,6 +27,7 @@ end
 
 When("I click the {string} button") do |string|
   click_link(string)
+  sleep(2)
 end
 
 Then("I should be on the {string} page") do |string|

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -88,6 +88,7 @@ end
 
 When("I select {string} in the {string} select box") do |option, label_text|
   select(option, from: label_text)
+  sleep(2)
 end
 
 Given("I search for schools near {string}") do |string|

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -75,6 +75,7 @@ end
 
 Given("I have changed the sort order to {string}") do |sort_by|
   select(sort_by, from: 'Sorted by')
+  sleep(2)
 end
 
 Given("the sort order has defaulted to {string}") do |string|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,7 @@
 
 require 'cucumber/rails'
 require 'selenium/webdriver'
+require 'capybara-screenshot/cucumber'
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any


### PR DESCRIPTION
### Context

The cucumber test running CD for IE are currently failing in a non-deterministic manner.

### Changes proposed in this pull request

The pipeline will be updated to use the 32 bit IE 11 driver (speeds up tests and general reliability).

The steps that failing intermittently seem to fail because of timing issues (page hasn't completed loading).

Therefore introducing pauses in the after certain clicks to allow page to complete loading.

Also have enabled the screen shot taking when cucumber tests fail.

### Guidance to review

The Release pipeline 'Functional Tests' has been testing this branch.

