### PR TITLE
register safari browser

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -115,6 +115,10 @@ Capybara.register_driver :ie do |app|
   Capybara::Selenium::Driver.new(app, browser: :internet_explorer, options: options)
 end
 
+Capybara.register_driver :safari do |app|
+  Capybara::Selenium::Driver.new(app, browser: :safari)
+end
+
 if (driver = ENV['CUC_DRIVER']) && driver.present?
   Capybara.default_driver = driver.to_sym
 else


### PR DESCRIPTION
### Context

Currently we don't register the Safari browser.

### Changes proposed in this pull request

Registering the Safari browser.

### Guidance to review

Have confirmed that this allows testing to occur but full validation can only occur after this merge.
