### PR TITLE
Add DFE Sign-in config for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,9 +110,16 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :delayed_job
 
-  config.x.phase_two.enabled = ENV["PHASE_TWO"].present?
-
   config.force_ssl = true
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
+
+  config.x.phase_two.enabled = ENV["PHASE_TWO"].present?
+
+  if config.x.phase_two.enabled
+    config.x.base_url = ENV.fetch('DFE_SIGNIN_BASE_URL') { 'https://schoolexperience.education.gov.uk' }
+    config.x.oidc_client_id = ENV.fetch('DFE_SIGNIN_CLIENT_ID') { 'schoolexperience' }
+    config.x.oidc_client_secret = ENV.fetch('DFE_SIGNIN_SECRET')
+    config.x.oidc_host = ENV.fetch('DFE_SIGNIN_HOST') { 'pp-oidc.signin.education.gov.uk' }
+  end
 end


### PR DESCRIPTION
### Context

In order to test DFE Sign-in in our research environment (and eventually deploy it) we need to provide the secret via an environment variable

### Changes proposed in this pull request

If `config.x.phase_two` is `enabled` allow the OIDC settings to be applied. In `development` and `test` envs these are hard-coded (and the secret is loaded from the credentials file) but we want a bit more flexibility in `production`

The four environment variables are called:

* `DFE_SIGNIN_BASE_URL`
* `DFE_SIGNIN_CLIENT_ID`
* `DFE_SIGNIN_HOST`
* `DFE_SIGNIN_SECRET`

Defaults are provided for all **except** `DFE_SIGNIN_SECRET`, if this is absent the application will fail to boot.

### Guidance to review

Ensure everything looks sensible