### PR TITLE
Adds school profile show screen from prototype

### DIFF
--- a/app/controllers/schools/on_boarding/on_boardings_controller.rb
+++ b/app/controllers/schools/on_boarding/on_boardings_controller.rb
@@ -8,6 +8,7 @@ module Schools
       end
 
       def get_current_school_profile
+        # TODO update this to build the record from the bookings school
         Schools::SchoolProfile.find_or_create_by! urn: current_school.urn
       end
 

--- a/app/controllers/schools/on_boarding/profiles_controller.rb
+++ b/app/controllers/schools/on_boarding/profiles_controller.rb
@@ -2,7 +2,7 @@ module Schools
   module OnBoarding
     class ProfilesController < OnBoardingsController
       def show
-        render plain: 'todo'
+        @profile = SchoolProfilePresenter.new(current_school_profile)
       end
     end
   end

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -30,7 +30,7 @@ module Schools
         %w(administration_fee_amount_pounds amount_pounds),
         %w(administration_fee_description description),
         %w(administration_fee_interval interval),
-        %w(administration_fee_payment_method payment_method),
+        %w(administration_fee_payment_method payment_method)
       ],
       constructor: :compose
 
@@ -41,7 +41,7 @@ module Schools
         %w(dbs_fee_amount_pounds amount_pounds),
         %w(dbs_fee_description description),
         %w(dbs_fee_interval interval),
-        %w(dbs_fee_payment_method payment_method),
+        %w(dbs_fee_payment_method payment_method)
       ],
       constructor: :compose
 
@@ -52,7 +52,7 @@ module Schools
         %w(other_fee_amount_pounds amount_pounds),
         %w(other_fee_description description),
         %w(other_fee_interval interval),
-        %w(other_fee_payment_method payment_method),
+        %w(other_fee_payment_method payment_method)
       ],
       constructor: :compose
 

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -1,0 +1,229 @@
+module Schools
+  module OnBoarding
+    class SchoolProfilePresenter
+      include ActionView::Helpers
+
+      def initialize(school_profile)
+        @school_profile = school_profile
+        # FIXME temp until this is merged with Pete's work and we associate
+        # school profile with a bookings school properly
+        @school = Bookings::School.find_by! urn: @school_profile.urn
+      end
+
+      def school_name
+        @school.name
+      end
+
+      def school_address
+        [
+          @school.address_1,
+          @school.address_2,
+          @school.address_3,
+          @school.town,
+          @school.county,
+          @school.postcode
+        ].map(&:presence).compact.join(', ')
+      end
+
+      def school_email
+        @school.contact_email
+      end
+
+      def fees
+        output = []
+
+        if @school_profile.fees.administration_fees
+          output << description_for_fee(@school_profile.administration_fee)
+        end
+
+        if @school_profile.fees.dbs_fees
+          output << description_for_fee(@school_profile.dbs_fee)
+        end
+
+        if @school_profile.fees.other_fees
+          output << description_for_fee(@school_profile.other_fee)
+        end
+
+        if output.empty?
+          'No'
+        else
+          'Yes - ' + output.to_sentence
+        end
+      end
+
+      def dbs_check_required
+        case @school_profile.candidate_requirement.dbs_requirement
+        when 'always'
+          'Yes - Always'
+        when 'sometimes'
+          'Yes - Sometimes. ' + @school_profile.candidate_requirement.dbs_policy
+        when 'never'
+          'No - Never'
+        else
+          fail "Unknown dbs_requirement profile: #{@school_profile.inspect}"
+        end
+      end
+
+      def individual_requirements
+        if @school_profile.candidate_requirement.requirements
+          'Yes - ' + @school_profile.candidate_requirement.requirements_details
+        else
+          'No'
+        end
+      end
+
+      def school_experience_phases
+        output = []
+
+        if @school_profile.phases_list.primary
+          output << 'primary'
+        end
+
+        if @school_profile.phases_list.secondary
+          output << 'secondary'
+        end
+
+        if @school_profile.phases_list.college
+          output << 'college'
+        end
+
+        fail "No phases for #{@school_profile.inspect}" if output.empty?
+
+        output.to_sentence
+      end
+
+      def primary_key_stages
+        return 'None' unless @school_profile.phases_list.primary
+
+        output = []
+
+        if @school_profile.key_stage_list.early_years
+          output << 'early years'
+        end
+
+        if @school_profile.key_stage_list.key_stage_1
+          output << 'key stage 1'
+        end
+
+        if @school_profile.key_stage_list.key_stage_2
+          output << 'key stage 2'
+        end
+
+        output.to_sentence
+      end
+
+      def secondary_subjects
+        return 'None' unless @school_profile.phases_list.secondary
+
+        @school_profile.secondary_subjects.pluck(:name).to_sentence
+      end
+
+      def college_subjects
+        return 'None' unless @school_profile.phases_list.college
+
+        @school_profile.college_subjects.pluck(:name).to_sentence
+      end
+
+      def specialisms
+        if @school_profile.specialism.has_specialism
+          'Yes - ' + @school_profile.specialism.details
+        else
+          'No'
+        end
+      end
+
+      def school_experience_details
+        @school_profile.experience_outline.candidate_experience
+      end
+
+      def teacher_training_links
+        if @school_profile.experience_outline.provides_teacher_training
+          details = sanitize(@school_profile.experience_outline.teacher_training_details)
+          url = link_to nil, sanitize(@school_profile.experience_outline.teacher_training_url)
+          "Yes - #{details}. #{url}".html_safe
+        else
+          'No'
+        end
+      end
+
+      def dress_code
+        output = []
+
+        if @school_profile.candidate_experience_detail.business_dress
+          output << 'business dress'
+        end
+
+        if @school_profile.candidate_experience_detail.cover_up_tattoos
+          output << 'cover up tattoos'
+        end
+
+        if @school_profile.candidate_experience_detail.remove_piercings
+          output << 'remove piercings'
+        end
+
+        if @school_profile.candidate_experience_detail.other_dress_requirements
+          output << @school_profile.candidate_experience_detail.other_dress_requirements_detail
+        end
+
+        output.to_sentence
+      end
+
+      def parking
+        if @school_profile.candidate_experience_detail.parking_provided
+          @school_profile.candidate_experience_detail.parking_details
+        else
+          @school_profile.candidate_experience_detail.nearby_parking_details
+        end
+      end
+
+      def disability_and_access_needs
+        if @school_profile.candidate_experience_detail.disabled_facilities
+          'Yes - ' + @school_profile.candidate_experience_detail.disabled_facilities_details
+        else
+          'No'
+        end
+      end
+
+      def start_time
+        @school_profile.candidate_experience_detail.start_time
+      end
+
+      def end_time
+        @school_profile.candidate_experience_detail.end_time
+      end
+
+      def flexible_on_times
+        if @school_profile.candidate_experience_detail.times_flexible
+          'Yes'
+        else
+          'No'
+        end
+      end
+
+      def availability
+        @school_profile.availability_description.description
+      end
+
+      def admin_contact_full_name
+        @school_profile.admin_contact.full_name
+      end
+
+      def admin_contact_phone
+        @school_profile.admin_contact.phone
+      end
+
+      def admin_contact_email
+        @school_profile.admin_contact.email
+      end
+
+    private
+
+      def description_for_fee(fee)
+        amount = number_to_currency fee.amount_pounds, unit: '£', raise: true
+        name = fee.model_name.human.downcase
+        interval = fee.interval.downcase
+        [amount, interval, name].join(' ')
+      end
+    end
+  end
+end

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -1,0 +1,46 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      Check your answers before setting up your school experience profile
+    </h1>
+
+    <h2 class="govuk-heading-m">School details</h2>
+    <dl class="govuk-summary-list">
+      <%= summary_row 'Full name', @profile.school_name, '' %>
+      <%= summary_row 'Address', @profile.school_address, '' %>
+      <%= summary_row 'Email address', @profile.school_email, '' %>
+    </dl>
+
+    <h2 class="govuk-heading-m">School experience details</h2>
+    <dl class="govuk-summary-list">
+      <%= summary_row 'Fees', @profile.fees, 'Change' %>
+      <%= summary_row 'DBS check required', @profile.dbs_check_required, 'Change' %>
+      <%= summary_row 'Individual requirements', @profile.individual_requirements, 'Change' %>
+      <%= summary_row 'School experience phases', @profile.school_experience_phases, 'Change' %>
+      <%= summary_row 'Primary key stages', @profile.primary_key_stages, 'Change' %>
+      <%= summary_row 'Secondary subjects', @profile.secondary_subjects, 'Change' %>
+      <%= summary_row '16 to 18 years', @profile.college_subjects, 'Change' %>
+      <%= summary_row 'Specialisms', @profile.specialisms, 'Change' %>
+      <%= summary_row 'School experience details', @profile.school_experience_details, 'Change' %>
+      <%= summary_row 'Teacher training links', @profile.teacher_training_links, 'Change' %>
+    </dl>
+
+    <h2 class="govuk-heading-m">Candidate information</h2>
+    <dl class="govuk-summary-list">
+      <%= summary_row 'Dress code', @profile.dress_code, 'Change' %>
+      <%= summary_row 'Parking', @profile.parking, 'Change' %>
+      <%= summary_row 'Disability and access needs', @profile.disability_and_access_needs, 'Change' %>
+      <%= summary_row 'Start time', @profile.start_time, 'Change' %>
+      <%= summary_row 'Finish time', @profile.end_time, 'Change' %>
+      <%= summary_row 'Flexible on times', @profile.flexible_on_times, 'Change' %>
+      <%= summary_row 'Availability', @profile.availability, 'Change' %>
+    </dl>
+
+    <h2 class="ogvuk-heading-m">Admin contact details</h2>
+    <dl class="govuk-summary-list">
+      <%= summary_row 'Full name', @profile.admin_contact_full_name, 'Change' %>
+      <%= summary_row 'UK telephone number', @profile.admin_contact_phone, 'Change' %>
+      <%= summary_row 'Email address', @profile.admin_contact_email, 'Change' %>
+    </dl>
+  </div>
+</div>

--- a/features/schools/admin_contact.feature
+++ b/features/schools/admin_contact.feature
@@ -5,6 +5,7 @@ Feature: Admin contact
 
   Background: I have completed the wizard thus far
     Given I am logged in as a DfE user
+    Given A school is returned from DFE sign in
     Given The secondary school phase is availble
     Given The college phase is availble
     And There are some subjects available

--- a/features/schools/school_profile.feature
+++ b/features/schools/school_profile.feature
@@ -1,0 +1,49 @@
+Feature: School Profile
+  So I can ensure the data I've entered is accurate
+  As a school administrator
+  I want to be able to view my school profile
+
+  Background: I have completed the wizard thus far
+    Given I am logged in as a DfE user
+    Given A school is returned from DFE sign in
+    Given The secondary school phase is availble
+    Given The college phase is availble
+    And There are some subjects available
+    And I have completed the Candidate Requirements step
+    And I have completed the Fees step, choosing only Other costs
+    And I have completed the Other costs step
+    And I have completed the Phases step
+    And I have completed the Secondary subjects step
+    And I have completed the College subjects step
+    And I have completed the Specialisms step
+    And I have completed the Candidate experience details step
+    And I have completed the Availability description step
+    And I have completed the Experience Outline step
+    And I have completed the Admin contact
+
+  Scenario: Viewing the profile
+    Given I am on the 'Profile' page
+    Then The page should have the following summary list information:
+      | Full name                   | school 1                                          |
+      | Address                     | \d{1,} something street, M\d{1,} 2JJ              |
+      | Email address               | school1@example.com                               |
+      | Fees                        | Yes - £300.00 daily other fee                     |
+      | DBS check required          | Yes - Sometimes. policy details                   |
+      | Individual requirements     | Yes - Candidates need to be good                  |
+      | School experience phases    | secondary and college                             |
+      | Primary key stages          | None                                              |
+      | Secondary subjects          | Maths                                             |
+      | 16 to 18 years              | Maths                                             |
+      | Specialisms                 | Yes - Race track                                  |
+      | School experience details   | A really good one                                 |
+      | Teacher training links      | Yes - We run our own training. http://example.com |
+      | Dress code                  | business dress and Must have nice hat             |
+      | Parking                     | Carpark next door                                 |
+      | Disability and access needs | No                                                |
+      | Start time                  | 8:15 am                                           |
+      | Finish time                 | 4:30 pm                                           |
+      | Flexible on times           | Yes                                               |
+      | Availability                | Whenever really                                   |
+      | Full name                   | Gary Chalmers                                     |
+      | UK telephone number         | 01234567890                                       |
+      | Email address               | g.chalmers@springfield.edu                        |

--- a/features/step_definitions/schools/shared_steps.rb
+++ b/features/step_definitions/schools/shared_steps.rb
@@ -119,9 +119,26 @@ Given "I have completed the Experience Outline step" do
   )
 end
 
+Given "I have completed the Admin contact" do
+  steps %(
+    Given I am on the 'Admin contact' page
+    And I enter 'Gary Chalmers' into the 'Full name' text area
+    And I enter '01234567890' into the 'UK telephone number' text area
+    And I enter 'g.chalmers@springfield.edu' into the 'Email address' text area
+    When I submit the form
+    Then I should be on the 'Profile' page
+  )
+end
+
 Then "I should see a validation error message" do
   within '.govuk-error-summary' do
     expect(page).to have_content 'There is a problem'
+  end
+end
+
+Then "The page should have the following summary list information:" do |table|
+  table.raw.to_h.each do |key, value|
+    expect(page).to have_text /#{key} #{value}/
   end
 end
 
@@ -135,4 +152,9 @@ end
 
 Given "There are some subjects available" do
   FactoryBot.create :bookings_subject, name: 'Maths'
+end
+
+Given "A school is returned from DFE sign in" do
+  # FIXME change this once we merge in phase2
+  FactoryBot.create :bookings_school, urn: 1234567890
 end

--- a/spec/factories/schools/on_boarding/candidate_experience_detail_factory.rb
+++ b/spec/factories/schools/on_boarding/candidate_experience_detail_factory.rb
@@ -14,5 +14,15 @@ FactoryBot.define do
     start_time { '8:15am' }
     end_time { '4:30pm' }
     times_flexible { true }
+
+    trait :without_parking do
+      parking_provided { false }
+      nearby_parking_details { 'Public car park across the street' }
+    end
+
+    trait :with_disabled_facilities do
+      disabled_facilities { true }
+      disabled_facilities_details { 'Full wheelchair access and hearing loops' }
+    end
   end
 end

--- a/spec/factories/schools/school_profile_factory.rb
+++ b/spec/factories/schools/school_profile_factory.rb
@@ -71,9 +71,24 @@ FactoryBot.define do
       specialism_details { 'Falconry' }
     end
 
+    transient do
+      parking { true }
+      disabled_facilities { false }
+    end
+
     trait :with_candidate_experience_detail do
-      after :build do |profile|
-        profile.candidate_experience_detail = FactoryBot.build :candidate_experience_detail
+      after :build do |profile, evaluator|
+        traits = []
+
+        if evaluator.parking == false
+          traits << :without_parking
+        end
+
+        if evaluator.disabled_facilities
+          traits << :with_disabled_facilities
+        end
+
+        profile.candidate_experience_detail = FactoryBot.build :candidate_experience_detail, *traits
       end
     end
 

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -180,7 +180,7 @@ describe Schools::SchoolProfile, type: :model do
   end
 
   context 'associations' do
-    context 'subjects' do
+    context '#subjects' do
       subject { described_class.create! urn: 1234567890 }
 
       let! :secondary_phase do

--- a/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
@@ -1,0 +1,407 @@
+require 'rails_helper'
+
+describe Schools::OnBoarding::SchoolProfilePresenter do
+  subject { described_class.new profile }
+
+  let! :school do
+    # FIXME remove this once we've changed the profile to belong_to a school
+    FactoryBot.create :bookings_school, :full_address, urn: 123456
+  end
+
+  before do
+    FactoryBot.create :bookings_phase, :secondary
+    FactoryBot.create :bookings_phase, :college
+  end
+
+  context '#school_name' do
+    let :profile do
+      FactoryBot.build :school_profile
+    end
+
+    it "returns the school's name" do
+      expect(subject.school_name).to eq school.name
+    end
+  end
+
+  context '#school_address' do
+    let :profile do
+      FactoryBot.build :school_profile
+    end
+
+    it "returns the school's address" do
+      expect(subject.school_address).to \
+        match(/\d{1,} Something Street, \d{1,} Something area, \d{1,} Something area, \d{1,} Something town, \d{1,} Something county, M\d{1,} 2JF/)
+    end
+  end
+
+  context '#school_email' do
+    let :profile do
+      FactoryBot.build :school_profile
+    end
+
+    it "returns the school's contact email" do
+      expect(subject.school_email).to eq school.contact_email
+    end
+  end
+
+  context '#fees' do
+    context 'with no fees' do
+      let :profile do
+        FactoryBot.build :school_profile
+      end
+
+      it 'returns no' do
+        expect(subject.fees).to eq 'No'
+      end
+    end
+
+    context 'with fees' do
+      context 'with administration_fees' do
+        let :profile do
+          FactoryBot.build \
+            :school_profile,
+            :with_administration_fee,
+            fees_administration_fees: true
+        end
+
+        it 'returns the administration fee' do
+          expect(subject.fees).to eq 'Yes - £123.45 daily administration fee'
+        end
+      end
+
+      context 'with dbs_fees' do
+        let :profile do
+          FactoryBot.build :school_profile, :with_dbs_fee, fees_dbs_fees: true
+        end
+
+        it 'returns the dbs fee' do
+          expect(subject.fees).to eq 'Yes - £200.00 one-off dbs fee'
+        end
+      end
+
+      context 'with other_fees' do
+        let :profile do
+          FactoryBot.build \
+            :school_profile,
+            :with_other_fee,
+            fees_other_fees: true
+        end
+
+        it 'returns the other fee' do
+          expect(subject.fees).to eq 'Yes - £444.44 one-off other fee'
+        end
+      end
+    end
+  end
+
+  context '#dbs_check_required' do
+    context 'when never' do
+      let :profile do
+        FactoryBot.build \
+          :school_profile,
+          candidate_requirement_dbs_requirement: 'never'
+      end
+
+      it 'returns No - Never' do
+        expect(subject.dbs_check_required).to eq 'No - Never'
+      end
+    end
+
+    context 'when always' do
+      let :profile do
+        FactoryBot.build \
+          :school_profile,
+          candidate_requirement_dbs_requirement: 'always'
+      end
+
+      it 'returns Yes - Always' do
+        expect(subject.dbs_check_required).to eq 'Yes - Always'
+      end
+    end
+
+    context 'when sometimes' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_candidate_requirement
+      end
+
+      it 'returns sometimes and the policy' do
+        expect(subject.dbs_check_required).to eq 'Yes - Sometimes. Super secure'
+      end
+    end
+  end
+
+  context '#individual_requirements' do
+    context 'without requirements' do
+      let :profile do
+        FactoryBot.build \
+          :school_profile, candidate_requirement_requirements: false
+      end
+
+      it 'returns no' do
+        expect(subject.individual_requirements).to eq 'No'
+      end
+    end
+
+    context 'with requirements' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_candidate_requirement
+      end
+
+      it 'returns yes with the requirements' do
+        expect(subject.individual_requirements).to eq 'Yes - Gotta go fast'
+      end
+    end
+  end
+
+  context '#school_experience_phases' do
+    context 'all phases selected' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_phases
+      end
+
+      it 'adds each selected phase to the output' do
+        expect(subject.school_experience_phases).to \
+          eq 'primary, secondary, and college'
+      end
+    end
+
+    context 'subset of phases selected' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_only_early_years_phase
+      end
+
+      it 'only adds the selected phases' do
+        expect(subject.school_experience_phases).to eq 'primary'
+      end
+    end
+  end
+
+  context '#primary_key_stages' do
+    context 'when primary phase not selected' do
+      let :profile do
+        FactoryBot.build \
+          :school_profile, :with_phases, phases_list_primary: false
+      end
+
+      it 'returns None' do
+        expect(subject.primary_key_stages).to eq 'None'
+      end
+    end
+
+    context 'when primary phase selected' do
+      let :profile do
+        FactoryBot.build \
+          :school_profile, :with_phases, :with_key_stage_list
+      end
+
+      it 'returns the key stages' do
+        expect(subject.primary_key_stages).to \
+          eq 'early years, key stage 1, and key stage 2'
+      end
+    end
+  end
+
+  context '#secondary_subjects' do
+    context 'when secondary phase not selected' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_only_early_years_phase
+      end
+
+      it 'returns None' do
+        expect(subject.secondary_subjects).to eq 'None'
+      end
+    end
+
+    context 'when secondary phase selected' do
+      let :profile do
+        FactoryBot.create \
+          :school_profile,
+          :with_phases,
+          :with_secondary_subjects
+      end
+
+      it 'returns the list of secondary subjects' do
+        expect(subject.secondary_subjects).to \
+          eq profile.secondary_subjects.pluck(:name).to_sentence
+      end
+    end
+  end
+
+  context '#college_subjects' do
+    context 'when college phase not selected' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_only_early_years_phase
+      end
+
+      it 'returns None' do
+        expect(subject.college_subjects).to eq 'None'
+      end
+    end
+
+    context 'when college phase selected' do
+      let :profile do
+        FactoryBot.create \
+          :school_profile,
+          :with_phases,
+          :with_college_subjects
+      end
+
+      it 'returns the list of secondary subjects' do
+        expect(subject.college_subjects).to \
+          eq profile.college_subjects.pluck(:name).to_sentence
+      end
+    end
+  end
+
+  context '#specialisms' do
+    context 'without specialisms' do
+      let :profile do
+        FactoryBot.build :school_profile
+      end
+
+      it 'returns no' do
+        expect(subject.specialisms).to eq 'No'
+      end
+    end
+
+    context 'with specialims' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_specialism
+      end
+
+      it 'returns the specialism' do
+        expect(subject.specialisms).to eq 'Yes - Falconry'
+      end
+    end
+  end
+
+  context '#school_experience_details' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_experience_outline
+    end
+
+    it 'returns the school experience details' do
+      expect(subject.school_experience_details).to eq 'Mostly teaching'
+    end
+  end
+
+  context '#dress_code' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_candidate_experience_detail
+    end
+
+    it 'returns the selected dress code options' do
+      expect(subject.dress_code).to \
+        eq "business dress, cover up tattoos, remove piercings, and Must have nice hat"
+    end
+  end
+
+  context '#parking' do
+    context 'when parking is offered' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_candidate_experience_detail
+      end
+
+      it 'returns parking details' do
+        expect(subject.parking).to eq 'Plenty of spaces'
+      end
+    end
+
+    context 'when parking is not offered' do
+      let :profile do
+        FactoryBot.build \
+          :school_profile, :with_candidate_experience_detail, parking: false
+      end
+
+      it 'returns nearby parking details' do
+        expect(subject.parking).to eq 'Public car park across the street'
+      end
+    end
+  end
+
+  context '#disability_and_access_needs' do
+    context 'when disability and access needs facilities not present' do
+      let :profile do
+        FactoryBot.build :school_profile, :with_candidate_experience_detail
+      end
+
+      it 'returns no' do
+        expect(subject.disability_and_access_needs).to eq 'No'
+      end
+    end
+
+    context 'when disability and access needs facilities present' do
+      let :profile do
+        FactoryBot.build \
+          :school_profile,
+          :with_candidate_experience_detail,
+          disabled_facilities: true
+      end
+
+      it 'returns the description' do
+        expect(subject.disability_and_access_needs).to \
+          eq 'Yes - Full wheelchair access and hearing loops'
+      end
+    end
+  end
+
+  context '#start_time' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_candidate_experience_detail
+    end
+
+    it 'returns the start time' do
+      expect(subject.start_time).to eq '8:15am'
+    end
+  end
+
+  context '#end_time' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_candidate_experience_detail
+    end
+
+    it 'returns the end time' do
+      expect(subject.end_time).to eq '4:30pm'
+    end
+  end
+
+  context '#availability' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_availability_description
+    end
+
+    it 'returns the availability' do
+      expect(subject.availability).to eq 'Whenever really'
+    end
+  end
+
+  context '#admin_contact_full_name' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_admin_contact
+    end
+
+    it "returns the admin contact's name" do
+      expect(subject.admin_contact_full_name).to eq 'Gary Chalmers'
+    end
+  end
+
+  context '#admin_contact_email' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_admin_contact
+    end
+
+    it "returns the admin contact's email" do
+      expect(subject.admin_contact_email).to eq 'g.chalmers@springfield.edu'
+    end
+  end
+
+  context '#admin_contact_phone' do
+    let :profile do
+      FactoryBot.build :school_profile, :with_admin_contact
+    end
+
+    it "returns the admin contact's phone" do
+      expect(subject.admin_contact_phone).to eq '+441234567890'
+    end
+  end
+end


### PR DESCRIPTION
### Context
Adds the school profile show page, still need to polish the show page to handle capitalising the sentences etc but that will be added when implementing fred's changes to the prototype

### Changes proposed in this pull request

### Guidance to review
Should seem sensible, should be able to complete the wizard and see the profile overview at the end
