### PR TITLE
Feature/school on boarding profile reset dependent steps

### DIFF
--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -24,6 +24,18 @@ module Schools
 
         other.attributes == self.attributes
       end
+
+      def administration_fees?
+        administration_fees
+      end
+
+      def dbs_fees?
+        dbs_fees
+      end
+
+      def other_fees?
+        other_fees
+      end
     end
   end
 end

--- a/app/forms/schools/on_boarding/phases_list.rb
+++ b/app/forms/schools/on_boarding/phases_list.rb
@@ -22,6 +22,18 @@ module Schools
         other.respond_to?(:attributes) && other.attributes == self.attributes
       end
 
+      def primary?
+        primary
+      end
+
+      def secondary?
+        secondary
+      end
+
+      def college?
+        college
+      end
+
     private
 
       def at_least_one_phase_offered

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -2,6 +2,31 @@ module Schools
   class SchoolProfile < ApplicationRecord
     validates :urn, presence: true, uniqueness: true
 
+    before_validation do
+      # Some steps in the wizard depend on previous steps and don't make
+      # sense if the profile is edited to uncheck the options that require
+      # these steps. If this is the case we want to reset those steps to their
+      # initial state.
+      unless fees.administration_fees
+        self.administration_fee = Schools::OnBoarding::AdministrationFee.new
+      end
+      unless fees.dbs_fees
+        self.dbs_fee = Schools::OnBoarding::DBSFee.new
+      end
+      unless fees.other_fees
+        self.other_fee = Schools::OnBoarding::OtherFee.new
+      end
+      unless phases_list.primary
+        self.key_stage_list = Schools::OnBoarding::KeyStageList.new
+      end
+      unless phases_list.secondary
+        self.secondary_subjects.destroy_all
+      end
+      unless phases_list.college
+        self.college_subjects.destroy_all
+      end
+    end
+
     composed_of \
       :candidate_requirement,
       class_name: 'Schools::OnBoarding::CandidateRequirement',

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -7,32 +7,32 @@ module Schools
       # sense if the profile is edited to uncheck the options that require
       # these steps. If this is the case we want to reset those steps to their
       # initial state.
-      unless fees.administration_fees
+      unless fees.administration_fees?
         self.administration_fee = Schools::OnBoarding::AdministrationFee.new
       end
-      unless fees.dbs_fees
+      unless fees.dbs_fees?
         self.dbs_fee = Schools::OnBoarding::DBSFee.new
       end
-      unless fees.other_fees
+      unless fees.other_fees?
         self.other_fee = Schools::OnBoarding::OtherFee.new
       end
-      unless phases_list.primary
+      unless phases_list.primary?
         self.key_stage_list = Schools::OnBoarding::KeyStageList.new
       end
-      unless phases_list.secondary
+      unless phases_list.secondary?
         self.secondary_subjects.destroy_all
       end
-      unless phases_list.college
+      unless phases_list.college?
         self.college_subjects.destroy_all
       end
     end
 
-    validate :administration_fee_not_set, unless: -> { fees.administration_fees }
-    validate :dbs_fee_not_set, unless: -> { fees.dbs_fees }
-    validate :other_fee_not_set, unless: -> { fees.other_fees }
-    validate :key_stage_list_not_set, unless: -> { phases_list.primary }
-    validate :no_secondary_subjects, unless: -> { phases_list.secondary }
-    validate :no_college_subjects, unless: -> { phases_list.college }
+    validate :administration_fee_not_set, unless: -> { fees.administration_fees? }
+    validate :dbs_fee_not_set, unless: -> { fees.dbs_fees? }
+    validate :other_fee_not_set, unless: -> { fees.other_fees? }
+    validate :key_stage_list_not_set, unless: -> { phases_list.primary? }
+    validate :no_secondary_subjects, unless: -> { phases_list.secondary? }
+    validate :no_college_subjects, unless: -> { phases_list.college? }
 
     DEPENDENT_STAGES = [
       [:administration_fee, 'fees.administration_fees'],

--- a/features/schools/administration_fee.feature
+++ b/features/schools/administration_fee.feature
@@ -5,7 +5,10 @@ Feature: Administration Fee
 
   Background: I have completed the previous steps
     Given I am logged in as a DfE user
+    Given The secondary school phase is availble
+    Given The college phase is availble
     And I have completed the Candidate Requirements step
+    And I have completed the Fees step, choosing only Administration costs
     And I have completed the Fees step, choosing only Administration costs
 
   Scenario: Completing the Administration costs step with error

--- a/features/schools/administration_fee.feature
+++ b/features/schools/administration_fee.feature
@@ -9,7 +9,6 @@ Feature: Administration Fee
     Given The college phase is availble
     And I have completed the Candidate Requirements step
     And I have completed the Fees step, choosing only Administration costs
-    And I have completed the Fees step, choosing only Administration costs
 
   Scenario: Completing the Administration costs step with error
     Given I have entered the following details into the form:

--- a/features/schools/dbs_fee.feature
+++ b/features/schools/dbs_fee.feature
@@ -5,6 +5,8 @@ Feature: DBS Fee
 
   Background: I have completed the previous steps
     Given I am logged in as a DfE user
+    Given The secondary school phase is availble
+    Given The college phase is availble
     Given I have completed the Candidate Requirements step
     And I have completed the Fees step, choosing only DBS costs
 

--- a/features/schools/fees.feature
+++ b/features/schools/fees.feature
@@ -5,6 +5,8 @@ Feature: Fees
 
   Background: I have completed the candidate requirement step
     Given I am logged in as a DfE user
+    Given The secondary school phase is availble
+    Given The college phase is availble
     And I have completed the Candidate Requirements step
 
   Scenario: Completing step choosing Adminsitration costs only

--- a/features/schools/other_fee.feature
+++ b/features/schools/other_fee.feature
@@ -5,7 +5,9 @@ Feature: Other Fee
 
   Background: I have completed the previous steps
     Given I am logged in as a DfE user
-    Given I have completed the Candidate Requirements step
+    Given The secondary school phase is availble
+    Given The college phase is availble
+    And I have completed the Candidate Requirements step
     And I have completed the Fees step, choosing only Other costs
 
   Scenario: Completing the Other costs step with error

--- a/spec/controllers/schools/on_boarding/admin_contacts_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/admin_contacts_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::OnBoarding::AdminContactsController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/controllers/schools/on_boarding/administration_fees_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/administration_fees_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::OnBoarding::AdministrationFeesController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create :school_profile, :with_candidate_requirement, :with_fees

--- a/spec/controllers/schools/on_boarding/availability_descriptions_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/availability_descriptions_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::OnBoarding::AvailabilityDescriptionsController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/controllers/schools/on_boarding/candidate_experience_details_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/candidate_experience_details_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::CandidateExperienceDetailsController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/controllers/schools/on_boarding/candidate_requirements_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/candidate_requirements_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::OnBoarding::CandidateRequirementsController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     create :school_profile

--- a/spec/controllers/schools/on_boarding/college_subjects_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/college_subjects_controller_spec.rb
@@ -4,14 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::CollegeSubjectsController, type: :request do
   include_context "logged in DfE user"
-
-  let! :secondary_phase do
-    FactoryBot.create :bookings_phase, :secondary
-  end
-
-  let! :college_phase do
-    FactoryBot.create :bookings_phase, :college
-  end
+  include_context 'with phases'
 
   let! :bookings_subject do
     FactoryBot.create :bookings_subject

--- a/spec/controllers/schools/on_boarding/dbs_fees_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/dbs_fees_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::DbsFeesController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/controllers/schools/on_boarding/experience_outlines_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/experience_outlines_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::OnBoarding::ExperienceOutlinesController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/controllers/schools/on_boarding/fees_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/fees_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::FeesController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create :school_profile, :with_candidate_requirement

--- a/spec/controllers/schools/on_boarding/key_stage_lists_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/key_stage_lists_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::KeyStageListsController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \
@@ -14,10 +15,6 @@ describe Schools::OnBoarding::KeyStageListsController, type: :request do
       :with_dbs_fee,
       :with_other_fee,
       :with_phases
-  end
-
-  let! :secondary_phase do
-    FactoryBot.create :bookings_phase, :secondary
   end
 
   context '#new' do

--- a/spec/controllers/schools/on_boarding/other_fees_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/other_fees_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::OtherFeesController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/controllers/schools/on_boarding/phases_lists_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/phases_lists_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::PhasesListsController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/controllers/schools/on_boarding/secondary_subjects_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/secondary_subjects_controller_spec.rb
@@ -4,14 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::SecondarySubjectsController, type: :request do
   include_context "logged in DfE user"
-
-  let! :secondary_phase do
-    FactoryBot.create :bookings_phase, :secondary
-  end
-
-  let! :college_phase do
-    FactoryBot.create :bookings_phase, :college
-  end
+  include_context 'with phases'
 
   let! :bookings_subject do
     FactoryBot.create :bookings_subject

--- a/spec/controllers/schools/on_boarding/specialisms_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/specialisms_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::OnBoarding::SpecialismsController, type: :request do
   include_context "logged in DfE user"
+  include_context 'with phases'
 
   let! :school_profile do
     FactoryBot.create \

--- a/spec/factories/bookings/phase_factory.rb
+++ b/spec/factories/bookings/phase_factory.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     sequence(:name) { |n| "phase #{n}" }
   end
 
+  trait :primary do
+    name { 'Primary' }
+  end
+
   trait :secondary do
     name { 'Secondary' }
   end

--- a/spec/factories/schools/school_profile_factory.rb
+++ b/spec/factories/schools/school_profile_factory.rb
@@ -109,5 +109,22 @@ FactoryBot.define do
         profile.availability_description = FactoryBot.build :availability_description
       end
     end
+
+    trait :completed do
+      with_candidate_requirement
+      with_fees
+      with_administration_fee
+      with_dbs_fee
+      with_other_fee
+      with_only_early_years_phase
+      with_key_stage_list
+      with_secondary_subjects
+      with_college_subjects
+      with_specialism
+      with_candidate_experience_detail
+      with_availability_description
+      with_experience_outline
+      with_admin_contact
+    end
   end
 end

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -538,9 +538,53 @@ describe Schools::SchoolProfile, type: :model do
         end
       end
 
-      context 'when key_stage_list no longer makes sense'
-      context 'when secondary_subjects no longer makes sense'
-      context 'when college_subjects no longer makes sense'
+      context 'when key_stage_list no longer makes sense' do
+        let :school_profile do
+          FactoryBot.create :school_profile, :with_phases, :with_key_stage_list
+        end
+
+        before do
+          school_profile.update! \
+            phases_list: Schools::OnBoarding::PhasesList.new(primary: false)
+        end
+
+        it 'resets key stage list' do
+          expect(school_profile.reload.key_stage_list).to \
+            eq Schools::OnBoarding::KeyStageList.new
+        end
+      end
+
+      context 'when secondary_subjects no longer makes sense' do
+        let :school_profile do
+          FactoryBot.create \
+            :school_profile, :with_phases, :with_secondary_subjects
+        end
+
+        before do
+          school_profile.update! \
+            phases_list: Schools::OnBoarding::PhasesList.new(secondary: false)
+        end
+
+        it 'removes secondary_subjects' do
+          expect(school_profile.reload.secondary_subjects).to be_empty
+        end
+      end
+
+      context 'when college_subjects no longer makes sense' do
+        let :school_profile do
+          FactoryBot.create \
+            :school_profile, :with_phases, :with_college_subjects
+        end
+
+        before do
+          school_profile.update! \
+            phases_list: Schools::OnBoarding::PhasesList.new(college: false)
+        end
+
+        it 'removes secondary_subjects' do
+          expect(school_profile.reload.college_subjects).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/support/with_phases.rb
+++ b/spec/support/with_phases.rb
@@ -1,0 +1,7 @@
+shared_context 'with phases' do
+  before do
+    FactoryBot.create :bookings_phase, :primary
+    FactoryBot.create :bookings_phase, :secondary
+    FactoryBot.create :bookings_phase, :college
+  end
+end


### PR DESCRIPTION
### Context
Review after [Adds school profile show screen from prototype](https://github.com/DFE-Digital/schools-experience/pull/325) is merged

Some steps in the wizard depend on previous steps and don't make
sense if the profile is edited to uncheck the options that require
these steps. If this is the case we want to reset those steps to their
initial state.

### Changes proposed in this pull request
Adds a callback to profiles to make sure they remain in a reasonable state.

### Guidance to review
