### PR TITLE
Feature/add date selection to candidate placement preferences screen

### DIFF
--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -4,7 +4,8 @@ module Candidates
       before_action :set_school
 
       def new
-        @placement_preference = PlacementPreference.new attributes_from_session
+        @placement_preference = PlacementPreference.new \
+          attributes_from_session.merge(urn: current_urn)
       end
 
       def create
@@ -43,9 +44,10 @@ module Candidates
       end
 
       def placement_preference_params
-        params.require(:candidates_registrations_placement_preference).permit \
+        params.require(:candidates_registrations_placement_preference).permit(
           :availability,
           :objectives
+        ).merge(urn: current_urn)
       end
 
       def attributes_from_session

--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -46,7 +46,8 @@ module Candidates
       def placement_preference_params
         params.require(:candidates_registrations_placement_preference).permit(
           :availability,
-          :objectives
+          :objectives,
+          :bookings_placement_date_id
         ).merge(urn: current_urn)
       end
 

--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -1,7 +1,7 @@
 module Candidates
   module Registrations
     class PlacementPreferencesController < RegistrationsController
-      before_action :set_school
+      before_action :set_school, :set_placement_dates
 
       def new
         @placement_preference = PlacementPreference.new \
@@ -41,6 +41,15 @@ module Candidates
       def set_school
         # FIXME modify to use current_registration.school
         @school = Candidates::School.find(params[:school_id])
+      end
+
+      def set_placement_dates
+        if @school.fixed_dates?
+          @placement_dates = @school
+            .school_profile
+            .bookings_placement_dates
+            .available
+        end
       end
 
       def placement_preference_params

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -42,7 +42,10 @@ class Schools::PlacementDatesController < Schools::BaseController
 private
 
   def set_placement_date
-    @placement_date = current_school.school_profile.bookings_placement_dates.find(params[:id])
+    @placement_date = current_school
+      .school_profile
+      .bookings_placement_dates
+      .find(params[:id])
   end
 
   def placement_date_params

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -4,7 +4,7 @@ class Schools::PlacementDatesController < Schools::BaseController
   def index
     @placement_dates = current_school
       .school_profile
-      .placement_dates
+      .bookings_placement_dates
       .future
       .in_date_order
   end
@@ -12,14 +12,14 @@ class Schools::PlacementDatesController < Schools::BaseController
   def new
     @placement_date = current_school
       .school_profile
-      .placement_dates
+      .bookings_placement_dates
       .new
   end
 
   def create
     @placement_date = current_school
       .school_profile
-      .placement_dates
+      .bookings_placement_dates
       .new(placement_date_params)
 
     if @placement_date.save
@@ -42,7 +42,7 @@ class Schools::PlacementDatesController < Schools::BaseController
 private
 
   def set_placement_date
-    @placement_date = current_school.school_profile.placement_dates.find(params[:id])
+    @placement_date = current_school.school_profile.bookings_placement_dates.find(params[:id])
   end
 
   def placement_date_params

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -18,5 +18,13 @@ module Bookings
     scope :in_date_order, -> { order(date: 'asc') }
     scope :active, -> { where(active: true) }
     scope :inactive, -> { where(active: false) }
+
+    def to_s
+      "%<date>s (%<duration>d %<unit>s)" % {
+        date: date.to_formatted_s(:govuk),
+        duration: duration,
+        unit: "day".pluralize(duration)
+      }
+    end
   end
 end

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -19,6 +19,8 @@ module Bookings
     scope :active, -> { where(active: true) }
     scope :inactive, -> { where(active: false) }
 
+    scope :available, -> { active.future.in_date_order }
+
     def to_s
       "%<date>s (%<duration>d %<unit>s)" % {
         date: date.to_formatted_s(:govuk),

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -10,5 +10,9 @@ module Bookings
       self.create! \
         Candidates::Registrations::RegistrationAsPlacementRequest.new(registration_session).attributes
     end
+
+    def school
+      @school ||= Candidates::School.find urn
+    end
   end
 end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -91,4 +91,8 @@ class Bookings::School < ApplicationRecord
   def disabled?
     !enabled?
   end
+
+  def fixed_dates?
+    school_profile&.fixed_dates?
+  end
 end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -76,6 +76,11 @@ class Bookings::School < ApplicationRecord
     end
   end
 
+  def availability_preference_fixed?
+    # school_profile.availability_preference.fixed?
+    false
+  end
+
   def to_param
     urn.to_s.presence
   end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -77,8 +77,7 @@ class Bookings::School < ApplicationRecord
   end
 
   def availability_preference_fixed?
-    # school_profile.availability_preference.fixed?
-    false
+    school_profile&.availability_preference&.fixed?
   end
 
   def to_param

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -252,5 +252,9 @@ module Schools
     def fixed_dates?
       availability_preference.fixed?
     end
+
+    def has_available_dates?
+      fixed_dates? && bookings_placement_dates.available.exists?
+    end
   end
 end

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -228,7 +228,7 @@ module Schools
       through: :college_phase_subjects,
       dependent: :destroy
 
-    has_many :placement_dates,
+    has_many :bookings_placement_dates,
       class_name: 'Bookings::PlacementDate',
       foreign_key: :schools_school_profile_id
 

--- a/app/notify/notify_email/candidate_request_confirmation.3860fb06-9af2-49c8-ac0b-007b9f360033.md
+++ b/app/notify/notify_email/candidate_request_confirmation.3860fb06-9af2-49c8-ac0b-007b9f360033.md
@@ -18,7 +18,7 @@ Personal details
 Request details
 
 * School or college: ((school_name))
-* Experience availability: ((placement_availability))
+* Availability/preferred dates: ((placement_availability))
 * Experience outcome: ((placement_outcome))
 * Degree stage: ((candidate_degree_stage))
 * Degree subject: ((candidate_degree_subject))

--- a/app/notify/notify_email/candidate_request_confirmation.rb
+++ b/app/notify/notify_email/candidate_request_confirmation.rb
@@ -51,7 +51,8 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
     NotifyEmail::CandidateRequestConfirmation.new(
       to: to,
       candidate_address: application_preview.full_address,
-      candidate_dbs_check_document: application_preview.dbs_check_document, candidate_degree_stage: application_preview.degree_stage,
+      candidate_dbs_check_document: application_preview.dbs_check_document,
+      candidate_degree_stage: application_preview.degree_stage,
       candidate_degree_subject: application_preview.degree_subject,
       candidate_email_address: application_preview.email_address,
       candidate_name: application_preview.full_name,

--- a/app/notify/notify_email/candidate_request_confirmation.rb
+++ b/app/notify/notify_email/candidate_request_confirmation.rb
@@ -61,7 +61,7 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
       placement_outcome: application_preview.placement_outcome,
-      placement_availability: application_preview.placement_availability,
+      placement_availability: (application_preview.placement_availability || application_preview.placement_date.to_s),
       school_name: application_preview.school
     )
   end

--- a/app/notify/notify_email/candidate_request_confirmation.rb
+++ b/app/notify/notify_email/candidate_request_confirmation.rb
@@ -61,7 +61,7 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
       placement_outcome: application_preview.placement_outcome,
-      placement_availability: (application_preview.placement_availability || application_preview.placement_date.to_s),
+      placement_availability: application_preview.placement_availability_description,
       school_name: application_preview.school
     )
   end

--- a/app/notify/notify_email/school_request_confirmation.3da1cb35-efd2-4aa6-8416-27efc5611d06.md
+++ b/app/notify/notify_email/school_request_confirmation.3da1cb35-efd2-4aa6-8416-27efc5611d06.md
@@ -16,13 +16,13 @@ Personal details:
 Request details:
 
 * School or college: ((school_name))
-* Experience availability: ((placement_availability))
+* Availability/preferred dates: ((placement_availability))
 * Experience outcome: ((placement_outcome))
+* Experience subject – first choice: ((candidate_teaching_subject_first_choice))
+* Experience subject – second choice: ((candidate_teaching_subject_second_choice))
 * Degree stage: ((candidate_degree_stage))
 * Degree subject: ((candidate_degree_subject))
 * Teaching stage (multiple choice): ((candidate_teaching_stage))
-* Teaching subject – first choice: ((candidate_teaching_subject_first_choice))
-* Teaching subject – second choice: ((candidate_teaching_subject_second_choice))
 * DBS certificate: ((candidate_dbs_check_document))
 
 # Accept or reject their request
@@ -31,8 +31,8 @@ The candidate is aware you may be in touch to discuss their school experience re
 
 It's your responsibility to book them on experience at your school and you can email or call them to:
 
-* discuss their suitability for school experience at your site
-offer and arrange the best available school experience dates
+* discuss their request and suitability for school experience at your site
+* offer and arrange the best available school experience dates
 * find out more about their requirements - including any disability or access needs
 * explain any background and security checks they might need to go through
 * explain any fees they might need to pay - including any administration, DBS check, parking or other fees

--- a/app/notify/notify_email/school_request_confirmation.rb
+++ b/app/notify/notify_email/school_request_confirmation.rb
@@ -61,7 +61,7 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
       placement_outcome: application_preview.placement_outcome,
-      placement_availability: (application_preview.placement_availability || application_preview.placement_date.to_s),
+      placement_availability: application_preview.placement_availability_description,
       school_name: application_preview.school
     )
   end

--- a/app/notify/notify_email/school_request_confirmation.rb
+++ b/app/notify/notify_email/school_request_confirmation.rb
@@ -61,7 +61,7 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
       placement_outcome: application_preview.placement_outcome,
-      placement_availability: application_preview.placement_availability,
+      placement_availability: (application_preview.placement_availability || application_preview.placement_date.to_s),
       school_name: application_preview.school
     )
   end

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -17,6 +17,7 @@ module Candidates
         to: :@contact_information
 
       delegate \
+        :school,
         :school_name,
         :degree_stage,
         :degree_subject,
@@ -52,8 +53,8 @@ module Candidates
         email
       end
 
-      def school
-        school_name
+      def placement_date
+        placement_preference.placement_date
       end
 
       def placement_availability

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -61,6 +61,10 @@ module Candidates
         placement_preference.availability
       end
 
+      def placement_availability_description
+        placement_preference.availability || placement_preference.placement_date
+      end
+
       def placement_outcome
         placement_preference.objectives
       end

--- a/app/services/candidates/registrations/behaviours/placement_preference.rb
+++ b/app/services/candidates/registrations/behaviours/placement_preference.rb
@@ -11,10 +11,10 @@ module Candidates
           validates :urn, presence: true
           validates :bookings_placement_date_id,
             presence: true,
-            if: -> { urn && school_offers_fixed_dates? }
+            if: -> { urn.present? && school_offers_fixed_dates? }
           validates :availability,
             presence: true,
-            unless: -> { urn && school_offers_fixed_dates? }
+            unless: -> { urn.present? && school_offers_fixed_dates? }
           validate :availability_not_too_long, if: -> { availability.present? }
           validates :objectives, presence: true
           validate  :objectives_not_too_long, if: -> { objectives.present? }

--- a/app/services/candidates/registrations/behaviours/placement_preference.rb
+++ b/app/services/candidates/registrations/behaviours/placement_preference.rb
@@ -8,13 +8,23 @@ module Candidates
         MAX_WORDS_FOR_OBJECTIVE = 149
 
         included do
-          validates :availability, presence: true
+          validates :urn, presence: true
+          validates :bookings_placement_date_id,
+            presence: true,
+            if: -> { urn && school_offers_fixed_dates? }
+          validates :availability,
+            presence: true,
+            unless: -> { urn && school_offers_fixed_dates? }
           validate :availability_not_too_long, if: -> { availability.present? }
           validates :objectives, presence: true
           validate  :objectives_not_too_long, if: -> { objectives.present? }
         end
 
       private
+
+        def school_offers_fixed_dates?
+          school.fixed_dates?
+        end
 
         def availability_not_too_long
           if availability_too_long?

--- a/app/services/candidates/registrations/behaviours/subject_preference.rb
+++ b/app/services/candidates/registrations/behaviours/subject_preference.rb
@@ -26,14 +26,6 @@ module Candidates
           validates :subject_second_choice, inclusion: { in: :second_subject_choices }, if: -> { subject_second_choice.present? }
         end
 
-        def school
-          @school ||= Candidates::School.find urn
-        end
-
-        def school_name
-          school.name
-        end
-
         def available_subject_choices
           @available_subject_choices ||= get_available_subject_choices
         end

--- a/app/services/candidates/registrations/placement_preference.rb
+++ b/app/services/candidates/registrations/placement_preference.rb
@@ -3,6 +3,7 @@ module Candidates
     class PlacementPreference < RegistrationStep
       include Behaviours::PlacementPreference
 
+      attribute :bookings_placement_date_id, :integer
       attribute :availability, :string
       attribute :objectives, :string
     end

--- a/app/services/candidates/registrations/placement_preference.rb
+++ b/app/services/candidates/registrations/placement_preference.rb
@@ -9,7 +9,11 @@ module Candidates
       attribute :objectives, :string
 
       def school
-        @school ||= Candidates::School.find urn
+        @school ||= Candidates::School.find(urn)
+      end
+
+      def placement_date
+        @placement_date ||= Bookings::PlacementDate.find(bookings_placement_date_id)
       end
     end
   end

--- a/app/services/candidates/registrations/placement_preference.rb
+++ b/app/services/candidates/registrations/placement_preference.rb
@@ -3,9 +3,14 @@ module Candidates
     class PlacementPreference < RegistrationStep
       include Behaviours::PlacementPreference
 
+      attribute :urn, :integer
       attribute :bookings_placement_date_id, :integer
       attribute :availability, :string
       attribute :objectives, :string
+
+      def school
+        @school ||= Candidates::School.find urn
+      end
     end
   end
 end

--- a/app/services/candidates/registrations/subject_preference.rb
+++ b/app/services/candidates/registrations/subject_preference.rb
@@ -10,6 +10,14 @@ module Candidates
       attribute :teaching_stage, :string
       attribute :subject_first_choice, :string
       attribute :subject_second_choice, :string
+
+      def school
+        @school ||= Candidates::School.find urn
+      end
+
+      def school_name
+        school.name
+      end
     end
   end
 end

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -42,14 +42,27 @@
 
       <%= summary_row \
         'School or college',
-        @application_preview.school %>
+        @application_preview.school_name %>
 
-      <%= summary_row \
-        'Experience availability',
-        @application_preview.placement_availability,
-        edit_candidates_school_registrations_placement_preference_path(
-          anchor: 'candidates_registrations_placement_preference_availability_container'
-        ) %>
+      <%- if @application_preview.school.availability_preference_fixed? -%>
+
+        <%= summary_row \
+          'Placement date',
+          @application_preview.placement_date,
+          edit_candidates_school_registrations_placement_preference_path(
+            anchor: 'candidates_registrations_placement_preference_availability_container'
+          ) %>
+
+      <%- else -%>
+
+        <%= summary_row \
+          'Experience availability',
+          @application_preview.placement_availability,
+          edit_candidates_school_registrations_placement_preference_path(
+            anchor: 'candidates_registrations_placement_preference_availability_container'
+          ) %>
+
+      <%- end -%>
 
       <%= summary_row \
         'Experience outcome',

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -11,7 +11,7 @@
 
         <mark>FIXME add a caption</mark>
         <%= f.radio_button_fieldset :bookings_placement_date_id,
-          choices: @school.school_profile.bookings_placement_dates,
+          choices: @placement_dates,
           value_method: :id,
           text_method: :to_s
         -%>

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -3,50 +3,69 @@
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Request school experience</h1>
-    <p>Tell us a few details so we can forward your experience requirements to the school.</p>
 
     <%= form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>
       <%= GovukElementsErrorsHelper.error_summary placement_preference, 'There is a problem', '' %>
-      <%= f.text_area_with_maxwords \
-          :availability,
-          rows: 5,
-          maxwords: { count: 150 },
-          placeholder: t('.availability_placeholder'),
-          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
-          <p>
-            Tell us about your availability. For example, if you're:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>
-              available for any specific experience dates offered by schools
-            </li>
-            <li>
-              only available or unavailable for experience on particular days, dates or for certain periods of time
-            </li>
-          </ul>
-          <p>
-            The school will use this information to offer you the best dates it has available and may contact you to arrange the exact date of your experience.
-          </p>
-          <p>
-            Depending on availability and time of year, schools may not always be able to offer you the exact dates you’re looking for.
-          </p>
 
-          <%- if @school.availability_info.present? -%>
-            <section class="govuk-se-warning">
+      <%- if @school.availability_preference_fixed? %>
 
-              <div class="govuk-warning-text">
-                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                <strong class="govuk-warning-text__text">
-                  <span class="govuk-warning-text__assistive">Warning</span>
-                  The school has provided the following information
-                </strong>
-              </div>
+        <mark>FIXME add a caption</mark>
+        <%= f.radio_button_fieldset :bookings_placement_date_id,
+          choices: @school.school_profile.bookings_placement_dates,
+          value_method: :id,
+          text_method: :to_s
+        -%>
 
-              <%= format_school_availability(@school) %>
-            </section>
-          <%- end -%>
+      <%- else -%>
+        <%= f.text_area_with_maxwords \
+            :availability,
+            rows: 5,
+            maxwords: { count: 150 },
+            placeholder: t('.availability_placeholder'),
+            label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
 
-      <% end %>
+            <mark>
+              FIXME two sentences starting with 'tell us' next to each other
+            </mark>
+
+            <p>
+              Tell us a few details so we can forward your experience requirements to the school.
+            </p>
+
+            <p>
+              Tell us about your availability. For example, if you're:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                available for any specific experience dates offered by schools
+              </li>
+              <li>
+                only available or unavailable for experience on particular days, dates or for certain periods of time
+              </li>
+            </ul>
+            <p>
+              The school will use this information to offer you the best dates it has available and may contact you to arrange the exact date of your experience.
+            </p>
+            <p>
+              Depending on availability and time of year, schools may not always be able to offer you the exact dates you’re looking for.
+            </p>
+
+            <%- if @school.availability_info.present? -%>
+              <section class="govuk-se-warning">
+
+                <div class="govuk-warning-text">
+                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                  <strong class="govuk-warning-text__text">
+                    <span class="govuk-warning-text__assistive">Warning</span>
+                    The school has provided the following information
+                  </strong>
+                </div>
+
+                <%= format_school_availability(@school) %>
+              </section>
+            <%- end -%>
+        <% end %>
+      <%- end -%>
 
       <%= f.text_area_with_maxwords \
           :objectives,

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -24,17 +24,14 @@
             placeholder: t('.availability_placeholder'),
             label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
 
-            <mark>
-              FIXME two sentences starting with 'tell us' next to each other
-            </mark>
-
             <p>
-              Tell us a few details so we can forward your experience requirements to the school.
+              We need a few details so we can forward your experience requirements to the school.
             </p>
 
             <p>
               Tell us about your availability. For example, if you're:
             </p>
+
             <ul class="govuk-list govuk-list--bullet">
               <li>
                 available for any specific experience dates offered by schools

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -10,7 +10,7 @@
     <h3 class="govuk-heading-m">What happens next</h3>
     <p>
       Your request for school experience will be forwarded to
-      <%= @application_preview.school %>.
+      <%= @application_preview.school_name %>.
     </p>
     <p class="govuk-!-font-weight-bold">
       The school will email or call you to discuss your request and experience

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -101,12 +101,17 @@
       </div>
 
       <div id="school-availability-info" class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Placement availability
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= format_school_availability(@school) %>
-        </dd>
+
+        <%- if @school.fixed_dates? -%>
+          <%= render partial: 'placement_dates', locals: { school: @school } %>
+        <%- else -%>
+          <dt class="govuk-summary-list__key">
+            Placement availability
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= format_school_availability(@school) %>
+          </dd>
+        <%- end -%>
       </div>
 
       <%- if @school.teacher_training_provider? -%>

--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -1,0 +1,21 @@
+<dt class="govuk-summary-list__key">
+  Upcoming placement dates
+</dt>
+
+<dd class="govuk-summary-list__value">
+  <%- if school.school_profile.has_available_dates? -%>
+
+    <ul class="govuk-list">
+      <%- school.school_profile.bookings_placement_dates.available.each do |pd| -%>
+        <li><%= pd.to_s %></li>
+      <%- end -%>
+    </ul>
+
+  <%- else -%>
+
+    <div class="govuk-inset-text">
+      There are no upcoming placement dates
+    </div>
+
+  <%- end -%>
+</dd>

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -7,5 +7,3 @@
 <h1 class="govuk-heading-l govuk-!-margin-top-4"><%= @school.name %></h1>
 
 <%= render @school.private_beta? ? 'phase2' : 'phase1', school: @school %>
-
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,9 @@ en:
       objectives:
         blank: "Enter what you want to get out of a placement"
         use_fewer_words: "Use 150 words or fewer"
+      bookings_placement_date_id:
+        blank: "Choose a placement date"
+
 
   subject_preference_errors: &subject_preference_errors
     attributes:

--- a/db/migrate/20190418180056_add_placement_date_id_to_bookings_placement_requests.rb
+++ b/db/migrate/20190418180056_add_placement_date_id_to_bookings_placement_requests.rb
@@ -1,0 +1,7 @@
+class AddPlacementDateIdToBookingsPlacementRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_placement_requests, :bookings_placement_date_id, :integer, null: true
+    add_index :bookings_placement_requests, :bookings_placement_date_id
+    add_foreign_key :bookings_placement_requests, :bookings_placement_dates
+  end
+end

--- a/db/migrate/20190418180420_allow_bookings_placement_requests_availability_to_be_null.rb
+++ b/db/migrate/20190418180420_allow_bookings_placement_requests_availability_to_be_null.rb
@@ -1,0 +1,5 @@
+class AllowBookingsPlacementRequestsAvailabilityToBeNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column :bookings_placement_requests, :availability, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2019_04_18_180420) do
     t.boolean "has_dbs_check", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "availability", null: false
+    t.text "availability"
     t.integer "bookings_placement_date_id"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,8 +9,7 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-
-ActiveRecord::Schema.define(version: 2019_04_18_151613) do
+ActiveRecord::Schema.define(version: 2019_04_18_180420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +48,8 @@ ActiveRecord::Schema.define(version: 2019_04_18_151613) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "availability", null: false
+    t.integer "bookings_placement_date_id"
+    t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
   end
 
   create_table "bookings_school_searches", force: :cascade do |t|
@@ -193,6 +194,7 @@ ActiveRecord::Schema.define(version: 2019_04_18_151613) do
     t.string "candidate_experience_detail_start_time"
     t.string "candidate_experience_detail_end_time"
     t.boolean "candidate_experience_detail_times_flexible"
+    t.integer "bookings_school_id", null: false
     t.text "experience_outline_candidate_experience"
     t.boolean "experience_outline_provides_teacher_training"
     t.text "experience_outline_teacher_training_details"
@@ -207,6 +209,7 @@ ActiveRecord::Schema.define(version: 2019_04_18_151613) do
   end
 
   add_foreign_key "bookings_placement_dates", "schools_school_profiles"
+  add_foreign_key "bookings_placement_requests", "bookings_placement_dates"
   add_foreign_key "bookings_schools", "bookings_school_types"
   add_foreign_key "bookings_schools_phases", "bookings_phases"
   add_foreign_key "bookings_schools_phases", "bookings_schools"

--- a/features/candidates/registrations/application_preview.feature
+++ b/features/candidates/registrations/application_preview.feature
@@ -1,0 +1,23 @@
+Feature: Previewing my application
+    So I can confirm the accuracy of my submission
+    As a potential candidate
+    I want to check my data before I submit it
+
+    Background:
+        Given my school of choice exists
+        And my school of choice offers 'Physics'
+
+    Scenario: Page contents (when the school has flexible availability)
+        Given my school has flexible dates
+        And I have completed the wizard
+        When I am on the 'Check your answers' page for my choice of school
+        Then I should see the following summary rows:
+            | Heading                 | Value                  | Change link path                                                   |
+            | Experience availability | Epiphany to Whitsunday | /candidates/schools/123456/registrations/placement_preference/edit |
+
+    Scenario: Page contents (when the school has flexible availability)
+        Given my school has fixed dates
+        And I have completed the wizard
+        When I am on the 'Check your answers' page for my choice of school
+        Then I should see a summary row containing my selected date
+        And the row should have a 'Change' link to '/candidates/schools/123456/registrations/placement_preference/edit'

--- a/features/candidates/registrations/request_school_experience_placement/page_contents.feature
+++ b/features/candidates/registrations/request_school_experience_placement/page_contents.feature
@@ -7,13 +7,6 @@ Feature: Request a school experience placement
         Given I am on the 'Request school experience placement' page for my school of choice
         Then the page's main header should be 'Request school experience'
 
-    Scenario: Form contents
-        Given I am on the 'Request school experience placement' page for my school of choice
-        Then I should see a form with the following fields:
-            | Label                                                                                 | Type     | Options |
-            | Is there anything schools need to know about your availability for school experience? | textarea |         |
-            | What do you want to get out of your school experience?                                | textarea |         |
-
     Scenario: Displaying a warning if the school has availability information
         Given my school has availability information set
         When I am on the 'Request school experience placement' page for my school of choice
@@ -45,9 +38,3 @@ Feature: Request a school experience placement
         Given I am on the 'Request school experience placement' page for my school of choice
         When I enter 'The quick brown fox' into the 'Is there anything schools need to know about your availability for school experience?' text area
         Then the 'Is there anything schools need to know about your availability for school experience?' word count should say 'You have 146 words remaining'
-
-    Scenario: Submitting my data
-        Given I am on the 'Request school experience placement' page for my school of choice
-        And I have filled in the form with accurate data
-        When I submit the form
-        Then I should be on the 'Enter your contact details' page for my school of choice

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_flexible_availability.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_flexible_availability.feature
@@ -1,0 +1,20 @@
+Feature: Request a school experience placement
+    So I can inform a school when I'd like to attend
+    As a potential candidate
+    I want to submit a description of my availability to the school
+
+    Background:
+        Given the school I'm applying to is flexible on dates
+
+    Scenario: Form contents
+        Given I am on the 'Request school experience placement' page for my school of choice
+        Then I should see a form with the following fields:
+            | Label                                                                                 | Type     |
+            | Is there anything schools need to know about your availability for school experience? | textarea |
+            | What do you want to get out of your school experience?                                | textarea |
+
+    Scenario: Submitting my data
+        Given I am on the 'Request school experience placement' page for my school of choice
+        And I have filled in the form with accurate data
+        When I submit the form
+        Then I should be on the 'Enter your contact details' page for my school of choice

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
@@ -1,0 +1,13 @@
+Feature: Request a school experience placement
+    So I can inform a school I would like to attend on a specified day
+    As a potential candidate
+    I want to pick a date from the list provided by the school
+
+    Background:
+        Given the school I'm applying to is not flexible on dates
+        And the school has 3 placements available in the upcoming weeks
+
+    Scenario: Form contents
+        Given I am on the 'Request school experience placement' page for my school of choice
+        Then there should be a 'What do you want to get out of your school experience?' text area
+        And there should be a radio button per date the school has specified

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
@@ -15,3 +15,11 @@ Feature: Request a school experience placement
         Given the school has 3 placements available in the upcoming weeks
         When I am on the 'Request school experience placement' page for my school of choice
         Then there should be a radio button per date the school has specified
+
+    Scenario: Submitting my data
+        Given the school has 3 placements available in the upcoming weeks
+        And I am on the 'Request school experience placement' page for my school of choice
+        When I choose a placement date
+        And I enter 'I just love teaching!' into the 'What do you want to get out of your school experience?' text area
+        And I submit the form
+        Then I should be on the 'Enter your contact details' page for my school of choice

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
@@ -5,9 +5,13 @@ Feature: Request a school experience placement
 
     Background:
         Given the school I'm applying to is not flexible on dates
-        And the school has 3 placements available in the upcoming weeks
 
     Scenario: Form contents
         Given I am on the 'Request school experience placement' page for my school of choice
+        When the school has 3 placements available in the upcoming weeks
         Then there should be a 'What do you want to get out of your school experience?' text area
-        And there should be a radio button per date the school has specified
+
+    Scenario: Radio buttons
+        Given the school has 3 placements available in the upcoming weeks
+        When I am on the 'Request school experience placement' page for my school of choice
+        Then there should be a radio button per date the school has specified

--- a/features/candidates/schools/show/full_school_details.feature
+++ b/features/candidates/schools/show/full_school_details.feature
@@ -1,7 +1,7 @@
 Feature: School show page (enhanced data)
     To help me evaluate a school
     As a potential candidate
-    I want to be able to view a scohol's details
+    I want to be able to view a school's details
 
     Background:
         Given there is a school called 'Springfield Elementary'
@@ -10,7 +10,7 @@ Feature: School show page (enhanced data)
         Given I am on the profile page for the chosen school
         Then the page's main heading should be "Springfield Elementary"
 
-    Scenario: School placement information:
+    Scenario: School placement information
         Given the school has placement information text:
             """
             Paragraph one

--- a/features/candidates/schools/show/school_with_fixed_dates.feature
+++ b/features/candidates/schools/show/school_with_fixed_dates.feature
@@ -1,0 +1,12 @@
+Feature: School show page (fixed dates)
+    To help me plan my school experience
+    As a potential candidate
+    I want to be able to view a school's details
+
+    Background:
+        Given the school I'm applying to is not flexible on dates
+        And the school has 3 placements available in the upcoming weeks
+
+    Scenario: Placement date display
+        Given I am on the profile page for the chosen school
+        Then I should see the list of 'Upcoming placement dates' in the sidebar

--- a/features/step_definitions/candidates/registrations/application_preview_steps.rb
+++ b/features/step_definitions/candidates/registrations/application_preview_steps.rb
@@ -1,0 +1,110 @@
+Given("I have completed the wizard") do
+  visit path_for('request school experience placement', school: @school)
+  step "I have filled in my placement preferences successfully"
+  step "I have filled in my contact information successfully"
+  step "I have filled in my subject preferences successfully"
+  step "I have filled in my background checks successfully"
+end
+
+Given("I have filled in my placement preferences successfully") do
+  # Submit registrations/placement_preference form successfully
+  if @fixed_dates
+    choose @wanted_bookings_placement_date
+  else
+    fill_in 'Is there anything schools need to know about your availability for school experience?', with: 'Only free from Epiphany to Whitsunday'
+  end
+  fill_in 'What do you want to get out of your school experience?', with: 'I enjoy teaching'
+  click_button 'Continue'
+
+  expect(page.current_path).to eq \
+    "/candidates/schools/#{@school.urn}/registrations/contact_information/new"
+end
+
+Given("I have filled in my contact information successfully") do
+  # Submit contact information form successfully
+  fill_in 'Full name', with: 'testy mctest'
+  fill_in 'Email address', with: 'test@example.com'
+  fill_in 'Building', with: 'Test house'
+  fill_in 'Street', with: 'Test street'
+  fill_in 'Town or city', with: 'Test Town'
+  fill_in 'County', with: 'Testshire'
+  fill_in 'Postcode', with: 'TE57 1NG'
+  fill_in 'UK telephone number', with: '01234567890'
+  click_button 'Continue'
+  expect(page.current_path).to eq \
+    "/candidates/schools/#{@school.urn}/registrations/subject_preference/new"
+end
+
+Given("I have filled in my subject preferences successfully") do
+  # Submit registrations/subject_preference form successfully
+  choose 'Graduate or postgraduate'
+  select 'Physics', from: 'If you have or are studying for a degree, tell us about your degree subject'
+  choose "I’m very sure and think I’ll apply"
+  select 'Physics', from: 'First choice'
+  click_button 'Continue'
+  expect(page.current_path).to eq \
+    "/candidates/schools/#{@school.urn}/registrations/background_check/new"
+end
+
+Given("I have filled in my background checks successfully") do
+  # Submit registrations/background_check form successfully
+  choose 'Yes'
+  click_button 'Continue'
+  expect(page.current_path).to eq \
+    "/candidates/schools/#{@school.urn}/registrations/application_preview"
+end
+
+Given("my school has flexible dates") do
+  @fixed_dates = false
+  # do nothing, it's the default
+end
+
+Given("my school has fixed dates") do
+  @fixed_dates = true
+  @school_profile.update_attributes(availability_preference_fixed: true)
+  (1..3).each { |i| i.weeks.from_now }.each do |date|
+    @school_profile.bookings_placement_dates.create(date: date.weeks.from_now)
+    @wanted_bookings_placement_date = @school_profile.bookings_placement_dates.last.to_s
+  end
+  # do nothing, it's the default
+end
+
+Given("my school of choice exists") do
+  @school_profile = FactoryBot.create(:school_profile)
+  @school = @school_profile.bookings_school
+end
+
+Given("my school of choice offers {string}") do |string|
+  string.split(", ").each do |subject_name|
+    @school.subjects << FactoryBot.create(:bookings_subject, name: subject_name)
+  end
+end
+
+Given("My school offers physics") do
+  @school.subjects << FactoryBot.create(:bookings_subject, name: "Physics")
+end
+
+When("I am on the {string} page for my choice of school") do |string|
+  expect(page.current_path).to eql(path_for(string, school: @school.urn))
+end
+
+Then("I should see the following summary rows:") do |table|
+  table.hashes.each do |row|
+    within(".#{row['Heading'].tr(' ', '-').downcase}") do
+      expect(page).to have_css('dd', text: row['Value'])
+      expect(page).to have_link('Change', href: /#{row['Change link path']}/)
+    end
+  end
+end
+
+Then("I should see a summary row containing my selected date") do
+  within(".placement-date") do
+    expect(page).to have_content(@wanted_bookings_placement_date)
+  end
+end
+
+Then("the row should have a {string} link to {string}") do |link_text, path|
+  within(".placement-date") do
+    expect(page).to have_link(link_text, href: /#{path}/)
+  end
+end

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -72,6 +72,7 @@ Given("the school has {int} placements available in the upcoming weeks") do |int
   end
 
   expect(@school_profile.bookings_placement_dates.count).to eql(int)
+  @placement_dates = @school_profile.bookings_placement_dates.map(&:to_s)
 end
 
 Then("there should be a radio button per date the school has specified") do

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -79,3 +79,8 @@ Then("there should be a radio button per date the school has specified") do
     expect(page).to have_field(date_string, type: 'radio')
   end
 end
+
+When("I choose a placement date") do
+  @last_date = @school_profile.bookings_placement_dates.last
+  choose @last_date.to_s
+end

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -52,3 +52,19 @@ end
 Then("I should see no warning containing the availability information") do
   expect(page).not_to have_css('section.govuk-se-warning')
 end
+
+Given("the school I'm applying to is flexible on dates") do
+  # do nothing, this is the default
+end
+
+Given("the school I'm applying to is not flexible on dates") do
+  pending # make the school inflexible... somehow!
+end
+
+Given("the school has {int} placements available in the upcoming weeks") do |int|
+  pending # Write code here that turns the phrase above into concrete actions
+end
+
+Then("there should be a radio button per date the school has specified") do
+  pending # Write code here that turns the phrase above into concrete actions
+end

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -58,13 +58,24 @@ Given("the school I'm applying to is flexible on dates") do
 end
 
 Given("the school I'm applying to is not flexible on dates") do
-  pending # make the school inflexible... somehow!
+  @school_profile = FactoryBot.create(:school_profile, :with_fixed_availability_preference)
+  @school = @school_profile.bookings_school
 end
 
 Given("the school has {int} placements available in the upcoming weeks") do |int|
-  pending # Write code here that turns the phrase above into concrete actions
+  (1..int).to_a.map { |i| i.weeks.from_now.to_date }.each do |date|
+    FactoryBot.create(
+      :bookings_placement_date,
+      date: date,
+      school_profile: @school_profile
+    )
+  end
+
+  expect(@school_profile.bookings_placement_dates.count).to eql(int)
 end
 
 Then("there should be a radio button per date the school has specified") do
-  pending # Write code here that turns the phrase above into concrete actions
+  @school_profile.bookings_placement_dates.map(&:to_s).each do |date_string|
+    expect(page).to have_field(date_string, type: 'radio')
+  end
 end

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -169,3 +169,12 @@ Then("the availability information in the sidebar should read {string}") do |str
     expect(page).to have_css('dd', text: string)
   end
 end
+
+Then("I should see the list of {string} in the sidebar") do |string|
+  within('#school-availability-info') do
+    expect(page).to have_css('dt', text: string)
+    @placement_dates.each do |pd|
+      expect(page).to have_css('li', text: pd.to_s)
+    end
+  end
+end

--- a/features/step_definitions/schools/placement_dates/index_steps.rb
+++ b/features/step_definitions/schools/placement_dates/index_steps.rb
@@ -6,7 +6,7 @@ end
 
 Given("my school has {int} placement dates") do |int|
   @placement_dates = FactoryBot.create_list(:bookings_placement_date, int, school_profile: @school_profile)
-  expect(@school_profile.placement_dates.count).to eql(int)
+  expect(@school_profile.bookings_placement_dates.count).to eql(int)
 end
 
 Then("I should see a list with {int} entries") do |int|
@@ -42,5 +42,5 @@ Then("there should be a {string} link to the new placement date page") do |strin
 end
 
 Given("my school has no placement dates") do
-  expect(@school_profile.placement_dates).to be_empty
+  expect(@school_profile.bookings_placement_dates).to be_empty
 end

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -86,7 +86,8 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
           expect(registration_session).to have_received(:save).with \
             Candidates::Registrations::PlacementPreference.new \
               availability: 'Every second Friday',
-              objectives: 'Become a teacher'
+              objectives: 'Become a teacher',
+              urn: 11048
         end
 
         it 'redirects to the next step' do
@@ -100,6 +101,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
   context 'with existing placement_preference in session' do
     let :existing_placement_preference do
       Candidates::Registrations::PlacementPreference.new \
+        urn: 11048,
         objectives: 'Become a teacher'
     end
 
@@ -174,6 +176,7 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
         it 'updates the session with the new details' do
           expect(registration_session).to have_received(:save).with \
             Candidates::Registrations::PlacementPreference.new \
+              urn: school_urn,
               availability: 'Every second Friday',
               objectives: 'I would like to become a teacher'
         end

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -3,45 +3,76 @@ FactoryBot.define do
     transient do
       current_time { DateTime.current }
       urn { 11048 }
+      placement_date { create(:bookings_placement_date) }
+
+      candidates_registrations_contact_information do
+        {
+          "full_name"    => 'Testy McTest',
+          "email"        => 'test@example.com',
+          "building"     => "Test building",
+          "street"       => "Test street",
+          "town_or_city" => "Test town",
+          "county"       => "Testshire",
+          "postcode"     => "TE57 1NG",
+          "phone"        => "01234567890",
+          "created_at"   => current_time,
+          "updated_at"   => current_time
+        }
+      end
+
+      candidates_registrations_background_check do
+        {
+          "has_dbs_check" => true,
+          "created_at"    => current_time,
+          "updated_at"    => current_time
+        }
+      end
+
+      candidates_registrations_placement_preference do
+        {
+          "urn"          => urn,
+          "availability" => "Every third Tuesday",
+          "objectives"   => "test the software",
+          "created_at"   => current_time,
+          "updated_at"   => current_time
+        }
+      end
+
+      candidates_registrations_subject_preference do
+        {
+          "degree_stage"              => "I don't have a degree and am not studying for one",
+          "degree_stage_explaination" => "",
+          "degree_subject"            => "Not applicable",
+          "teaching_stage"            => "I’m very sure and think I’ll apply",
+          "subject_first_choice"      => "Maths",
+          "subject_second_choice"     => "Physics",
+          "urn"                       => urn,
+          "created_at"                => current_time,
+          "updated_at"                => current_time
+        }
+      end
     end
 
     initialize_with do
       new \
-        "candidates_registrations_contact_information" => {
-          "full_name" => 'Testy McTest',
-          "email" => 'test@example.com',
-          "building" => "Test building",
-          "street" => "Test street",
-          "town_or_city" => "Test town",
-          "county" => "Testshire",
-          "postcode" => "TE57 1NG",
-          "phone" => "01234567890",
-          "created_at" => current_time,
-          "updated_at" => current_time
-        },
-        "candidates_registrations_background_check" => {
-          "has_dbs_check" => true,
-          "created_at" => current_time,
-          "updated_at" => current_time
-        },
-         "candidates_registrations_placement_preference" => {
-           "urn" => urn,
-           "availability" => "Every third Tuesday",
-           "objectives" => "test the software",
-           "created_at" => current_time,
-           "updated_at" => current_time
-        },
-         "candidates_registrations_subject_preference" => {
-           "degree_stage" => "I don't have a degree and am not studying for one",
-           "degree_stage_explaination" => "",
-           "degree_subject" => "Not applicable",
-           "teaching_stage" => "I’m very sure and think I’ll apply",
-           "subject_first_choice" => "Maths",
-           "subject_second_choice" => "Physics",
-           "urn" => urn,
-           "created_at" => current_time,
-           "updated_at" => current_time
-        }
+        "candidates_registrations_contact_information"  => candidates_registrations_contact_information,
+        "candidates_registrations_background_check"     => candidates_registrations_background_check,
+        "candidates_registrations_placement_preference" => candidates_registrations_placement_preference,
+        "candidates_registrations_subject_preference"   => candidates_registrations_subject_preference
+    end
+
+    trait :with_placement_date do
+      initialize_with do
+        new \
+          "candidates_registrations_contact_information"  => candidates_registrations_contact_information,
+          "candidates_registrations_background_check"     => candidates_registrations_background_check,
+          "candidates_registrations_subject_preference"   => candidates_registrations_subject_preference,
+          "candidates_registrations_placement_preference" => candidates_registrations_placement_preference
+            .merge(
+              "availability" => nil,
+              "bookings_placement_date_id" => placement_date.id
+            )
+      end
     end
   end
 end

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
           "updated_at" => current_time
         },
          "candidates_registrations_placement_preference" => {
+           "urn" => urn,
            "availability" => "Every third Tuesday",
            "objectives" => "test the software",
            "created_at" => current_time,

--- a/spec/factories/schools/school_profile_factory.rb
+++ b/spec/factories/schools/school_profile_factory.rb
@@ -118,6 +118,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_fixed_availability_preference do
+      after :build do |profile|
+        profile.availability_preference = FactoryBot.build(:availability_preference, :fixed)
+      end
+    end
+
     trait :completed do
       with_candidate_requirement
       with_fees

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -98,5 +98,12 @@ describe Bookings::PlacementDate, type: :model do
         expect(described_class.inactive).not_to include(active)
       end
     end
+
+    context '.available' do
+      after { described_class.available }
+      specify 'should combine the future, active and in_date_order scopes' do
+        expect(described_class).to receive_message_chain(:active, :future, :in_date_order)
+      end
+    end
   end
 end

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -11,6 +11,7 @@ describe Bookings::PlacementRequest, type: :model do
   it { is_expected.to have_db_column(:subject_first_choice).of_type(:string).with_options null: false }
   it { is_expected.to have_db_column(:subject_second_choice).of_type(:string).with_options null: false }
   it { is_expected.to have_db_column(:has_dbs_check).of_type(:boolean).with_options null: false }
+  it { is_expected.to have_db_column(:bookings_placement_date_id).of_type(:integer).with_options null: true }
 
   it_behaves_like 'a placement preference'
   it_behaves_like 'a subject preference'

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Bookings::PlacementRequest, type: :model do
-  it { is_expected.to have_db_column(:availability).of_type(:text).with_options null: false }
   it { is_expected.to have_db_column(:objectives).of_type(:text).with_options null: false }
   it { is_expected.to have_db_column(:urn).of_type(:integer).with_options null: false }
   it { is_expected.to have_db_column(:degree_stage).of_type(:string).with_options null: false }
@@ -11,6 +10,7 @@ describe Bookings::PlacementRequest, type: :model do
   it { is_expected.to have_db_column(:subject_first_choice).of_type(:string).with_options null: false }
   it { is_expected.to have_db_column(:subject_second_choice).of_type(:string).with_options null: false }
   it { is_expected.to have_db_column(:has_dbs_check).of_type(:boolean).with_options null: false }
+  it { is_expected.to have_db_column(:availability).of_type(:text).with_options null: true }
   it { is_expected.to have_db_column(:bookings_placement_date_id).of_type(:integer).with_options null: true }
 
   it_behaves_like 'a placement preference'

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -185,7 +185,7 @@ describe Schools::SchoolProfile, type: :model do
     it { is_expected.to have_many(:college_phase_subjects) }
     it { is_expected.to have_many(:secondary_subjects) }
     it { is_expected.to have_many(:college_subjects) }
-    it { is_expected.to have_many(:placement_dates) }
+    it { is_expected.to have_many(:bookings_placement_dates) }
     it { is_expected.to belong_to(:bookings_school) }
   end
 

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -91,12 +91,6 @@ describe Candidates::Registrations::ApplicationPreview do
     end
   end
 
-  context '#placement_availability' do
-    it 'returns the correct value' do
-      expect(subject.placement_availability).to eq 'From Epiphany to Whitsunday'
-    end
-  end
-
   context '#placement_outcome' do
     it 'returns the correct value' do
       expect(subject.placement_outcome).to eq "test the software"
@@ -153,6 +147,45 @@ describe Candidates::Registrations::ApplicationPreview do
 
       it 'returns the correct value' do
         expect(subject.dbs_check_document).to eq "No"
+      end
+    end
+  end
+
+  context 'placement dates' do
+    context 'when school has flexible dates' do
+      let(:pa) { 'From Epiphany to Whitsunday' }
+      context '#placement_availability' do
+        it 'returns the correct value' do
+          expect(subject.placement_availability).to eq pa
+        end
+      end
+
+      context '#placement_availability_description' do
+        it 'returns the #placement_availability when it is present' do
+          expect(subject.placement_availability_description).to eq pa
+        end
+      end
+    end
+
+    context 'when school has fixed dates' do
+      let(:pd) { '02 May 2019' }
+      let :placement_preference do
+        double Candidates::Registrations::PlacementPreference,
+          objectives: "test the software",
+          placement_date: pd,
+          availability: nil
+      end
+
+      context '#placement_availability' do
+        it 'returns the correct value' do
+          expect(subject.placement_date).to eq pd
+        end
+      end
+
+      context '#placement_availability_description' do
+        it 'returns the placement date when #placement_availability is absent' do
+          expect(subject.placement_availability_description).to eq pd
+        end
       end
     end
   end

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -28,6 +28,8 @@ describe Candidates::Registrations::ApplicationPreview do
       availability: 'From Epiphany to Whitsunday'
   end
 
+  let(:school) { build(:bookings_school) }
+
   let :subject_preference do
     double Candidates::Registrations::SubjectPreference,
       degree_stage: "I don't have a degree and am not studying for one",
@@ -36,7 +38,8 @@ describe Candidates::Registrations::ApplicationPreview do
       teaching_stage: "I'm thinking about teaching and want to find out more",
       subject_first_choice: "Architecture",
       subject_second_choice: "Maths",
-      school_name: 'Test school'
+      school_name: 'Test school',
+      school: school
   end
 
   let :registration_session do
@@ -78,7 +81,13 @@ describe Candidates::Registrations::ApplicationPreview do
 
   context '#school' do
     it 'returns the correct value' do
-      expect(subject.school).to eq "Test school"
+      expect(subject.school).to eq school
+    end
+  end
+
+  context '#school_name' do
+    it 'returns the correct value' do
+      expect(subject.school_name).to eq "Test school"
     end
   end
 

--- a/spec/services/candidates/registrations/registration_as_placement_request_spec.rb
+++ b/spec/services/candidates/registrations/registration_as_placement_request_spec.rb
@@ -21,6 +21,7 @@ describe Candidates::Registrations::RegistrationAsPlacementRequest do
   EXPECTED_ATTRIBUTES = {
     "has_dbs_check" => true,
     "availability" => "Every third Tuesday",
+    "bookings_placement_date_id" => nil,
     "objectives" => "test the software",
     "degree_stage" => "I don't have a degree and am not studying for one",
     "degree_stage_explaination" => "",

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -187,12 +187,23 @@ shared_examples_for "email template from application preview" do
         expect(subject.placement_outcome).to eql(ap.placement_outcome)
       end
 
-      specify 'placement_availability is correctly-assigned' do
-        expect(subject.placement_availability).to eql(ap.placement_availability)
-      end
-
       specify 'school_name is correctly-assigned' do
         expect(subject.school_name).to eql(ap.school)
+      end
+
+      context 'placement availability/dates' do
+        context 'when school availability is flexible' do
+          specify 'placement_availability is correctly-assigned' do
+            expect(subject.placement_availability).to eql(ap.placement_availability)
+          end
+        end
+
+        context 'when the school has set dates' do
+          let(:rs) { build(:registration_session, :with_placement_date) }
+          specify 'bookings_placement_date_id is correctly-assigned' do
+            expect(subject.placement_availability).to eql(Bookings::PlacementDate.last.to_s)
+          end
+        end
       end
     end
   end

--- a/spec/support/placement_preference_shared_examples.rb
+++ b/spec/support/placement_preference_shared_examples.rb
@@ -43,6 +43,21 @@ shared_examples 'a placement preference' do
       end
     end
 
+    context 'when the school mandates fixed dates' do
+      let(:placement_preference) { described_class.new(urn: school_urn) }
+
+      before do
+        allow(placement_preference).to receive(:school_offers_fixed_dates?).and_return(true)
+      end
+
+      before(:each) { placement_preference.validate }
+
+      it 'adds an error to availability' do
+        expect(placement_preference.errors[:bookings_placement_date_id]).to include \
+          "Choose a placement date"
+      end
+    end
+
     context 'when objectives are not present' do
       let :placement_preference do
         described_class.new

--- a/spec/support/placement_preference_shared_examples.rb
+++ b/spec/support/placement_preference_shared_examples.rb
@@ -1,11 +1,15 @@
 shared_examples 'a placement preference' do
+  include_context 'Stubbed candidates school'
+
   let! :today do
     Date.today
   end
 
   context 'attributes' do
+    it { is_expected.to respond_to :urn }
     it { is_expected.to respond_to :availability }
     it { is_expected.to respond_to :objectives }
+    it { is_expected.to respond_to :bookings_placement_date_id }
   end
 
   context 'validations' do
@@ -13,26 +17,29 @@ shared_examples 'a placement preference' do
       placement_preference.validate
     end
 
-    context 'when availability are not present' do
-      let :placement_preference do
-        described_class.new
+    context 'when the school allows flexible dates' do
+      let(:placement_preference) { described_class.new(urn: school_urn) }
+      context 'when availability are not present' do
+        let :placement_preference do
+          described_class.new
+        end
+
+        it 'adds an error to availability' do
+          expect(placement_preference.errors[:availability]).to eq \
+            ["Enter your availability"]
+        end
       end
 
-      it 'adds an error to availability' do
-        expect(placement_preference.errors[:availability]).to eq \
-          ["Enter your availability"]
-      end
-    end
+      context 'when availability are too long' do
+        let :placement_preference do
+          described_class.new \
+            availability: 151.times.map { 'word' }.join(' ')
+        end
 
-    context 'when availability are too long' do
-      let :placement_preference do
-        described_class.new \
-          availability: 151.times.map { 'word' }.join(' ')
-      end
-
-      it 'adds an error to availability' do
-        expect(placement_preference.errors[:availability]).to eq \
-          ["Use 150 words or fewer"]
+        it 'adds an error to availability' do
+          expect(placement_preference.errors[:availability]).to eq \
+            ["Use 150 words or fewer"]
+        end
       end
     end
 


### PR DESCRIPTION
### Context

If schools are set to use fixed dates, applying candidates should be presented with a set of radio buttons (one per placement date) instead of a text box asking for their availability.

### Changes proposed in this pull request

* replace the availability info text area with radio buttons for upcoming placement dates
* update the confirmation emails to contain either a date or the availability info
* record the booking placement date with the placement preference

### Guidance to review

There are some loose ends in this PR that will be addressed by upcoming changes, a couple of `FIXME`s, bits awaiting copy and no provision to stop candidates from beginning to register with schools that have no upcoming placement dates.

Other than that, make sure my changes are structured well and generally make sense 😅

