### PR TITLE
Removes link to edit school from school profile show

### DIFF
--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -9,9 +9,9 @@
 
       <h2 class="govuk-heading-m">School details</h2>
       <dl class="govuk-summary-list">
-        <%= summary_row 'Full name', @profile.school_name, '' %>
-        <%= summary_row 'Address', @profile.school_address, '' %>
-        <%= summary_row 'Email address', @profile.school_email, '' %>
+        <%= summary_row 'Full name', @profile.school_name %>
+        <%= summary_row 'Address', @profile.school_address %>
+        <%= summary_row 'Email address', @profile.school_email %>
       </dl>
 
       <h2 class="govuk-heading-m">School experience details</h2>


### PR DESCRIPTION
Removes links to edit the school's name, email, and address from
schools/on_boarding/profile#show as we don't have the corresponding pages in
the prototype.

### Context

### Changes proposed in this pull request

### Guidance to review

