### PR TITLE
Fixes error message anchor on schools profile show

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: 1b326d2385a8104ee757079aa0972bdad93e8a0d
+  revision: 51dcf1340f2897dfc9cf0016d53552103bec636c
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -53,7 +53,7 @@
       </dl>
 
       <h2 class="govuk-heading-m">Set up your school experience profile</h2>
-      <div class="govuk-form-group">
+      <div class="govuk-form-group" id="<%= f.form_group_id(:acceptance) %>">
         <%= f.check_box_input :acceptance %>
       </div>
       <%= f.submit 'Accept and set up profile' %>


### PR DESCRIPTION
We're using `f.check_box_input` outside of `check_box_fieldset` as we
don't want a legened for this check box. This caused us not to generate
the correct id for the containing form group div that the error message
links to.
To fix this we need to call `form_group_id` to set the id for the
containing form_group.

This PR bumps the form builder version which makes `form_group_id`
a public method.

### Context

### Changes proposed in this pull request

### Guidance to review

