### PR TITLE
Feature/allow schools to toggle being enabled

### DIFF
--- a/app/assets/stylesheets/school-dashboard.scss
+++ b/app/assets/stylesheets/school-dashboard.scss
@@ -1,7 +1,14 @@
 article#dashlette {
   // FIXME remove post phase 3
   ul > li {
-    margin-bottom: 1rem;
+    @include govuk-font($size: 19, $weight: normal);
+    margin: 1rem 0rem;
+
+    a {
+      display: inline-block;
+      margin-bottom: 0.5rem;
+    }
+
   }
 }
 

--- a/app/controllers/schools/toggle_enabled_controller.rb
+++ b/app/controllers/schools/toggle_enabled_controller.rb
@@ -1,0 +1,25 @@
+module Schools
+  class ToggleEnabledController < Schools::BaseController
+    before_action :set_school
+
+    def edit; end
+
+    def update
+      if current_school.update_attributes(school_availability_params)
+        redirect_to schools_dashboard_path
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def set_school
+      current_school
+    end
+
+    def school_availability_params
+      params.require(:bookings_school).permit(:enabled)
+    end
+  end
+end

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -9,4 +9,8 @@ module Schools::DashboardsHelper
       ])
     end
   end
+
+  def school_enabled_description(school)
+    school.enabled? ? "enabled" : "disabled"
+  end
 end

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -11,7 +11,7 @@
     </li>
 
     <li>
-      <%= link_to "Turn requests on / off", "#" %>
+      <%= link_to "Turn requests on / off", edit_schools_enabled_path %>
       <span class="govuk-hint">
         Choose to stop / start receiving requests from candidates.
         Requests are currently <strong><%= school_enabled_description(@current_school) %></strong>.

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -1,18 +1,36 @@
 <article id="dashlette">
-  <h1 class="govuk-heading-l">Dashboard</h1>
+  <h1 class="govuk-heading-l">Manage school experience at <%= @current_school.name %></h1>
 
   <ul class="govuk-list">
-    <li>
-      <%= link_to "Manage your school profile", schools_on_boarding_profile_path %>
-    </li>
-    <li>
-      <%= link_to "Add or modify placement dates", schools_placement_dates_path %>
-    </li>
-    <li>
-      <%= link_to "Toggle your school's inclusion in candidate searches", "#" %>
-    </li>
+
     <li>
       <%= link_to "Change school", "#" %>
+      <span class="govuk-hint">
+        Manage school experience for another school
+      </span>
     </li>
+
+    <li>
+      <%= link_to "Turn requests on / off", "#" %>
+      <span class="govuk-hint">
+        Choose to stop / start receiving requests from candidates.
+        Requests are currently <strong><%= school_enabled_description(@current_school) %></strong>.
+      </span>
+    </li>
+
+    <li>
+      <%= link_to "Update school profile", schools_on_boarding_profile_path %>
+      <span class="govuk-hint">
+        Add, edit and remove school profile details
+      </span>
+    </li>
+
+    <li>
+      <%= link_to "Update school experience dates", schools_placement_dates_path %>
+      <span class="govuk-hint">
+        Add, edit and disable <strong>fixed</strong> dates for candidates
+      </span>
+    </li>
+
   </ul>
 </article>

--- a/app/views/schools/toggle_enabled/edit.html.erb
+++ b/app/views/schools/toggle_enabled/edit.html.erb
@@ -1,0 +1,6 @@
+<% self.page_title = "Toggle requests" %>
+
+<%= form_for @current_school, url: schools_enabled_path, method: 'patch' do |form| %>
+  <%= form.radio_button_fieldset :enabled, choices: %w(true false) %>
+  <%= form.submit 'Continue' %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,6 +188,8 @@ en:
 
   helpers:
     fieldset:
+      bookings_school:
+        enabled: Turn requests on or off
       bookings_placement_date:
         date: Enter a start date
       phases: Education phases
@@ -230,6 +232,10 @@ en:
         provides_teacher_training: 'Do you run your own teacher training or have any links to teacher training organisations and providers?'
 
     hint:
+      bookings_school:
+        enabled: |
+          Turning requests off will prevent your school from appearing in candidate searches.
+          Requests that are already in-progress will continue as normal.
       bookings_placement_date:
         date: For example, 01 09 2019
       phases: Select all that apply
@@ -260,6 +266,10 @@ en:
         provides_teacher_training: 'For example, are you a School Direct lead or partner school or do you offer mainstream teacher training placements.'
 
     label:
+      bookings_school:
+        enabled:
+          true: Allow requests
+          false: Do not allow requests
       bookings_placement_date:
         duration: How many days will it last?
         active: Make this date available to candidates?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     namespace :schools do
       resource :session, only: %i(show destroy)
       resource :dashboard, only: :show
+      resource :toggle_enabled, only: %i(edit update), as: 'enabled', controller: 'toggle_enabled'
 
       resources :placement_requests do
         resource :accept, only: [:show, :create], controller: 'placement_requests/accept'

--- a/features/schools/toggle_enabling_and_disabling.feature
+++ b/features/schools/toggle_enabling_and_disabling.feature
@@ -1,0 +1,33 @@
+Feature: Toggling being enabled and disabled
+    So I can prevent being overloaded by new requests
+    As a school administrator
+    I want to be able to toggle the enabled flag
+
+    Background:
+        Given I am logged in as a DfE user
+
+    Scenario: Page title
+        Given I am on the 'toggle requests' page
+        Then the page title should be 'Toggle requests'
+
+    Scenario: Page contents
+        Given I am on the 'toggle requests' page
+        Then I should see radio buttons for 'Turn requests on or off' with the following options:
+            | Allow requests        |
+            | Do not allow requests |
+
+    Scenario: Disabling an enabled school
+        Given my school is enabled
+        And I am on the 'toggle requests' page
+        When I choose 'Do not allow requests' from the 'Turn requests on or off' radio buttons
+        And I submit the form
+        Then I should be on the 'schools dashboard' page
+        And my school should be disabled
+
+    Scenario: Enabling a disabled school
+        Given my school is disabled
+        And I am on the 'toggle requests' page
+        When I choose 'Allow requests' from the 'Turn requests on or off' radio buttons
+        And I submit the form
+        Then I should be on the 'schools dashboard' page
+        And my school should be enabled

--- a/features/step_definitions/schools/dfe_signin_steps.rb
+++ b/features/step_definitions/schools/dfe_signin_steps.rb
@@ -1,3 +1,4 @@
 Given("I am logged in as a DfE user") do
   visit insecure_auth_callback_path
+  @school = Bookings::School.find_by(urn: 123456)
 end

--- a/features/step_definitions/schools/toggle_requests_steps.rb
+++ b/features/step_definitions/schools/toggle_requests_steps.rb
@@ -1,0 +1,16 @@
+Given("my school is enabled") do
+  expect(@school).to be_enabled
+end
+
+Given("my school is disabled") do
+  @school.update(enabled: false)
+  expect(@school).to be_disabled
+end
+
+Then("my school should be enabled") do
+  expect(@school.reload).to be_enabled
+end
+
+Then("my school should be disabled") do
+  expect(@school.reload).to be_disabled
+end

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -37,7 +37,8 @@ def path_for(descriptor, school: nil, placement_date_id: nil)
     "availability preference" => [:new_schools_on_boarding_availability_preference_path],
     "availability description" => [:new_schools_on_boarding_availability_description_path],
     "admin contact" => [:new_schools_on_boarding_admin_contact_path],
-    "profile" => [:schools_on_boarding_profile_path]
+    "profile" => [:schools_on_boarding_profile_path],
+    "toggle requests" => [:edit_schools_enabled_path]
   }
 
   (path = mappings[descriptor.downcase]) ? send(*path) : fail("No mapping for #{descriptor}")

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Schools::DashboardsHelper, type: 'helper' do
-  context '#numbered_circle' do
+  describe '#numbered_circle' do
     let(:text) { '15' }
     let(:circle) { numbered_circle(text) }
     subject { Nokogiri.parse(circle) }
@@ -83,6 +83,24 @@ describe Schools::DashboardsHelper, type: 'helper' do
         specify "should be sized at the custom size" do
           expect(subject.at_css('svg > text')['font-size']).to eql(fs)
         end
+      end
+    end
+  end
+
+  describe '#school_enabled_description' do
+    subject { school_enabled_description(school) }
+
+    context 'when enabled' do
+      let(:school) { build(:bookings_school) }
+      specify "should be 'enabled' when enabled is true" do
+        expect(subject).to eql('enabled')
+      end
+    end
+
+    context 'when disabled' do
+      let(:school) { build(:bookings_school, :disabled) }
+      specify "should be 'disabled' when enabled is false" do
+        expect(subject).to eql('disabled')
       end
     end
   end


### PR DESCRIPTION
### Context

Schools that are overloaded would like the ability to deactivate themselves

### Changes proposed in this pull request

Allow schools to activate and deactivate themselves, plus add some dashlette copy

### Guidance to review

Ensure everything looks sane and sensible!


![Screenshot 2019-04-26 at 13 44 56](https://user-images.githubusercontent.com/128088/56808471-81ac2080-6829-11e9-9213-2c69a86d6f32.png)
