### PR TITLE
Fix CI for Phase2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ pool:
 
 variables:
   imageName: school-experience
+  imageTag: v$(Build.BuildNumber)
   POSTGRES_IMAGE: mdillon/postgis:11-alpine
   # define three more variables dockerId, dockerPassword and dockerRegistry in the build pipeline in UI
   POSTGRESS_PASSWORD: secret
@@ -80,7 +81,8 @@ steps:
     displayName: 'Push Docker image (built from master)'
 
   - script: |
-      docker push $(dockerRegistry)/$(imageName):$(imageTag)
+      docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(dockerRegistry)/$(imageName):$(imageTag)-phase2
+      docker push $(dockerRegistry)/$(imageName):$(imageTag)-phase2
       docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(dockerRegistry)/$(imageName):phase2
       docker push $(dockerRegistry)/$(imageName):phase2
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/phase2')


### PR DESCRIPTION
### Context

CI is broken for Phase2

### Changes proposed in this pull request

1. Bring master and Phase2 inline
2. Avoid dynamic variable assignment
3. Tag Docker Images accordingly to BuildNumber instead of BuildId

Note: This PR is to sort conflicts when merging the `bugfix/ci-build-number` branch into `phase2

