### PR TITLE
Don't validate nearby_parking_details unless parking option selected

### DIFF
--- a/app/forms/schools/on_boarding/candidate_experience_detail.rb
+++ b/app/forms/schools/on_boarding/candidate_experience_detail.rb
@@ -27,7 +27,7 @@ module Schools
       validates :other_dress_requirements_detail, presence: true, if: :other_dress_requirements
       validates :parking_provided, inclusion: [true, false]
       validates :parking_details, presence: true, if: :parking_provided
-      validates :nearby_parking_details, presence: true, unless: :parking_provided
+      validates :nearby_parking_details, presence: true, if: -> { !parking_provided && !parking_provided.nil? }
       validates :disabled_facilities, inclusion: [true, false]
       validates :disabled_facilities_details, presence: true, if: :disabled_facilities
       validates :start_time, presence: true


### PR DESCRIPTION
Want to make sure parking_provided is false and not nil before
validating nearby_parking_details. nearby_parking_details is hidden
behind a conditional reveal so the error isn't shown to the user unless
they have selected an option from the parking_provided radio buttons

### Context

### Changes proposed in this pull request

### Guidance to review

