### PR TITLE
Swapped back to BuildId

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pool:
 
 variables:
   imageName: school-experience
-  imageTag: v$(Build.BuildNumber)
+  imageTag: v$(Build.BuildId)
   POSTGRES_IMAGE: mdillon/postgis:11-alpine
   # define three more variables dockerId, dockerPassword and dockerRegistry in the build pipeline in UI
   POSTGRESS_PASSWORD: secret


### PR DESCRIPTION
### Context

We're going to be changing the CI build pipeline but it turns out using BuildID wont actually cause 
problems since thats consistent across the whole project.

This will reduce changes needed to the CD pipeline

### Changes proposed in this pull request

1. Swap back from BuildNumber to BuildId



