### PR TITLE
Se 847/schools/on boarding/word limit validation

### DIFF
--- a/app/forms/schools/on_boarding/candidate_requirement.rb
+++ b/app/forms/schools/on_boarding/candidate_requirement.rb
@@ -14,6 +14,7 @@ module Schools
       validates :dbs_requirement, presence: true
       validates :dbs_requirement, inclusion: { in: :dbs_requirements }, if: -> { dbs_requirement.present? }
       validates :dbs_policy, presence: true, if: :requires_policy_explanation?
+      validates :dbs_policy, number_of_words: { less_than: 50 }, if: -> { dbs_policy.present? }
       validates :requirements, inclusion: [true, false]
       validates :requirements_details, presence: true, if: :requirements
 

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -234,8 +234,7 @@ module Schools
 
     belongs_to :bookings_school,
       class_name: 'Bookings::School',
-      foreign_key: 'bookings_school_id',
-      dependent: :destroy
+      foreign_key: 'bookings_school_id'
 
     def available_secondary_subjects
       Bookings::Subject.all

--- a/app/services/candidates/registrations/behaviours/placement_preference.rb
+++ b/app/services/candidates/registrations/behaviours/placement_preference.rb
@@ -4,9 +4,6 @@ module Candidates
       module PlacementPreference
         extend ActiveSupport::Concern
 
-        MAX_WORDS_FOR_AVAILABILITY = 149
-        MAX_WORDS_FOR_OBJECTIVE = 149
-
         included do
           validates :urn, presence: true
           validates :bookings_placement_date_id,
@@ -15,35 +12,15 @@ module Candidates
           validates :availability,
             presence: true,
             unless: -> { urn.present? && school_offers_fixed_dates? }
-          validate :availability_not_too_long, if: -> { availability.present? }
+          validates :availability, number_of_words: { less_than: 150 }, if: -> { availability.present? }
           validates :objectives, presence: true
-          validate  :objectives_not_too_long, if: -> { objectives.present? }
+          validates :objectives, number_of_words: { less_than: 150 }, if: -> { objectives.present? }
         end
 
       private
 
         def school_offers_fixed_dates?
           school.fixed_dates?
-        end
-
-        def availability_not_too_long
-          if availability_too_long?
-            errors.add :availability, :use_fewer_words
-          end
-        end
-
-        def availability_too_long?
-          availability.scan(/\s/).size > MAX_WORDS_FOR_AVAILABILITY
-        end
-
-        def objectives_not_too_long
-          if objectives_too_long?
-            errors.add :objectives, :use_fewer_words
-          end
-        end
-
-        def objectives_too_long?
-          objectives.scan(/\s/).size > MAX_WORDS_FOR_OBJECTIVE
         end
       end
     end

--- a/app/validators/number_of_words_validator.rb
+++ b/app/validators/number_of_words_validator.rb
@@ -1,0 +1,15 @@
+class NumberOfWordsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    max_words = options.fetch(:less_than)
+
+    if number_of_words(value) > max_words
+      record.errors.add attribute, :use_fewer_words, count: max_words
+    end
+  end
+
+private
+
+  def number_of_words(string)
+    string.scan(/\s/).size + 1
+  end
+end

--- a/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
@@ -10,7 +10,7 @@
         <% f.object.dbs_requirements.each do |requirement| %>
           <% if f.object.policy_explanation_required? requirement %>
             <%= fieldset.radio_input requirement do %>
-              <%= fieldset.text_area :dbs_policy, class: 'govuk-!-width-two-thirds', rows: 7 %>
+              <%= fieldset.text_area_with_maxwords :dbs_policy, maxwords: { count: 50 }, class: 'govuk-!-width-two-thirds', rows: 7 %>
             <% end %>
           <% else %>
             <%= fieldset.radio_input requirement %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,13 +8,10 @@ en:
     attributes:
       availability:
         blank: "Enter your availability"
-        use_fewer_words: "Use 150 words or fewer"
       objectives:
         blank: "Enter what you want to get out of a placement"
-        use_fewer_words: "Use 150 words or fewer"
       bookings_placement_date_id:
         blank: "Choose a placement date"
-
 
   subject_preference_errors: &subject_preference_errors
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,8 @@
 en:
   errors:
    format: "%{message}"
+   messages:
+     use_fewer_words: "Use %{count} words or fewer"
 
   placement_preference_errors: &placement_preference_errors
     attributes:

--- a/spec/forms/schools/on_boarding/candidate_requirement_spec.rb
+++ b/spec/forms/schools/on_boarding/candidate_requirement_spec.rb
@@ -22,6 +22,22 @@ describe Schools::OnBoarding::CandidateRequirement, type: :model do
         it do
           is_expected.to validate_presence_of :dbs_policy
         end
+
+        context 'when dbs_policy is present' do
+          let :dbs_policy do
+            51.times.map { 'word' }.join(' ')
+          end
+
+          subject do
+            described_class.new \
+              dbs_requirement: 'sometimes', dbs_policy: dbs_policy
+          end
+
+          it "is expected to validate dbs_policy isn't too long" do
+            expect(subject.tap(&:validate).errors[:dbs_policy]).to \
+              eq ['Use 50 words or fewer']
+          end
+        end
       end
 
       context "when dbs_requirement not 'Yes - sometimes'" do

--- a/spec/validators/number_of_words_validator_spec.rb
+++ b/spec/validators/number_of_words_validator_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe NumberOfWordsValidator do
+  let :errors do
+    double 'errors', add: true
+  end
+
+  let :model do
+    double 'model', description: description, errors: errors
+  end
+
+  let :validator do
+    described_class.new attributes: :description, less_than: 150
+  end
+
+  before :each do
+    validator.validate_each model, :description, description
+  end
+
+  context 'less than' do
+    context 'too many words' do
+      let :description do
+        151.times.map { 'word' }.join(' ')
+      end
+
+      it 'adds an error to the correct attribute' do
+        expect(errors).to \
+          have_received(:add).with(:description, :use_fewer_words, count: 150)
+      end
+    end
+
+    context 'correct number of words' do
+      let :description do
+        149.times.map { 'word' }.join(' ')
+      end
+
+      it "doesn't add an error" do
+        expect(errors).not_to have_received(:add)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Need to validate number of words on schools/on_boarding/candidate_requirement#dbs_policy is less than 50

### Changes proposed in this pull request
Extracts number_of_words validation from candidate/registrations/placement_preference to validator.
Uses validator for dbs_policy.
Adds text_area_with_maxwords to dbs_policy field.

Also removes bookings_school dependent: :destroy from school_profile as we probably don't want to delete the school if the profile is deleted.

### Guidance to review

