### PR TITLE
Speed up cucumber

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ steps:
     displayName: Create Testing databases, import schema and fixtures
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rspec
     displayName: Run the Specs
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true $(dockerRegistry)/$(imageName):$(imageTag) cucumber --profile=$(CUCUMBER_PROFILE)
+  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 $(dockerRegistry)/$(imageName):$(imageTag) cucumber --profile=$(CUCUMBER_PROFILE)
     displayName: Run the Cucumber features
   - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) brakeman --no-pager
     displayName: Run the Brakeman security scan
@@ -56,11 +56,11 @@ steps:
     displayName: Run the GovUK Lint check
   - script: docker run --name=selenium-chrome -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-chrome
     displayName: Launch Selenium Chrome
-  - script: docker run --rm --link postgres:postgres --link=redis:redis --link selenium-chrome:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
+  - script: docker run --rm --link postgres:postgres --link=redis:redis --link selenium-chrome:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
     displayName: Run Cucumber via Selenium Chrome
   - script: docker run --name=selenium-firefox -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-firefox
     displayName: Launch Selenium Firefox
-  - script: docker run --rm --link postgres:postgres --link=redis:redis --link selenium-firefox:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e CUC_DRIVER=firefox -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
+  - script: docker run --rm --link postgres:postgres --link=redis:redis --link selenium-firefox:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e CUC_DRIVER=firefox -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
     displayName: Run Cucumber via Selenium Firefox
 
   - script: |

--- a/features/step_definitions/candidates/landing_page_steps.rb
+++ b/features/step_definitions/candidates/landing_page_steps.rb
@@ -27,7 +27,7 @@ end
 
 When("I click the {string} button") do |string|
   click_link(string)
-  sleep(2)
+  delay_page_load
 end
 
 Then("I should be on the {string} page") do |string|

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -88,7 +88,7 @@ end
 
 When("I select {string} in the {string} select box") do |option, label_text|
   select(option, from: label_text)
-  sleep(2)
+  delay_page_load
 end
 
 Given("I search for schools near {string}") do |string|

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -75,7 +75,7 @@ end
 
 Given("I have changed the sort order to {string}") do |sort_by|
   select(sort_by, from: 'Sorted by')
-  sleep(2)
+  delay_page_load
 end
 
 Given("the sort order has defaulted to {string}") do |string|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -133,7 +133,7 @@ else
 end
 
 if ENV['SELENIUM_HUB_HOSTNAME'].present?
-  capabilities = ENV.fetch('CUC_DRIVER') { 'chrome'}
+  capabilities = ENV.fetch('CUC_DRIVER') { 'chrome' }
 
   Capybara.run_server = false
   Capybara.register_driver :selenium_remote do |app|

--- a/features/support/feature_helper.rb
+++ b/features/support/feature_helper.rb
@@ -1,0 +1,5 @@
+def delay_page_load
+  if ENV['CUC_DRIVER'].present? || ENV['CUC_PAGE_DELAY'].present?
+    sleep Integer(ENV['CUC_PAGE_DELAY'] { 2 })
+  end
+end


### PR DESCRIPTION
### Context

Currently we have sleep statements within the Cucumber Tests. This enable the tests to pass on IE and FF in CD but take CI runs from approx 10 minutes to approx 30 minutes.

### Changes proposed in this pull request

This can be optimised by only using the delay in the CD. This change allows manually overriding the page delay time (including to a delay of 0), and only delays if CUC_DRIVER is set to something.

### Guidance to review

Are the tests still running correctly. Have the sped up
