### PR TITLE
Feature/omit schools with no fixed dates from search results

### DIFF
--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -44,9 +44,8 @@ module Candidates
       end
 
       def set_placement_dates
-        if @school.fixed_dates?
+        if @school.availability_preference_fixed?
           @placement_dates = @school
-            .school_profile
             .bookings_placement_dates
             .available
         end

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -16,6 +16,7 @@ class Candidates::SchoolsController < ApplicationController
 
   def show
     @school = Candidates::School.find(params[:id])
+    @available_dates = @school.bookings_placement_dates.available
   end
 
 private

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -3,7 +3,6 @@ class Schools::PlacementDatesController < Schools::BaseController
 
   def index
     @placement_dates = current_school
-      .school_profile
       .bookings_placement_dates
       .future
       .in_date_order
@@ -11,14 +10,12 @@ class Schools::PlacementDatesController < Schools::BaseController
 
   def new
     @placement_date = current_school
-      .school_profile
       .bookings_placement_dates
       .new
   end
 
   def create
     @placement_date = current_school
-      .school_profile
       .bookings_placement_dates
       .new(placement_date_params)
 
@@ -43,7 +40,6 @@ private
 
   def set_placement_date
     @placement_date = current_school
-      .school_profile
       .bookings_placement_dates
       .find(params[:id])
   end

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -1,10 +1,10 @@
 module Bookings
   class PlacementDate < ApplicationRecord
-    belongs_to :school_profile,
-      class_name: 'Schools::SchoolProfile',
-      foreign_key: 'schools_school_profile_id'
+    belongs_to :bookings_school,
+      class_name: 'Bookings::School',
+      foreign_key: 'bookings_school_id'
 
-    validates :school_profile, presence: true
+    validates :bookings_school, presence: true
     validates :date, presence: true
     validates :duration,
       presence: true,

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -50,7 +50,8 @@ class Bookings::School < ApplicationRecord
 
   has_many :bookings_placement_dates,
     class_name: 'Bookings::PlacementDate',
-    foreign_key: :bookings_school_id
+    foreign_key: :bookings_school_id,
+    dependent: :destroy
 
   scope :enabled, -> { where(enabled: true) }
 

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -108,6 +108,12 @@ class Bookings::School < ApplicationRecord
     !enabled?
   end
 
+  def has_availability?
+    !availability_preference_fixed? || has_available_dates?
+  end
+
+private
+
   def has_available_dates?
     bookings_placement_dates.available.any?
   end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -48,6 +48,10 @@ class Bookings::School < ApplicationRecord
     foreign_key: :bookings_school_id,
     dependent: :destroy
 
+  has_many :bookings_placement_dates,
+    class_name: 'Bookings::PlacementDate',
+    foreign_key: :bookings_school_id
+
   scope :enabled, -> { where(enabled: true) }
 
   scope :that_provide, ->(subject_ids) do
@@ -76,10 +80,6 @@ class Bookings::School < ApplicationRecord
     end
   end
 
-  def availability_preference_fixed?
-    school_profile&.availability_preference&.fixed?
-  end
-
   def to_param
     urn.to_s.presence
   end
@@ -92,7 +92,7 @@ class Bookings::School < ApplicationRecord
     !enabled?
   end
 
-  def fixed_dates?
-    school_profile&.fixed_dates?
+  def has_available_dates?
+    bookings_placement_dates.available.any?
   end
 end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -80,6 +80,22 @@ class Bookings::School < ApplicationRecord
     end
   end
 
+  scope :flexible, -> { where(availability_preference_fixed: false) }
+
+  scope :fixed, -> { where(availability_preference_fixed: true) }
+
+  scope :fixed_with_available_dates, -> {
+    fixed.where(
+      id: Bookings::School
+        .joins(:bookings_placement_dates)
+        .merge(Bookings::PlacementDate.available)
+        .except(:select)
+        .select(:id)
+    )
+  }
+
+  scope :with_availability, -> { flexible.or(fixed_with_available_dates) }
+
   def to_param
     urn.to_s.presence
   end

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -64,6 +64,7 @@ private
       .at_phases(phases)
       .costing_upto(max_fee)
       .enabled
+      .with_availability
       .distinct
   end
 

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -228,10 +228,6 @@ module Schools
       through: :college_phase_subjects,
       dependent: :destroy
 
-    has_many :bookings_placement_dates,
-      class_name: 'Bookings::PlacementDate',
-      foreign_key: :schools_school_profile_id
-
     belongs_to :bookings_school,
       class_name: 'Bookings::School',
       foreign_key: 'bookings_school_id',
@@ -259,10 +255,6 @@ module Schools
 
     def fixed_dates?
       availability_preference.fixed?
-    end
-
-    def has_available_dates?
-      fixed_dates? && bookings_placement_dates.available.exists?
     end
   end
 end

--- a/app/services/candidates/registrations/behaviours/placement_preference.rb
+++ b/app/services/candidates/registrations/behaviours/placement_preference.rb
@@ -23,7 +23,7 @@ module Candidates
       private
 
         def school_offers_fixed_dates?
-          school.fixed_dates?
+          school.availability_preference_fixed?
         end
 
         def availability_not_too_long

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -102,8 +102,8 @@
 
       <div id="school-availability-info" class="govuk-summary-list__row">
 
-        <%- if @school.fixed_dates? -%>
-          <%= render partial: 'placement_dates', locals: { school: @school } %>
+        <%- if @school.availability_preference_fixed? -%>
+          <%= render partial: 'placement_dates', locals: { available_dates: @available_dates } %>
         <%- else -%>
           <dt class="govuk-summary-list__key">
             Placement availability

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -45,11 +45,13 @@
       </p>
     </div>
 
+    <%- if @school.has_availability? -%>
     <p>
       <%= link_to "Start request",
                   new_candidates_school_registrations_placement_preference_path(@school),
                   class:"govuk-button" %>
     </p>
+    <%- end -%>
 
     <p>
       <strong>

--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -3,10 +3,10 @@
 </dt>
 
 <dd class="govuk-summary-list__value">
-  <%- if school.school_profile.has_available_dates? -%>
+  <%- if available_dates.any? -%>
 
     <ul class="govuk-list">
-      <%- school.school_profile.bookings_placement_dates.available.each do |pd| -%>
+      <%- available_dates.each do |pd| -%>
         <li><%= pd.to_s %></li>
       <%- end -%>
     </ul>

--- a/db/migrate/20190426154201_link_bookings_placement_dates_to_bookings_schools.rb
+++ b/db/migrate/20190426154201_link_bookings_placement_dates_to_bookings_schools.rb
@@ -1,0 +1,11 @@
+class LinkBookingsPlacementDatesToBookingsSchools < ActiveRecord::Migration[5.2]
+  def change
+    remove_foreign_key :bookings_placement_dates, :schools_school_profiles
+    remove_index :bookings_placement_dates, :schools_school_profile_id
+    remove_column :bookings_placement_dates, :schools_school_profile_id
+
+    add_column :bookings_placement_dates, :bookings_school_id, :integer, null: false
+    add_foreign_key :bookings_placement_dates, :bookings_schools
+    add_index :bookings_placement_dates, :bookings_school_id
+  end
+end

--- a/db/migrate/20190426165445_add_availability_preference_fixed_flag_to_bookings_schools.rb
+++ b/db/migrate/20190426165445_add_availability_preference_fixed_flag_to_bookings_schools.rb
@@ -1,0 +1,5 @@
+class AddAvailabilityPreferenceFixedFlagToBookingsSchools < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_schools, :availability_preference_fixed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,8 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 2019_04_18_180420) do
+
+ActiveRecord::Schema.define(version: 2019_04_26_165445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,12 +28,12 @@ ActiveRecord::Schema.define(version: 2019_04_18_180420) do
 
   create_table "bookings_placement_dates", force: :cascade do |t|
     t.date "date", null: false
-    t.integer "schools_school_profile_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "duration", default: 1, null: false
     t.boolean "active", default: true, null: false
-    t.index ["schools_school_profile_id"], name: "index_bookings_placement_dates_on_schools_school_profile_id"
+    t.integer "bookings_school_id", null: false
+    t.index ["bookings_school_id"], name: "index_bookings_placement_dates_on_bookings_school_id"
   end
 
   create_table "bookings_placement_requests", force: :cascade do |t|
@@ -97,6 +98,7 @@ ActiveRecord::Schema.define(version: 2019_04_18_180420) do
     t.text "availability_info"
     t.string "teacher_training_website"
     t.boolean "enabled", default: true, null: false
+    t.boolean "availability_preference_fixed", default: false, null: false
     t.index ["coordinates"], name: "index_bookings_schools_on_coordinates", using: :gist
     t.index ["name"], name: "index_bookings_schools_on_name"
     t.index ["urn"], name: "index_bookings_schools_on_urn", unique: true
@@ -203,12 +205,11 @@ ActiveRecord::Schema.define(version: 2019_04_18_180420) do
     t.string "admin_contact_email"
     t.string "admin_contact_phone"
     t.text "availability_description_description"
-    t.integer "bookings_school_id", null: false
     t.boolean "availability_preference_fixed"
     t.index ["bookings_school_id"], name: "index_schools_school_profiles_on_bookings_school_id"
   end
 
-  add_foreign_key "bookings_placement_dates", "schools_school_profiles"
+  add_foreign_key "bookings_placement_dates", "bookings_schools"
   add_foreign_key "bookings_placement_requests", "bookings_placement_dates"
   add_foreign_key "bookings_schools", "bookings_school_types"
   add_foreign_key "bookings_schools_phases", "bookings_phases"

--- a/features/candidates/schools/show/start_request_button_presence.feature
+++ b/features/candidates/schools/show/start_request_button_presence.feature
@@ -1,0 +1,20 @@
+Feature: School has no availability
+    To prevent me from applying to a school that can't accomodate me
+    As a potential candidate
+    I want the 'Start request' button to be hidden if there is no availability
+
+    Scenario: When the school has flexible dates
+        Given my school of choice has 'flexible' dates
+        When I am on the profile page for the chosen school
+        Then there should be a button called 'Start request' that begins the wizard
+
+    Scenario: When the school has fixed dates but none are available
+        Given my school of choice has 'fixed' dates
+        When I am on the profile page for the chosen school
+        Then there should not be a button called 'Start request' that begins the wizard
+
+    Scenario: When the school has fixed dates and some are available
+        Given my school of choice has 'fixed' dates
+        And there are some available dates in the future
+        When I am on the profile page for the chosen school
+        Then there should be a button called 'Start request' that begins the wizard

--- a/features/schools/placement_dates/edit.feature
+++ b/features/schools/placement_dates/edit.feature
@@ -5,7 +5,6 @@ Feature: Editing placement dates
 
     Background:
         Given I am logged in as a DfE user
-        And my school has a profile
 
     Scenario: Page title
         Given I am on the edit page for my placement

--- a/features/schools/placement_dates/index.feature
+++ b/features/schools/placement_dates/index.feature
@@ -5,7 +5,6 @@ Feature: Listing placement dates
 
     Background:
         Given I am logged in as a DfE user
-        And my school has a profile
 
     Scenario: Page title
         Given I am on the 'placement dates' page

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -5,7 +5,6 @@ Feature: Creating new placement dates
 
     Background:
         Given I am logged in as a DfE user
-        And my school has a profile
 
     Scenario: Page title
         Given I am on the 'new placement date' page

--- a/features/step_definitions/candidates/registrations/application_preview_steps.rb
+++ b/features/step_definitions/candidates/registrations/application_preview_steps.rb
@@ -61,17 +61,16 @@ end
 
 Given("my school has fixed dates") do
   @fixed_dates = true
-  @school_profile.update_attributes(availability_preference_fixed: true)
+  @school.update_attributes(availability_preference_fixed: true)
   (1..3).each { |i| i.weeks.from_now }.each do |date|
-    @school_profile.bookings_placement_dates.create(date: date.weeks.from_now)
-    @wanted_bookings_placement_date = @school_profile.bookings_placement_dates.last.to_s
+    @school.bookings_placement_dates.create(date: date.weeks.from_now)
+    @wanted_bookings_placement_date = @school.bookings_placement_dates.last.to_s
   end
   # do nothing, it's the default
 end
 
 Given("my school of choice exists") do
-  @school_profile = FactoryBot.create(:school_profile)
-  @school = @school_profile.bookings_school
+  @school = FactoryBot.create(:bookings_school, urn: 123456)
 end
 
 Given("my school of choice offers {string}") do |string|

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -58,8 +58,7 @@ Given("the school I'm applying to is flexible on dates") do
 end
 
 Given("the school I'm applying to is not flexible on dates") do
-  @school_profile = FactoryBot.create(:school_profile, :with_fixed_availability_preference)
-  @school = @school_profile.bookings_school
+  @school = FactoryBot.create(:bookings_school, :with_fixed_availability_preference)
 end
 
 Given("the school has {int} placements available in the upcoming weeks") do |int|
@@ -67,21 +66,21 @@ Given("the school has {int} placements available in the upcoming weeks") do |int
     FactoryBot.create(
       :bookings_placement_date,
       date: date,
-      school_profile: @school_profile
+      bookings_school: @school
     )
   end
 
-  expect(@school_profile.bookings_placement_dates.count).to eql(int)
-  @placement_dates = @school_profile.bookings_placement_dates.map(&:to_s)
+  expect(@school.bookings_placement_dates.count).to eql(int)
+  @placement_dates = @school.bookings_placement_dates.map(&:to_s)
 end
 
 Then("there should be a radio button per date the school has specified") do
-  @school_profile.bookings_placement_dates.map(&:to_s).each do |date_string|
+  @school.bookings_placement_dates.map(&:to_s).each do |date_string|
     expect(page).to have_field(date_string, type: 'radio')
   end
 end
 
 When("I choose a placement date") do
-  @last_date = @school_profile.bookings_placement_dates.last
+  @last_date = @school.bookings_placement_dates.last
   choose @last_date.to_s
 end

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -178,3 +178,23 @@ Then("I should see the list of {string} in the sidebar") do |string|
     end
   end
 end
+
+Given("my school of choice has {string} dates") do |option|
+  @school = if option == 'fixed'
+              FactoryBot.create(:bookings_school, :with_fixed_availability_preference)
+            elsif option == 'flexible'
+              FactoryBot.create(:bookings_school)
+            else
+              fail 'invalid flexibility option'
+            end
+end
+
+Then("there should not be a button called {string} that begins the wizard") do |string|
+  expect(page).not_to have_link(string, href: new_candidates_school_registrations_placement_preference_path(@school.urn))
+end
+
+Given("there are some available dates in the future") do
+  [1, 2, 3].each do |i|
+    FactoryBot.create(:bookings_placement_date, date: i.weeks.from_now, bookings_school: @school)
+  end
+end

--- a/features/step_definitions/schools/dfe_signin_steps.rb
+++ b/features/step_definitions/schools/dfe_signin_steps.rb
@@ -1,3 +1,4 @@
 Given("I am logged in as a DfE user") do
   visit insecure_auth_callback_path
+  @school = Bookings::School.find_by(urn: 123456)
 end

--- a/features/step_definitions/schools/placement_dates/edit_steps.rb
+++ b/features/step_definitions/schools/placement_dates/edit_steps.rb
@@ -3,7 +3,7 @@ Given("I am on the edit page for my placement") do
     :bookings_placement_date,
     date: 3.weeks.from_now,
     duration: 6,
-    school_profile: @school_profile
+    bookings_school: @school
   )
   path = edit_schools_placement_date_path(@placement_date)
   visit path
@@ -16,7 +16,7 @@ Given("I am on the edit page for my {string} placement") do |state|
     state.to_sym,
     date: 3.weeks.from_now,
     duration: 6,
-    school_profile: @school_profile
+    bookings_school: @school
   )
   path = edit_schools_placement_date_path(@placement_date)
   visit path

--- a/features/step_definitions/schools/placement_dates/index_steps.rb
+++ b/features/step_definitions/schools/placement_dates/index_steps.rb
@@ -1,12 +1,6 @@
-Given("my school has a profile") do
-  @school_profile = Schools::SchoolProfile.find_or_create_by!(
-    bookings_school: Bookings::School.find_by(urn: 123456)
-  )
-end
-
 Given("my school has {int} placement dates") do |int|
-  @placement_dates = FactoryBot.create_list(:bookings_placement_date, int, school_profile: @school_profile)
-  expect(@school_profile.bookings_placement_dates.count).to eql(int)
+  @placement_dates = FactoryBot.create_list(:bookings_placement_date, int, bookings_school: @school)
+  expect(@school.bookings_placement_dates.count).to eql(int)
 end
 
 Then("I should see a list with {int} entries") do |int|
@@ -20,7 +14,7 @@ Given("my school has a placement date") do
     :bookings_placement_date,
     date: 3.weeks.from_now,
     duration: 6,
-    school_profile: @school_profile
+    bookings_school: @school
   )
 end
 
@@ -42,5 +36,5 @@ Then("there should be a {string} link to the new placement date page") do |strin
 end
 
 Given("my school has no placement dates") do
-  expect(@school_profile.bookings_placement_dates).to be_empty
+  expect(@school.bookings_placement_dates).to be_empty
 end

--- a/spec/factories/bookings/placement_dates.rb
+++ b/spec/factories/bookings/placement_dates.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :bookings_placement_date, class: 'Bookings::PlacementDate' do
     date { 3.weeks.from_now }
-    association :school_profile, factory: :school_profile
+    association :bookings_school, factory: :bookings_school
 
     trait :in_the_past do
       date { 6.weeks.ago }

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -19,5 +19,9 @@ FactoryBot.define do
       sequence(:town) { |n| "#{n} Something town" }
       sequence(:county) { |n| "#{n} Something county" }
     end
+
+    trait :with_fixed_availability_preference do
+      availability_preference_fixed { true }
+    end
   end
 end

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Bookings::PlacementDate, type: :model do
   describe 'Columns' do
-    it { is_expected.to have_db_column(:schools_school_profile_id).of_type(:integer) }
+    it { is_expected.to have_db_column(:bookings_school_id).of_type(:integer) }
     it { is_expected.to have_db_column(:date).of_type(:date) }
     it { is_expected.to have_db_column(:duration).of_type(:integer) }
     it { is_expected.to have_db_column(:active).of_type(:boolean) }
@@ -16,8 +16,8 @@ describe Bookings::PlacementDate, type: :model do
       # FIXME should we prevent weekends?
     end
 
-    context '#school_profile' do
-      it { expect(subject).to validate_presence_of(:school_profile) }
+    context '#bookings_school' do
+      it { expect(subject).to validate_presence_of(:bookings_school) }
     end
 
     context '#duration' do
@@ -34,7 +34,7 @@ describe Bookings::PlacementDate, type: :model do
 
   describe 'Relationships' do
     subject { described_class.new }
-    it { expect(subject).to belong_to(:school_profile) }
+    it { expect(subject).to belong_to(:bookings_school) }
   end
 
   describe 'Scopes' do

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -328,6 +328,41 @@ describe Bookings::SchoolSearch do
         end
       end
     end
+
+    context 'Other scopes/criteria' do
+      let(:phases) { create_list(:bookings_phase, 2).map(&:id) }
+      let(:subjects) { create_list(:bookings_subject, 2).map(&:id) }
+      let(:max_fee) { 20 }
+
+      after do
+        Bookings::SchoolSearch.new(
+          location: 'Bury',
+          phases: phases,
+          subjects: subjects,
+          max_fee: max_fee
+        ).results
+      end
+
+      specify 'should apply the :enabled scope' do
+        expect(Bookings::School).to receive(:enabled).and_call_original
+      end
+
+      specify 'should apply the :with_availability scope' do
+        expect(Bookings::School).to receive(:enabled).and_call_original
+      end
+
+      specify 'should apply the :at_phases scope with supplied phases' do
+        expect(Bookings::School).to receive(:at_phases).with(phases).and_call_original
+      end
+
+      specify 'should apply the :that_provide scope with supplied subjects' do
+        expect(Bookings::School).to receive(:that_provide).with(subjects).and_call_original
+      end
+
+      specify 'should apply the :costing_upto scope with max fee' do
+        expect(Bookings::School).to receive(:costing_upto).with(max_fee).and_call_original
+      end
+    end
   end
 
   describe '#total_count' do

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -266,5 +266,66 @@ describe Bookings::School, type: :model do
         end
       end
     end
+
+    context 'Availability and placement dates' do
+      specify { expect(described_class).to respond_to(:flexible) }
+      specify { expect(described_class).to respond_to(:fixed) }
+      specify { expect(described_class).to respond_to(:fixed_with_available_dates) }
+      specify { expect(described_class).to respond_to(:with_availability) }
+
+      let!(:flexible) { create(:bookings_school) } # flexible by default
+      let!(:fixed_without_dates) { create(:bookings_school, :with_fixed_availability_preference) }
+      let!(:fixed_with_dates) { create(:bookings_school, :with_fixed_availability_preference) }
+
+      let!(:inactive_date) { create(:bookings_placement_date, bookings_school: fixed_without_dates, active: false) }
+      let!(:active_date) { create(:bookings_placement_date, bookings_school: fixed_with_dates) }
+
+      context '.flexible' do
+        subject { described_class.flexible }
+
+        specify 'should include schools that offer flexible dates' do
+          expect(subject).to include(flexible)
+        end
+
+        specify 'should not include schools that offer fixed dates' do
+          expect(subject).not_to include(fixed_with_dates, fixed_without_dates)
+        end
+      end
+
+      context '.fixed' do
+        subject { described_class.fixed }
+
+        specify 'should include schools that offer fixed dates' do
+          expect(subject).to include(fixed_with_dates, fixed_without_dates)
+        end
+
+        specify 'should not include schools that offer flexible dates' do
+          expect(subject).not_to include(flexible)
+        end
+      end
+
+      context '.fixed_with_available_dates' do
+        subject { described_class.fixed_with_available_dates }
+        specify 'should include schools that offer fixed dates and have available dates' do
+          expect(subject).to include(fixed_with_dates)
+        end
+
+        specify 'should not include schools that offer fixed dates but have no available dates' do
+          expect(subject).not_to include(fixed_without_dates)
+        end
+      end
+
+      context '.with_availability' do
+        subject { described_class.with_availability }
+
+        specify 'should include schools that are either flexible or fixed with available dates' do
+          expect(subject).to include(flexible, fixed_with_dates)
+        end
+
+        specify 'should not include schools that are fixed with no available dates' do
+          expect(subject).not_to include(fixed_without_dates)
+        end
+      end
+    end
   end
 end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -116,8 +116,16 @@ describe Bookings::School, type: :model do
     specify do
       is_expected.to(
         belong_to(:school_type)
-        .with_foreign_key(:bookings_school_type_id)
-        .class_name("Bookings::SchoolType")
+          .with_foreign_key(:bookings_school_type_id)
+          .class_name("Bookings::SchoolType")
+      )
+    end
+
+    specify do
+      is_expected.to(
+        have_many(:bookings_placement_dates)
+          .with_foreign_key(:bookings_school_id)
+          .class_name('Bookings::PlacementDate')
       )
     end
   end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -126,6 +126,7 @@ describe Bookings::School, type: :model do
         have_many(:bookings_placement_dates)
           .with_foreign_key(:bookings_school_id)
           .class_name('Bookings::PlacementDate')
+          .dependent(:destroy)
       )
     end
   end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -328,4 +328,27 @@ describe Bookings::School, type: :model do
       end
     end
   end
+
+  describe 'Methods' do
+    describe '#has_availability?' do
+      context 'when flexible' do
+        subject { build(:bookings_school) }
+        it { is_expected.to have_availability }
+      end
+
+      context 'when fixed with no dates' do
+        subject { build(:bookings_school, :with_fixed_availability_preference) }
+        it { is_expected.not_to have_availability }
+      end
+
+      context 'when fixed with no dates' do
+        subject { create(:bookings_school, :with_fixed_availability_preference) }
+        let!(:available_date) do
+          create(:bookings_placement_date, date: 1.week.from_now, bookings_school: subject)
+        end
+
+        it { is_expected.to have_availability }
+      end
+    end
+  end
 end

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -185,7 +185,6 @@ describe Schools::SchoolProfile, type: :model do
     it { is_expected.to have_many(:college_phase_subjects) }
     it { is_expected.to have_many(:secondary_subjects) }
     it { is_expected.to have_many(:college_subjects) }
-    it { is_expected.to have_many(:bookings_placement_dates) }
     it { is_expected.to belong_to(:bookings_school) }
   end
 


### PR DESCRIPTION
### Context

Schools that are set to fixed dates mode with availablity should not be bookable 

### Changes proposed in this pull request

This change prevents them from appearing in search results by using a subquery to isolate schools that are either flexible or fixed with future available dates. Additionally, in case candidates have bookmarked school profile pages, the 'Start request' button will be hidden if the school has no future dates.

### Guidance to review

Ensure the changes look sensible and everything's structured correctly.