### PR TITLE
Validate school start and end times

### DIFF
--- a/app/forms/schools/on_boarding/candidate_experience_detail.rb
+++ b/app/forms/schools/on_boarding/candidate_experience_detail.rb
@@ -4,6 +4,11 @@ module Schools
       include ActiveModel::Model
       include ActiveModel::Attributes
 
+      # Ensure that times look *roughly* valid. Note that it is
+      # still possible to input invalid ones like '25:00'.
+      # FIXME do we need to tighten this up/use a real timepicker?
+      SCHOOL_TIME_FORMAT = %r{\A((\d{1,2}):(\d{1,2})\s*((?:(am|pm)))?)|\A([\d{1,2}]\s*(am|pm))}i.freeze
+
       attribute :business_dress, :boolean, default: false
       attribute :cover_up_tattoos, :boolean, default: false
       attribute :remove_piercings, :boolean, default: false
@@ -30,9 +35,9 @@ module Schools
       validates :nearby_parking_details, presence: true, if: -> { !parking_provided && !parking_provided.nil? }
       validates :disabled_facilities, inclusion: [true, false]
       validates :disabled_facilities_details, presence: true, if: :disabled_facilities
-      validates :start_time, presence: true
-      validates :end_time, presence: true
       validates :times_flexible, inclusion: [true, false]
+      validates :start_time, presence: true, format: { with: SCHOOL_TIME_FORMAT }
+      validates :end_time, presence: true, format: { with: SCHOOL_TIME_FORMAT }
 
       def self.compose(
           business_dress,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -145,8 +145,10 @@ en:
                 blank: 'Provide details'
             start_time:
               blank: 'Provide details'
+              invalid: 'Enter a valid start time'
             end_time:
               blank: 'Provide details'
+              invalid: 'Enter a valid end time'
             times_flexible:
               inclusion: 'Select an option'
         schools/on_boarding/experience_outline:

--- a/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
+++ b/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
@@ -57,5 +57,30 @@ describe Schools::OnBoarding::CandidateExperienceDetail, type: :model do
       subject { described_class.new disabled_facilities: true }
       it { is_expected.to validate_presence_of :disabled_facilities_details }
     end
+
+    context 'start and end times' do
+      valid_times = ['8AM', '8:30AM', '8:30 AM', '8am', '3pm', '3 pm', '17:00']
+      invalid_times = [
+        '8A', '9;00am', 'nine forty in the morning', 'mid-morning', -2
+      ]
+
+      context 'valid times' do
+        valid_times.each do |vt|
+          specify "should allow #{vt} to be assigned to both start_time, end_time" do
+            is_expected.to allow_value(vt).for(:start_time)
+            is_expected.to allow_value(vt).for(:end_time)
+          end
+        end
+      end
+
+      context 'invalid times' do
+        invalid_times.each do |ivt|
+          specify "should not allow #{ivt} to be assigned to both start_time, end_time" do
+            is_expected.not_to allow_value(ivt).for(:start_time)
+            is_expected.not_to allow_value(ivt).for(:end_time)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This isn't really an ideal solution, but it's straightforward and
flexible. It is possible for invalid times to be entered, like 25:00
It's lower impact than going down the `type='time'` route for the time
being, thanks to some browsers requiring polyfills.

Fixes [SE-870](https://dfedigital.atlassian.net/browse/SE-870)