### PR TITLE
Fix page delay when CUC_DRIVER set but CUC_PAGE_DELAY not set

### DIFF
--- a/features/support/feature_helper.rb
+++ b/features/support/feature_helper.rb
@@ -1,5 +1,5 @@
 def delay_page_load
   if ENV['CUC_DRIVER'].present? || ENV['CUC_PAGE_DELAY'].present?
-    sleep Integer(ENV['CUC_PAGE_DELAY'] { 2 })
+    sleep Integer(ENV.fetch('CUC_PAGE_DELAY') { 2 })
   end
 end


### PR DESCRIPTION
### Context

Currently tests fail in CD. This is caused by incorrect code for reading the default CUC_PAGE_DELAY value.

### Changes proposed in this pull request

1. Fix reading CUC_PAGE_DELAY with a default 

