### PR TITLE
Create a Bookings::Profile when completing a Schools::SchoolProfile

### DIFF
--- a/app/controllers/schools/on_boarding/confirmations_controller.rb
+++ b/app/controllers/schools/on_boarding/confirmations_controller.rb
@@ -7,6 +7,7 @@ module Schools
         @confirmation = Confirmation.new confirmation_params
 
         if @confirmation.valid?
+          publish_profile!
           redirect_to schools_on_boarding_confirmation_path
         else
           @profile = SchoolProfilePresenter.new(current_school_profile)
@@ -18,6 +19,11 @@ module Schools
 
       def confirmation_params
         params.require(:schools_on_boarding_confirmation).permit :acceptance
+      end
+
+      def publish_profile!
+        school = current_school_profile.bookings_school
+        Bookings::ProfilePublisher.new(school, current_school_profile).update!
       end
     end
   end

--- a/app/models/bookings/profile.rb
+++ b/app/models/bookings/profile.rb
@@ -1,7 +1,6 @@
 class Bookings::Profile < ApplicationRecord
   DBS_REQUIREMENTS = %w(always sometimes never).freeze
   AVAILABLE_INTERVALS = %w(Daily One-off).freeze
-  TIME_FORMAT = /\A([0-9]|([01][0-9])|2[0-3]):[0-5][0-9]\z/.freeze
   EMAIL_FORMAT = /\A.*@.*\..*\z/.freeze
 
   FIELDS_TO_NILIFY = %i{dbs_policy teacher_training_info teacher_training_url}.freeze
@@ -41,8 +40,8 @@ class Bookings::Profile < ApplicationRecord
 
   validates :disabled_facilities, length: { minimum: 1 }, if: :disabled_facilities
 
-  validates :start_time, presence: true, format: TIME_FORMAT
-  validates :end_time, presence: true, format: TIME_FORMAT
+  validates :start_time, presence: true
+  validates :end_time, presence: true
   validates :flexible_on_times, inclusion: [true, false]
 
   validates :placement_info, presence: true

--- a/app/models/bookings/profile.rb
+++ b/app/models/bookings/profile.rb
@@ -4,7 +4,7 @@ class Bookings::Profile < ApplicationRecord
   TIME_FORMAT = /\A([0-9]|([01][0-9])|2[0-3]):[0-5][0-9]\z/.freeze
   EMAIL_FORMAT = /\A.*@.*\..*\z/.freeze
 
-  FIELDS_TO_NILIFY = %i{dbs_policy teacher_training_info teacher_training_website}.freeze
+  FIELDS_TO_NILIFY = %i{dbs_policy teacher_training_info teacher_training_url}.freeze
 
   FIELDS_TO_STRIP = %i{
     start_time end_time admin_contact_full_name admin_contact_email admin_contact_phone
@@ -47,7 +47,7 @@ class Bookings::Profile < ApplicationRecord
 
   validates :placement_info, presence: true
 
-  validates :teacher_training_website, format: URI::regexp(%w{http https}), if: :teacher_training_info
+  validates :teacher_training_url, format: URI::regexp(%w{http https}), if: :teacher_training_info
 
   validates :admin_contact_full_name, presence: true
   validates :admin_contact_email, presence: true

--- a/app/models/bookings/profile.rb
+++ b/app/models/bookings/profile.rb
@@ -1,0 +1,123 @@
+class Bookings::Profile < ApplicationRecord
+  DBS_REQUIREMENTS = %w(always sometimes never).freeze
+  AVAILABLE_INTERVALS = %w(Daily One-off).freeze
+  TIME_FORMAT = /\A([0-9]|([01][0-9])|2[0-3]):[0-5][0-9]\z/.freeze
+  EMAIL_FORMAT = /\A.*@.*\..*\z/.freeze
+
+  FIELDS_TO_NILIFY = %i{dbs_policy teacher_training_info teacher_training_website}.freeze
+
+  FIELDS_TO_STRIP = %i{
+    start_time end_time admin_contact_full_name admin_contact_email admin_contact_phone
+  }.freeze
+
+  belongs_to :school, class_name: 'Bookings::School'
+
+  validates :dbs_required, presence: true
+  validates :dbs_required, inclusion: DBS_REQUIREMENTS, unless: -> { dbs_required.nil? }
+  validates :dbs_policy, presence: true, if: -> { dbs_required == 'sometimes' }
+
+  validates :individual_requirements, length: { minimum: 1 }, if: :individual_requirements
+
+  validates :primary_phase, inclusion: [true, false]
+  validates :secondary_phase, inclusion: [true, false]
+  validates :college_phase, inclusion: [true, false]
+  validate :at_least_one_phase
+
+  validates :key_stage_early_years, inclusion: [true, false], if: :primary_phase
+  validates :key_stage_1, inclusion: [true, false], if: :primary_phase
+  validates :key_stage_2, inclusion: [true, false], if: :primary_phase
+  validate  :at_least_one_key_stage, if: :primary_phase
+
+  validates :specialism_details, length: { minimum: 1 }, if: :specialism_details
+
+  validates :dress_code_business, inclusion: [true, false]
+  validates :dress_code_cover_tattoos, inclusion: [true, false]
+  validates :dress_code_remove_piercings, inclusion: [true, false]
+  validates :dress_code_smart_casual, inclusion: [true, false]
+  validates :dress_code_other_details, length: { minimum: 1 }, if: :dress_code_other_details
+
+  validates :parking_provided, inclusion: [true, false]
+  validates :parking_details, presence: true
+
+  validates :disabled_facilities, length: { minimum: 1 }, if: :disabled_facilities
+
+  validates :start_time, presence: true, format: TIME_FORMAT
+  validates :end_time, presence: true, format: TIME_FORMAT
+  validates :flexible_on_times, inclusion: [true, false]
+
+  validates :placement_info, presence: true
+
+  validates :teacher_training_website, format: URI::regexp(%w{http https}), if: :teacher_training_info
+
+  validates :admin_contact_full_name, presence: true
+  validates :admin_contact_email, presence: true
+  validates :admin_contact_email, format: EMAIL_FORMAT, allow_blank: true
+  validates :admin_contact_phone, presence: true
+  validates :admin_contact_phone, phone: true, allow_blank: true
+
+  validates :fixed_availability, inclusion: [true, false]
+  validates :availability_info, presence: true, unless: :fixed_availability
+  validate :availability_info_is_blank, if: :fixed_availability
+
+  validates :administration_fee_amount_pounds, numericality: { greater_than: 0 }, allow_nil: true
+  validates :administration_fee_description, presence: true, if: :administration_fee_assigned
+  validates :administration_fee_interval, inclusion: AVAILABLE_INTERVALS, if: :administration_fee_assigned
+  validates :administration_fee_payment_method, presence: true, if: :administration_fee_assigned
+
+  validates :dbs_fee_amount_pounds, numericality: { greater_than: 0 }, allow_nil: true
+  validates :dbs_fee_description, presence: true, if: :dbs_fee_assigned
+  validates :dbs_fee_interval, inclusion: AVAILABLE_INTERVALS, if: :dbs_fee_assigned
+  validates :dbs_fee_payment_method, presence: true, if: :dbs_fee_assigned
+
+  validates :other_fee_amount_pounds, numericality: { greater_than: 0 }, allow_nil: true
+  validates :other_fee_description, presence: true, if: :other_fee_assigned
+  validates :other_fee_interval, inclusion: AVAILABLE_INTERVALS, if: :other_fee_assigned
+  validates :other_fee_payment_method, presence: true, if: :other_fee_assigned
+
+  before_validation :nilify_blank_fields
+  before_validation :strip_fields
+
+private
+
+  def at_least_one_phase
+    unless primary_phase || secondary_phase || college_phase
+      errors.add(:base, 'Choose at least one phase')
+    end
+  end
+
+  def at_least_one_key_stage
+    unless key_stage_early_years || key_stage_1 || key_stage_2
+      errors.add(:base, 'Choose at least one primary key stage')
+    end
+  end
+
+  def nilify_blank_fields
+    FIELDS_TO_NILIFY.each do |f|
+      send(:"#{f}=", nil) if send(f).blank?
+    end
+  end
+
+  def strip_fields
+    FIELDS_TO_STRIP.each do |f|
+      send(:"#{f}=", send(f).strip) if send(f).present?
+    end
+  end
+
+  def availability_info_is_blank
+    if availability_info && !availability_info.blank?
+      errors.add :availability_info, 'cannot be set if using fixed availibility'
+    end
+  end
+
+  def administration_fee_assigned
+    administration_fee_amount_pounds && administration_fee_amount_pounds.to_f.positive?
+  end
+
+  def dbs_fee_assigned
+    dbs_fee_amount_pounds && dbs_fee_amount_pounds.to_f.positive?
+  end
+
+  def other_fee_assigned
+    other_fee_amount_pounds && other_fee_amount_pounds.to_f.positive?
+  end
+end

--- a/app/models/bookings/profile_attributes_convertor.rb
+++ b/app/models/bookings/profile_attributes_convertor.rb
@@ -67,7 +67,7 @@ module Bookings
         output[:admin_contact_email] = input[:admin_contact_email]
         output[:admin_contact_phone] = input[:admin_contact_phone]
       else
-        input[:admin_contact_email] = input[:admin_contact_phone] = nil
+        output[:admin_contact_email] = output[:admin_contact_phone] = nil
       end
     end
 

--- a/app/models/bookings/profile_attributes_convertor.rb
+++ b/app/models/bookings/profile_attributes_convertor.rb
@@ -1,0 +1,154 @@
+module Bookings
+  class ProfileAttributesConvertor
+    attr_reader :input
+
+    def initialize(schools_profile_attrs)
+      @input = schools_profile_attrs.symbolize_keys
+    end
+
+    def profile_attributes
+      reset_output
+
+      convert_dbs
+      convert_nillable
+      convert_dress_code
+      convert_teacher_training
+      convert_admin_details
+      copy_phases
+      copy_key_stages
+      copy_parking
+      copy_fields
+      convert_availability
+      convert_fees(:administration)
+      convert_fees(:dbs)
+      convert_fees(:other)
+
+      output
+    end
+
+  private
+
+    def convert_dbs
+      output[:dbs_required] = input[:candidate_requirement_dbs_requirement]
+
+      needs_policy = output[:dbs_required] == 'sometimes'
+      output[:dbs_policy] = assign_or_nil(needs_policy, :candidate_requirement_dbs_policy)
+    end
+
+    def convert_nillable
+      output[:individual_requirements] = \
+        conditional_assign(:candidate_requirement_requirements,
+          :candidate_requirement_requirements_details)
+
+      output[:specialism_details] = \
+        conditional_assign(:specialism_has_specialism,
+          :specialism_details)
+
+      output[:disabled_facilities] = \
+        conditional_assign(:candidate_experience_detail_disabled_facilities,
+          :candidate_experience_detail_disabled_facilities_details)
+    end
+
+    def convert_dress_code
+      output[:dress_code_business] = !!input[:candidate_experience_detail_business_dress]
+      output[:dress_code_cover_tattoos] = !!input[:candidate_experience_detail_cover_up_tattoos]
+      output[:dress_code_remove_piercings] = !!input[:candidate_experience_detail_remove_piercings]
+      output[:dress_code_smart_casual] = !!input[:candidate_experience_detail_smart_casual]
+
+      output[:dress_code_other_details] = \
+        conditional_assign(:candidate_experience_detail_other_dress_requirements,
+          :candidate_experience_detail_other_dress_requirements_detail)
+    end
+
+    def convert_admin_details
+      output[:admin_contact_full_name] = input[:admin_contact_full_name].presence
+
+      if output[:admin_contact_full_name].present?
+        output[:admin_contact_email] = input[:admin_contact_email]
+        output[:admin_contact_phone] = input[:admin_contact_phone]
+      else
+        input[:admin_contact_email] = input[:admin_contact_phone] = nil
+      end
+    end
+
+    def convert_availability
+      output[:fixed_availability] = input[:availability_preference_fixed]
+
+      output[:availability_info] = \
+        inverse_conditional_assign(:availability_preference_fixed,
+          :availability_description_description)
+    end
+
+    def copy_phases
+      output[:primary_phase]    = !!input[:phases_list_primary]
+      output[:secondary_phase]  = !!input[:phases_list_secondary]
+      output[:college_phase]    = !!input[:phases_list_college]
+    end
+
+    def copy_key_stages
+      output[:key_stage_early_years] = input[:phases_list_primary] && input[:key_stage_list_early_years]
+      output[:key_stage_1]           = input[:phases_list_primary] && input[:key_stage_list_key_stage_1]
+      output[:key_stage_2]           = input[:phases_list_primary] && input[:key_stage_list_key_stage_2]
+    end
+
+    def copy_fields
+      output[:start_time]         = input[:candidate_experience_detail_start_time]
+      output[:end_time]           = input[:candidate_experience_detail_end_time]
+      output[:flexible_on_times]  = !!input[:candidate_experience_detail_times_flexible]
+      output[:placement_info]     = input[:experience_outline_candidate_experience]
+    end
+
+    def copy_parking
+      if input[:candidate_experience_detail_parking_provided]
+        output[:parking_provided] = true
+        output[:parking_details]  = input[:candidate_experience_detail_parking_details]
+      else
+        output[:parking_provided] = false
+        output[:parking_details]  = input[:candidate_experience_detail_nearby_parking_details]
+      end
+    end
+
+    def convert_teacher_training
+      if input[:experience_outline_provides_teacher_training]
+        output[:teacher_training_info]  = input[:experience_outline_teacher_training_details]
+        output[:teacher_training_url]   = input[:experience_outline_teacher_training_url]
+      else
+        output[:teacher_training_info] = output[:teacher_training_url] = nil
+      end
+    end
+
+    def convert_fees(type)
+      if input[:"fees_#{type}_fees"]
+        output[:"#{type}_fee_amount_pounds"]  = input[:"#{type}_fee_amount_pounds"]
+        output[:"#{type}_fee_description"]    = input[:"#{type}_fee_description"]
+        output[:"#{type}_fee_interval"]       = input[:"#{type}_fee_interval"]
+        output[:"#{type}_fee_payment_method"] = input[:"#{type}_fee_payment_method"]
+      else
+        output[:"#{type}_fee_amount_pounds"]  = nil
+        output[:"#{type}_fee_description"]    = nil
+        output[:"#{type}_fee_interval"]       = nil
+        output[:"#{type}_fee_payment_method"] = nil
+      end
+    end
+
+    def output
+      @output ||= {}
+    end
+
+    def reset_output
+      @output = {}
+    end
+
+    def conditional_assign(condition_key, input_key)
+      assign_or_nil(!!input[condition_key], input_key)
+    end
+
+    def inverse_conditional_assign(condition_key, input_key)
+      assign_or_nil(!input[condition_key], input_key)
+    end
+
+    def assign_or_nil(test_result, input_key)
+      test_result ? input[input_key] : nil
+    end
+  end
+end

--- a/app/models/bookings/profile_attributes_convertor.rb
+++ b/app/models/bookings/profile_attributes_convertor.rb
@@ -6,7 +6,7 @@ module Bookings
       @input = schools_profile_attrs.symbolize_keys
     end
 
-    def profile_attributes
+    def attributes
       reset_output
 
       convert_dbs

--- a/app/models/bookings/profile_publisher.rb
+++ b/app/models/bookings/profile_publisher.rb
@@ -1,0 +1,41 @@
+module Bookings
+  class ProfilePublisher
+    def initialize(urn_or_school, school_profile)
+      @urn_or_school = urn_or_school
+      @school_profile = school_profile
+
+      unless @school_profile.completed?
+        raise IncompleteSourceProfileError
+      end
+    end
+
+    def update!
+      profile.attributes = converted_attributes
+      profile.tap(&:save!)
+    end
+
+    class IncompleteSourceProfileError < RuntimeError; end
+
+  private
+
+    def school
+      @school ||= \
+        if @urn_or_school.is_a?(Bookings::School)
+          @urn_or_school
+        else
+          Bookings::School.find_by!(urn: urn_or_school)
+        end
+    end
+
+    def converted_attributes
+      @converted_attributes ||= \
+        ProfileAttributesConvertor.new(@school_profile.attributes).attributes
+    end
+
+    def profile
+      school.build_profile unless school.profile
+
+      school.profile
+    end
+  end
+end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -48,6 +48,11 @@ class Bookings::School < ApplicationRecord
     foreign_key: :bookings_school_id,
     dependent: :destroy
 
+  has_one :profile,
+    class_name: "Bookings::Profile",
+    foreign_key: :school_id,
+    dependent: :destroy
+
   scope :enabled, -> { where(enabled: true) }
 
   scope :that_provide, ->(subject_ids) do

--- a/db/migrate/20190424145543_create_bookings_profiles.rb
+++ b/db/migrate/20190424145543_create_bookings_profiles.rb
@@ -25,7 +25,7 @@ class CreateBookingsProfiles < ActiveRecord::Migration[5.2]
       t.boolean     :flexible_on_times, null: false
       t.text        :placement_info, null: false
       t.text        :teacher_training_info
-      t.string      :teacher_training_website
+      t.string      :teacher_training_url
       t.string      :admin_contact_full_name, null: false
       t.string      :admin_contact_email, null: false
       t.string      :admin_contact_phone, null: false

--- a/db/migrate/20190424145543_create_bookings_profiles.rb
+++ b/db/migrate/20190424145543_create_bookings_profiles.rb
@@ -1,0 +1,52 @@
+class CreateBookingsProfiles < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bookings_profiles do |t|
+      t.references  :school, index: true
+      t.string      :dbs_required, null: false
+      t.text        :dbs_policy
+      t.text        :individual_requirements
+      t.boolean     :primary_phase, null: false
+      t.boolean     :secondary_phase, null: false
+      t.boolean     :college_phase, null: false
+      t.boolean     :key_stage_early_years, null: false
+      t.boolean     :key_stage_1, null: false
+      t.boolean     :key_stage_2, null: false
+      t.text        :specialism_details
+      t.boolean     :dress_code_business, null: false
+      t.boolean     :dress_code_cover_tattoos, null: false
+      t.boolean     :dress_code_remove_piercings, null: false
+      t.boolean     :dress_code_smart_casual, null: false
+      t.text        :dress_code_other_details
+      t.boolean     :parking_provided, null: false
+      t.text        :parking_details, null: false
+      t.text        :disabled_facilities
+      t.string      :start_time, null: false
+      t.string      :end_time, null: false
+      t.boolean     :flexible_on_times, null: false
+      t.text        :placement_info, null: false
+      t.text        :teacher_training_info
+      t.string      :teacher_training_website
+      t.string      :admin_contact_full_name, null: false
+      t.string      :admin_contact_email, null: false
+      t.string      :admin_contact_phone, null: false
+      t.boolean     :fixed_availability, null: false
+      t.text        :availability_info
+      t.decimal     :administration_fee_amount_pounds, precision: 6, scale: 2
+      t.text        :administration_fee_description
+      t.string      :administration_fee_interval
+      t.text        :administration_fee_payment_method
+      t.decimal     :dbs_fee_amount_pounds, precision: 6, scale: 2
+      t.text        :dbs_fee_description
+      t.string      :dbs_fee_interval
+      t.text        :dbs_fee_payment_method
+      t.decimal     :other_fee_amount_pounds, precision: 6, scale: 2
+      t.text        :other_fee_description
+      t.string      :other_fee_interval
+      t.text        :other_fee_payment_method
+
+      t.timestamps
+    end
+
+    add_foreign_key :bookings_profiles, :bookings_schools, column: :school_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,8 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 2019_04_18_180420) do
+
+ActiveRecord::Schema.define(version: 2019_04_24_145543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +51,54 @@ ActiveRecord::Schema.define(version: 2019_04_18_180420) do
     t.text "availability"
     t.integer "bookings_placement_date_id"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
+  end
+
+  create_table "bookings_profiles", force: :cascade do |t|
+    t.bigint "school_id"
+    t.string "dbs_required", null: false
+    t.text "dbs_policy"
+    t.text "individual_requirements"
+    t.boolean "primary_phase", null: false
+    t.boolean "secondary_phase", null: false
+    t.boolean "college_phase", null: false
+    t.boolean "key_stage_early_years", null: false
+    t.boolean "key_stage_1", null: false
+    t.boolean "key_stage_2", null: false
+    t.text "specialism_details"
+    t.boolean "dress_code_business", null: false
+    t.boolean "dress_code_cover_tattoos", null: false
+    t.boolean "dress_code_remove_piercings", null: false
+    t.boolean "dress_code_smart_casual", null: false
+    t.text "dress_code_other_details"
+    t.boolean "parking_provided", null: false
+    t.text "parking_details", null: false
+    t.text "disabled_facilities"
+    t.string "start_time", null: false
+    t.string "end_time", null: false
+    t.boolean "flexible_on_times", null: false
+    t.text "placement_info", null: false
+    t.text "teacher_training_info"
+    t.string "teacher_training_website"
+    t.string "admin_contact_full_name", null: false
+    t.string "admin_contact_email", null: false
+    t.string "admin_contact_phone", null: false
+    t.boolean "fixed_availability", null: false
+    t.text "availability_info"
+    t.decimal "administration_fee_amount_pounds", precision: 6, scale: 2
+    t.text "administration_fee_description"
+    t.string "administration_fee_interval"
+    t.text "administration_fee_payment_method"
+    t.decimal "dbs_fee_amount_pounds", precision: 6, scale: 2
+    t.text "dbs_fee_description"
+    t.string "dbs_fee_interval"
+    t.text "dbs_fee_payment_method"
+    t.decimal "other_fee_amount_pounds", precision: 6, scale: 2
+    t.text "other_fee_description"
+    t.string "other_fee_interval"
+    t.text "other_fee_payment_method"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["school_id"], name: "index_bookings_profiles_on_school_id"
   end
 
   create_table "bookings_school_searches", force: :cascade do |t|
@@ -210,6 +259,7 @@ ActiveRecord::Schema.define(version: 2019_04_18_180420) do
 
   add_foreign_key "bookings_placement_dates", "schools_school_profiles"
   add_foreign_key "bookings_placement_requests", "bookings_placement_dates"
+  add_foreign_key "bookings_profiles", "bookings_schools", column: "school_id"
   add_foreign_key "bookings_schools", "bookings_school_types"
   add_foreign_key "bookings_schools_phases", "bookings_phases"
   add_foreign_key "bookings_schools_phases", "bookings_schools"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 2019_04_24_145543) do
     t.boolean "flexible_on_times", null: false
     t.text "placement_info", null: false
     t.text "teacher_training_info"
-    t.string "teacher_training_website"
+    t.string "teacher_training_url"
     t.string "admin_contact_full_name", null: false
     t.string "admin_contact_email", null: false
     t.string "admin_contact_phone", null: false

--- a/spec/controllers/schools/on_boarding/confirmations_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/confirmations_controller_spec.rb
@@ -28,6 +28,10 @@ describe Schools::OnBoarding::ConfirmationsController, type: :request do
       it 'rerenders the profile show page' do
         expect(response).to render_template 'schools/on_boarding/profiles/show'
       end
+
+      it 'does not create a Bookings::Profile' do
+        expect(school_profile.bookings_school.profile).to be_nil
+      end
     end
 
     context 'valid' do
@@ -37,6 +41,10 @@ describe Schools::OnBoarding::ConfirmationsController, type: :request do
 
       it 'redirects the to the confirmation show path' do
         expect(response).to redirect_to schools_on_boarding_confirmation_path
+      end
+
+      it 'creates a Bookings::Profile' do
+        expect(school_profile.bookings_school.profile).to be_persisted
       end
     end
   end

--- a/spec/factories/bookings/profile_factory.rb
+++ b/spec/factories/bookings/profile_factory.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  factory :bookings_profile, class: 'Bookings::Profile' do
+    association :school, factory: :bookings_school
+    dbs_required { 'never' }
+    primary_phase { true }
+    secondary_phase { false }
+    college_phase { false }
+    key_stage_early_years { false }
+    key_stage_1 { false }
+    key_stage_2 { true }
+    dress_code_business { false }
+    dress_code_cover_tattoos { false }
+    dress_code_remove_piercings { false }
+    dress_code_smart_casual { false }
+    parking_provided { false }
+    parking_details { 'nearby' }
+    start_time { '09:00' }
+    end_time { '16:00' }
+    flexible_on_times { false }
+    placement_info { 'some info' }
+    admin_contact_full_name { 'some one' }
+    admin_contact_email { 'some@one.com' }
+    admin_contact_phone { '07123456789' }
+    fixed_availability { false }
+    availability_info { 'whenever man' }
+  end
+end

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -55,5 +55,65 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       it { is_expected.to include(other_fee_interval: 'One-off') }
       it { is_expected.to include(other_fee_payment_method: 'Stamps') }
     end
+
+    context 'with completed profile with blank fields' do
+      let(:model_attrs) do
+        model = build(:school_profile, :completed, disabled_facilities: true)
+        model.candidate_requirement_dbs_requirement = 'never'
+        model.candidate_requirement_requirements = false
+        model.specialism_has_specialism = false
+        model.candidate_experience_detail_disabled_facilities = false
+        model.candidate_experience_detail_other_dress_requirements = false
+        model.admin_contact_full_name = ' '
+        model.availability_preference_fixed = true
+        model.phases_list_primary = false
+        model.candidate_experience_detail_parking_provided = false
+        model.candidate_experience_detail_nearby_parking_details = 'somewhere further away'
+        model.experience_outline_provides_teacher_training = false
+        model.fees_administration_fees = false
+        model.fees_dbs_fees = false
+        model.fees_other_fees = false
+
+        model.attributes
+      end
+
+      subject do
+        described_class.new(model_attrs).profile_attributes
+      end
+
+      it { is_expected.to include(dbs_required: 'never') }
+      it { is_expected.to include(dbs_policy: nil) }
+      it { is_expected.to include(individual_requirements: nil) }
+      it { is_expected.to include(specialism_details: nil) }
+      it { is_expected.to include(disabled_facilities: nil) }
+      it { is_expected.to include(dress_code_other_details: nil) }
+      it { is_expected.to include(admin_contact_full_name: nil) }
+      it { is_expected.to include(admin_contact_email: nil) }
+      it { is_expected.to include(admin_contact_phone: nil) }
+      it { is_expected.to include(primary_phase: false) }
+      it { is_expected.to include(secondary_phase: true) }
+      it { is_expected.to include(college_phase: true) }
+      it { is_expected.to include(key_stage_early_years: false) }
+      it { is_expected.to include(key_stage_1: false) }
+      it { is_expected.to include(key_stage_2: false) }
+      it { is_expected.to include(parking_provided: false) }
+      it { is_expected.to include(parking_details: 'somewhere further away') }
+      it { is_expected.to include(teacher_training_info: nil) }
+      it { is_expected.to include(teacher_training_url: nil) }
+      it { is_expected.to include(fixed_availability: true) }
+      it { is_expected.to include(availability_info: nil) }
+      it { is_expected.to include(administration_fee_amount_pounds: nil) }
+      it { is_expected.to include(administration_fee_description: nil) }
+      it { is_expected.to include(administration_fee_interval: nil) }
+      it { is_expected.to include(administration_fee_payment_method: nil) }
+      it { is_expected.to include(dbs_fee_amount_pounds: nil) }
+      it { is_expected.to include(dbs_fee_description: nil) }
+      it { is_expected.to include(dbs_fee_interval: nil) }
+      it { is_expected.to include(dbs_fee_payment_method: nil) }
+      it { is_expected.to include(other_fee_amount_pounds: nil) }
+      it { is_expected.to include(other_fee_description: nil) }
+      it { is_expected.to include(other_fee_interval: nil) }
+      it { is_expected.to include(other_fee_payment_method: nil) }
+    end
   end
 end

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
+  subject { described_class.new({}) } # Default empty profile
+
+  describe "#profile_attrs" do
+    context 'with completed profile' do
+      let(:completed_attrs) do
+        build(:school_profile, :completed, disabled_facilities: true).attributes
+      end
+
+      subject do
+        described_class.new(completed_attrs).profile_attributes
+      end
+
+      it { is_expected.to include(dbs_required: 'sometimes') }
+      it { is_expected.to include(dbs_policy: 'Super secure') }
+      it { is_expected.to include(individual_requirements: 'Gotta go fast') }
+      it { is_expected.to include(specialism_details: 'Falconry') }
+      it { is_expected.to include(disabled_facilities: 'Full wheelchair access and hearing loops') }
+      it { is_expected.to include(dress_code_business: true) }
+      it { is_expected.to include(dress_code_cover_tattoos: true) }
+      it { is_expected.to include(dress_code_remove_piercings: true) }
+      it { is_expected.to include(dress_code_smart_casual: true) }
+      it { is_expected.to include(dress_code_other_details: 'Must have nice hat') }
+      it { is_expected.to include(admin_contact_full_name: 'Gary Chalmers') }
+      it { is_expected.to include(admin_contact_email: 'g.chalmers@springfield.edu') }
+      it { is_expected.to include(admin_contact_phone: '+441234567890') }
+      it { is_expected.to include(primary_phase: true) }
+      it { is_expected.to include(secondary_phase: true) }
+      it { is_expected.to include(college_phase: true) }
+      it { is_expected.to include(key_stage_early_years: true) }
+      it { is_expected.to include(key_stage_1: true) }
+      it { is_expected.to include(key_stage_2: true) }
+      it { is_expected.to include(start_time: '8:15am') }
+      it { is_expected.to include(end_time: '4:30pm') }
+      it { is_expected.to include(flexible_on_times: true) }
+      it { is_expected.to include(placement_info: 'Mostly teaching') }
+      it { is_expected.to include(parking_provided: true) }
+      it { is_expected.to include(parking_details: 'Plenty of spaces') }
+      it { is_expected.to include(teacher_training_info: 'We offer teach training in house') }
+      it { is_expected.to include(teacher_training_url: 'https://example.com') }
+      it { is_expected.to include(fixed_availability: false) }
+      it { is_expected.to include(availability_info: 'Whenever really') }
+      it { is_expected.to include(administration_fee_amount_pounds: 123.45) }
+      it { is_expected.to include(administration_fee_description: 'General administration') }
+      it { is_expected.to include(administration_fee_interval: 'Daily') }
+      it { is_expected.to include(administration_fee_payment_method: 'Travelers Cheques') }
+      it { is_expected.to include(dbs_fee_amount_pounds: 200.00) }
+      it { is_expected.to include(dbs_fee_description: 'DBS check') }
+      it { is_expected.to include(dbs_fee_interval: 'One-off') }
+      it { is_expected.to include(dbs_fee_payment_method: 'Ethereum') }
+      it { is_expected.to include(other_fee_amount_pounds: 444.44) }
+      it { is_expected.to include(other_fee_description: 'Owl repellent / other protective gear') }
+      it { is_expected.to include(other_fee_interval: 'One-off') }
+      it { is_expected.to include(other_fee_payment_method: 'Stamps') }
+    end
+  end
+end

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       end
 
       subject do
-        described_class.new(completed_attrs).profile_attributes
+        described_class.new(completed_attrs).attributes
       end
 
       it { is_expected.to include(dbs_required: 'sometimes') }
@@ -78,7 +78,7 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       end
 
       subject do
-        described_class.new(model_attrs).profile_attributes
+        described_class.new(model_attrs).attributes
       end
 
       it { is_expected.to include(dbs_required: 'never') }

--- a/spec/models/bookings/profile_publisher_spec.rb
+++ b/spec/models/bookings/profile_publisher_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::ProfilePublisher, type: :model do
+  include_context 'with phases'
+
+  describe "#new" do
+    context "with complete School Profile" do
+      let(:completed_profile) { create(:school_profile, :completed) }
+
+      subject do
+        described_class.new(completed_profile.bookings_school.urn, completed_profile)
+      end
+
+      it { is_expected.to be_kind_of described_class }
+    end
+
+    context "with partially complete School Profile" do
+      let(:incomplete_profile) { create(:school_profile) }
+
+      it "will raise an exception" do
+        expect {
+          described_class.new(incomplete_profile.bookings_school.urn, incomplete_profile)
+        }.to raise_exception Bookings::ProfilePublisher::IncompleteSourceProfileError
+      end
+    end
+  end
+
+  describe '#update!' do
+    let(:school) { create(:bookings_school) }
+    let(:school_profile) { create(:school_profile, :completed) }
+
+    context "for School with Profile" do
+      subject { described_class.new(school, school_profile).update! }
+
+      it { is_expected.to be_kind_of Bookings::Profile }
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_valid }
+      it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
+    end
+
+    context "for School without Profile" do
+      before do
+        @initial_profile = create(:bookings_profile,
+          primary_phase: false,
+          secondary_phase: false,
+          college_phase: true,
+          school: school)
+      end
+
+      subject { described_class.new(school, school_profile).update! }
+
+      it { is_expected.to be_kind_of Bookings::Profile }
+      it { is_expected.to be_persisted }
+      it { is_expected.to be_valid }
+      it { is_expected.to eql @initial_profile }
+      it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
+    end
+  end
+end

--- a/spec/models/bookings/profile_spec.rb
+++ b/spec/models/bookings/profile_spec.rb
@@ -180,17 +180,17 @@ RSpec.describe Bookings::Profile, type: :model do
       it { is_expected.to allow_value('x').for(:teacher_training_info) }
     end
 
-    describe "teacher_training_website" do
+    describe "teacher_training_url" do
       context "with blank teacher_training_info" do
-        it { is_expected.to allow_value('').for(:teacher_training_website) }
+        it { is_expected.to allow_value('').for(:teacher_training_url) }
       end
 
       context 'with assigned teacher_training_info' do
         subject { described_class.new(teacher_training_info: 'hello world') }
-        it { is_expected.not_to allow_value('').for(:teacher_training_website) }
-        it { is_expected.to allow_value('https://test.com').for(:teacher_training_website) }
-        it { is_expected.to allow_value('http://test.com').for(:teacher_training_website) }
-        it { is_expected.not_to allow_value('test.com').for(:teacher_training_website) }
+        it { is_expected.not_to allow_value('').for(:teacher_training_url) }
+        it { is_expected.to allow_value('https://test.com').for(:teacher_training_url) }
+        it { is_expected.to allow_value('http://test.com').for(:teacher_training_url) }
+        it { is_expected.not_to allow_value('test.com').for(:teacher_training_url) }
       end
     end
 

--- a/spec/models/bookings/profile_spec.rb
+++ b/spec/models/bookings/profile_spec.rb
@@ -149,8 +149,11 @@ RSpec.describe Bookings::Profile, type: :model do
       it { is_expected.to allow_value('9:00').for(:start_time) }
       it { is_expected.to allow_value('09:00').for(:start_time) }
       it { is_expected.to allow_value(' 9:00 ').for(:start_time) }
-      it { is_expected.not_to allow_value('29:00').for(:start_time) }
-      it { is_expected.not_to allow_value('foobar').for(:start_time) }
+      it { is_expected.to allow_value('9:00am').for(:start_time) }
+      it { is_expected.to allow_value('09:00am').for(:start_time) }
+      it { is_expected.to allow_value('11:15pm').for(:start_time) }
+      it { is_expected.to allow_value('12:15am').for(:start_time) }
+      it { is_expected.to allow_value('12:15pm').for(:start_time) }
     end
 
     describe "end_time" do
@@ -160,8 +163,11 @@ RSpec.describe Bookings::Profile, type: :model do
       it { is_expected.to allow_value('9:00').for(:end_time) }
       it { is_expected.to allow_value('09:00').for(:end_time) }
       it { is_expected.to allow_value(' 9:00 ').for(:end_time) }
-      it { is_expected.not_to allow_value('29:00').for(:end_time) }
-      it { is_expected.not_to allow_value('foobar').for(:end_time) }
+      it { is_expected.to allow_value('9:00am').for(:end_time) }
+      it { is_expected.to allow_value('09:00am').for(:end_time) }
+      it { is_expected.to allow_value('11:15pm').for(:end_time) }
+      it { is_expected.to allow_value('12:15am').for(:end_time) }
+      it { is_expected.to allow_value('12:15pm').for(:end_time) }
     end
 
     describe "flexible_on_times" do

--- a/spec/models/bookings/profile_spec.rb
+++ b/spec/models/bookings/profile_spec.rb
@@ -1,0 +1,367 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::Profile, type: :model do
+  describe "relationships" do
+    it { is_expected.to belong_to(:school).class_name("Bookings::School").required }
+  end
+
+  describe "validations" do
+    describe "dbs" do
+      it { is_expected.to validate_presence_of :dbs_required }
+      described_class::DBS_REQUIREMENTS.each do |req|
+        it { is_expected.to allow_value(req).for :dbs_required }
+      end
+      it { is_expected.not_to allow_value(10).for :dbs_required }
+
+      context "when dbs_policy required" do
+        subject { described_class.new(dbs_required: 'sometimes') }
+        it { is_expected.to allow_value("something").for :dbs_policy }
+        it { is_expected.not_to allow_value("").for :dbs_policy }
+        it { is_expected.not_to allow_value(nil).for :dbs_policy }
+      end
+    end
+
+    describe "individual_requirements" do
+      it { is_expected.to allow_value(nil).for :individual_requirements }
+      it { is_expected.to allow_value("something").for :individual_requirements }
+      it { is_expected.not_to allow_value("").for :individual_requirements }
+    end
+
+    describe "phases" do
+      it { is_expected.to allow_value(true).for :primary_phase }
+      it { is_expected.to allow_value(false).for :primary_phase }
+      it { is_expected.not_to allow_value(nil).for :primary_phase }
+
+      it { is_expected.to allow_value(true).for :secondary_phase }
+      it { is_expected.to allow_value(false).for :secondary_phase }
+      it { is_expected.not_to allow_value(nil).for :secondary_phase }
+
+      it { is_expected.to allow_value(true).for :college_phase }
+      it { is_expected.to allow_value(false).for :college_phase }
+      it { is_expected.not_to allow_value(nil).for :college_phase }
+
+      context 'with none selected' do
+        subject do
+          build(:bookings_profile,
+            primary_phase: false,
+            secondary_phase: false,
+            college_phase: false)
+        end
+
+        it { expect(subject.valid?).to be false }
+      end
+    end
+
+    describe "key stages" do
+      context "with primary_phase enabled" do
+        subject do
+          build(:bookings_profile,
+            key_stage_early_years: false,
+            key_stage_1: false,
+            key_stage_2: false)
+        end
+
+        context 'with no key stage' do
+          it { expect(subject.valid?).to be false }
+        end
+
+        context 'with key_stage_early_years' do
+          before { subject.key_stage_early_years = true }
+          it { expect(subject.valid?).to be true }
+        end
+
+        context 'with key_stage_1' do
+          before { subject.key_stage_1 = true }
+          it { expect(subject.valid?).to be true }
+        end
+
+        context 'with key_stage_2' do
+          before { subject.key_stage_2 = true }
+          it { expect(subject.valid?).to be true }
+        end
+
+        context 'with multiple key stages' do
+          before do
+            subject.key_stage_early_years = true
+            subject.key_stage_1 = true
+          end
+          it { expect(subject.valid?).to be true }
+        end
+      end
+
+      context "with primary_phase disabled" do
+        subject do
+          build(:bookings_profile,
+            primary_phase: false,
+            secondary_phase: true,
+            key_stage_2: false)
+        end
+        it { expect(subject.valid?).to be true }
+      end
+    end
+
+    describe "specialism_details" do
+      it { is_expected.to allow_value(nil).for(:specialism_details) }
+      it { is_expected.to allow_value('x').for(:specialism_details) }
+      it { is_expected.not_to allow_value('').for(:specialism_details) }
+    end
+
+    describe "dress_code" do
+      it { is_expected.to allow_value(true).for :dress_code_business }
+      it { is_expected.to allow_value(false).for :dress_code_business }
+      it { is_expected.not_to allow_value(nil).for :dress_code_business }
+
+      it { is_expected.to allow_value(true).for :dress_code_cover_tattoos }
+      it { is_expected.to allow_value(false).for :dress_code_cover_tattoos }
+      it { is_expected.not_to allow_value(nil).for :dress_code_cover_tattoos }
+
+      it { is_expected.to allow_value(true).for :dress_code_remove_piercings }
+      it { is_expected.to allow_value(false).for :dress_code_remove_piercings }
+      it { is_expected.not_to allow_value(nil).for :dress_code_remove_piercings }
+
+      it { is_expected.to allow_value(true).for :dress_code_smart_casual }
+      it { is_expected.to allow_value(false).for :dress_code_smart_casual }
+      it { is_expected.not_to allow_value(nil).for :dress_code_smart_casual }
+
+      it { is_expected.to allow_value(nil).for(:dress_code_other_details) }
+      it { is_expected.to allow_value('x').for(:dress_code_other_details) }
+      it { is_expected.not_to allow_value('').for(:dress_code_other_details) }
+    end
+
+    describe "parking" do
+      it { is_expected.to allow_value(true).for :parking_provided }
+      it { is_expected.to allow_value(false).for :parking_provided }
+      it { is_expected.not_to allow_value(nil).for :parking_provided }
+
+      it { is_expected.to validate_presence_of(:parking_details) }
+    end
+
+    describe "disabled_facilities" do
+      it { is_expected.to allow_value(nil).for(:disabled_facilities) }
+      it { is_expected.to allow_value('x').for(:disabled_facilities) }
+      it { is_expected.not_to allow_value('').for(:disabled_facilities) }
+    end
+
+    describe "start_time" do
+      it { is_expected.to validate_presence_of(:start_time) }
+      it { is_expected.to allow_value('12:00').for(:start_time) }
+      it { is_expected.to allow_value('17:00').for(:start_time) }
+      it { is_expected.to allow_value('9:00').for(:start_time) }
+      it { is_expected.to allow_value('09:00').for(:start_time) }
+      it { is_expected.to allow_value(' 9:00 ').for(:start_time) }
+      it { is_expected.not_to allow_value('29:00').for(:start_time) }
+      it { is_expected.not_to allow_value('foobar').for(:start_time) }
+    end
+
+    describe "end_time" do
+      it { is_expected.to validate_presence_of(:end_time) }
+      it { is_expected.to allow_value('12:00').for(:end_time) }
+      it { is_expected.to allow_value('17:00').for(:end_time) }
+      it { is_expected.to allow_value('9:00').for(:end_time) }
+      it { is_expected.to allow_value('09:00').for(:end_time) }
+      it { is_expected.to allow_value(' 9:00 ').for(:end_time) }
+      it { is_expected.not_to allow_value('29:00').for(:end_time) }
+      it { is_expected.not_to allow_value('foobar').for(:end_time) }
+    end
+
+    describe "flexible_on_times" do
+      it { is_expected.to allow_value(true).for(:flexible_on_times) }
+      it { is_expected.to allow_value(false).for(:flexible_on_times) }
+      it { is_expected.not_to allow_value(nil).for(:flexible_on_times) }
+    end
+
+    describe "placement_info" do
+      it { is_expected.to validate_presence_of(:placement_info) }
+    end
+
+    describe "teacher_training_info" do
+      it { is_expected.to allow_value(nil).for(:teacher_training_info) }
+      it { is_expected.to allow_value('').for(:teacher_training_info) }
+      it { is_expected.to allow_value('x').for(:teacher_training_info) }
+    end
+
+    describe "teacher_training_website" do
+      context "with blank teacher_training_info" do
+        it { is_expected.to allow_value('').for(:teacher_training_website) }
+      end
+
+      context 'with assigned teacher_training_info' do
+        subject { described_class.new(teacher_training_info: 'hello world') }
+        it { is_expected.not_to allow_value('').for(:teacher_training_website) }
+        it { is_expected.to allow_value('https://test.com').for(:teacher_training_website) }
+        it { is_expected.to allow_value('http://test.com').for(:teacher_training_website) }
+        it { is_expected.not_to allow_value('test.com').for(:teacher_training_website) }
+      end
+    end
+
+    describe "admin_contact_full_name" do
+      it { is_expected.to validate_presence_of :admin_contact_full_name }
+    end
+
+    describe "admin_contact_email" do
+      it { is_expected.to allow_value('me@you.com').for :admin_contact_email }
+      it { is_expected.to allow_value('me.test@you.co.uk').for :admin_contact_email }
+      it { is_expected.not_to allow_value('you.com').for :admin_contact_email }
+      it { is_expected.not_to allow_value('https://you.com').for :admin_contact_email }
+      it { is_expected.not_to allow_value('me@you').for :admin_contact_email }
+      it { is_expected.not_to allow_value('').for :admin_contact_email }
+    end
+
+    describe "admin_contact_phone" do
+      it { is_expected.to allow_value('07123456789').for :admin_contact_phone }
+      it { is_expected.to allow_value('02019123456').for :admin_contact_phone }
+      it { is_expected.to allow_value('01909123456').for :admin_contact_phone }
+      it { is_expected.not_to allow_value('020991234').for :admin_contact_phone }
+      it { is_expected.not_to allow_value('foobar').for :admin_contact_phone }
+      it { is_expected.not_to allow_value('').for :admin_contact_phone }
+      it { is_expected.not_to allow_value(nil).for :admin_contact_phone }
+    end
+
+    describe "fixed_availibility" do
+      it { is_expected.to allow_value(true).for(:fixed_availability) }
+      it { is_expected.to allow_value(false).for(:fixed_availability) }
+      it { is_expected.not_to allow_value(nil).for(:fixed_availability) }
+    end
+
+    describe "availibility_info" do
+      context "for fixed_availibility" do
+        subject { described_class.new(fixed_availability: true) }
+        it { is_expected.not_to validate_presence_of :availability_info }
+      end
+
+      context "for flexible availibility" do
+        subject { described_class.new(fixed_availability: false) }
+        it { is_expected.to validate_presence_of :availability_info }
+      end
+    end
+
+    describe "administration_fee_amount_pounds" do
+      it { is_expected.to allow_value(10.00).for(:administration_fee_amount_pounds) }
+      it { is_expected.to allow_value(1).for(:administration_fee_amount_pounds) }
+      it { is_expected.not_to allow_value(0.00).for(:administration_fee_amount_pounds) }
+      it { is_expected.to allow_value(nil).for(:administration_fee_amount_pounds) }
+    end
+
+    describe "administration_fee_description" do
+      context "with amount_pounds set" do
+        subject { described_class.new(administration_fee_amount_pounds: 10.00) }
+        it { is_expected.to validate_presence_of :administration_fee_description }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :administration_fee_description }
+      end
+    end
+
+    describe "administration_fee_interval" do
+      context "with amount_pounds set" do
+        subject { described_class.new(administration_fee_amount_pounds: 10.00) }
+        described_class::AVAILABLE_INTERVALS.each do |interval|
+          it { is_expected.to allow_value(interval).for :administration_fee_interval }
+        end
+        it { is_expected.not_to allow_value('random').for :administration_fee_interval }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :administration_fee_interval }
+      end
+    end
+
+    describe "administration_fee_payment_method" do
+      context "with amount_pounds set" do
+        subject { described_class.new(administration_fee_amount_pounds: 10.00) }
+        it { is_expected.to validate_presence_of :administration_fee_payment_method }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :administration_fee_payment_method }
+      end
+    end
+
+    describe "dbs_fee_amount_pounds" do
+      it { is_expected.to allow_value(10.00).for(:dbs_fee_amount_pounds) }
+      it { is_expected.to allow_value(1).for(:dbs_fee_amount_pounds) }
+      it { is_expected.not_to allow_value(0.00).for(:dbs_fee_amount_pounds) }
+      it { is_expected.to allow_value(nil).for(:dbs_fee_amount_pounds) }
+    end
+
+    describe "dbs_fee_description" do
+      context "with amount_pounds set" do
+        subject { described_class.new(dbs_fee_amount_pounds: 10.00) }
+        it { is_expected.to validate_presence_of :dbs_fee_description }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :dbs_fee_description }
+      end
+    end
+
+    describe "dbs_fee_interval" do
+      context "with amount_pounds set" do
+        subject { described_class.new(dbs_fee_amount_pounds: 10.00) }
+        described_class::AVAILABLE_INTERVALS.each do |interval|
+          it { is_expected.to allow_value(interval).for :dbs_fee_interval }
+        end
+        it { is_expected.not_to allow_value('random').for :dbs_fee_interval }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :dbs_fee_interval }
+      end
+    end
+
+    describe "dbs_fee_payment_method" do
+      context "with amount_pounds set" do
+        subject { described_class.new(dbs_fee_amount_pounds: 10.00) }
+        it { is_expected.to validate_presence_of :dbs_fee_payment_method }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :dbs_fee_payment_method }
+      end
+    end
+
+    describe "other_fee_amount_pounds" do
+      it { is_expected.to allow_value(10.00).for(:other_fee_amount_pounds) }
+      it { is_expected.to allow_value(1).for(:other_fee_amount_pounds) }
+      it { is_expected.not_to allow_value(0.00).for(:other_fee_amount_pounds) }
+      it { is_expected.to allow_value(nil).for(:other_fee_amount_pounds) }
+    end
+
+    describe "other_fee_description" do
+      context "with amount_pounds set" do
+        subject { described_class.new(other_fee_amount_pounds: 10.00) }
+        it { is_expected.to validate_presence_of :other_fee_description }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :other_fee_description }
+      end
+    end
+
+    describe "other_fee_interval" do
+      context "with amount_pounds set" do
+        subject { described_class.new(other_fee_amount_pounds: 10.00) }
+        described_class::AVAILABLE_INTERVALS.each do |interval|
+          it { is_expected.to allow_value(interval).for :other_fee_interval }
+        end
+        it { is_expected.not_to allow_value('random').for :other_fee_interval }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :other_fee_interval }
+      end
+    end
+
+    describe "other_fee_payment_method" do
+      context "with amount_pounds set" do
+        subject { described_class.new(other_fee_amount_pounds: 10.00) }
+        it { is_expected.to validate_presence_of :other_fee_payment_method }
+      end
+
+      context "with amount_pounds unset" do
+        it { is_expected.not_to validate_presence_of :other_fee_payment_method }
+      end
+    end
+  end
+end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -120,6 +120,10 @@ describe Bookings::School, type: :model do
         .class_name("Bookings::SchoolType")
       )
     end
+
+    specify do
+      is_expected.to have_one(:profile).class_name("Bookings::Profile")
+    end
   end
 
   describe 'Paramterisation' do


### PR DESCRIPTION
### Context

Currently we have a Profile in the Schools namespace. This can be edited by the School Administrator though, and my represent a 'work in progress' whilst the Profile shown to Candidates should be the last complete version

### Changes proposed in this pull request

1. Add a second Profile model which is the one shown to the Candidates as part of the search.
2. Create or update the new Bookings::Profile as part when the user confirms the updates to their Profile held within the Schools namespace

### Guidance to review

1. There is currently no output of the Profile but it can be viewed within the rails console