### PR TITLE
Feature/update placement dates table styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,4 @@ $govuk-grid-widths: (
 @import "testing-fixes" ;
 @import "school-placement-requests" ;
 @import "school-dashboard" ;
+@import "school-placement-dates" ;

--- a/app/assets/stylesheets/global-styles.scss
+++ b/app/assets/stylesheets/global-styles.scss
@@ -71,11 +71,12 @@ dl.govuk-summary-list {
   }
 }
 
-.govuk-button--secondary {
-  $govuk-button-secondary-colour: govuk-colour("grey-1");
+.govuk-button.govuk-button--secondary {
+  $govuk-button-secondary-colour: govuk-colour("grey-3");
   $govuk-button-secondary-hover-colour: darken($govuk-button-secondary-colour, 5%);
   $govuk-button-secondary-shadow-colour: darken($govuk-button-secondary-colour, 15%);
   $button-shadow-size: $govuk-border-width-form-element;
+  color: $govuk-text-colour;
 
   background-color: $govuk-button-secondary-colour;
   box-shadow: 0 $button-shadow-size 0 $govuk-button-secondary-shadow-colour; // s0

--- a/app/assets/stylesheets/school-placement-dates.scss
+++ b/app/assets/stylesheets/school-placement-dates.scss
@@ -1,0 +1,12 @@
+table#placement-dates {
+  td.status {
+    strong {
+      &.govuk-tag--available {
+        background-color: govuk-colour('green');
+      }
+      &.govuk-tag--taken {
+        background-color: govuk-colour('red');
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/school-placement-requests.scss
+++ b/app/assets/stylesheets/school-placement-requests.scss
@@ -33,17 +33,6 @@
 
     .accept-or-reject {
       padding-left: 0rem;
-
-      .govuk-se-button-container {
-        .govuk-button--secondary {
-          background-color: govuk-colour('grey-4');
-          color: govuk-colour('black');
-
-          &:hover {
-            background-color: govuk-colour('grey-3');
-          }
-        }
-      }
     }
   }
 }

--- a/app/helpers/schools/placement_dates_helper.rb
+++ b/app/helpers/schools/placement_dates_helper.rb
@@ -1,5 +1,9 @@
 module Schools::PlacementDatesHelper
-  def display_status(val)
+  def placement_date_display_status(val)
     val ? "Available" : "Taken"
+  end
+
+  def placement_date_display_class(val)
+    val ? "govuk-tag--available" : "govuk-tag--taken"
   end
 end

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -33,7 +33,7 @@
                 <%= placement_date_display_status(placement_date.active) %>
               </strong>
             </td>
-            <td class="govuk-summary-list__actions">
+            <td class="govuk-table__cell">
               <%= link_to(edit_schools_placement_date_path(placement_date)) do %>
                 Change
                 <span class="govuk-visually-hidden"> placement date</span>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -29,12 +29,14 @@
               <%= pluralize(placement_date.duration, 'day') %>
             </td>
             <td class="govuk-table__cell status">
-              <%= display_status(placement_date.active) %>
+              <strong class="govuk-tag <%= placement_date_display_class(placement_date.active) %>">
+                <%= placement_date_display_status(placement_date.active) %>
+              </strong>
             </td>
             <td class="govuk-summary-list__actions">
               <%= link_to(edit_schools_placement_date_path(placement_date)) do %>
                 Change
-                <span class="govuk-visually-hidden"> name</span>
+                <span class="govuk-visually-hidden"> placement date</span>
               <%- end -%>
             </td>
           </tr>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -60,3 +60,7 @@
 <div>
   <%= link_to "Add new placement date", new_schools_placement_date_path, class: 'govuk-button' %>
 </div>
+
+<div>
+  <%= link_to "Return to dashboard", schools_dashboard_path, class: 'govuk-button govuk-button--secondary' %>
+</div>

--- a/features/schools/placement_dates/index.feature
+++ b/features/schools/placement_dates/index.feature
@@ -33,3 +33,7 @@ Feature: Listing placement dates
         Given my school has no placement dates
         When I am on the 'placement dates' page
         Then there should be a 'You have no placement dates, your school will not appear in candidate searches' warning
+
+    Scenario: The return to dashboard button
+        Given I am on the 'placement dates' page
+        Then there should be a 'Return to dashboard' link to the 'schools dashboard'

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -48,3 +48,7 @@ Then("there should be a {string} warning") do |string|
     expect(page).to have_content(string)
   end
 end
+
+Then("there should be a {string} link to the {string}") do |link, target|
+  expect(page).to have_link(link, href: path_for(target))
+end

--- a/features/step_definitions/schools/placement_dates/edit_steps.rb
+++ b/features/step_definitions/schools/placement_dates/edit_steps.rb
@@ -30,6 +30,6 @@ Then("my placement should have been {string}") do |operation|
   }[operation]
 
   within("tr[data-placement-date-id='#{@placement_date.id}']") do
-    expect(page).to have_css('td.status', text: description)
+    expect(page).to have_css('td.status', text: /#{description}/i)
   end
 end


### PR DESCRIPTION
### Context

The placement date functionality in the prototype and app had diverged, this change brings it back together

### Changes proposed in this pull request

Added extra styles on the status column and a navigate back to the dashboard link. Also standardise the styles for `govuk-button--secondary` so that it matches the prototype (black on light grey rather than vice versa) 

### Guidance to review

Make sure it's coloured in correctly 👨🏼‍🎨