### PR TITLE
Added feature flagging for multiple phases

### DIFF
--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -1,4 +1,4 @@
-<%- if true -%>
+<%- if Rails.application.config.x.phase <= 2 -%>
   <%= render partial: 'dashlette' %>
 <%- else -%>
   <%= render partial: 'full_dashboard' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
     Bullet.rails_logger = true
   end
 
-  config.x.phase_two.enabled = true
+  config.x.phase = 10000
 
   # dfe signin redirects back to https, so force it
   config.force_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,13 +114,17 @@ Rails.application.configure do
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 
-  config.x.default_phase = 1
+  config.x.default_phase = 2
   config.x.phase = Integer(ENV['PHASE'].presence || (ENV['PHASE_TWO'].present? && 2) || config.x.default_phase)
 
   if config.x.phase >= 2
     config.x.base_url = ENV.fetch('DFE_SIGNIN_BASE_URL') { 'https://schoolexperience.education.gov.uk' }
     config.x.oidc_client_id = ENV.fetch('DFE_SIGNIN_CLIENT_ID') { 'schoolexperience' }
-    config.x.oidc_client_secret = ENV.fetch('DFE_SIGNIN_SECRET')
+    config.x.oidc_client_secret = ENV.fetch('DFE_SIGNIN_SECRET') do
+      msg = "DFE_SIGNIN_SECRET has not been set"
+      config.logger ? config.logger.warn(msg) : puts(msg)
+      ''
+    end
     config.x.oidc_host = ENV.fetch('DFE_SIGNIN_HOST') { 'pp-oidc.signin.education.gov.uk' }
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -114,9 +114,10 @@ Rails.application.configure do
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 
-  config.x.phase_two.enabled = ENV["PHASE_TWO"].present?
+  config.x.default_phase = 1
+  config.x.phase = Integer(ENV['PHASE'].presence || (ENV['PHASE_TWO'].present? && 2) || config.x.default_phase)
 
-  if config.x.phase_two.enabled
+  if config.x.phase >= 2
     config.x.base_url = ENV.fetch('DFE_SIGNIN_BASE_URL') { 'https://schoolexperience.education.gov.uk' }
     config.x.oidc_client_id = ENV.fetch('DFE_SIGNIN_CLIENT_ID') { 'schoolexperience' }
     config.x.oidc_client_secret = ENV.fetch('DFE_SIGNIN_SECRET')

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # default to true but allow overriding in CI
   config.force_ssl = !ENV['SKIP_FORCE_SSL'].present?
 
-  config.x.phase_two.enabled = true
+  config.x.phase = 10000
 
   # dfe signin config, should be in credentials or env vars
   config.x.base_url = "https://localhost:#{ENV.fetch("PORT") { 3000 }}"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   # Don't actually attempt to delivery emails during tests
   Notify.notification_class = NotifyFakeClient
 
-  config.x.phase_two.enabled = true
+  config.x.phase = 10000
 
   config.x.base_url = 'https://some-host'
   config.x.oidc_client_id = 'se-test'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get '/privacy_policy', to: 'pages#privacy_policy'
   get '/cookies_policy', to: 'pages#cookies_policy'
 
-  if Rails.application.config.x.phase_two.enabled
+  if Rails.application.config.x.phase >= 2
     get '/auth/callback', to: 'schools/sessions#create'
 
     if Rails.env.servertest? || Rails.env.test?


### PR DESCRIPTION
### Context

We need to feature flag certain features so that the can be merged without being exposed to the public until we are ready to release a given phase

### Changes proposed in this pull request

Change from `config.x.phase_two.enabled` as a boolean, to be `config.x.phase` as an integer.
This means we can also target functionality to a specific phase, or a given phase and below.

This initially targets the `phase2` branch so has been set to default to phase 2
releases onwards.

This uses the PHASE environment variable, ie PHASE=3, to choose the phase.

It is also compatible with the old PHASE_TWO=true environment variable.

### Guidance to review

Does it work, does it make sense
