### PR TITLE
Limit Geocoder to GB, validate search location

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -2,9 +2,11 @@ class Candidates::SchoolsController < ApplicationController
   EXPANDED_SEARCH_RADIUS = 50
 
   def index
-    redirect_to new_candidates_school_search_path unless location_present?
+    return redirect_to new_candidates_school_search_path unless location_present?
 
     @search = Candidates::SchoolSearch.new(search_params)
+
+    return render 'candidates/school_searches/new' unless @search.valid?
 
     if @search.results.empty?
       @expanded_search_radius = true

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -97,8 +97,10 @@ private
   def geolocate(location)
     result = Geocoder.search(
       location,
-      region: 'gb',
-      params: { maxRes: 1 }
+      params: {
+        region: 'gb',
+        maxRes: 1
+      }
     )&.first
 
     if result.blank?

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -2,6 +2,8 @@ class Bookings::SchoolSearch < ApplicationRecord
   attr_accessor :requested_order
   attr_reader :location_name
 
+  validates :location, length: { minimum: 3 }, allow_nil: true
+
   AVAILABLE_ORDERS = [
     %w{distance Distance},
     %w{name Name}
@@ -93,7 +95,11 @@ private
   end
 
   def geolocate(location)
-    result = Geocoder.search(location)&.first
+    result = Geocoder.search(
+      location,
+      region: 'gb',
+      params: { maxRes: 1 }
+    )&.first
 
     if result.blank?
       Rails.logger.info("No Geocoder results found for #{location}")

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -22,7 +22,7 @@ module Candidates
     attr_accessor :query, :location, :order, :latitude, :longitude, :page
     attr_reader :distance, :max_fee
 
-    delegate :location_name, to: :school_search
+    delegate :location_name, :valid?, :errors, to: :school_search
 
     class << self
       delegate :available_orders, to: Bookings::SchoolSearch

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -22,6 +22,7 @@
               <%= f.search_field :location,
                     placeholder: 'Such as Manchester, M1 3BD',
                     required: true,
+                    minlength: "3",
                     data: {
                       action: "focus->grab-location#clearLocationInfo",
                       target: "grab-location.location"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,11 @@ en:
         bookings/placement_request:
           <<: [ *placement_preference_errors, *subject_preference_errors ]
 
+        bookings/school_search:
+          attributes:
+            location:
+              too_short: Must be at least 3 characters
+
   helpers:
     fieldset:
       phases: Education phases

--- a/features/candidates/schools/search/search.feature
+++ b/features/candidates/schools/search/search.feature
@@ -21,7 +21,15 @@ Feature: Schools search page
             | 25 | 25 miles |
         And the submit button should be labelled 'Find'
 
+    Scenario: Search form client-side validation
+        Given I am on the 'find a school' page
+        Then the 'location' input should require at least '3' characters
+
     Scenario: Navigating back to the search form
         Given I search for schools near 'Rochdale'
         When I click back on the results screen
         Then the location input should be populated with 'Rochdale'
+
+    Scenario: Entering an invalid search
+        Given I search for schools near 'Ex'
+        Then I should see an error message stating 'Must be at least 3 characters'

--- a/features/candidates/schools/search/search.feature
+++ b/features/candidates/schools/search/search.feature
@@ -31,5 +31,5 @@ Feature: Schools search page
         Then the location input should be populated with 'Rochdale'
 
     Scenario: Entering an invalid search
-        Given I search for schools near 'Ex'
+        Given I have made an invalid search for schools near 'Ex'
         Then I should see an error message stating 'Must be at least 3 characters'

--- a/features/step_definitions/candidates/schools/search_steps.rb
+++ b/features/step_definitions/candidates/schools/search_steps.rb
@@ -27,3 +27,9 @@ Then("the submit button should be labelled {string}") do |string|
     expect(page).to have_button(string)
   end
 end
+
+Given("I have made an invalid search for schools near {string}") do |string|
+  path = candidates_schools_path
+  visit(candidates_schools_path(location: string))
+  expect(page.current_path).to eql(path)
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -24,3 +24,7 @@ end
 Then("the page should have a heading called {string}") do |string|
   expect(page).to have_css("h1.govuk-fieldset__heading", text: string)
 end
+
+Then("I should see an error message stating {string}") do |string|
+  expect(page).to have_css('span.govuk-error-message', text: string)
+end

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -74,6 +74,11 @@ Given("I choose {string} from the {string} radio buttons") do |option, field|
   end
 end
 
+Then("the {string} input should require at least {string} characters") do |field, length|
+  input = page.find("input##{field}")
+  expect(input['minlength']).to eql(length)
+end
+
 LABEL_SELECTORS = %w(.govuk-label legend label).freeze
 def get_form_group(page, label_text)
   selector = LABEL_SELECTORS.detect do |selector|

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -11,6 +11,11 @@ describe Bookings::SchoolSearch do
     ]
   }
 
+  describe 'Validation' do
+    subject { described_class.new({}) }
+    it { is_expected.to validate_length_of(:location).is_at_least(3).allow_nil }
+  end
+
   describe '#geolocation' do
     let(:location) { 'Springfield' }
 

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe Candidates::SchoolSearch do
     end
   end
 
+  context 'delegation' do
+    it { expect(subject).to delegate_method(:valid?).to(:school_search) }
+    it { expect(subject).to delegate_method(:errors).to(:school_search) }
+    it { expect(subject).to delegate_method(:location_name).to(:school_search) }
+  end
+
   context '.subjects=' do
     context 'with blank strings' do
       before { subject.subjects = [1, '', 3] }


### PR DESCRIPTION
Geocoder searches previously weren't limited by region and returned
worldwide results. This is now limited to the `region: 'gb'`.

When Bing returned results we only use the first one, now the query is
limited so that Bing will only return one - this is more efficient from
both a network and cache point of view.

Finally, ensure location search strings are at least 3 characters long.
This is verified at the browser level via `minlength` and in Rails'
validation.
