### PR TITLE
Require an amount greater than zero for the School Fees

### DIFF
--- a/app/forms/schools/on_boarding/school_fee.rb
+++ b/app/forms/schools/on_boarding/school_fee.rb
@@ -12,7 +12,7 @@ module Schools
       attribute :payment_method, :string
 
       validates :amount_pounds, presence: true
-      validates :amount_pounds, numericality: { greater_than_or_equal_to: 0, less_than: 10000 }, if: -> { amount_pounds.present? }
+      validates :amount_pounds, numericality: { greater_than: 0, less_than: 10000 }, if: -> { amount_pounds.present? }
       validates :description, presence: true
       validates :interval, presence: true
       validates :interval, inclusion: { in: AVAILABLE_INTERVALS }, if: -> { interval.present? }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
     attributes:
       amount_pounds:
         blank: 'Enter an amount'
-        greater_than_or_equal_to: 'Must be greater than or equal to %{count}'
+        greater_than: 'Must be greater than %{count}'
         less_than: 'Must be less than %{count}'
       description:
         blank: 'Explanation required'

--- a/spec/support/schools/on_boarding/school_fee_shared_examples.rb
+++ b/spec/support/schools/on_boarding/school_fee_shared_examples.rb
@@ -35,7 +35,18 @@ shared_examples 'a school fee' do
 
         it 'add an error' do
           expect(subject.errors[:amount_pounds]).to \
-            eq ['Must be greater than or equal to 0']
+            eq ['Must be greater than 0']
+        end
+      end
+
+      context '0' do
+        let :amount do
+          0
+        end
+
+        it 'adds an error' do
+          expect(subject.errors[:amount_pounds]).to \
+            eq ['Must be greater than 0']
         end
       end
     end


### PR DESCRIPTION
### Context

Bug: SE-848 

Currently the School Administrator can enter a fee of 0 for the DBS/Admin/Other Fee - in this scenario they should instead be marking that a Fee is not required rather than entering a zero fee.

### Changes proposed in this pull request

Require the Fee to be greater than 0, instead of greater than or equal to 0



