### PR TITLE
Se 921/schools/on boarding/prepopulate wizard

### DIFF
--- a/app/controllers/schools/on_boarding/availability_descriptions_controller.rb
+++ b/app/controllers/schools/on_boarding/availability_descriptions_controller.rb
@@ -2,7 +2,8 @@ module Schools
   module OnBoarding
     class AvailabilityDescriptionsController < OnBoardingsController
       def new
-        @availability_description = AvailabilityDescription.new
+        @availability_description = \
+          AvailabilityDescription.new_from_bookings_school current_school
       end
 
       def create

--- a/app/controllers/schools/on_boarding/availability_preferences_controller.rb
+++ b/app/controllers/schools/on_boarding/availability_preferences_controller.rb
@@ -2,7 +2,8 @@ module Schools
   module OnBoarding
     class AvailabilityPreferencesController < OnBoardingsController
       def new
-        @availability_preference = AvailabilityPreference.new
+        @availability_preference = \
+          AvailabilityPreference.new_from_bookings_school current_school
       end
 
       def create

--- a/app/controllers/schools/on_boarding/experience_outlines_controller.rb
+++ b/app/controllers/schools/on_boarding/experience_outlines_controller.rb
@@ -2,7 +2,8 @@ module Schools
   module OnBoarding
     class ExperienceOutlinesController < OnBoardingsController
       def new
-        @experience_outline = ExperienceOutline.new
+        @experience_outline = \
+          ExperienceOutline.new_from_bookings_school current_school
       end
 
       def create

--- a/app/controllers/schools/on_boarding/key_stage_lists_controller.rb
+++ b/app/controllers/schools/on_boarding/key_stage_lists_controller.rb
@@ -2,7 +2,7 @@ module Schools
   module OnBoarding
     class KeyStageListsController < OnBoardingsController
       def new
-        @key_stage_list = KeyStageList.new
+        @key_stage_list = KeyStageList.new_from_bookings_school current_school
       end
 
       def create

--- a/app/controllers/schools/on_boarding/phases_lists_controller.rb
+++ b/app/controllers/schools/on_boarding/phases_lists_controller.rb
@@ -2,7 +2,7 @@ module Schools
   module OnBoarding
     class PhasesListsController < OnBoardingsController
       def new
-        @phases_list = PhasesList.new
+        @phases_list = PhasesList.new_from_bookings_school current_school
       end
 
       def create

--- a/app/controllers/schools/on_boarding/subjects_controller.rb
+++ b/app/controllers/schools/on_boarding/subjects_controller.rb
@@ -2,7 +2,7 @@ module Schools
   module OnBoarding
     class SubjectsController < OnBoardingsController
       def new
-        @subject_list = SubjectList.new
+        @subject_list = SubjectList.new_from_bookings_school current_school
       end
 
       def create

--- a/app/forms/schools/on_boarding/admin_contact.rb
+++ b/app/forms/schools/on_boarding/admin_contact.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class AdminContact
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class AdminContact < Step
       attribute :full_name, :string
       attribute :phone, :string
       attribute :email, :string
@@ -16,10 +13,6 @@ module Schools
 
       def self.compose(full_name, email, phone)
         new full_name: full_name, email: email, phone: phone
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
     end
   end

--- a/app/forms/schools/on_boarding/availability_description.rb
+++ b/app/forms/schools/on_boarding/availability_description.rb
@@ -1,18 +1,11 @@
 module Schools
   module OnBoarding
-    class AvailabilityDescription
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class AvailabilityDescription < Step
       attribute :description, :string
       validates :description, presence: true
 
       def self.compose(description)
         new description: description
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
     end
   end

--- a/app/forms/schools/on_boarding/availability_preference.rb
+++ b/app/forms/schools/on_boarding/availability_preference.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class AvailabilityPreference
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class AvailabilityPreference < Step
       attribute :fixed, :boolean
       validates :fixed, inclusion: [true, false]
 
@@ -17,10 +14,6 @@ module Schools
 
       def flexible?
         !fixed?
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
     end
   end

--- a/app/forms/schools/on_boarding/candidate_experience_detail.rb
+++ b/app/forms/schools/on_boarding/candidate_experience_detail.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class CandidateExperienceDetail
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class CandidateExperienceDetail < Step
       # Ensure that times look *roughly* valid. Note that it is
       # still possible to input invalid ones like '25:00'.
       # FIXME do we need to tighten this up/use a real timepicker?
@@ -70,10 +67,6 @@ module Schools
           start_time: start_time,
           end_time: end_time,
           times_flexible: times_flexible
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
     end
   end

--- a/app/forms/schools/on_boarding/candidate_requirement.rb
+++ b/app/forms/schools/on_boarding/candidate_requirement.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class CandidateRequirement
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class CandidateRequirement < Step
       DBS_REQUIRMENTS = %w(always sometimes never).freeze
 
       attribute :dbs_requirement, :string
@@ -24,10 +21,6 @@ module Schools
           dbs_policy: dbs_policy,
           requirements: requirements,
           requirements_details: requirements_details
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
 
       def dbs_requirements

--- a/app/forms/schools/on_boarding/confirmation.rb
+++ b/app/forms/schools/on_boarding/confirmation.rb
@@ -1,15 +1,8 @@
 module Schools
   module OnBoarding
-    class Confirmation
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class Confirmation < Step
       attribute :acceptance, :boolean
       validates :acceptance, acceptance: true
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
-      end
     end
   end
 end

--- a/app/forms/schools/on_boarding/experience_outline.rb
+++ b/app/forms/schools/on_boarding/experience_outline.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class ExperienceOutline
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class ExperienceOutline < Step
       attribute :candidate_experience, :string
       attribute :provides_teacher_training, :boolean
       attribute :teacher_training_details, :string
@@ -26,10 +23,6 @@ module Schools
           provides_teacher_training: provides_teacher_training,
           teacher_training_details: teacher_training_details,
           teacher_training_url: teacher_training_url
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
     end
   end

--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class Fees
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class Fees < Step
       attribute :administration_fees, :boolean
       attribute :dbs_fees, :boolean
       attribute :other_fees, :boolean
@@ -17,12 +14,6 @@ module Schools
           administration_fees: administration_fees,
           dbs_fees: dbs_fees,
           other_fees: other_fees
-      end
-
-      def ==(other)
-        return false unless other.respond_to? :attributes
-
-        other.attributes == self.attributes
       end
 
       def administration_fees?

--- a/app/forms/schools/on_boarding/from_bookings_school.rb
+++ b/app/forms/schools/on_boarding/from_bookings_school.rb
@@ -1,0 +1,54 @@
+# Maps attributes from a bookings school to attributes for a
+# schools/on_boarding/step
+module Schools
+  module OnBoarding
+    class FromBookingsSchool
+      def initialize(bookings_school)
+        @bookings_school = bookings_school
+      end
+
+      def [](model_name)
+        send "attributes_for_#{model_name}"
+      end
+
+    private
+
+      def attributes_for_availability_description
+        { description: @bookings_school.availability_info }
+      end
+
+      def attributes_for_availability_preference
+        fixed = @bookings_school.availability_info.present? ? false : nil
+        { fixed: fixed }
+      end
+
+      def attributes_for_experience_outline
+        {
+          candidate_experience: @bookings_school.placement_info,
+          provides_teacher_training: @bookings_school.teacher_training_provider.presence,
+          teacher_training_details: @bookings_school.teacher_training_info,
+          teacher_training_url: @bookings_school.teacher_training_website
+        }
+      end
+
+      def attributes_for_key_stage_list
+        stages = @bookings_school.primary_key_stage_info.to_s.split(', ')
+        {
+          early_years: stages.include?('Early years foundation stage (EYFS)'),
+          key_stage_1: stages.include?('Key stage 1'),
+          key_stage_2: stages.include?('Key stage 2')
+        }
+      end
+
+      def attributes_for_phases_list
+        {
+          primary: @bookings_school.primary_key_stage_info.present?
+        }
+      end
+
+      def attributes_for_subject_list
+        { subject_ids: @bookings_school.subject_ids }
+      end
+    end
+  end
+end

--- a/app/forms/schools/on_boarding/key_stage_list.rb
+++ b/app/forms/schools/on_boarding/key_stage_list.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class KeyStageList
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class KeyStageList < Step
       attribute :early_years, :boolean, default: false
       attribute :key_stage_1, :boolean, default: false
       attribute :key_stage_2, :boolean, default: false
@@ -15,18 +12,6 @@ module Schools
           early_years: early_years,
           key_stage_1: key_stage1,
           key_stage_2: key_stage2
-      end
-
-      def self.new_from_bookings_school(bookings_school)
-        stages = bookings_school.primary_key_stage_info.to_s.split(', ')
-        new \
-          early_years: stages.include?('Early years foundation stage (EYFS)'),
-          key_stage_1: stages.include?('Key stage 1'),
-          key_stage_2: stages.include?('Key stage 2')
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
 
     private

--- a/app/forms/schools/on_boarding/key_stage_list.rb
+++ b/app/forms/schools/on_boarding/key_stage_list.rb
@@ -17,6 +17,14 @@ module Schools
           key_stage_2: key_stage2
       end
 
+      def self.new_from_bookings_school(bookings_school)
+        stages = bookings_school.primary_key_stage_info.to_s.split(', ')
+        new \
+          early_years: stages.include?('Early years foundation stage (EYFS)'),
+          key_stage_1: stages.include?('Key stage 1'),
+          key_stage_2: stages.include?('Key stage 2')
+      end
+
       def ==(other)
         other.respond_to?(:attributes) && other.attributes == self.attributes
       end

--- a/app/forms/schools/on_boarding/phases_list.rb
+++ b/app/forms/schools/on_boarding/phases_list.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class PhasesList
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class PhasesList < Step
       attribute :primary, :boolean, default: false
       attribute :secondary, :boolean, default: false
       attribute :college, :boolean, default: false
@@ -22,10 +19,6 @@ module Schools
           secondary: secondary,
           college: college,
           secondary_and_college: secondary_and_college
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
 
       def primary?

--- a/app/forms/schools/on_boarding/school_fee.rb
+++ b/app/forms/schools/on_boarding/school_fee.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class SchoolFee
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class SchoolFee < Step
       AVAILABLE_INTERVALS = %w(Daily One-off).freeze
 
       attribute :amount_pounds, :decimal, scale: 2, precision: 4
@@ -28,12 +25,6 @@ module Schools
 
       def available_intervals
         AVAILABLE_INTERVALS
-      end
-
-      def ==(other)
-        return false unless other.respond_to? :attributes
-
-        other.attributes == self.attributes
       end
     end
   end

--- a/app/forms/schools/on_boarding/specialism.rb
+++ b/app/forms/schools/on_boarding/specialism.rb
@@ -1,9 +1,6 @@
 module Schools
   module OnBoarding
-    class Specialism
-      include ActiveModel::Model
-      include ActiveModel::Attributes
-
+    class Specialism < Step
       attribute :has_specialism, :boolean
       attribute :details, :string
 
@@ -12,10 +9,6 @@ module Schools
 
       def self.compose(has_specialism, details)
         new has_specialism: has_specialism, details: details
-      end
-
-      def ==(other)
-        other.respond_to?(:attributes) && other.attributes == self.attributes
       end
     end
   end

--- a/app/forms/schools/on_boarding/step.rb
+++ b/app/forms/schools/on_boarding/step.rb
@@ -1,0 +1,16 @@
+module Schools
+  module OnBoarding
+    class Step
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      def self.new_from_bookings_school(bookings_school)
+        new FromBookingsSchool.new(bookings_school)[model_name.element]
+      end
+
+      def ==(other)
+        other.respond_to?(:attributes) && other.attributes == self.attributes
+      end
+    end
+  end
+end

--- a/app/forms/schools/on_boarding/subject_list.rb
+++ b/app/forms/schools/on_boarding/subject_list.rb
@@ -1,7 +1,8 @@
 module Schools
   module OnBoarding
-    class SubjectList
-      include ActiveModel::Model
+    class SubjectList < Step
+      validate :at_least_one_subject_selected
+      validate :all_subjects_are_available, if: -> { at_least_one_subject_selected? }
 
       attr_reader :subject_ids
 
@@ -9,11 +10,10 @@ module Schools
         @subject_ids = array.reject(&:blank?).map(&:to_i)
       end
 
-      validate :at_least_one_subject_selected
-      validate :all_subjects_are_available, if: -> { at_least_one_subject_selected? }
-
       def ==(other)
         return false unless other.respond_to? :subject_ids
+
+        return false unless Array(other.subject_ids).size == Array(self.subject_ids).size
 
         Array(other.subject_ids).all? do |subject_id|
           Array(self.subject_ids).include? subject_id

--- a/spec/controllers/schools/on_boarding/key_stage_lists_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/key_stage_lists_controller_spec.rb
@@ -22,8 +22,8 @@ describe Schools::OnBoarding::KeyStageListsController, type: :request do
     end
 
     it 'assings the model' do
-      expect(assigns(:key_stage_list)).to \
-        eq Schools::OnBoarding::KeyStageList.new
+      expect(assigns(:key_stage_list).attributes).to \
+        eq Schools::OnBoarding::KeyStageList.new.attributes
     end
 
     it 'renders the new template' do

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -24,8 +24,36 @@ FactoryBot.define do
       availability_preference_fixed { true }
     end
 
+    trait :with_availability_info do
+      availability_info { 'We can offer placements throughout June and July for the remainder of this academic year (up to the 21st July).' }
+    end
+
+    trait :with_placement_info do
+      placement_info { 'Our free Taster Day will allow you to observe some lessons (subjects may vary), have a tour of the school, speak to students, staff and current trainee teachers' }
+    end
+
     trait :with_primary_key_stage_info do
       primary_key_stage_info { 'Early years foundation stage (EYFS), Key stage 1, Key stage 2' }
+    end
+
+    transient do
+      subject_count { 1 }
+    end
+
+    trait :with_subjects do
+      after :create do |school, evaluator|
+        evaluator.subject_count.times do
+          school.subjects << FactoryBot.create(:bookings_subject)
+        end
+      end
+    end
+
+    trait :with_teacher_training_info do
+      teacher_training_info { 'We offer a PGCE in partnership with Chester University. We are a lead school for School Direct' }
+    end
+
+    trait :with_teacher_training_website do
+      teacher_training_website { 'http://teacher-training.example.com' }
     end
   end
 end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :with_fixed_availability_preference do
       availability_preference_fixed { true }
     end
+
+    trait :with_primary_key_stage_info do
+      primary_key_stage_info { 'Early years foundation stage (EYFS), Key stage 1, Key stage 2' }
+    end
   end
 end

--- a/spec/forms/schools/on_boarding/availability_description_spec.rb
+++ b/spec/forms/schools/on_boarding/availability_description_spec.rb
@@ -8,4 +8,16 @@ describe Schools::OnBoarding::AvailabilityDescription, type: :model do
   context 'validations' do
     it { is_expected.to validate_presence_of :description }
   end
+
+  context '.new_from_bookings_school' do
+    let :school do
+      FactoryBot.build :bookings_school, :with_availability_info
+    end
+
+    subject { described_class.new_from_bookings_school school }
+
+    it 'sets the availabilty description from the bookings_school' do
+      expect(subject.description).to eq school.availability_info
+    end
+  end
 end

--- a/spec/forms/schools/on_boarding/availability_preference_spec.rb
+++ b/spec/forms/schools/on_boarding/availability_preference_spec.rb
@@ -40,4 +40,28 @@ describe Schools::OnBoarding::AvailabilityPreference, type: :model do
       end
     end
   end
+
+  context '.new_from_bookings_school' do
+    subject { described_class.new_from_bookings_school school }
+
+    context 'when school has availability_info' do
+      let :school do
+        FactoryBot.build :bookings_school, :with_availability_info
+      end
+
+      it 'sets fixed to false' do
+        expect(subject.fixed).to be false
+      end
+    end
+
+    context "when school doesn't have availability_info" do
+      let :school do
+        FactoryBot.build :bookings_school
+      end
+
+      it 'leaves fixed as nil' do
+        expect(subject.fixed).to be nil
+      end
+    end
+  end
 end

--- a/spec/forms/schools/on_boarding/experience_outline_spec.rb
+++ b/spec/forms/schools/on_boarding/experience_outline_spec.rb
@@ -24,4 +24,33 @@ describe Schools::OnBoarding::ExperienceOutline, type: :model do
       it { is_expected.not_to validate_presence_of :teacher_training_url }
     end
   end
+
+  context '.new_from_bookings_school' do
+    let :school do
+      FactoryBot.build \
+        :bookings_school,
+        :with_placement_info,
+        :with_teacher_training_info,
+        :with_teacher_training_website,
+        teacher_training_provider: true
+    end
+
+    subject { described_class.new_from_bookings_school school }
+
+    it "sets candidate_experience to the school's placement_info" do
+      expect(subject.candidate_experience).to eq school.placement_info
+    end
+
+    it "sets provides_teacher_training" do
+      expect(subject.provides_teacher_training).to be true
+    end
+
+    it "sets teacher_training_details to the school's teacher_training_info" do
+      expect(subject.teacher_training_details).to eq school.teacher_training_info
+    end
+
+    it "sets the teacher_training_url to the school's teacher_training_website" do
+      expect(subject.teacher_training_url).to eq school.teacher_training_website
+    end
+  end
 end

--- a/spec/forms/schools/on_boarding/from_bookings_school_spec.rb
+++ b/spec/forms/schools/on_boarding/from_bookings_school_spec.rb
@@ -1,0 +1,184 @@
+require 'rails_helper'
+
+describe Schools::OnBoarding::FromBookingsSchool do
+  subject { described_class.new school }
+
+  context '#[]' do
+    context 'availability_description' do
+      let :school do
+        FactoryBot.build :bookings_school, :with_availability_info
+      end
+
+      it 'returns the correct attributes' do
+        expect(subject['availability_description']).to \
+          eq description: school.availability_info
+      end
+    end
+
+    context 'availability_preference' do
+      context 'when the school has availability_info' do
+        let :school do
+          FactoryBot.build :bookings_school, :with_availability_info
+        end
+
+        it 'returns the correct attributes' do
+          expect(subject['availability_preference']).to eq fixed: false
+        end
+      end
+
+      context 'when the school does not have availability_info' do
+        let :school do
+          FactoryBot.build :bookings_school
+        end
+
+        it 'returns the correct attributes' do
+          expect(subject['availability_preference']).to eq fixed: nil
+        end
+      end
+    end
+
+    context 'experience_outline' do
+      let :school do
+        FactoryBot.build :bookings_school,
+          :with_placement_info,
+          :with_teacher_training_info,
+          :with_teacher_training_website,
+          teacher_training_provider: true
+      end
+
+      it 'returns the correct attributes' do
+        expect(subject['experience_outline']).to eq \
+          candidate_experience: school.placement_info,
+          provides_teacher_training: school.teacher_training_provider.presence,
+          teacher_training_details: school.teacher_training_info,
+          teacher_training_url: school.teacher_training_website
+      end
+
+      context 'provides_teacher_training' do
+        context 'when the school provides teacher training' do
+          let :school do
+            FactoryBot.build :bookings_school, teacher_training_provider: true
+          end
+
+          it 'returns the correct attributes' do
+            expect(
+              subject['experience_outline'][:provides_teacher_training]
+            ).to eq true
+          end
+        end
+
+        context 'when the school does not provide teacher training' do
+          let :school do
+            FactoryBot.build :bookings_school, teacher_training_provider: false
+          end
+
+          it 'returns the correct attributes' do
+            expect(
+              subject['experience_outline'][:provides_teacher_training]
+            ).to eq nil
+          end
+        end
+      end
+    end
+
+    context 'key_stage_list' do
+      context 'when has early years' do
+        let :school do
+          FactoryBot.build :bookings_school,
+            primary_key_stage_info: 'Early years foundation stage (EYFS)'
+        end
+
+        it 'returns the correct value for early_years' do
+          expect(subject['key_stage_list'][:early_years]).to be true
+        end
+      end
+
+      context 'when does not have early years' do
+        let :school do
+          FactoryBot.build :bookings_school,
+            primary_key_stage_info: 'Key stage 1'
+        end
+
+        it 'returns the correct value for early_years' do
+          expect(subject['key_stage_list'][:early_years]).to be false
+        end
+      end
+
+      context 'when has key stage 1' do
+        let :school do
+          FactoryBot.build :bookings_school,
+            primary_key_stage_info: 'Key stage 1'
+        end
+
+        it 'returns the correct value for key_stage_1' do
+          expect(subject['key_stage_list'][:key_stage_1]).to be true
+        end
+      end
+
+      context 'when does not have key stage 1' do
+        let :school do
+          FactoryBot.build :bookings_school,
+            primary_key_stage_info: 'Key stage 2'
+        end
+
+        it 'returns the correct value for key_stage_1' do
+          expect(subject['key_stage_list'][:key_stage_1]).to be false
+        end
+      end
+
+      context 'when has key stage 2' do
+        let :school do
+          FactoryBot.build :bookings_school,
+            primary_key_stage_info: 'Key stage 2'
+        end
+
+        it 'returns the correct value for key_stage_2' do
+          expect(subject['key_stage_list'][:key_stage_2]).to be true
+        end
+      end
+
+      context 'when does not have key stage 2' do
+        let :school do
+          FactoryBot.build :bookings_school,
+            primary_key_stage_info: 'Early years foundation stage (EYFS)'
+        end
+
+        it 'returns the correct value for key_stage_2' do
+          expect(subject['key_stage_list'][:key_stage_2]).to be false
+        end
+      end
+    end
+
+    context 'phases_list' do
+      context 'when primary_key_stage_info is present' do
+        let :school do
+          FactoryBot.build :bookings_school, :with_primary_key_stage_info
+        end
+
+        it 'returns the correct attributes' do
+          expect(subject['phases_list']).to eq primary: true
+        end
+      end
+
+      context 'when primary_key_stage_info is not present' do
+        let :school do
+          FactoryBot.build :bookings_school
+        end
+
+        it 'returns the correct attributes' do
+          expect(subject['phases_list']).to eq primary: false
+        end
+      end
+    end
+
+    context 'subject_list' do
+      let :school do
+        FactoryBot.create :bookings_school, :with_subjects
+      end
+
+      it 'returns the correct attributes' do
+        expect(subject['subject_list']).to eq subject_ids: school.subject_ids
+      end
+    end
+  end
+end

--- a/spec/forms/schools/on_boarding/key_stage_list_spec.rb
+++ b/spec/forms/schools/on_boarding/key_stage_list_spec.rb
@@ -13,4 +13,18 @@ describe Schools::OnBoarding::KeyStageList, type: :model do
         eq ['Select at least one key stage']
     end
   end
+
+  context '.new_from_bookings_school' do
+    let :school do
+      FactoryBot.build :bookings_school, :with_primary_key_stage_info
+    end
+
+    subject { described_class.new_from_bookings_school school }
+
+    it 'sets the attributes from the bookings_school' do
+      expect(subject.early_years).to be true
+      expect(subject.key_stage_1).to be true
+      expect(subject.key_stage_2).to be true
+    end
+  end
 end

--- a/spec/forms/schools/on_boarding/phases_list_spec.rb
+++ b/spec/forms/schools/on_boarding/phases_list_spec.rb
@@ -96,4 +96,18 @@ describe Schools::OnBoarding::PhasesList, type: :model do
       end
     end
   end
+
+  context '.new_from_bookings_school' do
+    let :school do
+      FactoryBot.create :bookings_school, :with_primary_key_stage_info
+    end
+
+    subject { described_class.new_from_bookings_school school }
+
+    it 'sets the attributes from the bookings_school' do
+      expect(subject.primary?).to be true
+      expect(subject.secondary?).to be false
+      expect(subject.college?).to be false
+    end
+  end
 end

--- a/spec/forms/schools/on_boarding/subject_list_spec.rb
+++ b/spec/forms/schools/on_boarding/subject_list_spec.rb
@@ -38,4 +38,16 @@ describe Schools::OnBoarding::SubjectList, type: :model do
       end
     end
   end
+
+  context '.new_from_bookings_school' do
+    let :bookings_school do
+      FactoryBot.create :bookings_school, :with_subjects
+    end
+
+    subject { described_class.new_from_bookings_school bookings_school }
+
+    it 'sets the subjects from the bookings school' do
+      expect(subject.subject_ids).to eq bookings_school.subject_ids
+    end
+  end
 end


### PR DESCRIPTION
    Prepopulates school on boarding wizard

    We have some schools that have already provided on boarding details via a
    google form. This commit adds support for prepopulating fields in the
    school on boarding wizard from an existing bookings/school, if the
    information is present, saving the school admin time.

    This commit also refactors the form models in schools/on_boarding to use
    a common base class.

    Once all existing bookings/schools that had supplied on boarding details
    via the google form have a bookings/profile
    schools/on_boarding/step#new_from_bookings_school and
    schools/on_boarding/from_bookings_school can be deleted.

### Guidance to review
Check the mapping in app/forms/schools/on_boarding/from_bookings_school.rb is be correct
