### PR TITLE
SE-929 Copy subjects keystages and phases between profiles

### DIFF
--- a/app/models/bookings/profile_attributes_convertor.rb
+++ b/app/models/bookings/profile_attributes_convertor.rb
@@ -27,6 +27,22 @@ module Bookings
       output
     end
 
+    def phase_ids
+      Set.new.tap do |ids|
+        if input[:phases_list_primary]
+          ids << edubase_ids[2]
+        end
+
+        if input[:phases_list_secondary] || input[:phases_list_secondary_or_college]
+          ids << edubase_ids[4]
+        end
+
+        if input[:phases_list_college] || input[:phases_list_secondary_or_college]
+          ids << edubase_ids[6]
+        end
+      end
+    end
+
   private
 
     def convert_dbs
@@ -150,6 +166,10 @@ module Bookings
 
     def assign_or_nil(test_result, input_key)
       test_result ? input[input_key] : nil
+    end
+
+    def edubase_ids
+      @edubase_ids ||= Hash[Bookings::Phase.pluck(:edubase_id, :id)]
     end
   end
 end

--- a/app/models/bookings/profile_attributes_convertor.rb
+++ b/app/models/bookings/profile_attributes_convertor.rb
@@ -30,6 +30,7 @@ module Bookings
     def phase_ids
       Set.new.tap do |ids|
         if input[:phases_list_primary]
+          ids << edubase_ids[1] if input[:key_stage_list_early_years]
           ids << edubase_ids[2]
         end
 

--- a/app/models/bookings/profile_publisher.rb
+++ b/app/models/bookings/profile_publisher.rb
@@ -13,6 +13,7 @@ module Bookings
       profile.transaction do
         profile.attributes = converted_attributes
         school.subject_ids = @school_profile.subject_ids
+        school.phase_ids = converted_phase_ids
         profile.tap(&:save!)
       end
     end
@@ -31,8 +32,15 @@ module Bookings
     end
 
     def converted_attributes
-      @converted_attributes ||= \
-        ProfileAttributesConvertor.new(@school_profile.attributes).attributes
+      @converted_attributes ||= convertor.attributes
+    end
+
+    def converted_phase_ids
+      @converted_phase_ids ||= convertor.phase_ids
+    end
+
+    def convertor
+      @convertor ||= ProfileAttributesConvertor.new(@school_profile.attributes)
     end
 
     def profile

--- a/app/models/bookings/profile_publisher.rb
+++ b/app/models/bookings/profile_publisher.rb
@@ -10,8 +10,11 @@ module Bookings
     end
 
     def update!
-      profile.attributes = converted_attributes
-      profile.tap(&:save!)
+      profile.transaction do
+        profile.attributes = converted_attributes
+        school.subject_ids = @school_profile.subject_ids
+        profile.tap(&:save!)
+      end
     end
 
     class IncompleteSourceProfileError < RuntimeError; end

--- a/spec/factories/bookings/phase_factory.rb
+++ b/spec/factories/bookings/phase_factory.rb
@@ -5,13 +5,16 @@ FactoryBot.define do
 
   trait :primary do
     name { 'Primary' }
+    edubase_id { 2 }
   end
 
   trait :secondary do
     name { 'Secondary' }
+    edubase_id { 4 }
   end
 
   trait :college do
     name { '16 plus' }
+    edubase_id { 6 }
   end
 end

--- a/spec/factories/bookings/phase_factory.rb
+++ b/spec/factories/bookings/phase_factory.rb
@@ -3,18 +3,23 @@ FactoryBot.define do
     sequence(:name) { |n| "phase #{n}" }
   end
 
+  trait :early_years do
+    name { 'Early years' }
+    edubase_id { 1 }
+  end
+
   trait :primary do
-    name { 'Primary' }
+    name { 'Primary (4 to 11)' }
     edubase_id { 2 }
   end
 
   trait :secondary do
-    name { 'Secondary' }
+    name { 'Secondary (11 to 16)' }
     edubase_id { 4 }
   end
 
   trait :college do
-    name { '16 plus' }
+    name { '16 to 18' }
     edubase_id { 6 }
   end
 end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -55,5 +55,23 @@ FactoryBot.define do
     trait :with_teacher_training_website do
       teacher_training_website { 'http://teacher-training.example.com' }
     end
+
+    trait :primary do
+      after(:create) do |school, _evaluator|
+        school.phases << Bookings::Phase.find_by!(edubase_id: 2)
+      end
+    end
+
+    trait :secondary do
+      after(:create) do |school, _evaluator|
+        school.phases << Bookings::Phase.find_by!(edubase_id: 4)
+      end
+    end
+
+    trait :college do
+      after(:create) do |school, _evaluator|
+        school.phases << Bookings::Phase.find_by!(edubase_id: 6)
+      end
+    end
   end
 end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -58,6 +58,12 @@ FactoryBot.define do
 
     trait :primary do
       after(:create) do |school, _evaluator|
+        school.phases << Bookings::Phase.find_by!(edubase_id: 1)
+      end
+    end
+
+    trait :primary do
+      after(:create) do |school, _evaluator|
         school.phases << Bookings::Phase.find_by!(edubase_id: 2)
       end
     end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
       teacher_training_website { 'http://teacher-training.example.com' }
     end
 
-    trait :primary do
+    trait :early_years do
       after(:create) do |school, _evaluator|
         school.phases << Bookings::Phase.find_by!(edubase_id: 1)
       end

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -116,4 +116,16 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       it { is_expected.to include(other_fee_payment_method: nil) }
     end
   end
+
+  describe '#phase_ids' do
+    before { @primary = create(:bookings_phase, :primary) }
+    before { @secondary = create(:bookings_phase, :secondary) }
+    before { @college = create(:bookings_phase, :college) }
+    let(:attrs) { build(:school_profile, :completed).attributes }
+    subject { described_class.new(attrs).phase_ids }
+
+    it { is_expected.to include(@primary.id) }
+    it { is_expected.to include(@secondary.id) }
+    it { is_expected.to include(@college.id) }
+  end
 end

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -118,12 +118,14 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
   end
 
   describe '#phase_ids' do
+    before { @early_years = create(:bookings_phase, :early_years) }
     before { @primary = create(:bookings_phase, :primary) }
     before { @secondary = create(:bookings_phase, :secondary) }
     before { @college = create(:bookings_phase, :college) }
     let(:attrs) { build(:school_profile, :completed).attributes }
     subject { described_class.new(attrs).phase_ids }
 
+    it { is_expected.to include(@early_years.id) }
     it { is_expected.to include(@primary.id) }
     it { is_expected.to include(@secondary.id) }
     it { is_expected.to include(@college.id) }

--- a/spec/models/bookings/profile_publisher_spec.rb
+++ b/spec/models/bookings/profile_publisher_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
   end
 
   describe '#update!' do
-    let(:school) { create(:bookings_school) }
-    let(:school_profile) { create(:school_profile, :completed) }
+    let(:school) { create(:bookings_school, :with_subjects) }
+    let(:school_profile) { create(:school_profile, :completed, :with_subjects) }
 
     context "for School with Profile" do
       subject { described_class.new(school, school_profile).update! }
@@ -34,6 +34,7 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to be_persisted }
       it { is_expected.to be_valid }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
+      it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
     end
 
     context "for School without Profile" do
@@ -52,6 +53,7 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to be_valid }
       it { is_expected.to eql @initial_profile }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
+      it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
     end
   end
 end

--- a/spec/models/bookings/profile_publisher_spec.rb
+++ b/spec/models/bookings/profile_publisher_spec.rb
@@ -24,10 +24,12 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
   end
 
   describe '#update!' do
-    let(:school) { create(:bookings_school, :with_subjects) }
+    include_context 'with phases'
+
+    let(:school) { create(:bookings_school, :with_subjects, :primary) }
     let(:school_profile) { create(:school_profile, :completed, :with_subjects) }
 
-    context "for School with Profile" do
+    context "for School without Profile" do
       subject { described_class.new(school, school_profile).update! }
 
       it { is_expected.to be_kind_of Bookings::Profile }
@@ -35,15 +37,12 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to be_valid }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
       it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
+      it { expect(subject.school.phase_ids.length).to eql(3) }
     end
 
-    context "for School without Profile" do
+    context "for School with Profile" do
       before do
-        @initial_profile = create(:bookings_profile,
-          primary_phase: false,
-          secondary_phase: false,
-          college_phase: true,
-          school: school)
+        @initial_profile = create(:bookings_profile, school: school)
       end
 
       subject { described_class.new(school, school_profile).update! }
@@ -54,6 +53,7 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to eql @initial_profile }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
       it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
+      it { expect(subject.school.phase_ids.length).to eql(3) }
     end
   end
 end

--- a/spec/models/bookings/profile_publisher_spec.rb
+++ b/spec/models/bookings/profile_publisher_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to be_valid }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
       it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
-      it { expect(subject.school.phase_ids.length).to eql(3) }
+      it { expect(subject.school.phase_ids.length).to eql(4) }
     end
 
     context "for School with Profile" do
@@ -53,7 +53,7 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to eql @initial_profile }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
       it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
-      it { expect(subject.school.phase_ids.length).to eql(3) }
+      it { expect(subject.school.phase_ids.length).to eql(4) }
     end
   end
 end

--- a/spec/support/with_phases.rb
+++ b/spec/support/with_phases.rb
@@ -1,0 +1,7 @@
+shared_context 'with phases' do
+  before do
+    FactoryBot.create :bookings_phase, :primary
+    FactoryBot.create :bookings_phase, :secondary
+    FactoryBot.create :bookings_phase, :college
+  end
+end

--- a/spec/support/with_phases.rb
+++ b/spec/support/with_phases.rb
@@ -1,5 +1,6 @@
 shared_context 'with phases' do
   before do
+    FactoryBot.create :bookings_phase, :early_years
     FactoryBot.create :bookings_phase, :primary
     FactoryBot.create :bookings_phase, :secondary
     FactoryBot.create :bookings_phase, :college


### PR DESCRIPTION
### Context

Currently we don't set the subjects or phases on the Bookings::School model when publishing a profile

### Changes proposed in this pull request

1. Copy the Subject Ids from Schools::SchoolProfile to Bookings::School
2. Map the Phases from the columns on Schools::SchoolProfile to Bookings::School#phase_ids

### Guidance to review

I've left the mostly redundant phases columns on the Bookings::Profile table

This is because they are currently used as part of the validation on that model. The mapping needs removing and the difference between schools and candidates refactoring at a future point anyway.

