### PR TITLE
Feature/rename phases

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -23,7 +23,9 @@ module Candidates::SchoolHelper
   end
 
   def format_school_phases(school)
-    safe_join school.phases.map(&:name), ', '
+    content_tag(:ul, class: 'govuk-list') do
+      safe_join(school.phases.map { |p| tag.li(p.name) })
+    end
   end
 
   def format_school_availability(school)

--- a/app/models/bookings/phase.rb
+++ b/app/models/bookings/phase.rb
@@ -16,12 +16,4 @@ class Bookings::Phase < ApplicationRecord
 
   acts_as_list
   default_scope -> { order(:position) }
-
-  def self.secondary
-    find_by! name: 'Secondary'.freeze
-  end
-
-  def self.college
-    find_by! name: '16 plus'.freeze
-  end
 end

--- a/db/data/phases.yml
+++ b/db/data/phases.yml
@@ -1,4 +1,4 @@
- 1: Nursery
- 2: Primary
- 4: Secondary
- 6: 16 plus
+ 1: Early years
+ 2: Primary (4 to 11)
+ 4: Secondary (11 to 16)
+ 6: 16 to 18

--- a/db/migrate/20190503120209_rename_phases.rb
+++ b/db/migrate/20190503120209_rename_phases.rb
@@ -1,0 +1,30 @@
+class RenamePhases < ActiveRecord::Migration[5.2]
+  def up
+    mapping.each { |edubase_id, data| modify(edubase_id, data[:new]) }
+  end
+
+  def down
+    mapping.each { |edubase_id, data| modify(edubase_id, data[:old]) }
+  end
+
+private
+
+  def modify(edubase_id, name)
+    Rails.logger.debug("renaming phase with edubase_id #{edubase_id} to '#{name}'")
+    Bookings::Phase
+      .find_by!(edubase_id: edubase_id)
+      .update(name: name)
+  end
+
+  # note, we're using the edubase_id field
+  # because it's static (wasn't automatically
+  # generated) and was set at import
+  def mapping
+    {
+      1 => { old: "Nursery", new: "Early years" },
+      2 => { old: "Primary", new: "Primary (4 to 11)" },
+      4 => { old: "Secondary", new: "Secondary (11 to 16)" },
+      6 => { old: "16 plus", new: "16 to 18" },
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,8 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 2019_05_02_084101) do
+
+ActiveRecord::Schema.define(version: 2019_05_03_120209) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/data/school_importer.rb
+++ b/lib/data/school_importer.rb
@@ -102,18 +102,18 @@ private
 
   def map_phase(edubase_id)
     # 0: Not applicable              -> ¯\_(ツ)_/¯
-    # 1: Nursery                     -> Nursery
-    # 2: Primary                     -> Primary
-    # 3: Middle deemed primary       -> Primary
-    # 4: Secondary                   -> Secondary
-    # 5: Middle deemed secondary     -> Secondary
-    # 6: 16 plus                     -> 16 plus
-    # 7: All through                 -> Nursery + Primary + Secondary + 16 plus
+    # 1: Nursery                     -> Early years
+    # 2: Primary                     -> Primary (4 to 11)
+    # 3: Middle deemed primary       -> Primary (4 to 11)
+    # 4: Secondary                   -> Secondary (11 to 16)
+    # 5: Middle deemed secondary     -> Secondary (11 to 16)
+    # 6: 16 plus                     -> 16 to 18
+    # 7: All through                 -> Nursery + Primary + Secondary + College
 
-    nursery      = phases['Nursery']
-    primary      = phases['Primary']
-    secondary    = phases['Secondary']
-    sixteen_plus = phases['16 plus']
+    nursery   = phases['Early years']
+    primary   = phases['Primary (4 to 11)']
+    secondary = phases['Secondary (11 to 16)']
+    college   = phases['16 to 18']
 
     {
       1 => nursery,
@@ -121,8 +121,8 @@ private
       3 => primary,
       4 => secondary,
       5 => secondary,
-      6 => sixteen_plus,
-      7 => [nursery, primary, secondary, sixteen_plus]
+      6 => college,
+      7 => [nursery, primary, secondary, college]
     }[edubase_id]
   end
 

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -69,16 +69,20 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
           OpenStruct.new(id: 3, name: 'Third')
         ]
       )
-
-      @formatted = format_school_phases(@school)
     end
+
+    let(:formatted) do
+      format_school_phases(@school)
+    end
+
+    let(:parsed) { Nokogiri.parse(formatted) }
 
     it 'should be html_safe' do
-      expect(@formatted.html_safe?).to be true
+      expect(formatted.html_safe?).to be true
     end
 
-    it 'should turn them into a sentence' do
-      expect(@formatted).to eq "First, Second, Third"
+    it 'should turn them into a list' do
+      expect(parsed.css('ul.govuk-list > li').map(&:text)).to eql(@school.phases.map(&:name))
     end
   end
 

--- a/spec/lib/data/school_importer_spec.rb
+++ b/spec/lib/data/school_importer_spec.rb
@@ -49,10 +49,10 @@ describe SchoolImporter do
       before do
         # note these values are present in spec/sample_data/edubase.csv
         {
-         1 => 'Nursery',
-         2 => 'Primary',
-         4 => 'Secondary',
-         6 => '16 plus',
+         1 => 'Early years',
+         2 => 'Primary (4 to 11)',
+         4 => 'Secondary (11 to 16)',
+         6 => '16 to 18',
          7 => 'All through'
         }.each do |i, name|
           create(:bookings_phase, name: name, edubase_id: i)
@@ -118,8 +118,8 @@ describe SchoolImporter do
 
       specify 'the new records should have the corret phases' do
         {
-          100492 => %w{Primary},
-          100171 => ['Nursery', 'Primary', 'Secondary', '16 plus']
+          100492 => ['Primary (4 to 11)'],
+          100171 => ['Early years', 'Primary (4 to 11)', 'Secondary (11 to 16)', '16 to 18']
         }.each do |urn, phase_names|
           Bookings::School.find_by(urn: urn).tap do |school|
             expect(school.phases.map(&:name)).to match_array(phase_names)


### PR DESCRIPTION
### Context

The phase names were adjusted in the prototype in the following manner:

 * Nursery should read ‘Early years’
 * 16+ should read ‘16 to 18’
 * Primary and secondary should include the age range in brackets

### Changes proposed in this pull request

Provide a data migration that updates the phases. The `edubase_id` is used to find them as it's not based on an auto-incrementing key

### Guidance to review

Ensure the changes look sensible, pay extra attention to the migration.

Note that the seed stuff isn't _really_ required, but it makes sense moving forwards so dev environments match production