### PR TITLE
Hide placement dates link for flexible schools

### DIFF
--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -25,12 +25,14 @@
       </span>
     </li>
 
-    <li>
-      <%= link_to "Update school experience dates", schools_placement_dates_path %>
-      <span class="govuk-hint">
-        Add, edit and disable <strong>fixed</strong> dates for candidates
-      </span>
-    </li>
+    <%- if @current_school.availability_preference_fixed? -%>
+      <li>
+        <%= link_to "Update school experience dates", schools_placement_dates_path %>
+        <span class="govuk-hint">
+          Add, edit and disable <strong>fixed</strong> dates for candidates
+        </span>
+      </li>
+    <%- end -%>
 
   </ul>
 </article>

--- a/spec/controllers/schools/dashboards_controller_spec.rb
+++ b/spec/controllers/schools/dashboards_controller_spec.rb
@@ -53,5 +53,28 @@ describe Schools::DashboardsController, type: :request do
         expect(subject).to redirect_to(schools_errors_no_school_path)
       end
     end
+
+    context 'dashlette' do
+      include_context "logged in DfE user"
+      before { allow(Rails.application.config.x).to receive(:phase).and_return(2) }
+
+      context 'when the school has fixed dates' do
+        before { @current_user_school.update(availability_preference_fixed: true) }
+        before { get '/schools/dashboard' }
+
+        specify 'should have the link' do
+          expect(response.body).to match(/Update school experience dates/)
+        end
+      end
+
+      context 'when the school has flexible dates' do
+        before { @current_user_school.update(availability_preference_fixed: false) }
+        before { get '/schools/dashboard' }
+
+        specify 'should have the link' do
+          expect(response.body).not_to match(/Update school experience dates/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
When schools are set to fixed dates show the manage placement dates link, otherwise hide it

