### PR TITLE
Make find_by not blow up when record absent

### DIFF
--- a/db/migrate/20190503120209_rename_phases.rb
+++ b/db/migrate/20190503120209_rename_phases.rb
@@ -12,8 +12,8 @@ private
   def modify(edubase_id, name)
     Rails.logger.debug("renaming phase with edubase_id #{edubase_id} to '#{name}'")
     Bookings::Phase
-      .find_by!(edubase_id: edubase_id)
-      .update(name: name)
+      .find_by(edubase_id: edubase_id)
+      &.update(name: name)
   end
 
   # note, we're using the edubase_id field


### PR DESCRIPTION
### Context
In CD the migrations are run from scratch against an empty database and
this migration uses `.find_by!` meaning it will fail when the records
it's looking for are absent.

Normally, in environments that have been seeded (ie in prod) this would
be the correct behaviour but it fails in CD, so we'll make it less fussy
and manually check that it's been successful afterwards...

### Changes proposed in this pull request

Change `.find_by!` to `.find_by` and add safe navigation to the following `.update`.

### Guidance to review

Make sure it'll work in CD
