### PR TITLE
Bugfix/fix school name in confirmation emails

### DIFF
--- a/app/notify/notify_email/candidate_request_confirmation.rb
+++ b/app/notify/notify_email/candidate_request_confirmation.rb
@@ -62,7 +62,7 @@ class NotifyEmail::CandidateRequestConfirmation < Notify
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
       placement_outcome: application_preview.placement_outcome,
       placement_availability: application_preview.placement_availability_description,
-      school_name: application_preview.school
+      school_name: application_preview.school.name
     )
   end
 

--- a/app/notify/notify_email/school_request_confirmation.rb
+++ b/app/notify/notify_email/school_request_confirmation.rb
@@ -62,7 +62,7 @@ class NotifyEmail::SchoolRequestConfirmation < Notify
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
       placement_outcome: application_preview.placement_outcome,
       placement_availability: application_preview.placement_availability_description,
-      school_name: application_preview.school
+      school_name: application_preview.school.name
     )
   end
 

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -252,4 +252,3 @@ Then("I should see the dress code policy information") do
     expect(page).to have_css('p', text: 'We were all blue on fridays')
   end
 end
-

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -188,7 +188,7 @@ shared_examples_for "email template from application preview" do
       end
 
       specify 'school_name is correctly-assigned' do
-        expect(subject.school_name).to eql(ap.school)
+        expect(subject.school_name).to eql(ap.school.name)
       end
 
       context 'placement availability/dates' do


### PR DESCRIPTION
### Context

Judith noticed that the confirmation emails contained a stringified hash of school data instead of the school's name

### Changes proposed in this pull request

Ensure we're passing the school's name rather than the school itself into when initialising the email object

### Guidance to review

Make sure it looks sensible
