### PR TITLE
improve timings script

### DIFF
--- a/script/check_timings.py
+++ b/script/check_timings.py
@@ -20,14 +20,22 @@ print('ignoring first failure which is always slow for various reasons (starting
 index=0
 
 for feature in json_data:
+  print(feature['id'])
   for scenario in feature['elements']:
+    print('  {0}'.format(scenario['name']))
     if scenario['type'] == 'scenario':
+      if 'before' in scenario:
+          for before in scenario['before']:
+              print('    {0:<7} {1: >13} {2}'.format('before', before['result']['duration'], before['match']['location']))
       for step in scenario['steps']:
         if step['result']['status'] == 'passed':
+          print('    {0:<7} {1: >13} {2}'.format('step', step['result']['duration'], step['name'].encode('utf-8')))
           if step['result']['duration'] > max_duration and index > 0:
             failures[feature['id'] + ' ' + scenario['id'] + ' ' + step['name']] = step['result']['duration']
           index = index + 1
-
+      if 'after' in scenario:
+          for after in scenario['after']:
+              print('    {0:<7} {1: >13} {2}'.format('after', after['result']['duration'], after['match']['location']))
 ninezeros = 1000000000
 
 for key, value in failures.items():


### PR DESCRIPTION
### Context

Currently we don't print out detailed timings information for Cucumber scripts which will help in analysing why they take so long.

### Changes proposed in this pull request

Print detailed timing information (note the usage format is not detailed enough).

### Guidance to review

Note that the mount using the `-v` flag must be fully qualified and changed to something that is correct on your machine (it currently references my home directory)
 
    docker-compose -f docker-compose-selenium.yml up
    docker-compose run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-chrome -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL='http://school-experience:3000' -v /Users/peterfry/projects/schools-experience/reports:/app/reports school-experience cucumber  --format json --out reports/cucumber-chrome.json
    python script/check_timings.py reports/cucumber-chrome.json 5000000000
