### PR TITLE
Use the email address from a Schools profile if they have one

### DIFF
--- a/app/services/candidates/registrations/placement_request_action.rb
+++ b/app/services/candidates/registrations/placement_request_action.rb
@@ -37,7 +37,13 @@ module Candidates
       end
 
       def school_contact_email
-        registration_session.school.contact_email
+        if registration_session.school.profile &&
+            registration_session.school.profile.admin_contact_email.present?
+
+          registration_session.school.profile.admin_contact_email
+        else
+          registration_session.school.contact_email
+        end
       end
 
       def candidate_email

--- a/spec/services/candidates/registrations/placement_request_action_spec.rb
+++ b/spec/services/candidates/registrations/placement_request_action_spec.rb
@@ -120,6 +120,24 @@ describe Candidates::Registrations::PlacementRequestAction do
             registration_session.uuid
         end
       end
+
+      context 'candidate notification succeeds and school has a profile' do
+        before do
+          create :bookings_profile,
+            school: school,
+            admin_contact_email: 'profile@address.com'
+        end
+
+        before do
+          subject.perform!
+        end
+
+        it 'instantiates the school_request_confirmation correctly' do
+          expect(NotifyEmail::SchoolRequestConfirmation).to \
+            have_received(:from_application_preview)
+            .with(school.profile.admin_contact_email, application_preview)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

Schools are asked to supply a contact address as part of their onboarding process. This should be used to send the Placement Request email to.

### Changes proposed in this pull request

Use this address if it has been supplied



