### PR TITLE
Limit searches to England rather than GB

### DIFF
--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -29,6 +29,37 @@ describe Bookings::SchoolSearch do
         expect { Bookings::SchoolSearch.new(query: '', location: 'France') }.to raise_error(expected_error)
       end
     end
+
+    context 'Limiting to England' do
+      specify 'region should be England' do
+        expect(described_class::REGION).to eql('England')
+      end
+
+      context "when a result with name 'England' is returned" do
+        before do
+          allow(Geocoder).to receive(:search).and_return(
+            [
+              Geocoder::Result::Test.new(
+                "latitude" => 53.488,
+                "longitude" => -2.242,
+                name: 'England'
+              )
+            ]
+          )
+        end
+
+        after { Bookings::SchoolSearch.new(location: 'Mumbai') }
+
+        specify "should append the region to the Geocoder query" do
+          expect(Geocoder).to receive(:search)
+            .with('Mumbai, England', params: described_class::GEOCODER_PARAMS)
+        end
+
+        specify 'should return an empty result' do
+          expect(Rails.logger).to receive(:info).with(/No Geocoder results/)
+        end
+      end
+    end
   end
 
   describe '#results' do


### PR DESCRIPTION
This was more of an exploratory look into improving searches and isn't yet tied to a ticket.

### Context

Limiting searches to GB (#387) doesn't appear to have been _entirely_ successful.

The Bing API [makes it appear that setting the region to `UK` or `GB` should limit the searches to those areas respectively](https://docs.microsoft.com/en-us/bingmaps/rest-services/locations/find-a-location-by-address), and Geocoder [should pass the param through to the search API](https://github.com/alexreisner/geocoder/blob/master/lib/geocoder/lookups/bing.rb#L23). However, we still appear to get results from further afield back.

### Changes proposed in this pull request

Rather than try specifying country codes that aren't really suitable for our (England-only) service, we can _ensure_ results are limited to England by adding ", England" onto the search query sent to Bing. This isn't surfaced to the user anywhere, but it provides an extra level of safety from non-useful results.

### Guidance to review

Ensure searching still works as expected and results are accurate. It looks to me like it is, here's a before and after, each time searching for **Boston**.

![Screenshot 2019-05-10 at 08 53 56](https://user-images.githubusercontent.com/128088/57511596-8b418800-7301-11e9-984c-5cc420f099ca.png)

![Screenshot 2019-05-10 at 08 40 37](https://user-images.githubusercontent.com/128088/57511684-bcba5380-7301-11e9-8704-94a998431b49.png)


