### PR TITLE
Add instructions and change school link to 'not registered' error

### DIFF
--- a/app/views/schools/errors/not_registered/show.html.erb
+++ b/app/views/schools/errors/not_registered/show.html.erb
@@ -16,5 +16,14 @@
       </a>
     </p>
 
+    <section>
+      <p>
+        If you administer other schools that are already signed up you can change to that school
+      </p>
+      <div>
+        <%= link_to "Change school", new_schools_switch_path, class: 'govuk-button' %>
+      </div>
+    </section>
+
   </div>
 </div>

--- a/features/schools/errors/not_registered.feature
+++ b/features/schools/errors/not_registered.feature
@@ -1,0 +1,12 @@
+Feature: The school not registered error page
+    So I know my school hasn't been registered with School Experience
+    As an administrator from an unregistered school
+    I want to see some informative instructions
+
+    Scenario: Email address
+        Given I am on the 'not registered error' page
+        Then I should see a email link to 'organise.school-experience@education.gov.uk'
+
+    Scenario: Change school link
+        Given I am on the 'not registered error' page
+        Then I should see a 'Change school' link to the 'change school' page

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -77,3 +77,6 @@ Then("I should see the following breadcrumbs:") do |table|
   end
 end
 
+Then("I should see a email link to {string}") do |string|
+  expect(page).to have_link(string, href: "mailto:#{string}")
+end

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -38,7 +38,9 @@ def path_for(descriptor, school: nil, placement_date_id: nil)
     "availability description" => [:new_schools_on_boarding_availability_description_path],
     "admin contact" => [:new_schools_on_boarding_admin_contact_path],
     "profile" => [:schools_on_boarding_profile_path],
-    "toggle requests" => [:edit_schools_enabled_path]
+    "toggle requests" => [:edit_schools_enabled_path],
+    "not registered error" => [:schools_errors_not_registered_path],
+    "change school" => [:new_schools_switch_path]
   }
 
   (path = mappings[descriptor.downcase]) ? send(*path) : fail("No mapping for #{descriptor}")


### PR DESCRIPTION
### Context

Users reach a dead end if they pick a school not registered with our service

### Changes proposed in this pull request

Add a 'Change school' link to the error page

### Guidance to review

Ensure it looks sensible. It's the exact same path used by the corresponding link used on the dashlette and works in exactly the same manner.
