### PR TITLE
Allow override of main site header

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -5,6 +5,7 @@ module Schools
     include DFEAuthentication
     before_action :require_auth
     before_action :set_current_school
+    before_action :set_site_header_text
 
     rescue_from ActionController::ParameterMissing, with: -> { redirect_to schools_errors_no_school_path }
     rescue_from SchoolNotRegistered, with: -> { redirect_to schools_errors_not_registered_path }
@@ -17,6 +18,10 @@ module Schools
       @current_school ||= retrieve_school(urn)
     end
     alias_method :set_current_school, :current_school
+
+    def set_site_header_text
+      @site_header_text = "Manage school experience"
+    end
 
   private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,10 @@ module ApplicationHelper
     end
   end
 
+  def site_header_text
+    @site_header_text || "Get school experience"
+  end
+
   def breadcrumbs
     content_for(:breadcrumbs)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Get school experience", root_path, class: 'govuk-header__link govuk-header__link--service-name' %>
+          <%= link_to site_header_text, root_path, class: 'govuk-header__link govuk-header__link--service-name' %>
         </div>
       </div>
     </header>

--- a/features/candidates/landing_page.feature
+++ b/features/candidates/landing_page.feature
@@ -3,6 +3,10 @@ Feature: Candidate landing page
     As a potential candidate
     I want to read an overview of the what the service offers
 
+    Scenario: Site header
+        Given I am on the 'landing' page
+        Then the main site header should be 'Get school experience'
+
     Scenario: Page heading
         Given I am on the 'landing' page
         Then the page's main header should be 'Get school experience'

--- a/features/candidates/splash_page.feature
+++ b/features/candidates/splash_page.feature
@@ -7,6 +7,10 @@ Feature: Candidate splash page
         Given I am on the 'splash' page
         Then the page's main header should be 'How the service works'
 
+    Scenario: Site header
+        Given I am on the 'splash' page
+        Then the main site header should be 'Get school experience'
+
     Scenario: The continue button
         Given I am on the 'splash' page
         When I click the 'Continue' button

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -6,7 +6,9 @@ Feature: The School Dashboard
     Background:
         Given I am logged in as a DfE user
 
-    # FIXME back link? Back to where?
+    Scenario: Site header
+        Given I am on the 'schools dashboard' page
+        Then the main site header should be 'Manage school experience'
 
     Scenario: Root redirect
         Given I navigate to the 'schools' path

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -80,3 +80,10 @@ end
 Then("I should see a email link to {string}") do |string|
   expect(page).to have_link(string, href: "mailto:#{string}")
 end
+
+Then("the main site header should be {string}") do |title_text|
+  expect(page).to have_css(
+    ".govuk-header .govuk-header__content .govuk-header__link--service-name",
+    text: title_text
+  )
+end


### PR DESCRIPTION
### Context

The schools' half of the application is known as 'Manage school experience' but the heading on the site currently is always 'Get school experience'.

### Changes proposed in this pull request

Make the header default to 'Get school experience' but override it in `Schools::BaseController` so it'll be 'Manage School Experience'.

### Guidance to review

Ensure it works and the change is made in a sensible manner. I was thinking about using `content_for` like we do elsewhere but that doesn't look accessible from controllers 🤷🏽‍♂️
