### PR TITLE
Remove Node.js from Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:2.5.5
+############# DEPLOY IMAGE ####################
+
+FROM ruby:2.5.5 AS deploy
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \
@@ -14,6 +16,16 @@ ENTRYPOINT ["bundle", "exec"]
 CMD ["rails", "server" ]
 HEALTHCHECK CMD bin/check_health.sh || exit 1
 
+# Install Gems removing artifacts
+COPY .ruby-version Gemfile Gemfile.lock ./
+RUN bundle install --without development --jobs=$(nproc --all) && \
+    rm -rf /root/.bundle/cache && \
+    rm -rf /usr/local/bundle/cache
+
+############# BUILD IMAGE #######################
+
+FROM deploy AS build
+
 # Install node, leaving as few artifacts as possible
 RUN apt-get update && apt-get install apt-transport-https && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
@@ -28,15 +40,18 @@ RUN apt-get update && apt-get install apt-transport-https && \
 COPY package.json yarn.lock ./
 RUN yarn install && yarn cache clean
 
-# Install Gems removing artifacts
-COPY .ruby-version Gemfile Gemfile.lock ./
-RUN bundle install --without development --jobs=$(nproc --all) && \
-    rm -rf /root/.bundle/cache && \
-    rm -rf /usr/local/bundle/cache
-
 # Add code and compile assets
 COPY . .
 RUN bundle exec rake assets:precompile SECRET_KEY_BASE=stubbed SKIP_REDIS=true
 
 # Create symlinks for CSS files without digest hashes for use in error pages
 RUN bundle exec rake assets:symlink_non_digested SECRET_KEY_BASE=stubbed SKIP_REDIS=true
+
+############# FINISH DEPLOY IMAGE ####################
+
+FROM deploy
+
+# Add code and compiled assets from build stage
+COPY . .
+COPY --from=build /app/public/assets /app/public/assets
+COPY --from=build /app/public/packs /app/public/packs

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,3 +55,6 @@ FROM deploy
 COPY . .
 COPY --from=build /app/public/assets /app/public/assets
 COPY --from=build /app/public/packs /app/public/packs
+
+# Dual purpose - symlink directories, also build the BootSnap cache
+RUN bundle exec rake assets:symlink_packs SECRET_KEY_BASE=stubbed SKIP_REDIS=true

--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,6 @@ gem 'puma', '~> 3.12'
 gem 'sassc-rails'
 gem "autoprefixer-rails"
 
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
-
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker'
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ gem 'puma', '~> 3.12'
 
 # Use SCSS for stylesheets
 gem 'sassc-rails'
-gem "autoprefixer-rails"
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,8 +71,6 @@ GEM
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
-    autoprefixer-rails (9.6.1)
-      execjs
     backports (3.13.0)
     bindata (2.4.4)
     bindex (0.7.0)
@@ -145,7 +143,6 @@ GEM
     exception_notification (4.3.0)
       actionmailer (>= 4.0, < 6)
       activesupport (>= 4.0, < 6)
-    execjs (2.7.0)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
     factory_bot_rails (5.0.2)
@@ -429,7 +426,6 @@ DEPENDENCIES
   acts_as_list
   addressable
   application_insights!
-  autoprefixer-rails
   bootsnap (>= 1.1.0)
   brakeman (>= 4.4.0)
   breasal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,8 +388,6 @@ GEM
     timeliness (0.4.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    uglifier (4.1.20)
-      execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.4)
     unicode-display_width (1.4.1)
     uniform_notifier (1.12.1)
@@ -479,7 +477,6 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
-  uglifier (>= 1.3.0)
   uk_postcode
   validates_timeliness (~> 5.0.0.alpha4)
   web-console (>= 3.3.0)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@
 - SassC (replacement for deprecated sass-rails)
 - [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend)
 - [GOV.UK Lint](https://github.com/alphagov/govuk-lint)
-- Autoprefixer rails
 - RSpec
 - Dotenv (managing environment variables)
 - Dockerfile to package app for deployment

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,15 +20,17 @@ steps:
   - script: docker run --name=redis -d $(REDIS_IMAGE)
     displayName: Launch Redis # done early to give it time to boot
 
-  - script: docker pull $(DOCKER_HUB_REPO):latest || true
+  - script: docker pull $(DOCKER_HUB_REPO):build || true
     displayName: Retrieve latest Docker build to use as cache
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - script: docker build -f Dockerfile --cache-from=$(DOCKER_HUB_REPO):latest -t $(DOCKER_HUB_REPO):$(imageTag) .
+  - script: docker build -f Dockerfile --cache-from=$(DOCKER_HUB_REPO):build -t $(DOCKER_HUB_REPO):$(imageTag) .
     displayName: Build Docker Image using Cache
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - script: docker build -f Dockerfile -t $(DOCKER_HUB_REPO):$(imageTag) .
+  - script: |
+      docker build -f Dockerfile --target=build -t $(DOCKER_HUB_REPO):build .
+      docker build -f Dockerfile -t $(DOCKER_HUB_REPO):$(imageTag) .
     displayName: Build Docker Image without Cache
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
@@ -91,6 +93,15 @@ steps:
       repository: $(DOCKER_HUB_REPO)
       command: push
       tags: latest
+
+  - task: Docker@2
+    displayName: 'push to docker hub'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    inputs:
+      containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
+      repository: $(DOCKER_HUB_REPO)
+      command: push
+      tags: build
 
   - task: CopyFiles@2
     inputs:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   }
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+# config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.

--- a/lib/tasks/assets/symlink_packs.rake
+++ b/lib/tasks/assets/symlink_packs.rake
@@ -1,0 +1,9 @@
+namespace :assets do
+  desc "Symlink production packs for use in test environments"
+  task symlink_packs: :environment do
+    production_packs = Rails.root.join('public', 'packs')
+    test_packs = Rails.root.join('public', 'packs-test')
+
+    File.symlink production_packs, test_packs
+  end
+end


### PR DESCRIPTION
### Context

We currently ship NodeJS as part of the docker image. This is not needed apart from asset compilation, removing this reduces the size and attack surface of the image. It also sets us up for future optimisations

### Changes proposed in this pull request

Remove the ExecJS dependency, Gems relying on it and NodeJS supplying it.

### Guidance to review

Does it still run!
