### PR TITLE
Removes not null constraint on experience_details

### DIFF
--- a/db/migrate/20190510173936_allow_null_for_bookings_profiles_experience_details.rb
+++ b/db/migrate/20190510173936_allow_null_for_bookings_profiles_experience_details.rb
@@ -1,0 +1,5 @@
+class AllowNullForBookingsProfilesExperienceDetails < ActiveRecord::Migration[5.2]
+  def change
+    change_column :bookings_profiles, :experience_details, :text, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -9,7 +9,8 @@
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
 # It's strongly recommended that you check this file into your version control system.
-ActiveRecord::Schema.define(version: 2019_05_07_145858) do
+
+ActiveRecord::Schema.define(version: 2019_05_10_173936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,7 +76,7 @@ ActiveRecord::Schema.define(version: 2019_05_07_145858) do
     t.string "start_time", null: false
     t.string "end_time", null: false
     t.boolean "flexible_on_times", null: false
-    t.text "experience_details", null: false
+    t.text "experience_details"
     t.text "teacher_training_info"
     t.string "teacher_training_url"
     t.string "admin_contact_full_name", null: false


### PR DESCRIPTION
We’ve removed the validation on ExperienceOutline#candidate_experience
(to allow admins to complete this at a later date) but we still have a
not null constraint on Bookings::Profile#experience_details which this
field is mapped to by Bookings::ProfileAttributesConvertor.

### Context

### Changes proposed in this pull request

### Guidance to review

