### PR TITLE
Add a more-generic login error page

### DIFF
--- a/app/controllers/schools/errors/auth_failed_controller.rb
+++ b/app/controllers/schools/errors/auth_failed_controller.rb
@@ -1,0 +1,7 @@
+module Schools
+  module Errors
+    class AuthFailedController < ApplicationController
+      def show; end
+    end
+  end
+end

--- a/app/views/schools/errors/auth_failed/show.html.erb
+++ b/app/views/schools/errors/auth_failed/show.html.erb
@@ -1,0 +1,24 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1>There was a problem signing you in</h1>
+
+    <section>
+      <p>
+        Please try to log in again.
+      </p>
+
+      <div>
+        <%= link_to "Log in again", new_schools_switch_path, class: 'govuk-button' %>
+      </div>
+    </section>
+
+    <p>
+      If you've tried several times and still can't log in please contact us
+      <a href="mailto:organise.school-experience@education.gov.uk">
+        organise.school-experience@education.gov.uk
+      </a>
+    </p>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
       namespace :errors do
         resource :not_registered, controller: :not_registered, only: :show
         resource :no_school, controller: :no_school, only: :show
+        resource :auth_failed, controller: :auth_failed, only: :show
       end
 
       namespace :on_boarding do


### PR DESCRIPTION
### Context

Login attempts that didn't go to plan (ie if a user reset their password mid-way through) resulted in them seeing an error page and hitting a dead end.

### Changes proposed in this pull request

Add `AuthFailedError` and `StateMissmatchError` classes and the `AuthFailedController`, which shows a more human-friendly error message. It contains details of who to contact if the problem persists.

### Guidance to review

Ensure changes look sensible