### PR TITLE
Replace FIXME placeholder with useful hint

### DIFF
--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -9,7 +9,6 @@
 
       <%- if @school.availability_preference_fixed? %>
 
-        <mark>FIXME add a caption</mark>
         <%= f.radio_button_fieldset :bookings_placement_date_id,
           choices: @placement_dates,
           value_method: :id,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -268,6 +268,7 @@ en:
       candidates_registrations_subject_preference:
         degree_subject: Select the nearest or equivalent subject.
       candidates_registrations_placement_preference:
+        bookings_placement_date_id: School experience is only available on the following days
         availability:
           - Tell us about your availability. For example, when you'll be
             available for placements or any particular days or periods when you

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
@@ -10,6 +10,7 @@ Feature: Request a school experience placement
         Given I am on the 'Request school experience placement' page for my school of choice
         When the school has 3 placements available in the upcoming weeks
         Then there should be a 'What do you want to get out of your school experience?' text area
+        And the "Bookings placement date" field should contain hint "School experience is only available on the following days"
 
     Scenario: Radio buttons
         Given the school has 3 placements available in the upcoming weeks

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -44,6 +44,12 @@ Given("there should be a hint stating {string}") do |string|
   expect(page).to have_css('.govuk-hint', text: string)
 end
 
+Then("the {string} field should contain hint {string}") do |label, hint|
+  within(get_form_group(page, label)) do
+    expect(page).to have_css('.govuk-hint', text: hint)
+  end
+end
+
 Then("I should see a select box containing degree subjects labelled {string}") do |string|
   @degree_subjects ||= YAML
     .load_file("#{Rails.root}/config/candidate_form_options.yml")['DEGREE_SUBJECTS']


### PR DESCRIPTION
### Context

Some placeholder text containing a `FIXME` was left in 🤦🏽‍♂️

### Changes proposed in this pull request

Replace it with a useful hint

### Guidance to review

Ensure text change looks sensible

