### PR TITLE
Fix bug where school updates dates as candidate views reg

### DIFF
--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -45,6 +45,10 @@ module Candidates
         ].compact.join(', ')
       end
 
+      def has_bookings_date?
+        @placement_preference.bookings_placement_date_id.present?
+      end
+
       def telephone_number
         phone
       end

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -44,7 +44,7 @@
         'School or college',
         @application_preview.school_name %>
 
-      <%- if @application_preview.school.availability_preference_fixed? -%>
+      <%- if @application_preview.has_bookings_date? -%>
 
         <%= summary_row \
           'Placement date',


### PR DESCRIPTION
Reference the type of placement date used for the registration rather
than the school'c current placement date type to avoid state mismatch
issue.

### Context

### Changes proposed in this pull request

### Guidance to review

