### PR TITLE
Use :latest instead of :phase2 image for build cache

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,11 +24,11 @@ steps:
   - script: docker run --name=redis -d $(REDIS_IMAGE)
     displayName: Launch Redis # done early to give it time to boot
 
-  - script: docker pull $(dockerRegistry)/$(imageName):phase2 || true
+  - script: docker pull $(dockerRegistry)/$(imageName):latest || true
     displayName: Retrieve latest Docker build to use as cache
     condition: and(ne(variables['Build.SourceBranch'], 'refs/heads/master'),ne(variables['Build.SourceBranch'], 'refs/heads/phase2'))
 
-  - script: docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):phase2 -t $(dockerRegistry)/$(imageName):$(imageTag) .
+  - script: docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):latest -t $(dockerRegistry)/$(imageName):$(imageTag) .
     displayName: Build Docker Image using Cache
     condition: and(ne(variables['Build.SourceBranch'], 'refs/heads/master'),ne(variables['Build.SourceBranch'], 'refs/heads/phase2'))
 


### PR DESCRIPTION
### Context

Currently we use the phase2 image as a build cache - the biggest speedup is the caching of Gems and the cache will stop being effective the first point we do a gem update on master.

### Changes proposed in this pull request

Use `master` (:latest tag in Docker) as the cache base instead



