### PR TITLE
Add validation on placement date dates

### DIFF
--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -5,13 +5,14 @@ module Bookings
       foreign_key: 'bookings_school_id'
 
     validates :bookings_school, presence: true
-    validates :date, presence: true
     validates :duration,
       presence: true,
       numericality: {
         greater_than_or_equal_to: 1,
         less_than: 100
       }
+    validates :date, presence: true
+    validate :date_must_be_in_the_future, on: :create
 
     scope :future, -> { where(arel_table[:date].gteq(Time.now)) }
     scope :past, -> { where(arel_table[:date].lt(Time.now)) }
@@ -27,6 +28,14 @@ module Bookings
         duration: duration,
         unit: "day".pluralize(duration)
       }
+    end
+
+  private
+
+    def date_must_be_in_the_future
+      if date.present? && date <= Date.today
+        errors.add(:date, "Date must be in the future")
+      end
     end
   end
 end

--- a/spec/factories/bookings/placement_dates.rb
+++ b/spec/factories/bookings/placement_dates.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
 
     trait :in_the_past do
       date { 6.weeks.ago }
+      to_create { |instance| instance.save(validate: false) }
     end
 
     trait :active do

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -28,12 +28,12 @@ describe Bookings::PlacementDate, type: :model do
         end
 
         context 'error messages' do
-          let(:message) { 'Date must be in the future' }
+          let(:message) { 'Validation failed: Date must be in the future' }
           let(:invalid_pd) { create(:bookings_placement_date, date: 3.weeks.ago) }
 
           specify 'should show a suitable error message' do
             expect { invalid_pd }.to(
-              raise_error(ActiveRecord::RecordInvalid, 'Validation failed: Date must be in the future')
+              raise_error(ActiveRecord::RecordInvalid, message)
             )
           end
         end


### PR DESCRIPTION
### Context

There was no validation (other than presence) on `Bookings::PlacementDate#date`.

### Changes proposed in this pull request

On new records, ensure `date` is in the future. Still allow older records to be modified, they shouldn't just become invalid when they expire

### Guidance to review

Ensure changes make sense
