### PR TITLE
Split full_name into first_name and last_name

### DIFF
--- a/app/controllers/candidates/registrations/contact_informations_controller.rb
+++ b/app/controllers/candidates/registrations/contact_informations_controller.rb
@@ -35,7 +35,8 @@ module Candidates
 
       def contact_information_params
         params.require(:candidates_registrations_contact_information).permit \
-          :full_name,
+          :first_name,
+          :last_name,
           :email,
           :building,
           :street,

--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -1,6 +1,8 @@
 module Candidates
   module Registrations
     class ContactInformation < RegistrationStep
+      attribute :first_name
+      attribute :last_name
       attribute :full_name
       attribute :email
       attribute :building
@@ -10,7 +12,8 @@ module Candidates
       attribute :postcode
       attribute :phone
 
-      validates :full_name, presence: true
+      validates :first_name, presence: true
+      validates :last_name, presence: true
       validates :phone, presence: true
       validates :phone, phone: true, if: -> { phone.present? }
       validates :email, presence: true
@@ -18,6 +21,20 @@ module Candidates
       validates :building, presence: true
       validates :postcode, presence: true
       validate :postcode_is_valid, if: -> { postcode.present? }
+
+      def full_name
+        full_name_attribute = super
+
+        if full_name_attribute.present?
+          return full_name_attribute
+        end
+
+        if first_name && last_name
+          return [first_name, last_name].map(&:to_s).join(' ')
+        end
+
+        nil
+      end
 
     private
 

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -13,7 +13,8 @@
         <%= form_for contact_information, url: candidates_school_registrations_contact_information_path do |f| %>
           <%= GovukElementsErrorsHelper.error_summary contact_information, 'There is a problem', '' %>
 
-          <%= f.text_field :full_name, autocomplete: 'on' %>
+          <%= f.text_field :first_name, autocomplete: 'given-name' %>
+          <%= f.text_field :last_name, autocomplete: 'family-name' %>
           <%= f.telephone_field :phone, autocomplete: 'on' %>
           <%= f.email_field :email, autocomplete: 'on' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,10 @@ en:
             email:
               blank: "Enter your email address"
               invalid: "Enter a valid email address"
+            first_name:
+              blank: 'Enter your first name'
+            last_name:
+              blank: 'Enter your last name'
             full_name:
               blank: "Enter your full name"
             phone:

--- a/features/candidates/registrations/contact_information.feature
+++ b/features/candidates/registrations/contact_information.feature
@@ -12,7 +12,8 @@ Feature: Contact Information
         Given I am on the 'Enter your contact details' page for my school of choice
         Then I should see a form with the following fields:
             | Label               | Type  |
-            | Full name           | text  |
+            | First name          | text  |
+            | Last name           | text  |
             | UK telephone number | tel   |
             | Email address       | email |
             | Building and street | text  |
@@ -23,7 +24,8 @@ Feature: Contact Information
     Scenario: Submitting my data
       Given I am on the 'Enter your contact details' page for my school of choice
         And I have entered the following details into the form:
-            | Full name           | Philip Gilbert         |
+            | First name          | Philip                 |
+            | Last name           | Gilbert                |
             | UK telephone number | 01234567890            |
             | Email address       | phil.gilbert@gmail.com |
             | Building and street | 221B           |

--- a/features/candidates/registrations/wizard.feature
+++ b/features/candidates/registrations/wizard.feature
@@ -7,13 +7,13 @@ Feature: Persisting registration information on navigating away
     Given I'm applying for a school
 
   Scenario: Returning to the wizard
-      Given I have completed the placement preference form
-      And I have completed the contact information form
-      And I have completed the subject preference form
-      And I have completed the background check form
-      And I have navigated away from the wizard
-      When I come back to the wizard
-      Then the placement preference form should populated with the details I've entered so far
-      And  the contact information form should populated with the details I've entered so far
-      And  the subject preference form should populated with the details I've entered so far
-      And  the background check form should populated with the details I've entered so far
+    Given I have completed the placement preference form
+    And I have completed the contact information form
+    And I have completed the subject preference form
+    And I have completed the background check form
+    And I have navigated away from the wizard
+    When I come back to the wizard
+    Then the placement preference form should populated with the details I've entered so far
+    And  the contact information form should populated with the details I've entered so far
+    And  the subject preference form should populated with the details I've entered so far
+    And  the background check form should populated with the details I've entered so far

--- a/features/step_definitions/candidates/registrations/application_preview_steps.rb
+++ b/features/step_definitions/candidates/registrations/application_preview_steps.rb
@@ -22,7 +22,8 @@ end
 
 Given("I have filled in my contact information successfully") do
   # Submit contact information form successfully
-  fill_in 'Full name', with: 'testy mctest'
+  fill_in 'First name', with: 'testy'
+  fill_in 'Last name', with: 'mctest'
   fill_in 'Email address', with: 'test@example.com'
   fill_in 'Building', with: 'Test house'
   fill_in 'Street', with: 'Test street'

--- a/features/step_definitions/candidates/registrations/wizard_steps.rb
+++ b/features/step_definitions/candidates/registrations/wizard_steps.rb
@@ -13,7 +13,8 @@ end
 
 Given("I have completed the contact information form") do
   visit path_for 'enter your contact details', school: @school
-  fill_in 'Full name', with: 'testy mctest'
+  fill_in 'First name', with: 'testy'
+  fill_in 'Last name', with: 'mctest'
   fill_in 'Email address', with: 'test@example.com'
   fill_in 'Building', with: 'Test house'
   fill_in 'Street', with: 'Test street'
@@ -58,7 +59,8 @@ end
 
 Then("the contact information form should populated with the details I've entered so far") do
   visit path_for 'enter your contact details', school: @school
-  expect(find_field('Full name').value).to eq 'testy mctest'
+  expect(find_field('First name').value).to eq 'testy'
+  expect(find_field('Last name').value).to eq 'mctest'
   expect(find_field('Email address').value).to eq 'test@example.com'
   expect(find_field('Building').value).to eq 'Test house'
   expect(find_field('Street').value).to eq 'Test street'

--- a/spec/factories/candidates/registrations/contact_information_factory.rb
+++ b/spec/factories/candidates/registrations/contact_information_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :contact_information, class: Candidates::Registrations::ContactInformation do
-    full_name { 'Testy McTest' }
+    first_name { 'Testy' }
+    last_name { 'Mc Test' }
     email { 'test@example.com' }
     building { 'New house' }
     street { 'Test street' }

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -7,7 +7,8 @@ FactoryBot.define do
 
       candidates_registrations_contact_information do
         {
-          "full_name"    => 'Testy McTest',
+          "first_name"   => 'Testy',
+          "last_name"    => 'McTest',
           "email"        => 'test@example.com',
           "building"     => "Test building",
           "street"       => "Test street",

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -63,12 +63,14 @@ feature 'Candidate Registrations', type: :feature do
       "/candidates/schools/#{school_urn}/registrations/contact_information/new"
 
     # Submit contact information form with errors
-    fill_in 'Full name', with: 'testy mctest'
+    fill_in 'First name', with: 'testy'
+    fill_in 'Last name', with: 'mctest'
     click_button 'Continue'
     expect(page).to have_text 'There is a problem'
 
     # Submit contact information form successfully
-    fill_in 'Full name', with: 'testy mctest'
+    fill_in 'First name', with: 'testy'
+    fill_in 'Last name', with: 'mctest'
     fill_in 'Email address', with: 'test@example.com'
     fill_in 'Building', with: 'Test house'
     fill_in 'Street', with: 'Test street'

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -5,6 +5,8 @@ describe Candidates::Registrations::ContactInformation, type: :model do
 
   context 'attributes' do
     it { is_expected.to respond_to :full_name }
+    it { is_expected.to respond_to :first_name }
+    it { is_expected.to respond_to :last_name }
     it { is_expected.to respond_to :email }
     it { is_expected.to respond_to :building }
     it { is_expected.to respond_to :street }
@@ -15,7 +17,8 @@ describe Candidates::Registrations::ContactInformation, type: :model do
   end
 
   context 'validations' do
-    it { is_expected.to validate_presence_of :full_name }
+    it { is_expected.to validate_presence_of :first_name }
+    it { is_expected.to validate_presence_of :last_name }
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_presence_of :building }
     it { is_expected.to validate_presence_of :postcode }
@@ -149,6 +152,34 @@ describe Candidates::Registrations::ContactInformation, type: :model do
           it "permits #{postcode}" do
             expect(subject.errors[:postcode]).to eq ['Enter your postcode']
           end
+        end
+      end
+    end
+  end
+
+  context '#full_name' do
+    context 'when first_name last_name attributes are set' do
+      subject { described_class.new first_name: 'Testy', last_name: 'McTest' }
+
+      it 'returns combined first_name last_name' do
+        expect(subject.full_name).to eq 'Testy McTest'
+      end
+    end
+
+    context 'when first_name last_name attributes are not set' do
+      context 'when full_name is not set' do
+        subject { described_class.new }
+
+        it 'returns nil' do
+          expect(subject.full_name).to eq nil
+        end
+      end
+
+      context 'when full_name is set' do
+        subject { described_class.new full_name: 'Testy McTest' }
+
+        it 'returns the value for the full_name attribute' do
+          expect(subject.full_name).to eq 'Testy McTest'
         end
       end
     end


### PR DESCRIPTION
In order to integrate with the CRM we need to provide a first name and
last name. This commit updates the candidate registration wizard to
capture first name and last name rather than full name.

### Context

### Changes proposed in this pull request

### Guidance to review
Should look sensible and backwards compatible. 
There is one edge case: if a candidate has completed the contact details screen and we push the update before they submit their application, they will get stuck on the application preview screen. There is a [ticket](https://dfedigital.atlassian.net/browse/SE-1006) to address this, it's currently blocked waiting for [this PR ](https://github.com/DFE-Digital/schools-experience/pull/429) to be merged