### PR TITLE
GiTiS CRM test suite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,11 +59,11 @@ gem 'phonelib'
 gem 'sentry-raven'
 
 gem 'rack-rewrite'
+gem 'rack-timeout'
 
 gem 'openid_connect'
 gem 'uk_postcode'
-
-gem 'rack-timeout'
+gem 'faraday'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
     msgpack (1.2.10)
     multi_json (1.13.1)
     multi_test (0.1.2)
-    multipart-post (2.0.0)
+    multipart-post (2.1.0)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -434,6 +434,7 @@ DEPENDENCIES
   dotenv-rails
   exception_notification
   factory_bot_rails
+  faraday
   font-awesome-rails
   foreman
   geocoder

--- a/lib/apimock/gitis_crm.rb
+++ b/lib/apimock/gitis_crm.rb
@@ -1,0 +1,222 @@
+module Apimock
+  class GitisCrm
+    def stub_contact_request(uuid, params = {})
+      stub_request(:get, "#{service_url}#{endpoint}/contacts(#{uuid})").
+        with(headers: get_headers).
+        to_return(
+          status: 200,
+          headers: {
+            'Content-Type' => 'application/json; odata.metadata=minimal',
+          },
+          body: contact_data.merge(
+            '@odata.context' => "#{service_url}#{endpoint}/$metadata#contacts/$entity",
+            'contactid' => uuid
+          ).merge(params.stringify_keys).to_json
+        )
+    end
+
+    def stub_contact_listing_request(uuid = SecureRandom.uuid)
+      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=1").
+        with(headers: get_headers).
+        to_return(
+          status: 200,
+          headers: {
+            'Content-Type' => 'application/json; odata.metadata=minimal',
+          },
+          body: {
+            "@odata.context" => "#{service_url}#{endpoint}/$metadata#contacts",
+            "value" => [contact_data.merge('contactid' => uuid)]
+          }.to_json
+        )
+    end
+
+    def stub_access_token
+      stub_request(:post, "#{auth_url}/#{auth_tenant_id}/oauth2/token").
+        with(
+          headers: { 'Accept' => 'application/json' },
+          body: {
+            "grant_type" => "client_credentials",
+            "scope" => "",
+            "client_id" => client_id,
+            "client_secret" => client_secret,
+            "resource" => service_url,
+          }.to_query
+        ).
+        to_return(
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' },
+          body: {
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+            'resource' => service_url,
+            'access_token' => "MY.STUB.TOKEN"
+          }.to_json
+        )
+    end
+
+    def stub_create_contact_request(params)
+      stub_request(:post, "#{service_url}#{endpoint}/contacts").
+        with(headers: post_headers, body: params.to_json).
+        to_return(
+          status: 204,
+          headers: {
+            'content-type' => 'application/json',
+            'odata-entityid' => "#{service_url}#{endpoint}/contacts(#{SecureRandom.uuid})"
+          },
+          body: ''
+        )
+    end
+
+    def stub_update_contact_request(uuid, params)
+      stub_request(:patch, "#{service_url}#{endpoint}/contacts(#{uuid})").
+        with(headers: post_headers, body: params.to_json).
+        to_return(
+          status: 204,
+          headers: { 'content-type' => 'application/json' },
+          body: ''
+        )
+    end
+
+    def stub_create_school_experience_request(params)
+      stub_request(:post, "#{service_url}#{endpoint}/dfe_candidateschoolexperiences").
+        with(headers: post_headers, body: params.to_json).
+        to_return(
+          status: 204,
+          headers: {
+            'content-type' => 'application/json',
+            'odata-entityid' => "#{service_url}#{endpoint}/dfe_candidateschoolexperiences(#{SecureRandom.uuid})"
+          },
+          body: ''
+        )
+    end
+
+    def stub_school_experience_request(uuid, params = {})
+      stub_request(:get, "#{service_url}#{endpoint}/dfe_candidateschoolexperiences(#{uuid})").
+        with(headers: get_headers).
+        to_return(
+          status: 200,
+          headers: {
+            'Content-Type' => 'application/json; odata.metadata=minimal',
+          },
+          body: {
+            '@odata.context' => "#{service_url}#{endpoint}/$metadata#contacts/$entity",
+            'dfe_candidateschoolexperienceid' => uuid,
+            'dfe_notes' => 'test suite'
+          }.merge(params.stringify_keys).to_json
+        )
+    end
+
+    def stub_update_school_experience_request(uuid, params)
+      stub_request(:patch, "#{service_url}#{endpoint}/dfe_candidateschoolexperiences(#{uuid})").
+        with(headers: post_headers, body: params.to_json).
+        to_return(
+          status: 204,
+          headers: { 'content-type' => 'application/json' },
+          body: ''
+        )
+    end
+
+    def stub_attach_school_experience_request(contact_id, experience_id)
+      stub_request(:post, "#{service_url}#{endpoint}/contacts(#{contact_id})/dfe_contact_dfe_candidateschoolexperience_ContactId/$ref").
+        with(headers: post_headers, body: {
+          "@odata.id" => "#{service_url}#{endpoint}/dfe_candidateschoolexperiences(#{experience_id})"
+        }.to_json).
+        to_return(
+          status: 204,
+          headers: { 'content-type' => 'application/json' },
+          body: ''
+        )
+    end
+
+    def stub_expanded_contact_request(contact_id, experience_id, contact_params = {}, experience_params = {})
+      stub_request(:get, "#{service_url}#{endpoint}/contacts(#{contact_id})?$expand=dfe_contact_dfe_candidateschoolexperience_ContactId").
+        with(headers: get_headers).
+        to_return(
+          status: 200,
+          headers: {
+            'Content-Type' => 'application/json; odata.metadata=minimal',
+          },
+          body: {
+            '@odata.context' => "#{service_url}#{endpoint}/$metadata#contacts/$entity",
+            'contactid' => contact_id,
+            'firstname' => 'first name',
+            'lastname' => 'last name',
+            'dfe_contact_dfe_candidateschoolexperience_ContactId' => [
+              {
+                'dfe_candidateschoolexperienceid' => experience_id,
+                'dfe_notes' => 'Some notes'
+              }.merge(experience_params.stringify_keys)
+            ]
+          }.merge(contact_params.stringify_keys).to_json
+        )
+    end
+
+  private
+
+    def stub_request(method, uri)
+      WebMock::StubRegistry.instance.
+        register_request_stub(WebMock::RequestStub.new(method, uri))
+    end
+
+    def auth_url
+      "https://login.microsoftonline.com"
+    end
+
+    def service_url
+      ENV.fetch('CRM_SERVICE_URL')
+    end
+
+    def client_id
+      ENV.fetch('CRM_CLIENT_ID')
+    end
+
+    def client_secret
+      ENV.fetch('CRM_CLIENT_SECRET')
+    end
+
+    def auth_tenant_id
+      ENV.fetch('CRM_AUTH_TENANT_ID')
+    end
+
+    def endpoint
+      "/api/data/v9.1"
+    end
+
+    def get_headers
+      {
+        'Accept' => 'application/json',
+        'Authorization' => /Bearer \w+\.\w+\.\w/,
+        "OData-MaxVersion" => "4.0",
+        "OData-Version" => "4.0",
+      }
+    end
+
+    def post_headers
+      {
+        'Accept' => 'application/json',
+        'Authorization' => /Bearer \w+\.\w+\.\w/,
+        "OData-MaxVersion" => "4.0",
+        "OData-Version" => "4.0",
+        "Content-Type" => "application/json"
+      }
+    end
+
+    def contact_data
+      {
+        'firstname' => "Test User",
+        'lastname' => "TestUser",
+        'emailaddress1' => "school-experience-testuser@education.gov.uk",
+        'mobilephone' => "07123456789",
+        'telephone1' => "01234567890",
+        'address1_line1' => "First Address Line",
+        'address1_line2' => "Second Address Line",
+        'address1_line3' => "Third Address Line",
+        'address1_city' => "Manchester",
+        'address1_stateorprovince' => "",
+        'address1_postalcode' => "MA1 1AM",
+        'statecode' => 0,
+        'dfe_channelcreation' => 222750021
+      }
+    end
+  end
+end

--- a/lib/tasks/external_specs.rake
+++ b/lib/tasks/external_specs.rake
@@ -1,20 +1,22 @@
-namespace :spec do
-  desc "Run API Specs against external APIs, both read and write"
-  RSpec::Core::RakeTask.new(external: "spec:prepare") do |t|
-    t.pattern = "./spec_external/*_spec.rb"
-  end
-
-  namespace :external do
-    desc "Run API Specs against external APIs, only read"
-    RSpec::Core::RakeTask.new(read: "spec:prepare") do |t|
+if Object.const_defined?('RSpec')
+  namespace :spec do
+    desc "Run API Specs against external APIs, both read and write"
+    RSpec::Core::RakeTask.new(external: "spec:prepare") do |t|
       t.pattern = "./spec_external/*_spec.rb"
-      t.rspec_opts = "--tag=read"
     end
 
-    desc "Run API Specs against external APIs, only write"
-    RSpec::Core::RakeTask.new(write: "spec:prepare") do |t|
-      t.pattern = "./spec_external/*_spec.rb"
-      t.rspec_opts = "--tag=write"
+    namespace :external do
+      desc "Run API Specs against external APIs, only read"
+      RSpec::Core::RakeTask.new(read: "spec:prepare") do |t|
+        t.pattern = "./spec_external/*_spec.rb"
+        t.rspec_opts = "--tag=read"
+      end
+
+      desc "Run API Specs against external APIs, only write"
+      RSpec::Core::RakeTask.new(write: "spec:prepare") do |t|
+        t.pattern = "./spec_external/*_spec.rb"
+        t.rspec_opts = "--tag=write"
+      end
     end
   end
 end

--- a/lib/tasks/external_specs.rake
+++ b/lib/tasks/external_specs.rake
@@ -1,0 +1,20 @@
+namespace :spec do
+  desc "Run API Specs against external APIs, both read and write"
+  RSpec::Core::RakeTask.new(external: "spec:prepare") do |t|
+    t.pattern = "./spec_external/*_spec.rb"
+  end
+
+  namespace :external do
+    desc "Run API Specs against external APIs, only read"
+    RSpec::Core::RakeTask.new(read: "spec:prepare") do |t|
+      t.pattern = "./spec_external/*_spec.rb"
+      t.rspec_opts = "--tag=read"
+    end
+
+    desc "Run API Specs against external APIs, only write"
+    RSpec::Core::RakeTask.new(write: "spec:prepare") do |t|
+      t.pattern = "./spec_external/*_spec.rb"
+      t.rspec_opts = "--tag=write"
+    end
+  end
+end

--- a/spec_external/gitis_crm_spec.rb
+++ b/spec_external/gitis_crm_spec.rb
@@ -1,0 +1,227 @@
+require 'rails_helper'
+
+# This is an independent test suite which formalises my adhoc tests against the
+# GiTiS CRM system. It does not make use of the abstractions in the application
+# to ensure its only testing the API against our understanding of how it should
+# behave
+
+RSpec.describe "The GITIS CRM Api" do
+  before(:each) { WebMock.disable! }
+  after(:each) { WebMock.enable! }
+
+  let(:access_token) { retrieve_access_token }
+
+  it "can read the from the CRM", :read do
+    # Read the first contact
+    resp = crm_get("/contacts", "$top" => "1")
+
+    expect(resp.status).to eql(200)
+    expect(resp.headers).to include('content-type' => 'application/json; odata.metadata=minimal')
+
+    data = JSON.parse(resp.body)
+    expect(data['value'].length).to eql(1)
+    firstcontact = data['value'][0]
+    expect(firstcontact['contactid']).not_to be_blank
+
+    # Read the contact by Id
+    resp = crm_get("/contacts(#{firstcontact['contactid']})")
+
+    expect(resp.status).to eql(200)
+    expect(resp.headers).to include('content-type' => 'application/json; odata.metadata=minimal')
+
+    contact = JSON.parse(resp.body)
+    expect(contact['contactid']).to eql(firstcontact['contactid'])
+  end
+
+  it "can write to the CRM", :write do
+    # Create a new contact
+    resp = crm_post('/contacts', new_contact_data)
+    expect(resp.status).to eql(204)
+    expect(resp.headers['odata-entityid']).not_to be_nil
+
+    contact_url = resp.headers['odata-entityid']
+    expect(contact_url).to match(%r{#{service_url}#{endpoint}/contacts\([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\)})
+
+    contact_id = contact_url.gsub(%r{#{service_url}#{endpoint}/contacts\(([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\)}, '\1')
+
+    # Read Contact Back
+    resp = crm_get("/contacts(#{contact_id})")
+    expect(resp.status).to eql(200)
+
+    data = JSON.parse(resp.body)
+    expect(data).to include('contactid' => contact_id)
+    expect(data).to include('firstname' => new_contact_data['firstname'])
+    expect(data).to include('lastname' => new_contact_data['lastname'])
+
+    # Update the newly created contact
+    resp = crm_patch("/contacts(#{contact_id})", {
+      'lastname' => 'New Last Name'
+    })
+    expect(resp.status).to eql(204)
+
+    # Read Contact Back
+    resp = crm_get("/contacts(#{contact_id})")
+    expect(resp.status).to eql(200)
+
+    data = JSON.parse(resp.body)
+    expect(data).to include('contactid' => contact_id)
+    expect(data).to include('firstname' => new_contact_data['firstname'])
+    expect(data).to include('lastname' => "New Last Name")
+
+    # Create School Experience
+    resp = crm_post('/dfe_candidateschoolexperiences', {
+      'dfe_notes' => 'test suite'
+    })
+    expect(resp.status).to eql(204)
+    expect(resp.headers['odata-entityid']).not_to be_nil
+
+    experience_url = resp.headers['odata-entityid']
+    expect(experience_url).to match(%r{#{service_url}#{endpoint}/dfe_candidateschoolexperiences\([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\)})
+    experience_id = experience_url.gsub(%r{#{service_url}#{endpoint}/dfe_candidateschoolexperiences\(([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\)}, '\1')
+
+    # Read School Experience Back
+    resp = crm_get("/dfe_candidateschoolexperiences(#{experience_id})")
+    expect(resp.status).to eql(200)
+
+    data = JSON.parse(resp.body)
+    expect(data).to include('dfe_candidateschoolexperienceid' => experience_id)
+    expect(data).to include('dfe_notes' => "test suite")
+
+    # Update School Experience
+    resp = crm_patch("/dfe_candidateschoolexperiences(#{experience_id})", {
+      "dfe_notes" => "First Line\r\n\r\nSecond Line"
+    })
+    expect(resp.status).to eql(204)
+
+    resp = crm_get("/dfe_candidateschoolexperiences(#{experience_id})")
+    expect(resp.status).to eql(200)
+
+    data = JSON.parse(resp.body)
+    expect(data).to include('dfe_candidateschoolexperienceid' => experience_id)
+    expect(data).to include('dfe_notes' => "First Line\r\n\r\nSecond Line")
+
+    resp = crm_post("/contacts(#{contact_id})/dfe_contact_dfe_candidateschoolexperience_ContactId/$ref", {
+      "@odata.id" => "#{service_url}#{endpoint}/dfe_candidateschoolexperiences(#{experience_id})"
+    })
+    expect(resp.status).to eql(204)
+
+    resp = crm_get("/contacts(#{contact_id})?$expand=dfe_contact_dfe_candidateschoolexperience_ContactId")
+    expect(resp.status).to eql(200)
+
+    data = JSON.parse(resp.body)
+    expect(data).to include('contactid' => contact_id)
+    expect(data).to include('firstname' => new_contact_data['firstname'])
+
+    contact_se_data = data['dfe_contact_dfe_candidateschoolexperience_ContactId'][0]
+    expect(contact_se_data).to include('dfe_candidateschoolexperienceid' => experience_id)
+    expect(contact_se_data).to include('dfe_notes' => "First Line\r\n\r\nSecond Line")
+  end
+
+  private
+
+  def retrieve_access_token
+    params = {
+      "grant_type" => "client_credentials",
+      "scope" => "",
+      "client_id" => client_id,
+      "client_secret" => client_secret,
+      "resource" => service_url,
+    }
+
+    conn = Faraday.new(auth_url)
+    resp = conn.post do |req|
+      req.url "/#{auth_tenant_id}/oauth2/token"
+      req.headers['Accept'] = 'application/json'
+      req.body = params.to_query
+    end
+
+    token_data = JSON.parse(resp.body)
+    token_data['access_token']
+  end
+
+  def crm_get(url, params = nil)
+    combined = "#{endpoint}#{url}"
+    combined += "?#{params.to_query}" if params
+
+    conn = Faraday.new(service_url)
+    resp = conn.get do |req|
+      req.headers['Accept'] = 'application/json'
+      req.headers['Authorization'] = "Bearer #{access_token}"
+      req.headers["OData-MaxVersion"] = "4.0"
+      req.headers["OData-Version"] = "4.0"
+
+      req.url combined
+    end
+  end
+
+  def crm_post(url, params)
+    conn = Faraday.new(service_url)
+    resp = conn.post do |req|
+      req.headers['Accept'] = 'application/json'
+      req.headers['Authorization'] = "Bearer #{access_token}"
+      req.headers["OData-MaxVersion"] = "4.0"
+      req.headers["OData-Version"] = "4.0"
+      req.headers["Content-Type"] = "application/json"
+
+      req.url "#{endpoint}#{url}"
+      req.body = params.to_json
+    end
+  end
+
+  def crm_patch(url, params)
+    conn = Faraday.new(service_url)
+    resp = conn.patch do |req|
+      req.headers['Accept'] = 'application/json'
+      req.headers['Authorization'] = "Bearer #{access_token}"
+      req.headers["OData-MaxVersion"] = "4.0"
+      req.headers["OData-Version"] = "4.0"
+      req.headers["Content-Type"] = "application/json"
+
+      req.url "#{endpoint}#{url}"
+      req.body = params.to_json
+    end
+  end
+
+  def auth_url
+    "https://login.microsoftonline.com"
+  end
+
+  def service_url
+    ENV.fetch('CRM_SERVICE_URL')
+  end
+
+  def client_id
+    ENV.fetch('CRM_CLIENT_ID')
+  end
+
+  def client_secret
+    ENV.fetch('CRM_CLIENT_SECRET')
+  end
+
+  def auth_tenant_id
+    ENV.fetch('CRM_AUTH_TENANT_ID')
+  end
+
+  def endpoint
+    "/api/data/v9.1"
+  end
+
+  def new_contact_data
+    {
+      'firstname' => "Test User",
+      'lastname' => "TestUser",
+      'emailaddress1' => "school-experience-testuser@education.gov.uk",
+      'mobilephone' => "07123456789",
+      'telephone1' => "01234567890",
+      'address1_line1' => "First Address Line",
+      'address1_line2' => "Second Address Line",
+      'address1_line3' => "Third Address Line",
+      'address1_city' => "Manchester",
+      'address1_stateorprovince' => "",
+      'address1_postalcode' => "MA1 1AM",
+      'statecode' => 0,
+      'dfe_channelcreation' => 222750021
+    }
+  end
+
+end


### PR DESCRIPTION
### Context

Gitis CRM has a complex schema and permissions model. We need some means of verifying we have appropriate access to their API, and the Schema still matches our expectations.

### Changes proposed in this pull request

1. Add a separate test suite for external apis
  1. Adds `rails spec:external` to run all api tests
  2. Adds `rails spec:external:read` to run api tests which don't modify external services
  3. Adds `rails spec:external:write` to run api tests which **do** modify external services
2. Adds some helpers to mock out CRM api requests - this is intended for use as part of future CRM work but was developed tested against the new test suite in (1).

### Guidance to review
At this point its really just code checking - I can share credentials for running the read only parts if required.

