### PR TITLE
Support additional extension options

### DIFF
--- a/config/initializers/phonelib.rb
+++ b/config/initializers/phonelib.rb
@@ -1,1 +1,2 @@
 Phonelib.default_country = 'GB'
+Phonelib.extension_separate_symbols = %w(ext # ; extension)

--- a/spec/forms/schools/on_boarding/admin_contact_spec.rb
+++ b/spec/forms/schools/on_boarding/admin_contact_spec.rb
@@ -35,6 +35,16 @@ describe Schools::OnBoarding::AdminContact, type: :model do
           expect(subject.errors[:phone]).to be_empty
         end
       end
+
+      context 'correct format with extension' do
+        let :phone do
+          '01234567890 ext 123'
+        end
+
+        it 'is valid' do
+          expect(subject.errors[:phone]).to be_empty
+        end
+      end
     end
 
     context 'email address format' do


### PR DESCRIPTION
During research we observed users entering their phone number and
“ext 451” into the same field; this is their extension within the
school.

Add 'ext' and 'extension' to the list of supported extension symbols.
';' and '#' are the default extension separators.

### Context

### Changes proposed in this pull request

### Guidance to review

