### PR TITLE
Added Rack Timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ruby:2.5.5
 ENV RAILS_ENV=production \
     NODE_ENV=production \
     RAILS_SERVE_STATIC_FILES=true \
-    RAILS_LOG_TO_STDOUT=true
+    RAILS_LOG_TO_STDOUT=true \
+    RACK_TIMEOUT_SERVICE_TIMEOUT=120
 
 RUN mkdir /app
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem 'rack-rewrite'
 gem 'openid_connect'
 gem 'uk_postcode'
 
+gem 'rack-timeout'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,7 @@ GEM
     rack-rewrite (1.5.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-timeout (0.5.1)
     rails (5.2.3)
       actioncable (= 5.2.3)
       actionmailer (= 5.2.3)
@@ -444,6 +445,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.12)
   rack-rewrite
+  rack-timeout
   rails (~> 5.2.3)
   rails-controller-testing
   redis (~> 4.1)


### PR DESCRIPTION
### Context

The timeout is currently set really quite long but its only to handle
exceptional delays for now, we can bring it down to something more reasonable
later on.

### Changes proposed in this pull request

1. Add Rack Timeout to cancel requests which overrun the timeout. Defaults to 120 seconds when run from within Docker Container. Controllable via Env Var - RACK_TIMEOUT_SERVICE_TIMEOUT

