### PR TITLE
refactors candidate registration specs

### DIFF
--- a/spec/controllers/candidates/registrations/application_previews_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/application_previews_controller_spec.rb
@@ -2,27 +2,16 @@ require 'rails_helper'
 
 describe Candidates::Registrations::ApplicationPreviewsController, type: :request do
   include_context 'Stubbed candidates school'
-
-  let! :uncompleted_registration_session do
-    Candidates::Registrations::RegistrationSession.new({})
-  end
-
-  let! :completed_registration_session do
-    FactoryBot.build :registration_session
-  end
+  include_context 'Stubbed current_registration'
 
   context '#show' do
     before do
-      allow(Candidates::Registrations::RegistrationSession).to receive :new do
-        registration_session
-      end
-
       get '/candidates/schools/urn/registrations/application_preview'
     end
 
     context 'candidate skipped ahead' do
       let :registration_session do
-        uncompleted_registration_session
+        Candidates::Registrations::RegistrationSession.new({})
       end
 
       it 'redirects to the first missing step' do
@@ -33,7 +22,7 @@ describe Candidates::Registrations::ApplicationPreviewsController, type: :reques
 
     context 'candidate has not skipped ahead' do
       let :registration_session do
-        completed_registration_session
+        FactoryBot.build :registration_session
       end
 
       it 'renders the show template' do

--- a/spec/controllers/candidates/registrations/resend_confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/resend_confirmation_emails_controller_spec.rb
@@ -2,26 +2,24 @@ require 'rails_helper'
 
 describe Candidates::Registrations::ResendConfirmationEmailsController, type: :request do
   include_context 'Stubbed candidates school'
+  include_context 'Stubbed current_registration'
 
-  let! :registration_session do
+  let :registration_session do
     FactoryBot.build :registration_session
   end
 
   before do
     allow(Candidates::Registrations::SendEmailConfirmationJob).to \
       receive :perform_later
-
-    allow(Candidates::Registrations::RegistrationSession).to \
-      receive(:new) { registration_session }
-
-    Candidates::Registrations::RegistrationStore.instance.store! \
-      registration_session
   end
 
   context '#create' do
     context 'session found' do
       context 'session not pending email confirmation' do
         before do
+          Candidates::Registrations::RegistrationStore.instance.store! \
+            registration_session
+
           post candidates_school_registrations_resend_confirmation_email_path \
             registration_session.school
         end
@@ -40,6 +38,9 @@ describe Candidates::Registrations::ResendConfirmationEmailsController, type: :r
       context 'session pending email confirmation' do
         before do
           registration_session.flag_as_pending_email_confirmation!
+
+          Candidates::Registrations::RegistrationStore.instance.store! \
+            registration_session
 
           post candidates_school_registrations_resend_confirmation_email_path \
             registration_session.school
@@ -62,6 +63,9 @@ describe Candidates::Registrations::ResendConfirmationEmailsController, type: :r
     context 'session not found' do
       before do
         allow(ExceptionNotifier).to receive :notify_exception
+
+        Candidates::Registrations::RegistrationStore.instance.store! \
+          registration_session
 
         Candidates::Registrations::RegistrationStore.instance.delete! \
           registration_session.uuid

--- a/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_preferences_controller_spec.rb
@@ -2,34 +2,13 @@ require 'rails_helper'
 
 describe Candidates::Registrations::SubjectPreferencesController, type: :request do
   include_context 'Stubbed candidates school'
-
-  let! :date do
-    DateTime.now
-  end
+  include_context 'Stubbed current_registration'
 
   let :registration_session do
-    double Candidates::Registrations::RegistrationSession,
-      save: true,
-      subject_preference: existing_subject_preference,
-      subject_preference_attributes: subject_preference_attributes
-  end
-
-  before do
-    allow(DateTime).to receive(:now) { date }
-
-    allow(Candidates::Registrations::RegistrationSession).to \
-      receive(:new) { registration_session }
+    Candidates::Registrations::RegistrationSession.new({})
   end
 
   context 'without existing subject_preference in session' do
-    let :existing_subject_preference do
-      nil
-    end
-
-    let :subject_preference_attributes do
-      {}
-    end
-
     context '#new' do
       before do
         get '/candidates/schools/11048/registrations/subject_preference/new'
@@ -41,26 +20,26 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
     end
 
     context '#create' do
+      let :subject_preference_params do
+        {
+          candidates_registrations_subject_preference: \
+            subject_preference.attributes
+        }
+      end
+
       before do
         post '/candidates/schools/11048/registrations/subject_preference',
           params: subject_preference_params
       end
 
       context 'invalid' do
-        let :subject_preference_params do
-          {
-            candidates_registrations_subject_preference: {
-              degree_stage: "I don't have a degree and am not studying for one",
-              degree_subject: "geology &amp; earth science",
-              teaching_stage: "I’m very sure and think I’ll apply",
-              subject_first_choice: "Astronomy",
-              subject_second_choice: "History"
-            }
-          }
+        let :subject_preference do
+          Candidates::Registrations::SubjectPreference.new
         end
 
         it 'doesnt modify the session' do
-          expect(registration_session).not_to have_received(:save)
+          expect { registration_session.subject_preference }.to raise_error \
+            Candidates::Registrations::RegistrationSession::StepNotFound
         end
 
         it 'rerenders the new template' do
@@ -69,28 +48,13 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
       end
 
       context 'valid' do
-        let :subject_preference_params do
-          {
-            candidates_registrations_subject_preference: {
-              degree_stage: "I don't have a degree and am not studying for one",
-              degree_subject: "Not applicable",
-              teaching_stage: "I’m very sure and think I’ll apply",
-              subject_first_choice: "Astronomy",
-              subject_second_choice: "History"
-            }
-          }
+        let :subject_preference do
+          FactoryBot.build :subject_preference, urn: school.urn
         end
 
         it 'stores the subject_preference in the session' do
-          expect(registration_session).to have_received(:save).with \
-            Candidates::Registrations::SubjectPreference.new \
-              degree_stage: "I don't have a degree and am not studying for one",
-              degree_stage_explaination: nil,
-              degree_subject: "Not applicable",
-              teaching_stage: "I’m very sure and think I’ll apply",
-              subject_first_choice: "Astronomy",
-              subject_second_choice: "History",
-              urn: 11048
+          expect(registration_session.subject_preference).to \
+            eq_model subject_preference
         end
 
         it 'redirects to the next step' do
@@ -103,18 +67,11 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
 
   context 'with existing subject_preference in session' do
     let :existing_subject_preference do
-      Candidates::Registrations::SubjectPreference.new \
-        degree_stage: "I don't have a degree and am not studying for one",
-        degree_stage_explaination: nil,
-        degree_subject: "Not applicable",
-        teaching_stage: "I’m very sure and think I’ll apply",
-        subject_first_choice: "Astronomy",
-        subject_second_choice: "History",
-        urn: 11048
+      FactoryBot.build :subject_preference, urn: school.urn
     end
 
-    let :subject_preference_attributes do
-      existing_subject_preference.attributes
+    before do
+      registration_session.save existing_subject_preference
     end
 
     context '#new' do
@@ -123,7 +80,8 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
       end
 
       it 'populates the new form with values from the session' do
-        expect(assigns(:subject_preference)).to eq existing_subject_preference
+        expect(assigns(:subject_preference)).to \
+          eq_model existing_subject_preference
       end
 
       it 'renders the new template' do
@@ -137,7 +95,8 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
       end
 
       it 'populates the edit form with values from the session' do
-        expect(assigns(:subject_preference)).to eq existing_subject_preference
+        expect(assigns(:subject_preference)).to \
+          eq_model existing_subject_preference
       end
 
       it 'renders the edit template' do
@@ -146,26 +105,26 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
     end
 
     context '#update' do
+      let :subject_preference_params do
+        {
+          candidates_registrations_subject_preference: \
+            subject_preference.attributes
+        }
+      end
+
       before do
         patch '/candidates/schools/11048/registrations/subject_preference',
           params: subject_preference_params
       end
 
       context 'invalid' do
-        let :subject_preference_params do
-          {
-            candidates_registrations_subject_preference: {
-              degree_stage: "I don't have a degree and am not studying for one",
-              degree_subject: "Not applicable",
-              teaching_stage: "I’m very sure and think I’ll apply",
-              subject_first_choice: "Astrology",
-              subject_second_choice: "History"
-            }
-          }
+        let :subject_preference do
+          Candidates::Registrations::SubjectPreference.new
         end
 
         it 'doesnt modify the session' do
-          expect(registration_session).not_to have_received(:save)
+          expect(registration_session.subject_preference).to \
+            eq_model existing_subject_preference
         end
 
         it 'rerenders the edit template' do
@@ -174,29 +133,14 @@ describe Candidates::Registrations::SubjectPreferencesController, type: :request
       end
 
       context 'valid' do
-        let :subject_preference_params do
-          {
-            candidates_registrations_subject_preference: {
-              degree_stage: "Other",
-              degree_stage_explaination: 'Sabbatical',
-              degree_subject: "History",
-              teaching_stage: "I’m very sure and think I’ll apply",
-              subject_first_choice: "Astronomy",
-              subject_second_choice: "History"
-            }
-          }
+        let :subject_preference do
+          FactoryBot.build \
+            :subject_preference, :with_degree_stage_other, urn: school.urn
         end
 
         it 'updates the session with the new details' do
-          expect(registration_session).to have_received(:save).with \
-            Candidates::Registrations::SubjectPreference.new \
-              degree_stage: "Other",
-              degree_stage_explaination: 'Sabbatical',
-              degree_subject: "History",
-              teaching_stage: "I’m very sure and think I’ll apply",
-              subject_first_choice: "Astronomy",
-              subject_second_choice: "History",
-              urn: 11048
+          expect(registration_session.subject_preference).to \
+            eq_model subject_preference
         end
 
         it 'redirects to the application preview' do

--- a/spec/factories/candidates/registrations/background_check_factory.rb
+++ b/spec/factories/candidates/registrations/background_check_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :background_check, class: Candidates::Registrations::BackgroundCheck do
+    has_dbs_check { true }
+  end
+end

--- a/spec/factories/candidates/registrations/placement_preference_factory.rb
+++ b/spec/factories/candidates/registrations/placement_preference_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :placement_preference, class: Candidates::Registrations::PlacementPreference do
+    availability { 'Every second Friday' }
+    objectives { 'Become a teacher' }
+  end
+end

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       current_time { DateTime.current }
       urn { 11048 }
       placement_date { create(:bookings_placement_date) }
+      uuid { 'some-uuid' }
 
       candidates_registrations_contact_information do
         {
@@ -55,6 +56,7 @@ FactoryBot.define do
 
     initialize_with do
       new \
+        "uuid" => uuid,
         "candidates_registrations_contact_information"  => candidates_registrations_contact_information,
         "candidates_registrations_background_check"     => candidates_registrations_background_check,
         "candidates_registrations_placement_preference" => candidates_registrations_placement_preference,
@@ -64,6 +66,7 @@ FactoryBot.define do
     trait :with_placement_date do
       initialize_with do
         new \
+          "uuid" => uuid,
           "candidates_registrations_contact_information"  => candidates_registrations_contact_information,
           "candidates_registrations_background_check"     => candidates_registrations_background_check,
           "candidates_registrations_subject_preference"   => candidates_registrations_subject_preference,

--- a/spec/factories/candidates/registrations/subject_preference_factory.rb
+++ b/spec/factories/candidates/registrations/subject_preference_factory.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :subject_preference, class: Candidates::Registrations::SubjectPreference do
+    degree_stage { "I don't have a degree and am not studying for one" }
+    degree_stage_explaination { nil }
+    degree_subject { "Not applicable" }
+    teaching_stage { "I’m very sure and think I’ll apply" }
+    subject_first_choice { "Astronomy" }
+    subject_second_choice { "History" }
+
+    trait :with_degree_stage_other do
+      degree_stage { "Other" }
+      degree_stage_explaination { "Sabbatical" }
+      degree_subject { "History" }
+    end
+  end
+end

--- a/spec/services/candidates/registrations/registration_store_spec.rb
+++ b/spec/services/candidates/registrations/registration_store_spec.rb
@@ -6,11 +6,7 @@ describe Candidates::Registrations::RegistrationStore do
   end
 
   let :session do
-    FactoryBot.build :registration_session
-  end
-
-  before do
-    allow(SecureRandom).to receive(:urlsafe_base64) { 'sekret' }
+    FactoryBot.build :registration_session, uuid: 'sekret'
   end
 
   subject { described_class.instance }

--- a/spec/support/eq_model_matcher.rb
+++ b/spec/support/eq_model_matcher.rb
@@ -1,0 +1,10 @@
+RSpec::Matchers.define :eq_model do |expected|
+  match do |actual|
+    actual.attributes.except('created_at', 'updated_at') == \
+      expected.attributes.except('created_at', 'updated_at')
+  end
+
+  failure_message do |actual|
+    "expected #{actual.attributes.except('created_at', 'updated_at')} to == #{expected.attributes.except('created_at', 'updated_at')}"
+  end
+end

--- a/spec/support/stubbed_current_registration.rb
+++ b/spec/support/stubbed_current_registration.rb
@@ -1,0 +1,6 @@
+shared_context 'Stubbed current_registration' do
+  before do
+    allow_any_instance_of(described_class).to \
+      receive(:current_registration) { registration_session }
+  end
+end


### PR DESCRIPTION
Refactors candidate registrations specs to remove doubles and stubbing
to better test integration.

### Context

### Changes proposed in this pull request

### Guidance to review

