### PR TITLE
Add school to registration_session

### DIFF
--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -17,8 +17,6 @@ module Candidates
         to: :@contact_information
 
       delegate \
-        :school,
-        :school_name,
         :degree_stage,
         :degree_subject,
         :teaching_stage,
@@ -28,11 +26,18 @@ module Candidates
 
       delegate :has_dbs_check, to: :@background_check
 
+      delegate :school, to: :@registration_session
+
       def initialize(registration_session)
+        @registration_session = registration_session
         @contact_information = registration_session.contact_information
         @placement_preference = registration_session.placement_preference
         @subject_preference = registration_session.subject_preference
         @background_check = registration_session.background_check
+      end
+
+      def school_name
+        school.name
       end
 
       def full_address
@@ -58,7 +63,7 @@ module Candidates
       end
 
       def placement_date
-        placement_preference.placement_date
+        placement_preference.placement_date.to_s
       end
 
       def placement_availability

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -47,8 +47,16 @@ module Candidates
         contact_information.email
       end
 
+      def urn
+        @registration_session.fetch 'urn'
+      end
+
       def school
-        subject_preference.school
+        @school ||= Candidates::School.find urn
+      end
+
+      def school_name
+        school.name
       end
 
       def background_check

--- a/app/services/candidates/registrations/school_session.rb
+++ b/app/services/candidates/registrations/school_session.rb
@@ -5,6 +5,7 @@ module Candidates
     class SchoolSession
       def initialize(urn, session)
         @school_session = session["schools/#{urn}/registrations"] ||= {}
+        @school_session.merge! 'urn' => urn
       end
 
       def current_registration

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -56,7 +56,8 @@ FactoryBot.define do
 
     initialize_with do
       new \
-        "uuid" => uuid,
+        "uuid"                                          => uuid,
+        "urn"                                           => urn,
         "candidates_registrations_contact_information"  => candidates_registrations_contact_information,
         "candidates_registrations_background_check"     => candidates_registrations_background_check,
         "candidates_registrations_placement_preference" => candidates_registrations_placement_preference,
@@ -66,7 +67,8 @@ FactoryBot.define do
     trait :with_placement_date do
       initialize_with do
         new \
-          "uuid" => uuid,
+          "uuid"                                          => uuid,
+          "urn"                                           => urn,
           "candidates_registrations_contact_information"  => candidates_registrations_contact_information,
           "candidates_registrations_background_check"     => candidates_registrations_background_check,
           "candidates_registrations_subject_preference"   => candidates_registrations_subject_preference,

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -6,7 +6,7 @@ describe Candidates::Registrations::ApplicationPreview do
   end
 
   let :contact_information do
-    double Candidates::Registrations::ContactInformation,
+    build :contact_information,
       full_name: 'Testy McTest',
       email: 'test@example.com',
       building: "Test building",
@@ -18,36 +18,34 @@ describe Candidates::Registrations::ApplicationPreview do
   end
 
   let :background_check do
-    double Candidates::Registrations::BackgroundCheck,
-      has_dbs_check: has_dbs_check
+    build :background_check, has_dbs_check: has_dbs_check
   end
 
   let :placement_preference do
-    double Candidates::Registrations::PlacementPreference,
+    build :placement_preference,
       objectives: "test the software",
       availability: 'From Epiphany to Whitsunday'
   end
 
-  let(:school) { build(:bookings_school) }
+  let(:school) { create(:bookings_school, name: 'Test school') }
 
   let :subject_preference do
-    double Candidates::Registrations::SubjectPreference,
+    build :subject_preference,
       degree_stage: "I don't have a degree and am not studying for one",
       degree_stage_explaination: "",
       degree_subject: "Not applicable",
       teaching_stage: "I'm thinking about teaching and want to find out more",
       subject_first_choice: "Architecture",
-      subject_second_choice: "Maths",
-      school_name: 'Test school',
-      school: school
+      subject_second_choice: "Maths"
   end
 
   let :registration_session do
-    double Candidates::Registrations::RegistrationSession,
-      contact_information: contact_information,
-      placement_preference: placement_preference,
-      subject_preference: subject_preference,
-      background_check: background_check
+    Candidates::Registrations::RegistrationSession.new \
+      'urn' => school.urn,
+      'candidates_registrations_contact_information' => contact_information.attributes,
+      'candidates_registrations_placement_preference' => placement_preference.attributes,
+      'candidates_registrations_subject_preference' => subject_preference.attributes,
+      'candidates_registrations_background_check' => background_check.attributes
   end
 
   subject do
@@ -168,23 +166,32 @@ describe Candidates::Registrations::ApplicationPreview do
     end
 
     context 'when school has fixed dates' do
-      let(:pd) { '02 May 2019' }
+      let :placement_date do
+        3.days.from_now.strftime "%d %B %Y"
+      end
+
+      let :bookings_placement_date do
+        create :bookings_placement_date,
+          date: placement_date, bookings_school: school
+      end
+
       let :placement_preference do
-        double Candidates::Registrations::PlacementPreference,
+        build :placement_preference,
           objectives: "test the software",
-          placement_date: pd,
+          bookings_placement_date_id: bookings_placement_date.id,
           availability: nil
       end
 
       context '#placement_availability' do
         it 'returns the correct value' do
-          expect(subject.placement_date).to eq pd
+          expect(subject.placement_date).to eq placement_date + ' (1 day)'
         end
       end
 
       context '#placement_availability_description' do
         it 'returns the placement date when #placement_availability is absent' do
-          expect(subject.placement_availability_description).to eq pd
+          expect(subject.placement_availability_description).to \
+            eq placement_date + ' (1 day)'
         end
       end
     end

--- a/spec/services/candidates/registrations/school_session_spec.rb
+++ b/spec/services/candidates/registrations/school_session_spec.rb
@@ -38,6 +38,7 @@ describe Candidates::Registrations::SchoolSession do
 
       it 'stores the registration in the session' do
         expect(session).to eq "schools/#{school_urn_1}/registrations" => {
+          'urn' => school_urn_1,
           contact_information_1.model_name.param_key => contact_information_1.attributes
         }
       end
@@ -68,9 +69,11 @@ describe Candidates::Registrations::SchoolSession do
       it 'stores the registratiosn for each school seperatley' do
         expect(session).to eq \
           "schools/#{school_urn_1}/registrations" => {
+            'urn' => school_urn_1,
             contact_information_1.model_name.param_key => contact_information_1.attributes
           },
           "schools/#{school_urn_2}/registrations" => {
+            'urn' => school_urn_2,
             contact_information_2.model_name.param_key => contact_information_2.attributes
           }
       end


### PR DESCRIPTION
RegistrationSession shouldn't be delegating `school` to it's
subject_ preference. Instead pass a urn into the registration session
when it's initialized, use this to find the correct school.

### Context
Now we have two steps in the candidate registration wizard that require a school (subject_preference and placement_preference) the knowledge of how to get the school is duplicated. This is the first step in moving that out of the steps and up into the registration session.

### Changes proposed in this pull request
Add a school and urn method to the registrations session.
Refactor some specs to use factories.

### Guidance to review
Should look sensible.
Code is backwards compatible with existing `registration_sessions` as we merge the urn into the registration_session when we fetch it.