### PR TITLE
adding debug option for database cleaner

### DIFF
--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -3,3 +3,6 @@ exceptions = {except: %w{schema_migrations spatial_ref_sys}}
 DatabaseCleaner.clean_with(:truncation, exceptions)
 DatabaseCleaner.strategy = :truncation, exceptions
 Cucumber::Rails::Database.javascript_strategy = :truncation, exceptions
+if ENV['DEBUG_DATABASE_CLEANER'].present?
+  ActiveRecord::Base.logger = Logger.new(STDOUT)
+end


### PR DESCRIPTION
### Context

Currently we do not have an understanding of the overhead of using the database cleaner. It would be useful to understand when it is interacting with the database and how long certain operations are taking.

### Changes proposed in this pull request

Adding an environment variable to toggle on and off the use of a STDOUT logger as the logger for Active Record.

    ActiveRecord::Base.logger = Logger.new(STDOUT)

### Guidance to review

Checkout this branch and do a docker build

    docker build -f Dockerfile -t school-experience:latest .
Then to check current behaviour is unchanged 

    docker-compose run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-chrome -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL='http://school-experience:3000' school-experience cucumber

Then to enable logging

    docker-compose run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-chrome -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL='http://school-experience:3000' -e DEBUG_DATABASE_CLEANER=true school-experience cucumber
