### PR TITLE
Update placement request cancellation emails

### DIFF
--- a/app/notify/notify_email/candidate_request_cancellation.12370ef4-5146-4732-87c9-76f852b4bfa9.md
+++ b/app/notify/notify_email/candidate_request_cancellation.12370ef4-5146-4732-87c9-76f852b4bfa9.md
@@ -1,7 +1,7 @@
 Dear ((candidate_name)),
 
-You’ve cancelled your request for school experience at ((school_name)) for the following dates:
+You’ve cancelled your request for school experience at ((school_name)) with the following requested availability:
 
-* ((placement_start_date)) to ((placement_finish_date))
+((requested_availability))
 
 ^ The school has been notified about this cancellation

--- a/app/notify/notify_email/candidate_request_cancellation.rb
+++ b/app/notify/notify_email/candidate_request_cancellation.rb
@@ -1,11 +1,10 @@
 class NotifyEmail::CandidateRequestCancellation < Notify
-  attr_accessor :school_name, :candidate_name, :placement_start_date, :placement_finish_date
+  attr_accessor :school_name, :candidate_name, :requested_availability
 
-  def initialize(to:, school_name:, candidate_name:, placement_start_date:, placement_finish_date:)
+  def initialize(to:, school_name:, candidate_name:, requested_availability:)
     self.school_name    = school_name
     self.candidate_name = candidate_name
-    self.placement_start_date     = placement_start_date
-    self.placement_finish_date    = placement_finish_date
+    self.requested_availability = requested_availability
     super(to: to)
   end
 
@@ -19,8 +18,7 @@ private
     {
       school_name: school_name,
       candidate_name: candidate_name,
-      placement_start_date: placement_start_date,
-      placement_finish_date: placement_finish_date
+      requested_availability: requested_availability
     }
   end
 end

--- a/app/notify/notify_email/school_request_cancellation.1d2b44bc-9d73-4839-b06b-41f35012c14d.md
+++ b/app/notify/notify_email/school_request_cancellation.1d2b44bc-9d73-4839-b06b-41f35012c14d.md
@@ -1,5 +1,8 @@
 Dear ((school_admin_name)),
 
-((candidate_name)) has cancelled their request for school experience at ((school_name)) for the following dates:
+((candidate_name)) has cancelled their request for school experience at ((school_name)) with requested availability ((requested_availability))
 
-* ((placement_start_date)) to ((placement_finish_date))
+They have provided the following reasons for the cancellation:
+((cancellation_reasons))
+
+The cancelled request can be viewed here ((placement_request_url))

--- a/app/notify/notify_email/school_request_cancellation.rb
+++ b/app/notify/notify_email/school_request_cancellation.rb
@@ -2,23 +2,26 @@ class NotifyEmail::SchoolRequestCancellation < Notify
   attr_accessor :school_admin_name,
     :school_name,
     :candidate_name,
-    :placement_start_date,
-    :placement_finish_date
+    :cancellation_reasons,
+    :requested_availability,
+    :placement_request_url
 
   def initialize(
     to:,
     school_name:,
     school_admin_name:,
     candidate_name:,
-    placement_start_date:,
-    placement_finish_date:
+    cancellation_reasons:,
+    requested_availability:,
+    placement_request_url:
   )
 
-    self.school_admin_name     = school_admin_name
-    self.school_name           = school_name
-    self.candidate_name        = candidate_name
-    self.placement_start_date  = placement_start_date
-    self.placement_finish_date = placement_finish_date
+    self.school_admin_name      = school_admin_name
+    self.school_name            = school_name
+    self.candidate_name         = candidate_name
+    self.cancellation_reasons   = cancellation_reasons
+    self.requested_availability = requested_availability
+    self.placement_request_url  = placement_request_url
     super(to: to)
   end
 
@@ -31,10 +34,11 @@ private
   def personalisation
     {
       school_admin_name: school_admin_name,
+      school_name: school_name,
       candidate_name: candidate_name,
-      placement_start_date: placement_start_date,
-      placement_finish_date: placement_finish_date,
-      school_name: school_name
+      cancellation_reasons: cancellation_reasons,
+      requested_availability: requested_availability,
+      placement_request_url: placement_request_url
     }
   end
 end

--- a/spec/notify/notify_email/candidate_request_cancellation_spec.rb
+++ b/spec/notify/notify_email/candidate_request_cancellation_spec.rb
@@ -4,6 +4,5 @@ describe NotifyEmail::CandidateRequestCancellation do
   it_should_behave_like "email template", "12370ef4-5146-4732-87c9-76f852b4bfa9",
     school_name: "Springfield Elementary School",
     candidate_name: "Nelson Muntz",
-    placement_start_date: "2020-04-05",
-    placement_finish_date: "2020-04-12"
+    requested_availability: 'won lottery going on holiday'
 end

--- a/spec/notify/notify_email/school_request_cancellation_spec.rb
+++ b/spec/notify/notify_email/school_request_cancellation_spec.rb
@@ -5,6 +5,7 @@ describe NotifyEmail::SchoolRequestCancellation do
     school_admin_name: "Seymour Skinner",
     school_name: "Springfield Elementary School",
     candidate_name: "Otto Mann",
-    placement_start_date: "2022-04-01",
-    placement_finish_date: "2022-04-20"
+    cancellation_reasons: 'Spinal Tap playing same day',
+    requested_availability: 'whenever',
+    placement_request_url: 'http://example.com/schools/placement_requests/1'
 end


### PR DESCRIPTION
Placement requests don't have the concept of a start and end date so
this has been replaced with availability in the emails. Also added
additional information to the school's notification so they can more
easily identify which request has been cancelled.

### Context

### Changes proposed in this pull request

### Guidance to review
No code is currently using these emails at the minute
