### PR TITLE
Allow schools to enter times with point delimiter

### DIFF
--- a/app/forms/schools/on_boarding/candidate_experience_detail.rb
+++ b/app/forms/schools/on_boarding/candidate_experience_detail.rb
@@ -4,7 +4,7 @@ module Schools
       # Ensure that times look *roughly* valid. Note that it is
       # still possible to input invalid ones like '25:00'.
       # FIXME do we need to tighten this up/use a real timepicker?
-      SCHOOL_TIME_FORMAT = %r{\A((\d{1,2}):(\d{1,2})\s*((?:(am|pm)))?)|\A([\d{1,2}]\s*(am|pm))}i.freeze
+      SCHOOL_TIME_FORMAT = %r{\A((\d{1,2})(?:(\.|:))(\d{1,2})\s*((?:(am|pm)))?)|\A([\d{1,2}]\s*(am|pm))}i.freeze
 
       attribute :business_dress, :boolean, default: false
       attribute :cover_up_tattoos, :boolean, default: false

--- a/app/forms/schools/on_boarding/candidate_experience_detail.rb
+++ b/app/forms/schools/on_boarding/candidate_experience_detail.rb
@@ -4,7 +4,7 @@ module Schools
       # Ensure that times look *roughly* valid. Note that it is
       # still possible to input invalid ones like '25:00'.
       # FIXME do we need to tighten this up/use a real timepicker?
-      SCHOOL_TIME_FORMAT = %r{\A((\d{1,2})(?:(\.|:))(\d{1,2})\s*((?:(am|pm)))?)|\A([\d{1,2}]\s*(am|pm))}i.freeze
+      SCHOOL_TIME_FORMAT = %r{\A((\d{1,2})(?:(\.|:))(\d{1,2})\s*((?:(am|pm)))?)|\A([\d{1,2}]\s*(am|pm))|\A\d{1,2}\z}i.freeze
 
       attribute :business_dress, :boolean, default: false
       attribute :cover_up_tattoos, :boolean, default: false

--- a/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
+++ b/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
@@ -60,7 +60,7 @@ describe Schools::OnBoarding::CandidateExperienceDetail, type: :model do
     end
 
     context 'start and end times' do
-      valid_times = ['8AM', '8.15', '8:30AM', '8:30 AM', '8am', '8.00am', '3pm', '3 pm', '17:00']
+      valid_times = ['3', '19', '8AM', '8.15', '8:30AM', '8:30 AM', '8am', '8.00am', '3pm', '3 pm', '17:00']
       invalid_times = [
         '8A', '9;00am', 'nine forty in the morning', 'mid-morning', -2
       ]

--- a/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
+++ b/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
@@ -60,7 +60,7 @@ describe Schools::OnBoarding::CandidateExperienceDetail, type: :model do
     end
 
     context 'start and end times' do
-      valid_times = ['8AM', '8:30AM', '8:30 AM', '8am', '3pm', '3 pm', '17:00']
+      valid_times = ['8AM', '8.15', '8:30AM', '8:30 AM', '8am', '8.00am', '3pm', '3 pm', '17:00']
       invalid_times = [
         '8A', '9;00am', 'nine forty in the morning', 'mid-morning', -2
       ]


### PR DESCRIPTION
### Context

Schools want to express time as 11.15am instead of 11:15am 🤷🏽‍♂️

### Changes proposed in this pull request

Relax the regular expression accordingly

### Guidance to review

Make sure it looks ok
