### PR TITLE
Make geo search unchainable when point absent

### DIFF
--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -28,13 +28,19 @@ module Candidates::ResultsHelper
   end
 
   def expanded_search_radius_header_text
-    "0 results found within #{pluralize(params[:distance], 'mile')}"
+    if @search.has_coordinates?
+      "0 results found within #{pluralize(params[:distance], 'mile')}"
+    else
+      "0 results found"
+    end
   end
 
   def expanded_search_nearby_info_text
     if @search.results.empty?
       capture do
-        concat(tag.p { 'Not all schools in your area have signed up to use this website.' })
+        if @search.has_coordinates?
+          concat(tag.p { 'Not all schools in your area have signed up to use this website.' })
+        end
 
         concat(tag.p do
           <<~FIND_OUT_MORE

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -52,6 +52,10 @@ class Bookings::SchoolSearch < ApplicationRecord
     end
   end
 
+  def has_coordinates?
+    coordinates.present?
+  end
+
 private
 
   def save_with_result_count(count)

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -22,7 +22,7 @@ module Candidates
     attr_accessor :query, :location, :order, :latitude, :longitude, :page
     attr_reader :distance, :max_fee
 
-    delegate :location_name, :valid?, :errors, to: :school_search
+    delegate :location_name, :has_coordinates?, :valid?, :errors, to: :school_search
 
     class << self
       delegate :available_orders, to: Bookings::SchoolSearch

--- a/app/models/concerns/geographic_search.rb
+++ b/app/models/concerns/geographic_search.rb
@@ -39,7 +39,7 @@ module GeographicSearch
 
         query
       else
-        all
+        none
       end
     end
   end

--- a/spec/helpers/candidates/results_helper_spec.rb
+++ b/spec/helpers/candidates/results_helper_spec.rb
@@ -1,9 +1,21 @@
 require 'rails_helper'
 
 describe Candidates::ResultsHelper, type: :helper do
-  let(:search) { Candidates::SchoolSearch.new(query: 'School') }
+  let(:point_in_manchester) { Bookings::School::GEOFACTORY.point(-2.241, 53.481) }
+
+  let(:geocoder_manchester_search_result) {
+    [
+      Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK'),
+      Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229, name: 'Manchester, UK')
+    ]
+  }
+  let(:search) { Candidates::SchoolSearch.new(location: 'Manchester') }
 
   subject { school_results_info(search) }
+
+  before do
+    allow(Geocoder).to receive(:search).and_return(geocoder_manchester_search_result)
+  end
 
   describe '#school_results_info' do
     context 'When there are no results' do
@@ -11,12 +23,12 @@ describe Candidates::ResultsHelper, type: :helper do
     end
 
     context 'When there fewer than one page of results' do
-      let!(:schools) { create_list(:bookings_school, 5) }
+      let!(:schools) { create_list(:bookings_school, 5, coordinates: point_in_manchester) }
       specify { expect(subject).to eql('Displaying all 5 results') }
     end
 
     context 'When there are more than one page of results' do
-      let!(:schools) { create_list(:bookings_school, 18) }
+      let!(:schools) { create_list(:bookings_school, 18, coordinates: point_in_manchester) }
       specify { expect(subject).to eql("Showing 1&ndash;15 of 18 results") }
     end
   end

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -3,8 +3,11 @@ require 'rails_helper'
 describe Bookings::SchoolSearch do
   let(:point_in_manchester) { Bookings::School::GEOFACTORY.point(-2.241, 53.481) }
   let(:point_in_leeds) { Bookings::School::GEOFACTORY.point(-1.548, 53.794) }
+  let(:coords_in_manchester) do
+    { latitude: point_in_manchester.latitude, longitude: point_in_manchester.longitude }
+  end
 
-  let(:manchester_coordinates) {
+  let(:geocoder_manchester_search_result) {
     [
       Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK'),
       Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229, name: 'Manchester, UK')
@@ -65,7 +68,7 @@ describe Bookings::SchoolSearch do
   describe '#results' do
     context 'Search Criteria' do
       before do
-        allow(Geocoder).to receive(:search).and_return([])
+        allow(Geocoder).to receive(:search).and_return(geocoder_manchester_search_result)
       end
 
       let!(:matching_school) do
@@ -88,8 +91,8 @@ describe Bookings::SchoolSearch do
 
       context 'When no conditions are supplied' do
         subject { Bookings::SchoolSearch.new(query: '', location: '').results }
-        specify 'results should include all schools' do
-          expect(subject.count).to eql(Bookings::School.count)
+        specify 'results should include no schools' do
+          expect(subject.count).to be_zero
         end
       end
 
@@ -109,7 +112,7 @@ describe Bookings::SchoolSearch do
       end
 
       context 'When coodinates are supplied' do
-        let!(:coords) { manchester_coordinates[0] }
+        let!(:coords) { geocoder_manchester_search_result[0] }
 
         context 'When text and latitude and longitude are supplied' do
           subject do
@@ -180,7 +183,7 @@ describe Bookings::SchoolSearch do
       context 'Geocoder' do
         context 'When Geocoder finds a location' do
           before do
-            allow(Geocoder).to receive(:search).and_return(manchester_coordinates)
+            allow(Geocoder).to receive(:search).and_return(geocoder_manchester_search_result)
           end
 
           context 'When text and location are supplied' do
@@ -221,7 +224,7 @@ describe Bookings::SchoolSearch do
             subject { Bookings::SchoolSearch.new(location: 'Chippewa, Michigan').results }
 
             specify 'results should include all schools' do
-              expect(subject.size).to eql(Bookings::School.count)
+              expect(subject.size).to be_zero
             end
           end
         end
@@ -255,7 +258,7 @@ describe Bookings::SchoolSearch do
             non_matching_school.subjects << physics
           end
 
-          subject { Bookings::SchoolSearch.new(query: '', location: '', subjects: maths.id).results }
+          subject { Bookings::SchoolSearch.new(query: '', location: coords_in_manchester, subjects: maths.id).results }
 
           specify 'should return matching results' do
             expect(subject).to include(matching_school)
@@ -272,7 +275,7 @@ describe Bookings::SchoolSearch do
             non_matching_school.phases << secondary
           end
 
-          subject { Bookings::SchoolSearch.new(query: '', location: '', phases: college.id).results }
+          subject { Bookings::SchoolSearch.new(query: '', location: coords_in_manchester, phases: college.id).results }
 
           specify 'should return matching results' do
             expect(subject).to include(matching_school)
@@ -284,7 +287,7 @@ describe Bookings::SchoolSearch do
         end
 
         context 'Filtering on fees' do
-          subject { Bookings::SchoolSearch.new(query: '', location: '', max_fee: 20).results }
+          subject { Bookings::SchoolSearch.new(query: '', location: coords_in_manchester, max_fee: 20).results }
 
           specify 'should return matching results' do
             expect(subject).to include(matching_school)
@@ -301,7 +304,7 @@ describe Bookings::SchoolSearch do
         let(:physics) { Bookings::Subject.find_by! name: "Physics" }
 
         before do
-          allow(Geocoder).to receive(:search).and_return(manchester_coordinates)
+          allow(Geocoder).to receive(:search).and_return(geocoder_manchester_search_result)
         end
 
         before do
@@ -338,7 +341,7 @@ describe Bookings::SchoolSearch do
         let!(:leeds_school) { create(:bookings_school, name: "Leeds", coordinates: point_in_leeds) }
 
         before do
-          allow(Geocoder).to receive(:search).and_return(manchester_coordinates)
+          allow(Geocoder).to receive(:search).and_return(geocoder_manchester_search_result)
         end
 
         subject do
@@ -351,12 +354,12 @@ describe Bookings::SchoolSearch do
       end
 
       context 'Sorting by name' do
-        let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive") }
-        let!(:bath) { create(:bookings_school, name: "Bath High School") }
-        let!(:coventry) { create(:bookings_school, name: "Coventry Academy") }
+        let!(:cardiff) { create(:bookings_school, name: "Cardiff Comprehensive", coordinates: point_in_manchester) }
+        let!(:bath) { create(:bookings_school, name: "Bath High School", coordinates: point_in_manchester) }
+        let!(:coventry) { create(:bookings_school, name: "Coventry Academy", coordinates: point_in_manchester) }
 
         subject do
-          Bookings::SchoolSearch.new(query: '', requested_order: 'name').results
+          Bookings::SchoolSearch.new(location: coords_in_manchester, requested_order: 'name').results
         end
 
         specify 'schools should be ordered alphabetically by name' do

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -453,4 +453,18 @@ describe Bookings::SchoolSearch do
       end
     end
   end
+
+  describe '#has_coordinates?' do
+    subject { Bookings::SchoolSearch.new(location: "Bury") }
+
+    context 'when coordinates are present' do
+      before { allow(subject).to receive(:coordinates).and_return(point_in_leeds) }
+      it { is_expected.to have_coordinates }
+    end
+
+    context 'when coordinates are absent' do
+      before { allow(subject).to receive(:coordinates).and_return([]) }
+      it { is_expected.not_to have_coordinates }
+    end
+  end
 end

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Candidates::SchoolSearch do
     it { expect(subject).to delegate_method(:valid?).to(:school_search) }
     it { expect(subject).to delegate_method(:errors).to(:school_search) }
     it { expect(subject).to delegate_method(:location_name).to(:school_search) }
+    it { expect(subject).to delegate_method(:has_coordinates?).to(:school_search) }
   end
 
   context '.subjects=' do


### PR DESCRIPTION
### Context

Previously if we couldn't find a point to search around (either via
Geocoder or 'Use my current location') the `.close_to` scope would call
`.call` and all schools that matched the other criteria would be
returned.

### Changes proposed in this pull request

Now, if we have no point to search around, we call `.none` instead and
return zero results.

### Guidance to review

Ensure everything works as expected