### PR TITLE
Add disableScrollWheelZoom option for maps

### DIFF
--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -29,7 +29,8 @@ export default class extends Controller {
         showDashboard: true,
         enableSearchLogo: false,
         enableClickableLogo: false,
-        showCopyright: true
+        showCopyright: true,
+        disableScrollWheelZoom: true
     }) ;
 
     let pin = new Microsoft.Maps.Pushpin(location);


### PR DESCRIPTION
### Context

Scrolling on the school profile page occasionally causes accidental map zooming

### Changes proposed in this pull request

This option prevents the map from zooming in and out inadvertently when
scrolling up and down the page. Plus and minus buttons are still visible
to facilitate zooming

https://docs.microsoft.com/en-us/bingmaps/v8-web-control/map-control-api/mapoptions-object

### Guidance to review

Ensure changes fix the problem