### PR TITLE
Redirect to schools root on logout

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -15,7 +15,7 @@ module Schools
     def destroy
       Rails.logger.warn("Clearing session: #{session.to_json}")
       session.clear
-      redirect_to root_path
+      redirect_to schools_root_path
     end
 
     def create

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -122,7 +122,7 @@ describe Schools::SessionsController, type: :request do
     end
 
     specify "should redirect to the homepage" do
-      expect(subject).to redirect_to(root_path)
+      expect(subject).to redirect_to(schools_root_path)
     end
   end
 end


### PR DESCRIPTION
### Context

Clicking logout as a school admin takes you to the application root `/`, which is candidate-focussed

### Changes proposed in this pull request

Instead, redirect them to the schools root `/schools`

### Guidance to review

Ensure it works