### PR TITLE
Feature/add availability preferences screen se 1037

### DIFF
--- a/app/assets/stylesheets/school-dashboard.scss
+++ b/app/assets/stylesheets/school-dashboard.scss
@@ -73,3 +73,8 @@ article#dashboard {
     }
   }
 }
+
+.govuk-hint.govuk-hint__indented {
+  margin-left: 3.3rem;
+  display: inline-block;
+}

--- a/app/controllers/schools/availability_info_controller.rb
+++ b/app/controllers/schools/availability_info_controller.rb
@@ -1,0 +1,19 @@
+class Schools::AvailabilityInfoController < Schools::BaseController
+  def edit; end
+
+  def update
+    if @current_school.update(placement_date_params)
+      redirect_to schools_dashboard_path
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def placement_date_params
+    params
+      .require(:bookings_school)
+      .permit(:availability_info)
+  end
+end

--- a/app/controllers/schools/availability_preferences_controller.rb
+++ b/app/controllers/schools/availability_preferences_controller.rb
@@ -1,9 +1,15 @@
 class Schools::AvailabilityPreferencesController < Schools::BaseController
-  def edit; end
+  def edit
+    @placement_dates = @current_school.bookings_placement_dates.available
+  end
 
   def update
     if @current_school.update(placement_date_params)
-      redirect_to schools_dashboard_path
+      if @current_school.availability_preference_fixed?
+        redirect_to schools_placement_dates_path
+      else
+        redirect_to schools_dashboard_path
+      end
     else
       render :edit
     end

--- a/app/controllers/schools/availability_preferences_controller.rb
+++ b/app/controllers/schools/availability_preferences_controller.rb
@@ -1,0 +1,17 @@
+class Schools::AvailabilityPreferencesController < Schools::BaseController
+  def edit; end
+
+  def update
+    if @current_school.update(placement_date_params)
+      redirect_to schools_dashboard_path
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def placement_date_params
+    params.require(:bookings_school).permit(:availability_preference_fixed)
+  end
+end

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -29,7 +29,7 @@ class Schools::PlacementDatesController < Schools::BaseController
   def edit; end
 
   def update
-    if @placement_date.update_attributes(placement_date_params)
+    if @placement_date.update(placement_date_params)
       redirect_to schools_placement_dates_path
     else
       render :edit

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -14,13 +14,13 @@ module Schools::DashboardsHelper
     school.enabled? ? "enabled" : "disabled"
   end
 
-  def show_no_placement_dates_warning?
-    @current_school.availability_preference_fixed? &&
-      @current_school.bookings_placement_dates.none?
+  def show_no_placement_dates_warning?(school)
+    school.availability_preference_fixed? &&
+      school.bookings_placement_dates.available.none?
   end
 
-  def show_no_availability_info_warning?
-    !@current_school.availability_preference_fixed? &&
-      @current_school.availability_info.nil?
+  def show_no_availability_info_warning?(school)
+    !school.availability_preference_fixed? &&
+      school.availability_info.nil?
   end
 end

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -13,4 +13,9 @@ module Schools::DashboardsHelper
   def school_enabled_description(school)
     school.enabled? ? "enabled" : "disabled"
   end
+
+  def show_no_placement_dates_warning?
+    @current_school.availability_preference_fixed &&
+      @current_school.bookings_placement_dates.none?
+  end
 end

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -15,7 +15,12 @@ module Schools::DashboardsHelper
   end
 
   def show_no_placement_dates_warning?
-    @current_school.availability_preference_fixed &&
+    @current_school.availability_preference_fixed? &&
       @current_school.bookings_placement_dates.none?
+  end
+
+  def show_no_availability_info_warning?
+    !@current_school.availability_preference_fixed? &&
+      @current_school.availability_info.nil?
   end
 end

--- a/app/helpers/schools/placement_dates_helper.rb
+++ b/app/helpers/schools/placement_dates_helper.rb
@@ -1,6 +1,6 @@
 module Schools::PlacementDatesHelper
   def placement_date_display_status(val)
-    val ? "Available" : "Taken"
+    val ? "Open" : "Closed"
   end
 
   def availability_status_display_status(val)

--- a/app/helpers/schools/placement_dates_helper.rb
+++ b/app/helpers/schools/placement_dates_helper.rb
@@ -3,6 +3,10 @@ module Schools::PlacementDatesHelper
     val ? "Available" : "Taken"
   end
 
+  def availability_status_display_status(val)
+    val ? "fixed dates" : "flexible dates"
+  end
+
   def placement_date_display_class(val)
     val ? "govuk-tag--available" : "govuk-tag--taken"
   end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -2,6 +2,8 @@ class Bookings::School < ApplicationRecord
   include FullTextSearch
   include GeographicSearch
 
+  before_validation :nilify_availability_info
+
   validates :name,
     presence: true,
     length: { maximum: 128 }
@@ -18,6 +20,10 @@ class Bookings::School < ApplicationRecord
     with: URI::MailTo::EMAIL_REGEXP,
     message: "isn't a valid email address"
   }
+
+  validates :availability_info,
+    allow_nil: true,
+    length: { minimum: 10 }
 
   has_many :bookings_schools_subjects,
     class_name: "Bookings::SchoolsSubject",
@@ -127,5 +133,9 @@ private
 
   def has_available_dates?
     bookings_placement_dates.available.any?
+  end
+
+  def nilify_availability_info
+    self.availability_info = nil if availability_info == ''
   end
 end

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -1,0 +1,20 @@
+<%- self.page_title = "Modify availability information" %>
+
+<%
+  self.breadcrumbs = {
+    @current_school.name => schools_root_path,
+    'Modify availability information' => nil
+  }
+%>
+
+<h1>Modify placement date</h1>
+
+<%= form_for @current_school, url: schools_availability_info_path, method: :patch do |form| %>
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+      <%= form.text_area :availability_info %>
+    </fieldset>
+  </div>
+
+  <%= form.submit 'Continue' %>
+<%- end -%>

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -1,17 +1,17 @@
-<%- self.page_title = "Modify availability information" %>
+<%- self.page_title = "Availability information" %>
 
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,
-    'Modify availability information' => nil
+    'Availability information' => nil
   }
 %>
 
-<h1>Modify placement date</h1>
+<h1>When are your school's placements available?</h1>
 
 <%= form_for @current_school, url: schools_availability_info_path, method: :patch do |form| %>
   <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+    <fieldset class="govuk-fieldset">
       <%= form.text_area :availability_info %>
     </fieldset>
   </div>

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -1,20 +1,34 @@
-<%- self.page_title = "Availability information" %>
+<%- self.page_title = "Describe your school experience availability" %>
 
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,
-    'Availability information' => nil
+    'Describe your school experience availability' => nil
   }
 %>
 
-<h1>When are your school's placements available?</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @current_school, url: schools_availability_info_path, method: :patch do |form| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <%= form.text_area :availability_info, label_options: { overwrite_defaults!: true, class: 'govuk-heading-l' } do %>
+            <p>Outline when you offer school experience at your school.</p>
 
-<%= form_for @current_school, url: schools_availability_info_path, method: :patch do |form| %>
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      <%= form.text_area :availability_info %>
-    </fieldset>
+            <p>
+              For example, on specific days of the week and open days or around
+              exams, holidays and term times.
+            </p>
+
+            <p>
+              These details will be shown to candidates to help them choose
+              school experience at your school.
+            </p>
+          <%- end -%>
+        </fieldset>
+      </div>
+
+      <%= form.submit 'Continue' %>
+    <%- end -%>
   </div>
-
-  <%= form.submit 'Continue' %>
-<%- end -%>
+</div>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -1,9 +1,9 @@
-<%- self.page_title = "Availability preference" %>
+<%- self.page_title = "Change how availability and dates are displayed" %>
 
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,
-    'Availability preference' => nil
+    'Change how availability and dates are displayed' => nil
   }
 %>
 
@@ -14,41 +14,24 @@
 
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
-      <p>
-        You need to contact individual candidates to discuss, arrange and offer
-        them a placement date after you’ve received their school experience
-        request.
-      </p>
-      <p>
-        You should try and respond to requests within 10 working days during
-        term time.
-      </p>
-      <p>
-        Once you’ve accepted a request you’ll be asked to confirm the
-        candidate’s placement dates as part of confirming their school
-        experience booking.
-      </p>
-
       <%= f.hidden_field :fixed, value: nil %>
 
       <%= f.radio_button_fieldset :availability_preference_fixed do |fieldset| %>
         <p>
-          Select whether you’d like to tell candidates about your school
-          experience by outlining your school's availability or telling them
-          about fixed dates:
+          Select how you’d like to show about your school experience availability
+          and dates to candidates:
         </p>
-        <%= fieldset.radio_input true %>
+        <%= fieldset.radio_input(true, 'aria-describedby' => 'availability-preference-fixed-true-hint') %>
+        <span id="availability-preference-fixed-true-hint" class="govuk-hint govuk-hint__indented">
+          Any existing flexible date description will be hidden from candidates
+          and <strong>will not be lost</strong>
+        </span>
 
-        <%- if @current_school.availability_preference_fixed? && @placement_dates.any? %>
-          <%= fieldset.radio_input false do %>
-            <span class="govuk-hint">
-              If you change your school to use flexible dates all your existing fixed dates
-              will be hidden from candidates.
-            </span>
-          <%- end -%>
-        <%- else -%>
-          <%= fieldset.radio_input false %>
-        <%- end -%>
+        <%= fieldset.radio_input(false, 'aria-describedby' => 'availability-preference-fixed-false-hint') %>
+        <span id="availability-preference-fixed-false-hint" class="govuk-hint govuk-hint__indented">
+          All your existing fixed dates will be hidden from candidates and <strong>will
+          not be lost</strong>
+        </span>
       <% end %>
 
       <%= f.submit 'Continue' %>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = "Availability preference" %>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -1,0 +1,45 @@
+<%
+  self.breadcrumbs = {
+    @current_school.name => schools_root_path,
+    'Availability preference' => nil
+  }
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @current_school, url: schools_availability_preference_path, method: 'patch' do |f| %>
+      <h1 class="govuk-heading-l">School experience availability or fixed dates</h1>
+
+      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+
+      <p>
+        You need to contact individual candidates to discuss, arrange and offer
+        them a placement date after you’ve received their school experience
+        request.
+      </p>
+      <p>
+        You should try and respond to requests within 10 working days during
+        term time.
+      </p>
+      <p>
+        Once you’ve accepted a request you’ll be asked to confirm the
+        candidate’s placement dates as part of confirming their school
+        experience booking.
+      </p>
+
+      <%= f.hidden_field :fixed, value: nil %>
+
+      <%= f.radio_button_fieldset :availability_preference_fixed do |fieldset| %>
+        <p>
+          Select whether you’d like to tell candidates about your school
+          experience by outlining your school's availability or telling them
+          about fixed dates:
+        </p>
+        <%= fieldset.radio_input true %>
+        <%= fieldset.radio_input false %>
+      <% end %>
+
+      <%= f.submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -36,7 +36,17 @@
           about fixed dates:
         </p>
         <%= fieldset.radio_input true %>
-        <%= fieldset.radio_input false %>
+
+        <%- if @current_school.availability_preference_fixed? && @placement_dates.any? %>
+          <%= fieldset.radio_input false do %>
+            <span class="govuk-hint">
+              If you change your school to use flexible dates all your existing fixed dates
+              will be hidden from candidates.
+            </span>
+          <%- end -%>
+        <%- else -%>
+          <%= fieldset.radio_input false %>
+        <%- end -%>
       <% end %>
 
       <%= f.submit 'Continue' %>

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -25,14 +25,29 @@
       </span>
     </li>
 
-    <%- if @current_school.availability_preference_fixed? -%>
+  </ul>
+
+  <section class="availability-preferences">
+    <h3 class="govuk-heading-m">Availability preferences</h3>
+
+    <ul class="govuk-list">
       <li>
-        <%= link_to "Update school experience dates", schools_placement_dates_path %>
+        <%= link_to "Change your flexibility preference", edit_schools_availability_preference_path %>
         <span class="govuk-hint">
-          Add, edit and disable <strong>fixed</strong> dates for candidates
+          <%= @current_school.name %> is currently set to
+          <strong><%= availability_status_display_status(@current_school.availability_preference_fixed?) %></strong>.
         </span>
       </li>
-    <%- end -%>
 
-  </ul>
+      <%- if @current_school.availability_preference_fixed? -%>
+        <li>
+          <%= link_to "Update school experience dates", schools_placement_dates_path %>
+          <span class="govuk-hint">
+            Add, edit and disable <strong>fixed</strong> dates for candidates
+          </span>
+        </li>
+      <%- end -%>
+
+    </ul>
+  </section>
 </article>

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -6,7 +6,7 @@
   <%- end -%>
 
   <%- if show_no_availability_info_warning? -%>
-    <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
+    <%= render partial: 'schools/dashboards/no_availability_info_warning' %>
   <%- end -%>
 
   <ul class="govuk-list">

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -28,7 +28,7 @@
   </ul>
 
   <section class="availability-preferences">
-    <h3 class="govuk-heading-m">Availability preferences</h3>
+    <h3 class="govuk-heading-s">Availability preferences</h3>
 
     <ul class="govuk-list">
       <li>
@@ -46,8 +46,15 @@
             Add, edit and disable <strong>fixed</strong> dates for candidates
           </span>
         </li>
+      <%- else -%>
+        <li>
+          <%= link_to "Modify your availability description", edit_schools_availability_info_path %>
+          <span class="govuk-hint">
+            Change the description of your school's availability to inform
+            candidates when is best to apply
+          </span>
+        </li>
       <%- end -%>
-
     </ul>
   </section>
 </article>

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -1,11 +1,11 @@
 <article id="dashlette">
   <h1 class="govuk-heading-l">Manage school experience at <%= @current_school.name %></h1>
 
-  <%- if show_no_placement_dates_warning? -%>
+  <%- if show_no_placement_dates_warning?(@current_school) -%>
     <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
   <%- end -%>
 
-  <%- if show_no_availability_info_warning? -%>
+  <%- if show_no_availability_info_warning?(@current_school) -%>
     <%= render partial: 'schools/dashboards/no_availability_info_warning' %>
   <%- end -%>
 

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -5,6 +5,10 @@
     <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
   <%- end -%>
 
+  <%- if show_no_availability_info_warning? -%>
+    <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
+  <%- end -%>
+
   <ul class="govuk-list">
 
     <li>

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -36,30 +36,30 @@
   </ul>
 
   <section class="availability-preferences">
-    <h3 class="govuk-heading-s">Availability preferences</h3>
+    <h3 class="govuk-heading-s">Availability and dates</h3>
 
     <ul class="govuk-list">
       <li>
-        <%= link_to "Change your flexibility preference", edit_schools_availability_preference_path %>
+        <%= link_to "Change how availability and dates are displayed", edit_schools_availability_preference_path %>
         <span class="govuk-hint">
-          <%= @current_school.name %> is currently set to
-          <strong><%= availability_status_display_status(@current_school.availability_preference_fixed?) %></strong>.
+          Your school currently displays
+          <strong><%= availability_status_display_status(@current_school.availability_preference_fixed?) %></strong>
+          to candidates
         </span>
       </li>
 
       <%- if @current_school.availability_preference_fixed? -%>
         <li>
-          <%= link_to "Update school experience dates", schools_placement_dates_path %>
+          <%= link_to "Manage fixed dates", schools_placement_dates_path %>
           <span class="govuk-hint">
-            Add, edit and disable <strong>fixed</strong> dates for candidates
+            Add, remove, close and open <strong>fixed dates</strong> for school experience
           </span>
         </li>
       <%- else -%>
         <li>
-          <%= link_to "Modify your availability description", edit_schools_availability_info_path %>
+          <%= link_to "Manage flexible dates", edit_schools_availability_info_path %>
           <span class="govuk-hint">
-            Change the description of your school's availability to inform
-            candidates when is best to apply
+            Update your availability and <strong>flexible dates</strong> for school experience
           </span>
         </li>
       <%- end -%>

--- a/app/views/schools/dashboards/_dashlette.html.erb
+++ b/app/views/schools/dashboards/_dashlette.html.erb
@@ -1,6 +1,10 @@
 <article id="dashlette">
   <h1 class="govuk-heading-l">Manage school experience at <%= @current_school.name %></h1>
 
+  <%- if show_no_placement_dates_warning? -%>
+    <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
+  <%- end -%>
+
   <ul class="govuk-list">
 
     <li>

--- a/app/views/schools/dashboards/_no_availability_info_warning.html.erb
+++ b/app/views/schools/dashboards/_no_availability_info_warning.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    You have no availability information, your school will not appear in candidate
+    searches
+  </strong>
+</div>

--- a/app/views/schools/dashboards/_no_availability_info_warning.html.erb
+++ b/app/views/schools/dashboards/_no_availability_info_warning.html.erb
@@ -3,6 +3,6 @@
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
     You have no availability information, your school will not appear in candidate
-    searches
+    searches. <%= link_to "Enter dates", edit_schools_availability_info_path %>
   </strong>
 </div>

--- a/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
+++ b/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
@@ -1,0 +1,8 @@
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    You have no placement dates, your school will not appear in candidate
+    searches
+  </strong>
+</div>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -1,13 +1,13 @@
-<%- self.page_title = "Placement dates" %>
+<%- self.page_title = "Manage fixed dates" %>
 
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,
-    'Placement dates' => nil
+    'Manage fixed dates' => nil
   }
 %>
 
-<h1>Placement dates</h1>
+<h1>Manage fixed dates</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -56,7 +56,7 @@
 </div>
 
 <div>
-  <%= link_to "Add new placement date", new_schools_placement_date_path, class: 'govuk-button' %>
+  <%= link_to "Add dates", new_schools_placement_date_path, class: 'govuk-button' %>
 </div>
 
 <div>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -49,14 +49,7 @@
         </tbody>
       </table>
     <%- else -%>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          You have no placement dates, your school will not appear in candidate
-          searches
-        </strong>
-      </div>
+      <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
     <%- end -%>
 
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,7 +210,7 @@ en:
     fieldset:
       bookings_school:
         enabled: Turn requests on or off
-        availability_preference_fixed: Choose your availability preference
+        availability_preference_fixed: Change how availability and dates are displayed
       bookings_placement_date:
         date: Enter a start date
       phases: Education phases
@@ -293,8 +293,10 @@ en:
           true: Allow requests
           false: Do not allow requests
         availability_preference_fixed:
-          true: Fixed dates
-          false: Flexible dates
+          true_html: <strong>Fixed dates</strong> - display set dates
+          false_html: <strong>Flexible dates</strong> - display a description of your availability
+        availability_info: Describe your school experience availability
+
       bookings_placement_date:
         duration: How many days will it last?
         active: Make this date available to candidates?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -210,6 +210,7 @@ en:
     fieldset:
       bookings_school:
         enabled: Turn requests on or off
+        availability_preference_fixed: Choose your availability preference
       bookings_placement_date:
         date: Enter a start date
       phases: Education phases
@@ -291,6 +292,9 @@ en:
         enabled:
           true: Allow requests
           false: Do not allow requests
+        availability_preference_fixed:
+          true: Fixed dates
+          false: Flexible dates
       bookings_placement_date:
         duration: How many days will it last?
         active: Make this date available to candidates?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
       end
 
       resource :availability_preference, only: %i(edit update)
-      resource :availability_info, only: %i(edit update)
+      resource :availability_info, only: %i(edit update), controller: 'availability_info'
       resources :placement_dates
 
       namespace :errors do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
         end
       end
 
+      resource :availability_preference, only: %i(edit update)
+      resource :availability_info, only: %i(edit update)
       resources :placement_dates
 
       namespace :errors do

--- a/features/schools/availability_information/edit.feature
+++ b/features/schools/availability_information/edit.feature
@@ -9,23 +9,23 @@ Feature: Editing availability info
 
     Scenario: Page title
         Given I am on the 'availability information' page
-        Then the page title should be 'Availability information'
+        Then the page title should be 'Describe your school experience availability'
 
     Scenario: Breadcrumbs
         Given I am on the 'availability information' page
         Then I should see the following breadcrumbs:
-            | Text                     | Link     |
-            | Some school              | /schools |
-            | Availability information | None     |
+            | Text                                         | Link     |
+            | Some school                                  | /schools |
+            | Describe your school experience availability | None     |
 
     Scenario: Page contents
         Given I am on the 'availability information' page
-        Then there should be a 'Availability info' text area
+        Then there should be a 'Describe your school experience availability' text area
         And the submit button should contain text 'Continue'
 
     Scenario: Submitting the form
         Given I am on the 'availability information' page
-        When I enter 'Every third Tuesday' into the 'Availability info' text area
+        When I enter 'Every third Tuesday' into the 'Describe your school experience availability' text area
         And I submit the form
         Then I should be on the 'schools dashboard' page
         And my school's availabiltiy info should have been updated

--- a/features/schools/availability_information/edit.feature
+++ b/features/schools/availability_information/edit.feature
@@ -1,0 +1,31 @@
+Feature: Editing availability info
+    So I can give candidates guidance when they are applying
+    As a school administrator
+    I want to be able to set my availability information text
+
+    Background:
+        Given I am logged in as a DfE user
+        And my school is set to use 'flexible' dates
+
+    Scenario: Page title
+        Given I am on the 'availability information' page
+        Then the page title should be 'Availability information'
+
+    Scenario: Breadcrumbs
+        Given I am on the 'availability information' page
+        Then I should see the following breadcrumbs:
+            | Text                     | Link     |
+            | Some school              | /schools |
+            | Availability information | None     |
+
+    Scenario: Page contents
+        Given I am on the 'availability information' page
+        Then there should be a 'Availability info' text area
+        And the submit button should contain text 'Continue'
+
+    Scenario: Submitting the form
+        Given I am on the 'availability information' page
+        When I enter 'Every third Tuesday' into the 'Availability info' text area
+        And I submit the form
+        Then I should be on the 'schools dashboard' page
+        And my school's availabiltiy info should have been updated

--- a/features/schools/availability_preferences/edit.feature
+++ b/features/schools/availability_preferences/edit.feature
@@ -5,6 +5,7 @@ Feature: Editing placement dates
 
     Background:
         Given I am logged in as a DfE user
+        And my school is set to use 'fixed' dates
 
     Scenario: Page title
         Given I am on the 'availability preferences' page
@@ -25,8 +26,7 @@ Feature: Editing placement dates
         And the submit button should contain text 'Continue'
 
     Scenario: Submitting the form
-        Given my school is set to use 'fixed' dates
-        And I am on the 'availability preferences' page
+        Given I am on the 'availability preferences' page
         When I choose 'Flexible dates' from the 'Choose your availability preference' radio buttons
         And I submit the form
         Then I should be on the 'schools dashboard' page
@@ -34,8 +34,7 @@ Feature: Editing placement dates
 
     @javascript
     Scenario: Warning
-        Given my school is set to use 'fixed' dates
-        And my school has 2 placement dates
+        Given my school has 2 placement dates
         When I am on the 'availability preferences' page
         And I choose 'Flexible dates' from the 'Choose your availability preference' radio buttons
         Then there should be a hint stating "If you change your school to use flexible dates"

--- a/features/schools/availability_preferences/edit.feature
+++ b/features/schools/availability_preferences/edit.feature
@@ -9,32 +9,25 @@ Feature: Editing placement dates
 
     Scenario: Page title
         Given I am on the 'availability preferences' page
-        Then the page title should be 'Availability preference'
+        Then the page title should be 'Change how availability and dates are displayed'
 
     Scenario: Breadcrumbs
         Given I am on the 'availability preferences' page
         Then I should see the following breadcrumbs:
-            | Text                     | Link     |
-            | Some school              | /schools |
-            | Availability preference  | None     |
+            | Text                                            | Link     |
+            | Some school                                     | /schools |
+            | Change how availability and dates are displayed | None     |
 
     Scenario: Page contents
         Given I am on the 'availability preferences' page
-        Then I should see radio buttons for 'Choose your availability preference' with the following options:
-            | Fixed dates    |
-            | Flexible dates |
+        Then I should see radio buttons for 'Change how availability and dates are displayed' with the following options:
+            | Fixed dates - display set dates                             |
+            | Flexible dates - display a description of your availability |
         And the submit button should contain text 'Continue'
 
     Scenario: Submitting the form
         Given I am on the 'availability preferences' page
-        When I choose 'Flexible dates' from the 'Choose your availability preference' radio buttons
+        When I choose 'Flexible dates - display a description of your availability' from the 'Change how availability and dates are displayed' radio buttons
         And I submit the form
         Then I should be on the 'schools dashboard' page
         And my school's availability preference should be 'fixed'
-
-    @javascript
-    Scenario: Warning
-        Given my school has 2 placement dates
-        When I am on the 'availability preferences' page
-        And I choose 'Flexible dates' from the 'Choose your availability preference' radio buttons
-        Then there should be a hint stating "If you change your school to use flexible dates"

--- a/features/schools/availability_preferences/edit.feature
+++ b/features/schools/availability_preferences/edit.feature
@@ -1,0 +1,41 @@
+Feature: Editing placement dates
+    So I can control availability on my school profile
+    As a school administrator
+    I want to be able to switch between flexible and fixed dates
+
+    Background:
+        Given I am logged in as a DfE user
+
+    Scenario: Page title
+        Given I am on the 'availability preferences' page
+        Then the page title should be 'Availability preference'
+
+    Scenario: Breadcrumbs
+        Given I am on the 'availability preferences' page
+        Then I should see the following breadcrumbs:
+            | Text                     | Link     |
+            | Some school              | /schools |
+            | Availability preference  | None     |
+
+    Scenario: Page contents
+        Given I am on the 'availability preferences' page
+        Then I should see radio buttons for 'Choose your availability preference' with the following options:
+            | Fixed dates    |
+            | Flexible dates |
+        And the submit button should contain text 'Continue'
+
+    Scenario: Submitting the form
+        Given my school is set to use 'fixed' dates
+        And I am on the 'availability preferences' page
+        When I choose 'Flexible dates' from the 'Choose your availability preference' radio buttons
+        And I submit the form
+        Then I should be on the 'schools dashboard' page
+        And my school's availability preference should be 'fixed'
+
+    @javascript
+    Scenario: Warning
+        Given my school is set to use 'fixed' dates
+        And my school has 2 placement dates
+        When I am on the 'availability preferences' page
+        And I choose 'Flexible dates' from the 'Choose your availability preference' radio buttons
+        Then there should be a hint stating "If you change your school to use flexible dates"

--- a/features/schools/placement_dates/edit.feature
+++ b/features/schools/placement_dates/edit.feature
@@ -10,13 +10,13 @@ Feature: Editing placement dates
         Given I am on the edit page for my placement
         Then the page title should be 'Modify placement date'
 
-  Scenario: Breadcrumbs
-    Given I am on the edit page for my placement
-    Then I should see the following breadcrumbs:
-        | Text                  | Link                     |
-        | Some school           | /schools                 |
-        | Placement dates       | /schools/placement_dates |
-        | Modify placement date | None                     |
+    Scenario: Breadcrumbs
+        Given I am on the edit page for my placement
+        Then I should see the following breadcrumbs:
+            | Text                  | Link                     |
+            | Some school           | /schools                 |
+            | Placement dates       | /schools/placement_dates |
+            | Modify placement date | None                     |
 
     Scenario: Placement date form
         Given I am on the edit page for my placement

--- a/features/schools/placement_dates/index.feature
+++ b/features/schools/placement_dates/index.feature
@@ -8,14 +8,14 @@ Feature: Listing placement dates
 
     Scenario: Page title
         Given I am on the 'placement dates' page
-        Then the page title should be 'Placement dates'
+        Then the page title should be 'Manage fixed dates'
 
   Scenario: Breadcrumbs
     Given I am on the 'placement dates' page
     Then I should see the following breadcrumbs:
-        | Text            | Link     |
-        | Some school     | /schools |
-        | Placement dates | None     |
+        | Text               | Link     |
+        | Some school        | /schools |
+        | Manage fixed dates | None     |
 
     Scenario: List contents
         Given my school has 5 placement dates
@@ -30,7 +30,7 @@ Feature: Listing placement dates
 
     Scenario: The add a new placement date button
         Given I am on the 'placement dates' page
-        Then there should be a 'Add new placement date' link to the new placement date page
+        Then there should be a 'Add dates' link to the new placement date page
 
     Scenario: Warning displayed when there are no dates
         Given my school has no placement dates

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -4,10 +4,6 @@ Then("the {string} word count should say {string}") do |label_text, expectation|
   end
 end
 
-When("I enter {string} into the {string} text area") do |value, label|
-  fill_in label, with: value
-end
-
 Then("the {string} section should have {string} and {string} radio buttons") do |section, option_one, option_two|
   within(".#{section.parameterize}") do
     ensure_radio_buttons_exist(page, [option_one, option_two])

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -104,6 +104,12 @@ When("I uncheck the {string} checkbox") do |string|
   uncheck string
 end
 
+When("I enter {string} into the {string} text area") do |value, label|
+  @filled_in_value = value
+  fill_in label, with: value
+end
+
+
 LABEL_SELECTORS = %w(.govuk-label legend label).freeze
 def get_form_group(page, label_text)
   selector = LABEL_SELECTORS.detect do |s|

--- a/features/step_definitions/schools/availability_information_steps.rb
+++ b/features/step_definitions/schools/availability_information_steps.rb
@@ -1,0 +1,3 @@
+Then("my school's availabiltiy info should have been updated") do
+  expect(@school.reload.availability_info).to eql(@filled_in_value)
+end

--- a/features/step_definitions/schools/availability_preference_steps.rb
+++ b/features/step_definitions/schools/availability_preference_steps.rb
@@ -1,0 +1,17 @@
+Given("my school is set to use {string} dates") do |option|
+  fail 'must be fixed or flexible' unless option.in?(%w(fixed flexible))
+
+    @school.update(availability_preference_fixed: availability_preference_flag?(option))
+end
+
+Then("my school's availability preference should be {string}") do |option|
+  if availability_preference_flag?(option)
+    expect(@school).to be_availability_preference_fixed
+  else
+    expect(@school).not_to be_availability_preference_fixed
+  end
+end
+
+def availability_preference_flag?(option)
+  option == 'fixed'
+end

--- a/features/step_definitions/schools/availability_preference_steps.rb
+++ b/features/step_definitions/schools/availability_preference_steps.rb
@@ -1,7 +1,7 @@
 Given("my school is set to use {string} dates") do |option|
   fail 'must be fixed or flexible' unless option.in?(%w(fixed flexible))
 
-    @school.update(availability_preference_fixed: availability_preference_flag?(option))
+  @school.update(availability_preference_fixed: availability_preference_flag?(option))
 end
 
 Then("my school's availability preference should be {string}") do |option|

--- a/features/step_definitions/schools/placement_dates/edit_steps.rb
+++ b/features/step_definitions/schools/placement_dates/edit_steps.rb
@@ -25,8 +25,8 @@ end
 
 Then("my placement should have been {string}") do |operation|
   description = {
-    'deactivated' => 'Taken',
-    'activated'   => 'Available'
+    'deactivated' => 'Closed',
+    'activated'   => 'Open'
   }[operation]
 
   within("tr[data-placement-date-id='#{@placement_date.id}']") do

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -37,6 +37,7 @@ def path_for(descriptor, school: nil, placement_date_id: nil, booking_id: nil)
     "candidate experience details" => [:new_schools_on_boarding_candidate_experience_detail_path],
     "availability" => [:new_schools_on_boarding_availability_path],
     "availability preferences" => [:edit_schools_availability_preference_path],
+    "availability information" => [:edit_schools_availability_info_path],
     "placement dates" => [:schools_placement_dates_path],
     "new placement date" => [:new_schools_placement_date_path],
     "edit placement date" => [:edit_schools_placement_date_path, placement_date_id],

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -36,6 +36,7 @@ def path_for(descriptor, school: nil, placement_date_id: nil, booking_id: nil)
     "description" => [:new_schools_on_boarding_description_path],
     "candidate experience details" => [:new_schools_on_boarding_candidate_experience_detail_path],
     "availability" => [:new_schools_on_boarding_availability_path],
+    "availability preferences" => [:edit_schools_availability_preference_path],
     "placement dates" => [:schools_placement_dates_path],
     "new placement date" => [:new_schools_placement_date_path],
     "edit placement date" => [:edit_schools_placement_date_path, placement_date_id],

--- a/spec/controllers/schools/dashboards_controller_spec.rb
+++ b/spec/controllers/schools/dashboards_controller_spec.rb
@@ -63,7 +63,7 @@ describe Schools::DashboardsController, type: :request do
         before { get '/schools/dashboard' }
 
         specify 'should have the link' do
-          expect(response.body).to match(/Update school experience dates/)
+          expect(response.body).to match(/Add, remove, close and open.*fixed dates.*for school experience/)
         end
       end
 
@@ -72,7 +72,7 @@ describe Schools::DashboardsController, type: :request do
         before { get '/schools/dashboard' }
 
         specify 'should have the link' do
-          expect(response.body).not_to match(/Update school experience dates/)
+          expect(response.body).to match(/Update your availability and.*flexible dates.*for school experience/)
         end
       end
     end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -48,6 +48,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_placement_dates do
+      after :create do |school|
+        FactoryBot.create(:bookings_placement_date, bookings_school: school)
+      end
+    end
+
     trait :with_teacher_training_info do
       teacher_training_info { 'We offer a PGCE in partnership with Chester University. We are a lead school for School Direct' }
     end

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -104,4 +104,62 @@ describe Schools::DashboardsHelper, type: 'helper' do
       end
     end
   end
+
+  context '#show_no_placement_dates_warning?' do
+    context 'when availability preference is fixed and dates are available' do
+      let(:school) { create(:bookings_school, :with_fixed_availability_preference, :with_placement_dates) }
+      subject { show_no_placement_dates_warning?(school) }
+
+      specify 'should be false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when availability preference is flexible and dates are available' do
+      let(:school) { create(:bookings_school, :with_placement_dates) }
+      subject { show_no_placement_dates_warning?(school) }
+
+      specify 'should be false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when availability preference is fixed and dates are not available' do
+      let(:school) { create(:bookings_school, :with_fixed_availability_preference) }
+      subject { show_no_placement_dates_warning?(school) }
+
+      specify 'should be true' do
+        expect(subject).to be true
+      end
+    end
+  end
+
+  context '#show_no_availability_info_warning?' do
+    context 'when availability preference is flexible and availability info present' do
+      let(:school) { create(:bookings_school, :with_availability_info) }
+      subject { show_no_availability_info_warning?(school) }
+
+      specify 'should be false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when availability preference is fixed and availability info is present' do
+      let(:school) { create(:bookings_school, :with_fixed_availability_preference, :with_availability_info) }
+      subject { show_no_availability_info_warning?(school) }
+
+      specify 'should be false' do
+        expect(subject).to be false
+      end
+    end
+
+    context 'when availability preference is fixed and dates are not available' do
+      let(:school) { create(:bookings_school) }
+      subject { show_no_availability_info_warning?(school) }
+
+      specify 'should be true' do
+        expect(subject).to be true
+      end
+    end
+  end
 end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -12,6 +12,19 @@ describe Bookings::School, type: :model do
       it { is_expected.to validate_numericality_of(:fee).is_greater_than_or_equal_to(0) }
     end
 
+    context 'availability_info' do
+      it { is_expected.to allow_value(nil).for(:availability_info) }
+      it { is_expected.to validate_length_of(:availability_info).is_at_least(10) }
+
+      context 'overwriting empty strings before validation' do
+        subject { create(:bookings_school) }
+        before { subject.update(availability_info: '') }
+        specify 'should overwrite empty strings with nil' do
+          expect(subject.availability_info).to be_nil
+        end
+      end
+    end
+
     shared_examples "websites" do |field_name|
       valid_urls = %w{http://www.bbc.co.uk https://bbc.co.uk http://news.bbc.com}
       invalid_urls = [


### PR DESCRIPTION
### Context

Add the ability for schools to modify their date strategy without using the onboarding wizard

### Changes proposed in this pull request

Add a new `Schools::AvailabilityInfoController` that allows for the `availability_info` to be edited. The dashlette has been updated so that when the schools is set for fixed dates they see a link to the placement dates management screen, and when they're set for flexible dates they see a link to the availability info editing screen.

Additionally, there are warnings at the top of the dashlette informing schools that they won't appear in candidate searches if their appropriate data isn't present/set

### Guidance to review

Ensure it works as described and that everything looks ok.
