### PR TITLE
Added Spring RSpec integration to speed up repeated test runs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-commands-rspec'
 
   # Manage multiple processes i.e. web server and webpack
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -361,6 +361,8 @@ GEM
     slack-notifier (2.3.2)
     spring (2.0.2)
       activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -465,6 +467,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.0)
   slack-notifier
   spring
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
### Context

Repeated runs of tests boot the entire application each time. I'm used to this being fairly quick in minitest, rspec is noticeably slower. I'm currently doing lots of fiddly test runs as part of the CRM work.

### Changes proposed in this pull request

1. Enable spring for rspec

### Guidance to review

Spring is only used when running `bin/rspec` but not `rspec` outside of the binstub, allowing those who dislike spring it to bypass it.

