### PR TITLE
Ensure start button is at bottom of school profile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,3 +32,4 @@ $govuk-grid-widths: (
 @import "school-bookings" ;
 @import "school-dashboard" ;
 @import "school-placement-dates" ;
+@import "school-profile" ;

--- a/app/assets/stylesheets/school-profile.scss
+++ b/app/assets/stylesheets/school-profile.scss
@@ -1,0 +1,13 @@
+.school-start-request-button__mobile {
+  // hide the button at every size bigger than mobile
+  @include govuk-media-query($from: tablet) {
+    display: none;
+  }
+}
+
+.school-start-request-button__tablet_plus {
+  // hide the button at sizes smaller than mobile
+  @include govuk-media-query($from: mobile, $until: tablet) {
+    display: none;
+  }
+}

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -45,14 +45,6 @@
       </p>
     </div>
 
-    <%- if @school.has_availability? -%>
-    <p>
-      <%= link_to "Start request",
-                  new_candidates_school_registrations_placement_preference_path(@school),
-                  class:"govuk-button" %>
-    </p>
-    <%- end -%>
-
     <p>
       <strong>
         For more information about our school use the following links:
@@ -88,6 +80,15 @@
       </li>
       <%- end -%>
     </ul>
+
+    <%- if @school.has_availability? -%>
+    <div class="school-start-request-button__tablet_plus">
+      <%= link_to "Start request",
+                  new_candidates_school_registrations_placement_preference_path(@school),
+                  class:"govuk-button" %>
+    </div>
+    <%- end -%>
+
   </div>
 
   <div class="govuk-grid-column-one-third column-top-border">
@@ -127,6 +128,14 @@
       </div>
       <%- end -%>
     </dl>
+
+    <%- if @school.has_availability? -%>
+    <div class="school-start-request-button__mobile">
+      <%= link_to "Start request",
+                  new_candidates_school_registrations_placement_preference_path(@school),
+                  class:"govuk-button" %>
+    </div>
+  <%- end -%>
 
   </div>
 </div>

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -39,12 +39,6 @@
       </p>
     </div>
 
-    <p>
-      <%= link_to "Start request",
-                  new_candidates_school_registrations_placement_preference_path(@presenter.school),
-                  class:"govuk-button" %>
-    </p>
-
     <div>
       <h2>About our school</h2>
 
@@ -89,6 +83,12 @@
         </li>
         <%- end -%>
       </ul>
+    </div>
+
+    <div class="school-start-request-button__tablet_plus">
+      <%= link_to "Start request",
+                  new_candidates_school_registrations_placement_preference_path(@presenter.school),
+                  class:"govuk-button" %>
     </div>
 
     <p>
@@ -198,5 +198,11 @@
         </p>
       <% end if @presenter.teacher_training_info.present? %>
     </dl>
+
+    <div class="school-start-request-button__mobile">
+      <%= link_to "Start request",
+                  new_candidates_school_registrations_placement_preference_path(@presenter.school),
+                  class:"govuk-button" %>
+    </div>
   </div>
 </div>

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -26,6 +26,12 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
     it "will include dress code information" do
       expect(rendered).to have_css("#dress-code")
     end
+
+    it "has two start request buttons with appropriate responsive classes" do
+      %w(school-start-request-button__tablet_plus school-start-request-button__mobile).each do |css_class|
+        expect(rendered).to have_css("div.#{css_class} > a", text: 'Start request')
+      end
+    end
   end
 
   context 'without profile' do
@@ -41,6 +47,12 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
     it "will provide a link to apply" do
       link = new_candidates_school_registrations_placement_preference_path(school)
       expect(rendered).to have_css("a.govuk-button[href=\"#{link}\"]")
+    end
+
+    it "has two start request buttons with appropriate responsive classes" do
+      %w(school-start-request-button__tablet_plus school-start-request-button__mobile).each do |css_class|
+        expect(rendered).to have_css("div.#{css_class} > a", text: 'Start request')
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

The start button should always be at the bottom of the school profile page

### Changes proposed in this pull request

Ensure the start request is always at the bottom using media queries. There are actually two buttons but one will always be hidden

### Guidance to review

Ensure it works! It looks like it does
