### PR TITLE
Link searches and placement requests for analytics SE-1012

### DIFF
--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -16,7 +16,7 @@ module Candidates
 
           RegistrationStore.instance.store! registration_session
 
-          PlacementRequestJob.perform_later registration_session.uuid
+          PlacementRequestJob.perform_later registration_session.uuid, session[:analytics_tracking_uuid]
         end
 
         redirect_to candidates_school_registrations_placement_request_path \

--- a/app/controllers/candidates/school_searches_controller.rb
+++ b/app/controllers/candidates/school_searches_controller.rb
@@ -1,4 +1,6 @@
 class Candidates::SchoolSearchesController < ApplicationController
+  include AnalyticsTracking
+
   def new
     @search = Candidates::SchoolSearch.new(search_params)
   end

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -1,17 +1,18 @@
 class Candidates::SchoolsController < ApplicationController
+  include AnalyticsTracking
   EXPANDED_SEARCH_RADIUS = 50
 
   def index
     return redirect_to new_candidates_school_search_path unless location_present?
 
-    @search = Candidates::SchoolSearch.new(search_params)
+    @search = Candidates::SchoolSearch.new(search_params_with_analytics_tracking)
 
     return render 'candidates/school_searches/new' unless @search.valid?
 
     if @search.results.empty?
       @expanded_search_radius = true
       @search = Candidates::SchoolSearch.new(
-        search_params.merge(distance: EXPANDED_SEARCH_RADIUS)
+        search_params_with_analytics_tracking.merge(distance: EXPANDED_SEARCH_RADIUS)
       )
     end
   end
@@ -37,5 +38,9 @@ private
       :query, :location, :latitude, :longitude, :page,
       :distance, :max_fee, :order, phases: [], subjects: []
     )
+  end
+
+  def search_params_with_analytics_tracking
+    search_params.merge(analytics_tracking_uuid: session[:analytics_tracking_uuid])
   end
 end

--- a/app/controllers/concerns/analytics_tracking.rb
+++ b/app/controllers/concerns/analytics_tracking.rb
@@ -1,0 +1,15 @@
+module AnalyticsTracking
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :set_analytics_tracking_uuid
+
+  private
+
+    def set_analytics_tracking_uuid
+      if session[:analytics_tracking_uuid].blank?
+        session[:analytics_tracking_uuid] = SecureRandom.uuid
+      end
+    end
+  end
+end

--- a/app/jobs/candidates/registrations/placement_request_job.rb
+++ b/app/jobs/candidates/registrations/placement_request_job.rb
@@ -5,8 +5,8 @@ module Candidates
 
       retry_on Notify::RetryableError, wait: A_DECENT_AMOUNT_LONGER, attempts: 5
 
-      def perform(uuid)
-        PlacementRequestAction.new(uuid).perform!
+      def perform(uuid, analytics_tracking_uuid = nil)
+        PlacementRequestAction.new(uuid, analytics_tracking_uuid).perform!
       end
     end
   end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -10,9 +10,12 @@ module Bookings
       class_name: 'Bookings::School',
       foreign_key: :bookings_school_id
 
-    def self.create_from_registration_session!(registration_session)
+    def self.create_from_registration_session!(registration_session, analytics_tracking_uuid = nil)
       self.create! \
-        Candidates::Registrations::RegistrationAsPlacementRequest.new(registration_session).attributes
+        Candidates::Registrations::RegistrationAsPlacementRequest
+          .new(registration_session)
+          .attributes
+          .merge(analytics_tracking_uuid: analytics_tracking_uuid)
     end
   end
 end

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -19,7 +19,8 @@ module Candidates
       ['90', 'up to £90']
     ].freeze
 
-    attr_accessor :query, :location, :order, :latitude, :longitude, :page
+    attr_accessor :query, :location, :order, :latitude,
+                  :longitude, :page, :analytics_tracking_uuid
     attr_reader :distance, :max_fee
 
     delegate :location_name, :valid?, :errors, to: :school_search
@@ -113,7 +114,8 @@ module Candidates
         phases: phases,
         max_fee: max_fee,
         requested_order: order,
-        page: page
+        page: page,
+        analytics_tracking_uuid: analytics_tracking_uuid
       )
     end
 

--- a/app/services/candidates/registrations/placement_request_action.rb
+++ b/app/services/candidates/registrations/placement_request_action.rb
@@ -1,15 +1,17 @@
 module Candidates
   module Registrations
     class PlacementRequestAction
-      def initialize(uuid)
+      def initialize(uuid, analytics_tracking_uuid = nil)
         @uuid = uuid
+        @analytics_tracking_uuid = analytics_tracking_uuid
       end
 
       def perform!
         school_request_confirmation.despatch!
         candidate_request_confirmation.despatch!
         Bookings::PlacementRequest.create_from_registration_session! \
-          registration_session
+          registration_session,
+          @analytics_tracking_uuid
 
         RegistrationStore.instance.delete! registration_session.uuid
       end

--- a/db/migrate/20190524103626_add_tracking_uuid_to_bookings_school_searches.rb
+++ b/db/migrate/20190524103626_add_tracking_uuid_to_bookings_school_searches.rb
@@ -1,0 +1,7 @@
+class AddTrackingUuidToBookingsSchoolSearches < ActiveRecord::Migration[5.2]
+  def change
+    # no indexes, these won't be used by the app
+    add_column :bookings_school_searches, :analytics_tracking_uuid, :uuid, null: true
+    add_column :bookings_placement_requests, :analytics_tracking_uuid, :uuid, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_16_140550) do
+ActiveRecord::Schema.define(version: 2019_05_24_103626) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 2019_05_16_140550) do
     t.text "availability"
     t.integer "bookings_placement_date_id"
     t.integer "bookings_school_id"
+    t.uuid "analytics_tracking_uuid"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
     t.index ["bookings_school_id"], name: "index_bookings_placement_requests_on_bookings_school_id"
   end
@@ -128,6 +129,7 @@ ActiveRecord::Schema.define(version: 2019_05_16_140550) do
     t.geography "coordinates", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.uuid "analytics_tracking_uuid"
   end
 
   create_table "bookings_school_types", force: :cascade do |t|

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -70,7 +70,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
 
         it 'enqueues the placement request job' do
           expect(Candidates::Registrations::PlacementRequestJob).to \
-            have_received(:perform_later).with uuid
+            have_received(:perform_later).with uuid, nil
         end
 
         it 'redirects to placement request show' do

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -72,6 +72,24 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         specify { expect(response).to have_http_status(:success) }
       end
     end
+
+    context 'analytics tracking' do
+      # set the uuid in the session, grab it then do a search
+      before { get new_candidates_school_search_path }
+      before { @uuid = session[:analytics_tracking_uuid] }
+      before { get candidates_schools_path(query_params) }
+
+      specify 'should persist the analytics_tracking_uuid if present' do
+        expect(Bookings::SchoolSearch.last.analytics_tracking_uuid).to eql(@uuid)
+      end
+
+      specify 'make sure it looks like a UUID' do
+        @uuid.split('-').tap do |parts|
+          expect(parts.map(&:length)).to eql([8, 4, 4, 4, 12])
+          expect(parts).to all(match(/[0-9a-f]/))
+        end
+      end
+    end
   end
 
   context "GET #show" do

--- a/spec/jobs/candidates/registrations/placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/placement_request_job_spec.rb
@@ -7,6 +7,10 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
     'some-uuid'
   end
 
+  let :analytics_tracking_uuid do
+    'some-analytics-uuid'
+  end
+
   let :placement_request_action do
     double Candidates::Registrations::PlacementRequestAction, perform!: true
   end
@@ -19,15 +23,30 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
 
   context '#perform' do
     context 'no errors' do
-      before do
-        described_class.perform_later uuid
+      context 'with only a uuid' do
+        before do
+          described_class.perform_later uuid
+        end
+
+        it 'calls PlacementRequestAction with a uuid' do
+          expect(Candidates::Registrations::PlacementRequestAction).to \
+            have_received(:new).with(uuid, nil)
+
+          expect(placement_request_action).to have_received(:perform!)
+        end
       end
 
-      it 'calls PlacementRequestAction with the correct arguments' do
-        expect(Candidates::Registrations::PlacementRequestAction).to \
-          have_received(:new).with(uuid)
+      context 'with a uuid and an analytics_tracking_uuid' do
+        before do
+          described_class.perform_later uuid, analytics_tracking_uuid
+        end
 
-        expect(placement_request_action).to have_received :perform!
+        it 'calls PlacementRequestAction with a uuid and a analytics_tracking_uuid' do
+          expect(Candidates::Registrations::PlacementRequestAction).to \
+            have_received(:new).with(uuid, analytics_tracking_uuid)
+
+          expect(placement_request_action).to have_received :perform!
+        end
       end
     end
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -15,6 +15,7 @@ describe Bookings::PlacementRequest, type: :model do
   it { is_expected.to have_db_column(:has_dbs_check).of_type(:boolean).with_options null: false }
   it { is_expected.to have_db_column(:availability).of_type(:text).with_options null: true }
   it { is_expected.to have_db_column(:bookings_placement_date_id).of_type(:integer).with_options null: true }
+  it { is_expected.to have_db_column(:analytics_tracking_uuid).of_type(:uuid).with_options null: true }
 
   it_behaves_like 'a background check'
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -50,6 +50,24 @@ describe Bookings::PlacementRequest, type: :model do
         }.to change { described_class.count }.by 1
       end
     end
+
+    context 'with analytics_tracking_uuid' do
+      let! :analytics_tracking_uuid do
+        SecureRandom.uuid
+      end
+
+      let :registration_session do
+        FactoryBot.build :registration_session
+      end
+
+      subject do
+        described_class.create_from_registration_session! registration_session, analytics_tracking_uuid
+      end
+
+      specify 'it stores the analytics_tracking_uuid correctly if supplied' do
+        expect(subject.analytics_tracking_uuid).to eql(analytics_tracking_uuid)
+      end
+    end
   end
 
   context 'attributes' do

--- a/spec/services/candidates/registrations/placement_request_action_spec.rb
+++ b/spec/services/candidates/registrations/placement_request_action_spec.rb
@@ -109,10 +109,25 @@ describe Candidates::Registrations::PlacementRequestAction do
             .with(registration_session.email, application_preview)
         end
 
-        it 'persists the registration in postgres' do
-          expect(Bookings::PlacementRequest).to \
-            have_received(:create_from_registration_session!).with \
-              registration_session
+        context 'when a analytics_tracking_uuid is not present' do
+          it 'persists the registration in postgres' do
+            expect(Bookings::PlacementRequest).to \
+              have_received(:create_from_registration_session!).with \
+                registration_session,
+                nil
+          end
+        end
+
+        context 'when a analytics_tracking_uuid is present' do
+          let(:analytics_tracking_uuid) { 'some-analytics-uuid' }
+          subject { described_class.new uuid, analytics_tracking_uuid }
+
+          it 'persists the registration in postgres' do
+            expect(Bookings::PlacementRequest).to \
+              have_received(:create_from_registration_session!).with \
+                registration_session,
+                analytics_tracking_uuid
+          end
         end
 
         it 'removes the registration_session from redis' do


### PR DESCRIPTION
### Context

Currently we are unable to link searches to requests in our analytics as there is no common data shared between the two aspects of the app. This makes producing certain kinds of reports much more diffcult for @onah-noelyn 

### Changes proposed in this pull request

Introduce a concern, `AnalyticsTracking` included by the `Candidates::SchoolSearchesController` and `Candidates::SchoolsController` that, if one isn't already set, adds an `analytics_tracking_uuid` to the session. It is stored with every search.

If that value is still present in the session when the actual placement request is made, it is stored in the `Bookings::PlacementRequest`.

These two `uuid` values can then be matched either in the analytics layer or prior to that (as part of the [analytics preparation](https://github.com/DFE-Digital/analytics-preparation) stage).

### Guidance to review

Ensure these changes don't risk or break any part of the candidate sign-up wizard
