### PR TITLE
Added stub method which the Candidate auth screens can build around

### DIFF
--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -25,6 +25,15 @@ module Bookings
         end
       end
 
+      # Will return nil of it cannot match a Contact on final implementation
+      def find_contact_for_signin(email:, firstname:, lastname:, date_of_birth:)
+        # if condition is to keep the linter happy about unused variables
+        # temporary since this is a shim for now
+        if firstname && lastname && date_of_birth
+          find_by_email(email)
+        end
+      end
+
       def write(contact)
         raise ArgumentError unless contact.is_a?(Contact)
         return false unless contact.valid?

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -14,7 +14,7 @@ describe Bookings::Gitis::CRM, type: :model do
     end
   end
 
-  describe '.find' do
+  describe '#find' do
     let!(:uuids) do
       [
         "03ec3075-a9f9-400f-bc43-a7a5cdf68579",
@@ -69,7 +69,7 @@ describe Bookings::Gitis::CRM, type: :model do
     end
   end
 
-  describe '.find_by_email' do
+  describe '#find_by_email' do
     let(:email) { 'me@something.com' }
 
     it "will return a contact record" do
@@ -77,7 +77,24 @@ describe Bookings::Gitis::CRM, type: :model do
     end
   end
 
-  describe '.write' do
+  describe '#find_contact_for_signin' do
+    let(:email) { 'me@something.com' }
+
+    subject do
+      gitis.find_contact_for_signin(
+        email: email,
+        firstname: 'ignore',
+        lastname: 'ignore',
+        date_of_birth: 'invalid'
+      )
+    end
+
+    it "will return a contact record" do
+      is_expected.to have_attributes(email: email)
+    end
+  end
+
+  describe '#write' do
     # Note: this is just stubbed functionality for now
     context 'with a valid contact' do
       before { @contact = build(:gitis_contact) }


### PR DESCRIPTION
### Context

Implementation of the Candidate sign in screens don't need the gitis integration completing, just a consistent API to operate around.

### Changes proposed in this pull request

Add a new method `Bookings::Gitis::CRM#find_contact_for_signin` which can be used within the auth flow. This can then be back filled with an actual implementation as part of the Gitis API work

### Guidance to review

Does it seem reasonable

