### PR TITLE
Add titles to the school onboarding pages

### DIFF
--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = title -%>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -1,9 +1,11 @@
-<%
+<%- self.page_title = 'Enter school experience admin contact details' -%>
+
+<%-
   self.breadcrumbs = {
     @current_school.name => schools_root_path,
     'Enter school experience admin contact details' => nil
   }
-%>
+-%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/availability_descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/availability_descriptions/_form.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = 'Describe your school experience availability' %>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = 'Enter school experience details for candidates' -%>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
@@ -1,3 +1,4 @@
+<%- self.page_title = 'Enter your school experience details' %>
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -1,3 +1,12 @@
+<%- self.page_title = 'DBS check costs' -%>
+
+<%
+  self.breadcrumbs = {
+    @current_school.name => schools_root_path,
+    'DBS check costs' => nil
+  }
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-heading-l">

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = 'Enter a short description of your school' -%>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/experience_outlines/_form.html.erb
+++ b/app/views/schools/on_boarding/experience_outlines/_form.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = 'Outline experience and teacher training' -%>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = 'Do you charge fees to cover any of the following?' -%>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = 'Confirm number of primary key stages' -%>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -1,3 +1,4 @@
+<%- self.page_title = 'Select school experience phases' %>
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -1,3 +1,5 @@
+<%- self.page_title = 'Check your answers before setting up your school experience profile' -%>
+
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/app/views/schools/on_boarding/subjects/_form.html.erb
+++ b/app/views/schools/on_boarding/subjects/_form.html.erb
@@ -1,3 +1,4 @@
+<%- self.page_title = 'Select school experience subjects' %>
 <%
   self.breadcrumbs = {
     @current_school.name => schools_root_path,

--- a/features/schools/onboarding/admin_contact.feature
+++ b/features/schools/onboarding/admin_contact.feature
@@ -22,6 +22,10 @@ Feature: Admin contact
         | Availability description     |                           |
         | Experience Outline           |                           |
 
+  Scenario: Page title
+    Given I am on the 'Admin contact' page
+    Then the page title should be 'Enter school experience admin contact details'
+
   Scenario: Completing the step with error
     Given I am on the 'Admin contact' page
     And I enter 'Gary Chalmers' into the 'Full name' text area

--- a/features/schools/onboarding/administration_fee.feature
+++ b/features/schools/onboarding/administration_fee.feature
@@ -12,6 +12,10 @@ Feature: Administration Fee
         | Candidate Requirements |                                    |
         | Fees                   | choosing only Administration costs |
 
+  Scenario: Page title
+    Given I am already on the 'administration costs' page
+    Then the page title should be 'Administration costs'
+
   Scenario: Breadcrumbs
     Given I am already on the 'administration costs' page
     Then I should see the following breadcrumbs:

--- a/features/schools/onboarding/availability_description.feature
+++ b/features/schools/onboarding/availability_description.feature
@@ -19,6 +19,10 @@ Feature: Availability description
         | Candidate experience details |                           |
         | Availability preference      |                           |
 
+  Scenario: Page title
+    Given I am already on the 'availability description' page
+    Then the page title should be 'Describe your school experience availability'
+
   Scenario: Breadcrumbs
     Given I am already on the 'availability description' page
     Then I should see the following breadcrumbs:

--- a/features/schools/onboarding/candidate_experience_detail.feature
+++ b/features/schools/onboarding/candidate_experience_detail.feature
@@ -17,6 +17,10 @@ Feature: Candidate experience details
         | Subjects                     |                           |
         | Description                  |                           |
 
+  Scenario: Page title
+    Given I am already on the 'candidate experience details' page
+    Then the page title should be 'Enter school experience details for candidates'
+
   Scenario: Breadcrumbs
     Given I am already on the 'candidate experience details' page
     Then I should see the following breadcrumbs:

--- a/features/schools/onboarding/candidate_requirements.feature
+++ b/features/schools/onboarding/candidate_requirements.feature
@@ -6,6 +6,10 @@ Feature: Candidate requirements
   Background:
     Given I am logged in as a DfE user
 
+  Scenario: Page title
+    Given I am on the 'candidate requirements' page
+    Then the page title should be 'Enter your school experience details'
+
   Scenario: Breadcrumbs
     Given I am on the 'candidate requirements' page
     Then I should see the following breadcrumbs:

--- a/features/schools/onboarding/dbs_fee.feature
+++ b/features/schools/onboarding/dbs_fee.feature
@@ -8,9 +8,20 @@ Feature: DBS Fee
     And the secondary school phase is availble
     And the college phase is availble
     And I have completed the following steps:
-        | Step name              | Extra                              |
-        | Candidate Requirements |                                    |
+        | Step name              | Extra                   |
+        | Candidate Requirements |                         |
         | Fees                   | choosing only DBS costs |
+
+  Scenario: Page title
+    Given I am on the 'dbs check costs' page
+    Then the page title should be 'DBS check costs'
+
+  Scenario: Breadcrumbs
+    Given I am on the 'dbs check costs' page
+    Then I should see the following breadcrumbs:
+        | Text            | Link     |
+        | Some school     | /schools |
+        | DBS check costs | None     |
 
   Scenario: Completing the DBS costs step with error
     Given I have entered the following details into the form:

--- a/features/schools/onboarding/descriptions.feature
+++ b/features/schools/onboarding/descriptions.feature
@@ -16,6 +16,10 @@ Feature: Description
         | Phases                       |                           |
         | Subjects                     |                           |
 
+  Scenario: Page title
+    Given I am on the 'description' page
+    Then the page title should be 'Enter a short description of your school'
+
   Scenario: Breadcrumbs
     Given I am already on the 'description' page
     Then I should see the following breadcrumbs:

--- a/features/schools/onboarding/experience_outline.feature
+++ b/features/schools/onboarding/experience_outline.feature
@@ -25,6 +25,10 @@ Feature: Experience Outline
         | Some school                             | /schools |
         | Outline experience and teacher training | None     |
 
+  Scenario: Page title
+    Given I am on the 'Experience Outline' page
+    Then the page title should be 'Outline experience and teacher training'
+
   Scenario: Completing the step with error
     Given I am on the 'Experience Outline' page
     And I enter 'A really good one' into the 'What kind of school experience do you offer candidates?' text area

--- a/features/schools/onboarding/fees.feature
+++ b/features/schools/onboarding/fees.feature
@@ -9,6 +9,18 @@ Feature: Fees
     And the college phase is availble
     And I have completed the Candidate Requirements step
 
+
+  Scenario: Page title
+    Given I am on the 'fees charged' page
+    Then the page title should be 'Do you charge fees to cover any of the following?'
+
+  Scenario: Breadcrumbs
+    Given I am already on the 'fees charged' page
+    Then I should see the following breadcrumbs:
+        | Text                                              | Link     |
+        | Some school                                       | /schools |
+        | Do you charge fees to cover any of the following? | None     |
+
   Scenario: Completing step choosing Adminsitration costs only
     Given I am on the 'fees charged' page
     And I choose 'Yes' from the 'Administration costs' radio buttons

--- a/features/schools/onboarding/other_fee.feature
+++ b/features/schools/onboarding/other_fee.feature
@@ -12,6 +12,10 @@ Feature: Other Fee
         | Candidate Requirements       |                           |
         | Fees                         | choosing only Other costs |
 
+  Scenario: Page title
+    Given I am on the 'other costs' page
+    Then the page title should be 'Other costs'
+
   Scenario: Breadcrumbs
     Given I am already on the 'other costs' page
     Then I should see the following breadcrumbs:

--- a/features/schools/onboarding/phases.feature
+++ b/features/schools/onboarding/phases.feature
@@ -13,6 +13,10 @@ Feature: Phases
         | Fees                         | choosing only Other costs |
         | Other costs                  |                           |
 
+  Scenario: Page title
+    Given I am on the 'phases' page
+    Then the page title should be 'Select school experience phases'
+
   Scenario: Breadcrumbs
     Given I am on the 'phases' page
     Then I should see the following breadcrumbs:

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -24,6 +24,18 @@ Feature: School Profile
         | Admin contact                |                           |
 
 
+  Scenario: Page title
+    Given I am on the 'Profile' page
+    Then the page title should be 'Check your answers before setting up your school experience profile'
+
+  Scenario: Breadcrumbs
+    Given I am on the 'Profile' page
+    Then I should see the following breadcrumbs:
+        | Text                                                                | Link     |
+        | Some school                                                         | /schools |
+        | Check your answers before setting up your school experience profile | None     |
+
+
   Scenario: Viewing the profile
     Given I am on the 'Profile' page
     Then the page should have the following summary list information:

--- a/features/schools/onboarding/secondary_subjects.feature
+++ b/features/schools/onboarding/secondary_subjects.feature
@@ -15,6 +15,10 @@ Feature: Subjects
         | Other costs                  |                           |
         | Phases                       |                           |
 
+  Scenario: Page title
+    Given I am on the 'Subjects' page
+    Then the page title should be 'Select school experience subjects'
+
   Scenario: Breadcrumbs
     Given I am already on the 'Subjects' page
     Then I should see the following breadcrumbs:


### PR DESCRIPTION
### Context

The school onboarding pages were difficult to identify in Analytics because they didn't have a page title.

### Changes proposed in this pull request

Set the page titles for all onboarding pages, for the time being set it to the same value as appears in the breadcrumbs

### Guidance to review

Make sure everything looks ok.
