### PR TITLE
Feature/remove fee defaults se 1061

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -1,5 +1,6 @@
 module Schools
   class SchoolNotRegistered < StandardError; end
+  class MissingURN < StandardError; end
 
   class BaseController < ApplicationController
     include DFEAuthentication
@@ -7,12 +8,12 @@ module Schools
     before_action :set_current_school
     before_action :set_site_header_text
 
-    rescue_from ActionController::ParameterMissing, with: -> { redirect_to schools_errors_no_school_path }
+    rescue_from MissingURN, with: -> { redirect_to schools_errors_no_school_path }
     rescue_from SchoolNotRegistered, with: -> { redirect_to schools_errors_not_registered_path }
 
     def current_school
       urn = session[:urn]
-      raise ActionController::ParameterMissing, 'urn is missing, unable to match with school' unless urn.present?
+      raise MissingURN, 'urn is missing, unable to match with school' unless urn.present?
 
       Rails.logger.debug("Looking for school #{urn}")
       @current_school ||= retrieve_school(urn)

--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -1,9 +1,9 @@
 module Schools
   module OnBoarding
     class Fees < Step
-      attribute :administration_fees, :boolean, default: false
-      attribute :dbs_fees, :boolean, default: false
-      attribute :other_fees, :boolean, default: false
+      attribute :administration_fees, :boolean
+      attribute :dbs_fees, :boolean
+      attribute :other_fees, :boolean
 
       validates :administration_fees, inclusion: [true, false]
       validates :dbs_fees, inclusion: [true, false]

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -24,6 +24,9 @@
         This includes fees to cover administration costs, background and security ‘DBS check’ charges or any other school experience-related costs schools might incur.
       </p>
 
+      <% # hidden_field ensures the form is submitted if no radios selected %>
+      <%= f.hidden_field :administration_fees %>
+
       <%= f.radio_button_fieldset :administration_fees, choices: [true, false] %>
       <%= f.radio_button_fieldset :dbs_fees, choices: [true, false] %>
       <%= f.radio_button_fieldset :other_fees, choices: [true, false] %>

--- a/features/schools/onboarding/fees.feature
+++ b/features/schools/onboarding/fees.feature
@@ -24,18 +24,24 @@ Feature: Fees
   Scenario: Completing step choosing Adminsitration costs only
     Given I am on the 'fees charged' page
     And I choose 'Yes' from the 'Administration costs' radio buttons
+    And I choose 'No' from the 'DBS check costs' radio buttons
+    And I choose 'No' from the 'Other costs' radio buttons
     When I submit the form
     Then I should be on the 'Administration costs' page
 
   Scenario: Completing step choosing DBS costs only
     Given I am on the 'fees charged' page
     And I choose 'Yes' from the 'DBS check costs' radio buttons
+    And I choose 'No' from the 'Administration costs' radio buttons
+    And I choose 'No' from the 'Other costs' radio buttons
     When I submit the form
     Then I should be on the 'DBS check costs' page
 
   Scenario: Completing step choosing Other costs only
     Given I am on the 'fees charged' page
     And I choose 'Yes' from the 'Other costs' radio buttons
+    And I choose 'No' from the 'DBS check costs' radio buttons
+    And I choose 'No' from the 'Administration costs' radio buttons
     When I submit the form
     Then I should be on the 'Other costs' page
 
@@ -46,8 +52,3 @@ Feature: Fees
     And I choose 'Yes' from the 'Other costs' radio buttons
     When I submit the form
     Then I should be on the 'Administration costs' page
-
-  Scenario: Completing step choosing no costs
-    Given I am on the 'fees charged' page
-    When I submit the form
-    Then I should be on the 'Phases' page

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -18,6 +18,8 @@ Given "I have completed the Fees step, choosing only Administration costs" do
     Given I have completed the Candidate Requirements step
     Given I am on the 'fees charged' page
     And I choose 'Yes' from the 'Administration costs' radio buttons
+    And I choose 'No' from the 'DBS check costs' radio buttons
+    And I choose 'No' from the 'Other costs' radio buttons
     When I submit the form
   )
 end
@@ -26,6 +28,8 @@ Given "I have completed the Fees step, choosing only DBS costs" do
   steps %(
     Given I am on the 'fees charged' page
     And I choose 'Yes' from the 'DBS check costs' radio buttons
+    And I choose 'No' from the 'Administration costs' radio buttons
+    And I choose 'No' from the 'Other costs' radio buttons
     When I submit the form
   )
 end
@@ -34,6 +38,8 @@ Given "I have completed the Fees step, choosing only Other costs" do
   steps %(
     Given I am on the 'fees charged' page
     And I choose 'Yes' from the 'Other costs' radio buttons
+    And I choose 'No' from the 'Administration costs' radio buttons
+    And I choose 'No' from the 'DBS check costs' radio buttons
     When I submit the form
   )
 end


### PR DESCRIPTION
### Context

Remove default from fees

### Changes proposed in this pull request

Fees were changed from checkboxes (which default to `false`) to radios in #390, the old behaviour was implemented using radio buttons. The GOV.UK Design System favours radio buttons without a default, so it is being removed

### Guidance to review

Ensure it looks ok.
