### PR TITLE
Allow for multiple OLD_SEP_DOMAIN redirects

### DIFF
--- a/config/initializers/canonical_redirect.rb
+++ b/config/initializers/canonical_redirect.rb
@@ -7,8 +7,8 @@ if ENV['CANONICAL_DOMAIN'].present? || Rails.env.test? || Rails.env.servertest?
       lambda { |match, rack_env| "#{proto}://#{ENV['CANONICAL_DOMAIN']}/pages/migration" },
       if: Proc.new { |rack_env|
         ENV['CANONICAL_DOMAIN'].present? &&
-          ENV['OLD_SEP_DOMAIN'].present? &&
-          rack_env['HTTP_HOST'] == ENV['OLD_SEP_DOMAIN']
+          ENV['OLD_SEP_DOMAINS'].present? &&
+          rack_env['HTTP_HOST'].in?(ENV['OLD_SEP_DOMAINS'].split(',').compact)
       }
 
     r302 %r{(.*)},

--- a/spec/requests/canonical_url_redirection_spec.rb
+++ b/spec/requests/canonical_url_redirection_spec.rb
@@ -5,12 +5,11 @@ describe "Redirecting to Canonical Domain", type: :request do
     @orig_canonical_domain = ENV['CANONICAL_DOMAIN']
     @orig_sep_domain = ENV['OLD_SEP_DOMAIN']
     ENV['CANONICAL_DOMAIN'] = "canonical-domain"
-    ENV['OLD_SEP_DOMAIN'] = "migrate-domain"
   end
 
   after do
     ENV['CANONICAL_DOMAIN'] = @orig_canonical_domain
-    ENV['OLD_SEP_DOMAIN'] = @orig_sep_domain
+    ENV['OLD_SEP_DOMAINS'] = @orig_sep_domain
   end
 
   context "with request to canonical-domain" do
@@ -35,13 +34,46 @@ describe "Redirecting to Canonical Domain", type: :request do
   end
 
   context "with request to migrate domain" do
-    before { host! "migrate-domain" }
+    context 'when there is one migrate domain' do
+      before do
+        ENV['OLD_SEP_DOMAINS'] = "migrate-domain-one"
+      end
+      before { host! "migrate-domain-one" }
 
-    specify "will redirect to migration page" do
-      get "/candidates?foo=bar"
+      specify "will redirect to migration page" do
+        get "/candidates?foo=bar"
 
-      expect(response).to have_http_status(302)
-      expect(response).to redirect_to("http://canonical-domain/pages/migration")
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to("http://canonical-domain/pages/migration")
+      end
+    end
+
+    context 'when there are two migrate domains' do
+      before do
+        ENV['OLD_SEP_DOMAINS'] = "migrate-domain-one,migrate-domain-two"
+      end
+
+      context 'first migrate domain' do
+        before { host! "migrate-domain-one" }
+
+        specify "will redirect to migration page" do
+          get "/candidates?foo=bar"
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to("http://canonical-domain/pages/migration")
+        end
+      end
+
+      context 'first migrate domain' do
+        before { host! "migrate-domain-two" }
+
+        specify "will redirect to migration page" do
+          get "/candidates?foo=bar"
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to("http://canonical-domain/pages/migration")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

SEP are redirecting to our service from multiple domains.

### Changes proposed in this pull request

Instead of allowing a single one (in `OLD_SEP_DOMAIN`) this change allows multiple separated by commas. The environment variable has been renamed to `OLD_SEP_DOMAINS` to reflect this, but it will still work with just one

### Guidance to review

This'll need some changes to our live config, best to be checked by @petenorth 
