### PR TITLE
Remove date changing from placement date edit

### DIFF
--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -17,7 +17,7 @@ class Schools::PlacementDatesController < Schools::BaseController
   def create
     @placement_date = current_school
       .bookings_placement_dates
-      .new(placement_date_params)
+      .new(new_placement_date_params)
 
     if @placement_date.save
       redirect_to schools_placement_dates_path
@@ -29,7 +29,7 @@ class Schools::PlacementDatesController < Schools::BaseController
   def edit; end
 
   def update
-    if @placement_date.update(placement_date_params)
+    if @placement_date.update(edit_placement_date_params)
       redirect_to schools_placement_dates_path
     else
       render :edit
@@ -44,7 +44,11 @@ private
       .find(params[:id])
   end
 
-  def placement_date_params
+  def new_placement_date_params
     params.require(:bookings_placement_date).permit(:date, :duration, :active)
+  end
+
+  def edit_placement_date_params
+    params.require(:bookings_placement_date).permit(:duration, :active)
   end
 end

--- a/app/views/schools/placement_dates/_form.html.erb
+++ b/app/views/schools/placement_dates/_form.html.erb
@@ -1,2 +1,0 @@
-<%= form.date_field :date %>
-<%= form.number_field :duration, width: 3, required: true %>

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -11,7 +11,15 @@
 <h1>Modify placement date</h1>
 
 <%= form_for @placement_date, url: schools_placement_date_path(@placement_date), method: :put do |form| %>
-  <%= render partial: 'form', locals: { form: form } %>
+
+  <div>
+    <h3>Start date</h3>
+    <p class="placement-start-date">
+      <%= @placement_date.date.to_formatted_s(:govuk) %>
+    </p>
+  </div>
+
+  <%= form.number_field :duration, width: 3, required: true %>
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="waste-hint">

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -11,6 +11,7 @@
 <h1>Create a placement date</h1>
 
 <%= form_for @placement_date, url: schools_placement_dates_path, method: :post do |form| %>
-  <%= render partial: 'form', locals: { form: form } %>
+  <%= form.date_field :date %>
+  <%= form.number_field :duration, width: 3, required: true %>
   <%= form.submit 'Continue' %>
 <%- end -%>

--- a/features/schools/placement_dates/edit.feature
+++ b/features/schools/placement_dates/edit.feature
@@ -22,13 +22,13 @@ Feature: Editing placement dates
         Given I am on the edit page for my placement
         Then I should see a form with the following fields:
             | Label                       | Type   |
-            | Enter a start date          | date   |
             | How many days will it last? | number |
         And there should be a 'Make this date available to candidates?' checkbox
+        And the current start date should be present
 
     Scenario: Filling in and submitting the form
         Given I am on the edit page for my placement
-        And I fill in the form with a future date and duration of 6
+        And I fill in the form with a duration of 6
         When I submit the form
         Then I should be on the 'placement dates' page
         And my newly-created placement date should be listed

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -109,7 +109,6 @@ When("I enter {string} into the {string} text area") do |value, label|
   fill_in label, with: value
 end
 
-
 LABEL_SELECTORS = %w(.govuk-label legend label).freeze
 def get_form_group(page, label_text)
   selector = LABEL_SELECTORS.detect do |s|

--- a/features/step_definitions/schools/placement_dates/edit_steps.rb
+++ b/features/step_definitions/schools/placement_dates/edit_steps.rb
@@ -33,3 +33,7 @@ Then("my placement should have been {string}") do |operation|
     expect(page).to have_css('td.status', text: /#{description}/i)
   end
 end
+
+Then("the current start date should be present") do
+  expect(page).to have_css('.placement-start-date', text: @placement_date.date.strftime('%d %B %Y'))
+end

--- a/features/step_definitions/schools/placement_dates/new_steps.rb
+++ b/features/step_definitions/schools/placement_dates/new_steps.rb
@@ -5,9 +5,13 @@ Given("I fill in the form with a future date and duration of {int}") do |int|
   fill_in "How many days will it last?", with: @duration
 end
 
+Given("I fill in the form with a duration of {int}") do |int|
+  @duration = int
+  fill_in "How many days will it last?", with: @duration
+end
+
 Then("my newly-created placement date should be listed") do
   within('#placement-dates .placement-date') do
-    expect(page).to have_css('th', text: @date.to_date.to_formatted_s(:govuk))
     expect(page).to have_css('td', text: "#{@duration} days")
   end
 end


### PR DESCRIPTION
### Context

Date validation for placement dates (that they're in the future) only occurs on create. When editing, school admins could set them in the past which would mean they'd expire and disappear

### Changes proposed in this pull request

Remove the ability to edit placement dates. This will make the process simpler and schools have the opportunity to prevent unwanted dates from appearing by disabling them

### Guidance to review

Ensure it looks fine and works
