### PR TITLE
adding configurable support for Application Insights Javascript tracking

### DIFF
--- a/config/initializers/application_insights.rb
+++ b/config/initializers/application_insights.rb
@@ -4,6 +4,9 @@ unless Rails.env.test?
       # the optional extra params are buffer_size (= 500) and send_interval (= 60),
       # leaving for now as they appear sensible
       config.middleware.use(ApplicationInsights::Rack::TrackRequest, app_insights_key)
+      if 'true' ==  ENV["APPINSIGHTS_JAVASCRIPT_ENABLED"]
+          config.middleware.use(ApplicationInsights::Rack::InjectJavaScriptTracking, app_insights_key)
+      end
     end
 
     # # This isn't needed _until_ we want to track events and metrics in addition


### PR DESCRIPTION
### Context

It would be nice to have the Javascript tracking enabled via Application Insights as we will be able to get more context information.

### Changes proposed in this pull request

Toggle the Javascript tracking Application Insights initialiser via an environment variable.

### Guidance to review

Toggle on and off via APPINSIGHTS_JAVASCRIPT_ENABLED environment variable



