### PR TITLE
Raise authentication failures in Slack and Sentry

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -5,8 +5,8 @@ module Schools
   class SessionsController < ApplicationController
     include DFEAuthentication
 
-    rescue_from AuthFailedError,     with: -> { redirect_to schools_errors_auth_failed_path }
-    rescue_from StateMissmatchError, with: -> { redirect_to schools_errors_auth_failed_path }
+    rescue_from AuthFailedError,     with: :authentication_failure
+    rescue_from StateMissmatchError, with: :authentication_failure
 
     def show
       # nothing yet, the view just contains a 'logout' button
@@ -53,6 +53,13 @@ module Schools
 
         raise StateMissmatchError
       end
+    end
+
+    def authentication_failure(exception)
+      ExceptionNotifier.notify_exception(exception)
+      Raven.capture_exception(exception)
+
+      redirect_to schools_errors_auth_failed_path
     end
   end
 end


### PR DESCRIPTION
Continue to show the user the 'please try again' page as before.

### Context

Previously authentication failures would have been more visible since it would result in an exception. Now we swallow the exception and show the user a nice page, this has reduced our visibility of problems and requires us to go back through the logs to find any issues users have encountered.

### Changes proposed in this pull request

1. Manually raise the exceptions in Sentry and Slack.



