### PR TITLE
Features/use docker compose in ci mk2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,6 +82,7 @@ jobs:
       filePath: ./script/generate_matrix.sh
 
 - job: FunctionalTesting
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   pool:
     vmImage: 'ubuntu-16.04'
   dependsOn: BuildAndNonBrowserTesting
@@ -98,7 +99,6 @@ jobs:
       sleep 15
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
       docker-compose -f docker-compose.yml -f docker-compose-selenium.yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: Run Cucumber via Selenium
     env:
       pswd: $(dockerPassword)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,14 +92,13 @@ jobs:
   steps:
 
   - script: |
-      docker login $(dockerRegistry) -u $(dockerId) -p $pswd	      
-      docker pull $(dockerRegistry)/$(imageName):latest	
-      docker tag $(dockerRegistry)/$(imageName):latest $(imageName):latest
+      docker pull $(DOCKER_HUB_REPO):$(imageTag)
+      docker tag  $(DOCKER_HUB_REPO):$(imageTag) $(imageName):latest
       docker-compose -f docker-compose.yml -f docker-compose-selenium.yml up -d
       sleep 15
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
       docker-compose -f docker-compose.yml -f docker-compose-selenium.yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
-    condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: Run Cucumber via Selenium
     env:
       pswd: $(dockerPassword)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,77 +1,59 @@
-pool:
-  vmImage: 'ubuntu-16.04'
-
 variables:
   imageTag: v$(Build.BuildId)
   POSTGRES_IMAGE: mdillon/postgis:11-alpine
   # define four more variables imageName, dockerId, dockerPassword and dockerRegistry in the build pipeline in UI
   POSTGRESS_PASSWORD: secret
-  DATABASE_URL: postgis://postgres:secret@postgres/school_experience_test
-  WEB_URL: postgis://postgres:secret@postgres/school_experience
   SECRET_KEY_BASE: stubbed
   REDIS_IMAGE: redis:5-alpine
-  REDIS_URL: redis://redis:6379/1
   CUCUMBER_PROFILE: continuous_integration
+  APP_URL: http://school-experience:3000
 
-steps:
+jobs:
+- job: BuildAndNonBrowserTesting
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
 
   - script: docker login $(dockerRegistry) -u $(dockerId) -p $pswd
     env:
       pswd: $(dockerPassword)
     displayName: 'Docker login'
-
-  - script: docker run --name=postgres -e POSTGRES_PASSWORD -d $(POSTGRES_IMAGE)
-    displayName: Launch Postgres # done early to give it time to boot
-  - script: docker run --name=redis -d $(REDIS_IMAGE)
-    displayName: Launch Redis # done early to give it time to boot
-
+  
   - script: docker pull $(dockerRegistry)/$(imageName):latest || true
     displayName: Retrieve latest Docker build to use as cache
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - script: docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):latest -t $(dockerRegistry)/$(imageName):$(imageTag) .
+  - script: docker build -f Dockerfile --cache-from=$(dockerRegistry)/$(imageName):latest -t $(imageName):latest .
     displayName: Build Docker Image using Cache
     condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - script: docker build -f Dockerfile -t $(dockerRegistry)/$(imageName):$(imageTag) .
+  - script: docker build -f Dockerfile -t $(imageName):latest .
     displayName: Build Docker Image without Cache
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:test:prepare
-    displayName: Create Testing databases, import schema and fixtures
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) rspec
+  - script: |
+      docker-compose up -d
+      sleep 15
+    displayName: bring up postgres, redis and create database (for the web app) and spin up application
+
+  - script: docker-compose run --rm db-tasks rspec
     displayName: Run the Specs
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 $(dockerRegistry)/$(imageName):$(imageTag) cucumber --profile=$(CUCUMBER_PROFILE)
+
+  - script: docker-compose run --rm -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true db-tasks cucumber --profile=continuous_integration
     displayName: Run the Cucumber features
-  - script: docker run --rm --link postgres:postgres -e DATABASE_URL --link redis:redis -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) brakeman --no-pager
+
+  - script: docker-compose run --rm db-tasks brakeman --no-pager
     displayName: Run the Brakeman security scan
-  - script: docker run --rm --link postgres:postgres --link redis:redis -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e SECRET_KEY_BASE=stubbed $(dockerRegistry)/$(imageName):$(imageTag) rake db:create db:schema:load
-    displayName: Create Smoketest database and import schema
-  - script: docker run -d --name=smoketest --health-interval=4s --link postgres:postgres --link redis:redis -e RAILS_ENV=servertest -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e SECRET_KEY_BASE=stubbed -e SKIP_FORCE_SSL=true $(dockerRegistry)/$(imageName):$(imageTag)
-    displayName: Spin up app
-  - script: sleep 15 # ugly but gives the web app time to boot
-    displayName: Pause to allow app to boot
-  - script: docker ps | grep smoketest | grep '(healthy)' || false
-    displayName: Check app reports as Healthy
-  - script: docker run --rm --link postgres:postgres --link redis:redis -e DATABASE_URL -e REDIS_URL -e RAILS_ENV=test $(dockerRegistry)/$(imageName):$(imageTag) govuk-lint-ruby app lib spec
+
+  - script: docker-compose run --rm db-tasks govuk-lint-ruby app lib spec
     displayName: Run the GovUK Lint check
 
   - script: |
-      docker run --name=selenium-chrome -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-chrome
-      docker run --rm --link postgres:postgres --link=redis:redis --link selenium-chrome:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'),eq(variables['Build.SourceBranch'], 'refs/heads/phase2'))
-    displayName: Run Cucumber via Selenium Chrome
-
-  - script: |
-      docker run --name=selenium-firefox -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-firefox
-      docker run --rm --link postgres:postgres --link=redis:redis --link selenium-firefox:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e CUC_DRIVER=firefox -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'),eq(variables['Build.SourceBranch'], 'refs/heads/phase2'))
-    displayName: Run Cucumber via Selenium Firefox
-
-  - script: |
-      docker push $(dockerRegistry)/$(imageName):$(imageTag)
-      docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(dockerRegistry)/$(imageName):latest
+      docker tag $(imageName):latest $(dockerRegistry)/$(imageName):latest
       docker push $(dockerRegistry)/$(imageName):latest
+      docker tag $(dockerRegistry)/$(imageName):latest $(dockerRegistry)/$(imageName):$(imageTag)
+      docker push $(dockerRegistry)/$(imageName):$(imageTag)
       docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(DOCKER_HUB_REPO):$(imageTag)
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: 'Push Docker image (built from master)'
@@ -91,6 +73,44 @@ steps:
       repository: $(DOCKER_HUB_REPO)
       command: push
       tags: $(imageTag)
+
+  - task: Bash@3
+    name: mtrx
+    displayName: 'set up functional test matrix variable'
+    inputs:
+      targetType: filePath
+      filePath: ./script/generate_matrix.sh
+
+- job: FunctionalTesting
+  pool:
+    vmImage: 'ubuntu-16.04'
+  dependsOn: BuildAndNonBrowserTesting
+  strategy:
+    maxParallel: 5
+    matrix: $[ dependencies.BuildAndNonBrowserTesting.outputs['mtrx.legs'] ]
+
+  steps:
+
+  - script: |
+      docker login $(dockerRegistry) -u $(dockerId) -p $pswd	      
+      docker pull $(dockerRegistry)/$(imageName):latest	
+      docker tag $(dockerRegistry)/$(imageName):latest $(imageName):latest
+      docker-compose -f docker-compose.yml -f docker-compose-selenium.yml up -d
+      sleep 15
+      echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
+      docker-compose -f docker-compose.yml -f docker-compose-selenium.yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
+    condition: not(eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: Run Cucumber via Selenium
+    env:
+      pswd: $(dockerPassword)
+
+- job: PublishArtifacts
+  pool:
+    vmImage: 'ubuntu-16.04'
+  dependsOn:
+  - FunctionalTesting
+
+  steps:
 
   - task: CopyFiles@2
     inputs:

--- a/docker-compose-selenium.yml
+++ b/docker-compose-selenium.yml
@@ -1,55 +1,6 @@
 version: '3.3'
 
 services:
-   school-experience:
-     image: school-experience:latest
-     ports:
-       - "3000:3000"
-     restart: always
-     healthcheck:
-       disable: true
-     environment:
-       - RAILS_ENV=servertest
-       - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
-       - REDIS_URL=redis://redis:6379/1
-       - SECRET_KEY_BASE=stubbed
-       - SKIP_FORCE_SSL=true
-       - WEB_URL=postgis://postgres:secret@postgres/school_experience
-     depends_on:
-       - create-db
-
-   delayed-jobs:
-     image: school-experience:latest
-     command: rake jobs:work
-     restart: always
-     healthcheck:
-       disable: true
-     environment:
-       - RAILS_ENV=servertest
-       - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
-       - REDIS_URL=redis://redis:6379/1
-       - SECRET_KEY_BASE=stubbed
-       - SKIP_FORCE_SSL=true
-       - WEB_URL=postgis://postgres:secret@postgres/school_experience
-     depends_on:
-       - create-db
-  
-   create-db:
-     image: school-experience:latest
-     command: rake db:create db:schema:load
-     restart: on-failure
-     healthcheck:
-       disable: true
-     environment:
-       - RAILS_ENV=test
-       - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
-       - REDIS_URL=redis://redis:6379/1
-       - SECRET_KEY_BASE=stubbed
-       - SKIP_FORCE_SSL=true
-       - WEB_URL=postgis://postgres:secret@postgres/school_experience
-     depends_on:
-       - postgres
-       - redis
 
    selenium-chrome:
      image: selenium/standalone-chrome
@@ -61,8 +12,3 @@ services:
      volumes:
        - /dev/shm:/dev/shm
 
-   postgres:
-     image: mdillon/postgis:11-alpine
-     
-   redis:
-     image: redis:5-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
        - "3000:3000"
      restart: always
      healthcheck:
-       disable: true
+       disable: false
      environment:
        - RAILS_ENV=servertest
        - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
@@ -16,14 +16,14 @@ services:
        - SKIP_FORCE_SSL=true
        - WEB_URL=postgis://postgres:secret@postgres/school_experience
      depends_on:
-       - create-db
+       - db-tasks
 
    delayed-jobs:
      image: school-experience:latest
      command: rake jobs:work
      restart: always
      healthcheck:
-       disable: true
+       disable: false
      environment:
        - RAILS_ENV=servertest
        - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
@@ -32,9 +32,9 @@ services:
        - SKIP_FORCE_SSL=true
        - WEB_URL=postgis://postgres:secret@postgres/school_experience
      depends_on:
-       - create-db
+       - db-tasks
   
-   create-db:
+   db-tasks:
      image: school-experience:latest
      command: rake db:create db:schema:load
      restart: on-failure

--- a/script/generate_matrix.sh
+++ b/script/generate_matrix.sh
@@ -1,0 +1,29 @@
+find . -type f -name "*.feature" > features.txt
+
+split -n r/5 features.txt
+
+ls -l
+
+index=1
+matrix="{"
+for browser in chrome firefox
+do
+  for filename in x*; do
+    data=$(
+    while read line
+    do
+      echo -n " ${line}"
+    done < $filename)
+    if [ $index -ne 1 ]
+    then
+      matrix+=","
+    fi
+    matrix+="'${browser}${index}':{'browser':'${browser}', 'features':'${data}'}"
+    echo $index $data
+    ((index++))
+  done
+done
+matrix+="}"
+echo $matrix
+
+echo "##vso[task.setVariable variable=legs;isOutput=true]${matrix}"


### PR DESCRIPTION
### Context
We have previously introduced a docker-compose file which greatly simplifies spinning up developer environments.

Currently though this is not included in any CD or CI pipelines so could become out of date or broken without developers or devops being aware.

This pull request suggests using docker-compose within the CI pipeline. Hopefully it is apparent that this leads to a greatly simplified CI pipeline yaml definition.

### Changes proposed in this pull request
Replace individual docker run commands with either docker-compose up and docker-compose run commands.

In addition the functional tests are run parallel via a dynamically generated job matrix. They are split across browsers and and groups of features. The feature groups are determined by distributing the features in a round robin fashion to a group.

### Guidance to review
This pull request has been tested on the branch in a previous commit enabling the functional tests for that branch, obviously this has now been reset to master. There is some master branch specific logic which may fail but the scope of this is hopefully minimal.

Note that a service db-tasks exists in the docker compose file which is reused for the some of the CI testing tasks. Meaning that environment variables such as RAILS_ENV is no longer needed.