### PR TITLE
Add candidate model

### DIFF
--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -1,0 +1,6 @@
+class Bookings::Candidate < ApplicationRecord
+  UUID_V4_FORMAT = /\A[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\z/.freeze
+
+  validates :gitis_uuid, presence: true, format: { with: UUID_V4_FORMAT }
+  validates :gitis_uuid, uniqueness: { case_sensitive: false }
+end

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -1,5 +1,5 @@
 class Bookings::Candidate < ApplicationRecord
-  UUID_V4_FORMAT = /\A[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\z/.freeze
+  UUID_V4_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/.freeze
 
   validates :gitis_uuid, presence: true, format: { with: UUID_V4_FORMAT }
   validates :gitis_uuid, uniqueness: { case_sensitive: false }

--- a/db/migrate/20190606081440_create_bookings_candidates.rb
+++ b/db/migrate/20190606081440_create_bookings_candidates.rb
@@ -1,0 +1,10 @@
+class CreateBookingsCandidates < ActiveRecord::Migration[5.2]
+  def change
+    create_table :bookings_candidates do |t|
+      t.string :gitis_uuid, limit: 36, null: false
+
+      t.timestamps
+    end
+    add_index :bookings_candidates, :gitis_uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_04_105251) do
+ActiveRecord::Schema.define(version: 2019_06_06_081440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,13 @@ ActiveRecord::Schema.define(version: 2019_06_04_105251) do
     t.index ["bookings_placement_request_id"], name: "index_bookings_bookings_on_bookings_placement_request_id", unique: true
     t.index ["bookings_school_id"], name: "index_bookings_bookings_on_bookings_school_id"
     t.index ["bookings_subject_id"], name: "index_bookings_bookings_on_bookings_subject_id"
+  end
+
+  create_table "bookings_candidates", force: :cascade do |t|
+    t.string "gitis_uuid", limit: 36, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["gitis_uuid"], name: "index_bookings_candidates_on_gitis_uuid", unique: true
   end
 
   create_table "bookings_phases", force: :cascade do |t|

--- a/spec/factories/bookings/candidates_factory.rb
+++ b/spec/factories/bookings/candidates_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :candidate, class: 'Bookings::Candidate' do
+    gitis_uuid { SecureRandom.uuid }
+  end
+end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::Candidate, type: :model do
+  describe 'database structure' do
+    it { is_expected.to have_db_column(:gitis_uuid).of_type(:string).with_options(limit: 36) }
+    it { is_expected.to have_db_index(:gitis_uuid).unique }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :gitis_uuid }
+
+    it { is_expected.to allow_value(SecureRandom.uuid).for :gitis_uuid }
+    it { is_expected.not_to allow_value(nil).for :gitis_uuid }
+    it { is_expected.not_to allow_value('').for :gitis_uuid }
+    it { is_expected.not_to allow_value('foobar').for :gitis_uuid }
+
+    it do
+      is_expected.not_to \
+        allow_value(SecureRandom.uuid + SecureRandom.uuid).for :gitis_uuid
+    end
+
+    context 'with existing record' do
+      before { create(:candidate) }
+      it { is_expected.to validate_uniqueness_of(:gitis_uuid).case_insensitive }
+    end
+  end
+end


### PR DESCRIPTION
### Context

We need a reference point for candidates - those are currently a UUID referencing a Contact entity in GitisCRM but that may not be the case in the future.

### Changes proposed in this pull request

1. Add a simple Candidate model which other models can associate with

