### PR TITLE
Set default contact name if the school hasnt onboarded

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -140,7 +140,7 @@ class Bookings::School < ApplicationRecord
   end
 
   def admin_contact_name
-    profile&.admin_contact_full_name
+    profile ? profile.admin_contact_full_name : contact_email
   end
 
 private


### PR DESCRIPTION
### Context
Default school admin contact to the school email if the school hasn't completed the onboarding wizard and we don't know the admins name

### Changes proposed in this pull request

### Guidance to review

