### PR TITLE
Display notifications_email not contact_email

### DIFF
--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -9,7 +9,7 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
   validate :placement_request_not_closed, on: :create, if: :placement_request
 
   def school_email
-    placement_request.school.contact_email
+    placement_request.school.notifications_email
   end
 
   def school_name

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -32,7 +32,7 @@ module Schools
       end
 
       def school_email
-        @school.contact_email
+        @school.notifications_email
       end
 
       def fees


### PR DESCRIPTION
User research has indicated school admins are confused by the school
email shown on the school profile show page being the original email
we got from get information about schools rather than the email they
entered in the school on boarding wizard.

Display the school notification email rather than the contact email.
Bookings::School#notification_email defaults to the original email if
the school hasn't completed the onboarding wizard

### Context

### Changes proposed in this pull request

### Guidance to review

