### PR TITLE
Replace Thread.current with class vars

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -5,15 +5,23 @@ class Notify
 
   class RetryableError < ArgumentError; end
 
+  # rubocop:disable Style/ClassVars
+  # Rubocop complains about classvars as they're inherited by subclasses,
+  # in this case that is the behaviour we want.
   class << self
     def notification_class
-      Thread.current[:notification_class] || Notifications::Client
+      if class_variable_defined?(:@@notification_class) && @@notification_class
+        @@notification_class
+      else
+        Notifications::Client
+      end
     end
 
     def notification_class=(klass)
-      Thread.current[:notification_class] = klass
+      @@notification_class = klass
     end
   end
+  # rubocop:enable Style/ClassVars
 
   def initialize(to:)
     self.to = to

--- a/features/candidates/placement_requests/cancelling_a_placement_request.feature
+++ b/features/candidates/placement_requests/cancelling_a_placement_request.feature
@@ -1,4 +1,3 @@
-@wip
 Feature: Cancelling a placement requests
   So I don't waste schools time
   As a potential candidate


### PR DESCRIPTION
### Context
Our stub notify client, set in the initializer, was being lost when a
new thread was spun off between requests in cd.

### Changes proposed in this pull request
Replace storing notification_class in Thread.current with a class variable.

### Guidance to review
Should pass when run against the docker-compose-selenium cucumber tests