### PR TITLE
If prior bookings exist pre-populate the form

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/add_more_details_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/add_more_details_controller.rb
@@ -6,7 +6,7 @@ module Schools
         before_action :ensure_previous_step_complete
 
         def new
-          @add_more_details = Schools::PlacementRequests::AddMoreDetails.new
+          @add_more_details = Schools::PlacementRequests::AddMoreDetails.for_school(@current_school)
         end
 
         def create

--- a/app/forms/schools/placement_requests/add_more_details.rb
+++ b/app/forms/schools/placement_requests/add_more_details.rb
@@ -13,6 +13,17 @@ module Schools
       validates :contact_number, presence: true
       validates :contact_email, presence: true
       validates :location, presence: true
+
+      def self.for_school(school)
+        return new unless (last_booking = school.bookings.accepted.order(id: 'desc').first)
+
+        new(
+          contact_name: last_booking.contact_name,
+          contact_number: last_booking.contact_number,
+          contact_email: last_booking.contact_email,
+          location: last_booking.location
+        )
+      end
     end
   end
 end

--- a/features/schools/placement_requests/acceptance/add_more_details.feature
+++ b/features/schools/placement_requests/acceptance/add_more_details.feature
@@ -7,15 +7,16 @@ Feature: Accepting placement requests
         Given I am logged in as a DfE user
         And the subjects 'Biology' and 'Chemistry' exist
         And there is a new placement request
-        And I have completed the 'confirm booking' page
 
     Scenario: Page heading
-        Given I have progressed to the 'add more details' page for my chosen placement request
+        Given I have completed the 'confirm booking' page
+        And I have progressed to the 'add more details' page for my chosen placement request
         Then the page's main header should be 'Add more booking details'
         And the subheading should be 'Enter contact and location details'
 
     Scenario: Page contents
-        Given I have progressed to the 'add more details' page for my chosen placement request
+        Given I have completed the 'confirm booking' page
+        And I have progressed to the 'add more details' page for my chosen placement request
         Then I should see a form with the following fields:
             | Label          | Type     |
             | Contact name   | text     |
@@ -23,8 +24,15 @@ Feature: Accepting placement requests
             | Contact email  | email    |
             | Location       | textarea |
 
+    Scenario: Prepopulation when previous accepted bookings exist
+        Given my school has previous accepted bookings
+        When I have completed the 'confirm booking' page
+        And I have progressed to the 'add more details' page for my chosen placement request
+        Then the contact details should have been filled with those from the latest accepted booking
+
     Scenario: Filling in and submitting the form
-        Given I have progressed to the 'add more details' page for my chosen placement request
+        Given I have completed the 'confirm booking' page
+        And I have progressed to the 'add more details' page for my chosen placement request
         And I have entered the following details into the form:
             | Contact name   | Dewey Largo                                       |
             | Contact number | 01234 567 890                                     |
@@ -35,5 +43,6 @@ Feature: Accepting placement requests
         And the relevant fields in the booking should have been saved
 
     Scenario: Back link
-        Given I have progressed to the 'add more details' page for my chosen placement request
+        Given I have completed the 'confirm booking' page
+        And I have progressed to the 'add more details' page for my chosen placement request
         Then there should be a link back to the placement request

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -123,6 +123,14 @@ def get_form_group(page, label_text)
   label.ancestor('div.govuk-form-group')
 end
 
+def get_input(page, label_text)
+  selector = LABEL_SELECTORS.detect do |s|
+    page.has_css?(s, text: label_text)
+  end
+  label = page.find(selector, text: label_text)
+  page.find('input', id: label['for'])
+end
+
 def ensure_date_field_exists(form_group)
   %w{Day Month Year}.each do |date_part|
     form_group.find('label', text: date_part).tap do |inner_label|

--- a/features/step_definitions/schools/placement_requests/add_more_details_steps.rb
+++ b/features/step_definitions/schools/placement_requests/add_more_details_steps.rb
@@ -30,3 +30,26 @@ Then("the relevant fields in the booking should have been saved") do
     expect(b.location).to eql('Please come to the reception in the East Building')
   end
 end
+
+Given("my school has previous accepted bookings") do
+  @latest_accepted_booking = FactoryBot.create(
+    :bookings_booking,
+    :accepted,
+    :with_more_details_added,
+    bookings_school: @school
+  )
+end
+
+Then("the contact details should have been filled with those from the latest accepted booking") do
+  {
+    "Contact name"   => @latest_accepted_booking.contact_name,
+    "Contact number" => @latest_accepted_booking.contact_number,
+    "Contact email"  => @latest_accepted_booking.contact_email,
+  }.each do |label, value|
+    expect(get_input(page, label)['value']).to eql(value)
+  end
+
+  within(get_form_group(page, 'Location')) do
+    expect(page.find('textarea')['value']).to eql(@latest_accepted_booking.location)
+  end
+end

--- a/spec/factories/bookings/bookings_factory.rb
+++ b/spec/factories/bookings/bookings_factory.rb
@@ -18,5 +18,12 @@ FactoryBot.define do
         bb.bookings_subject = bb.bookings_school.subjects.first
       end
     end
+
+    trait :with_more_details_added do
+      contact_name { 'William MacDougal' }
+      contact_email { 'gcw@springfield.edu' }
+      contact_number { '01234 456 245' }
+      location { 'Come to reception in the East building' }
+    end
   end
 end

--- a/spec/forms/schools/placement_requests/add_more_details_spec.rb
+++ b/spec/forms/schools/placement_requests/add_more_details_spec.rb
@@ -18,4 +18,55 @@ describe Schools::PlacementRequests::AddMoreDetails, type: :model do
       end
     end
   end
+
+  describe 'Methods' do
+    describe '.for_school' do
+      context 'when there is a previous accepted booking' do
+        let(:contact_name) { 'David Test' }
+        let(:contact_email) { 'd.test@some-school.org' }
+        let(:contact_number) { '01234 456 678' }
+        let(:location) { 'Reception in the East building' }
+
+        let!(:booking) do
+          create(
+            :bookings_booking,
+            :accepted,
+            contact_name: contact_name,
+            contact_email: contact_email,
+            contact_number: contact_number,
+            location: location
+          )
+        end
+
+        subject { described_class.for_school(booking.bookings_school) }
+
+        specify 'should initialize a Schools::PlacementRequests::AddMoreDetails' do
+          expect(subject).to be_a(Schools::PlacementRequests::AddMoreDetails)
+        end
+
+        specify 'should have the correct attributes assigned' do
+          expect(subject.contact_name).to eql(contact_name)
+          expect(subject.contact_email).to eql(contact_email)
+          expect(subject.contact_number).to eql(contact_number)
+          expect(subject.location).to eql(location)
+        end
+      end
+
+      context 'when there are no previous accepted bookings' do
+        let(:school) { create(:bookings_school) }
+        subject { described_class.for_school(school) }
+
+        specify 'should initialize a Schools::PlacementRequests::AddMoreDetails' do
+          expect(subject).to be_a(Schools::PlacementRequests::AddMoreDetails)
+        end
+
+        specify 'should have no attributes assigned' do
+          expect(subject.contact_name).to be_nil
+          expect(subject.contact_email).to be_nil
+          expect(subject.contact_number).to be_nil
+          expect(subject.location).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

If schools are repeatedly having to type in contact info when accepting placement requests it could be frustrating

### Changes proposed in this pull request

When schools have prior accepted bookings we default the form to use the values from the previous booking. This should speed up the process for most schools, making it easier and avoiding potential typos

### Guidance to review

Ensure the approach is logical
