### PR TITLE
Deal with empty strings in addition to nils

### DIFF
--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -69,7 +69,7 @@ end
 
 Then("the date fields should be empty") do
   within(page.find('.govuk-date-input')) do
-    expect(page.all('input').map(&:value).compact).to be_empty
+    expect(page.all('input').map(&:value).map(&:presence).compact).to be_empty
   end
 end
 


### PR DESCRIPTION
Capybara returns nil if the value isn't present but Selenium returns
empty strings. The latter causes this step to fail. This change fixes it.

