### PR TITLE
Crm API library - take 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem 'uk_postcode'
 gem 'application_insights', github: 'microsoft/ApplicationInsights-Ruby', ref: 'a7429200'
 gem 'faraday'
 
+gem 'addressable'
+gem 'faraday'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,6 +427,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-postgis-adapter
   acts_as_list
+  addressable
   application_insights!
   autoprefixer-rails
   bootsnap (>= 1.1.0)

--- a/app/services/bookings/gitis/api.rb
+++ b/app/services/bookings/gitis/api.rb
@@ -1,0 +1,127 @@
+module Bookings::Gitis
+  class API
+    ENDPOINT = '/api/data/v9.1'.freeze
+
+    attr_reader :endpoint_url, :access_token
+
+    def initialize(token, service_url: nil, endpoint: nil)
+      @access_token = token
+      @service_url = service_url || ENV.fetch("CRM_SERVICE_URL")
+      @endpoint = endpoint || ENDPOINT
+      @endpoint_url = "#{@service_url}#{@endpoint}"
+    end
+
+    def get(url, params = {}, headers = {})
+      validate_url! url
+
+      response = connection.get do |req|
+        req.url url
+        req.headers = get_headers.merge(headers.stringify_keys)
+        req.params = params if params.any?
+      end
+
+      parse_response response
+    end
+
+    def post(url, params, headers = {})
+      validate_url! url
+
+      response = connection.post do |req|
+        req.url url
+        req.headers = post_headers.merge(headers.stringify_keys)
+        req.body = params.to_json
+      end
+
+      parse_response response
+    end
+
+    def patch(url, params, headers = {})
+      validate_url! url
+
+      response = connection.patch do |req|
+        req.url url
+        req.headers = post_headers.merge(headers.stringify_keys)
+        req.body = params.to_json
+      end
+
+      parse_response response
+    end
+
+    class UnsupportedAbsoluteUrlError < RuntimeError; end
+
+    class BadResponseError < RuntimeError
+      def initialize(resp)
+        if resp.headers['content-type'].to_s.match?(%r{application/json})
+          @data = JSON.parse(resp.body)
+          @msg = "#{resp.status}: #{@data.dig('error', 'message') || resp.body}"
+        else
+          @msg = "#{resp.status}: #{resp.body}"
+        end
+
+        super(@msg)
+      end
+    end
+
+    class UnknownUrlError < BadResponseError; end
+    class AccessDeniedError < BadResponseError; end
+
+  private
+
+    def connection
+      Faraday.new(endpoint_url)
+    end
+
+    def get_headers
+      {
+        'Accept' => 'application/json',
+        'Authorization' => "Bearer #{access_token}",
+        'OData-MaxVersion' => '4.0',
+        'OData-Version' => '4.0'
+      }
+    end
+
+    def post_headers
+      {
+        'Accept' => 'application/json',
+        'Authorization' => "Bearer #{access_token}",
+        'Content-Type' => 'application/json',
+        'OData-MaxVersion' => '4.0',
+        'OData-Version' => '4.0'
+      }
+    end
+
+    # don't allow absolute paths since they don't combine with the endpoint
+    def validate_url!(url)
+      if url.to_s.starts_with? '/'
+        fail UnsupportedAbsoluteUrlError
+      end
+
+      true
+    end
+
+    def parse_response(resp)
+      case resp.status
+      when 200
+        if resp.headers['content-type'].to_s.match?(%r{application/json})
+          JSON.parse(resp.body)
+        else
+          resp.body
+        end
+      when 201
+        parse_entity_id(resp.headers['odata-entityid']) || resp.body
+      when 204
+        parse_entity_id(resp.headers['odata-entityid']) || true
+      when 401
+        raise AccessDeniedError.new(resp)
+      when 404
+        raise UnknownUrlError.new(resp)
+      else
+        raise BadResponseError.new(resp)
+      end
+    end
+
+    def parse_entity_id(entity_id)
+      entity_id&.gsub(%r{\A#{endpoint_url}\/}, '')
+    end
+  end
+end

--- a/app/services/bookings/gitis/auth.rb
+++ b/app/services/bookings/gitis/auth.rb
@@ -1,0 +1,78 @@
+require 'apimock/gitis_crm'
+
+module Bookings
+  module Gitis
+    class Auth
+      CACHE_KEY = 'gitis-auth-token'.freeze
+      AUTH_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/token".freeze
+      attr_reader :service_url, :expires_at, :expires_in
+
+      delegate :cache, to: Rails
+
+      def initialize(client_id: nil, client_secret: nil, tenant_id: nil, service_url: nil)
+        @client_id = client_id || ENV.fetch('CRM_CLIENT_ID')
+        @client_secret = client_secret || ENV.fetch('CRM_CLIENT_SECRET')
+        @tenant_id = tenant_id || ENV.fetch('CRM_AUTH_TENANT_ID')
+        @service_url = service_url || ENV.fetch('CRM_SERVICE_URL')
+      end
+
+      def token(force_reload = false)
+        if !force_reload && (cached_token = fetch_cached_token)
+          cached_token
+        elsif (new_token = retrieve_token)
+          cache.write(CACHE_KEY, new_token, expires_in: expires_in)
+          new_token
+        end
+      end
+
+      class UnableToRetrieveToken < RuntimeError; end
+
+    private
+
+      def params
+        {
+          grant_type: 'client_credentials',
+          scope: '',
+          client_id: @client_id,
+          client_secret: @client_secret,
+          resource: service_url
+        }
+      end
+
+      def auth_url
+        Addressable::Template.new(AUTH_URL).expand(tenant_id: @tenant_id).to_s
+      end
+
+      def retrieve_token
+        response = Faraday.post(auth_url) do |request|
+          request.headers['Content-Type'] = 'application/x-www-form-urlencoded'
+          request.headers['Accept'] = 'application/json'
+          request.body = params.to_query
+        end
+
+        if response.status != 200
+          store_failed_response response
+        else
+          parse_successful_response response
+        end
+      end
+
+      def store_failed_response(response)
+        @response_status = response.status
+        @response_body = response.body
+        raise UnableToRetrieveToken
+      end
+
+      def parse_successful_response(response)
+        data = JSON.parse(response.body)
+        @expires_in = data['expires_in'].to_i
+        @expires_at = Time.zone.now + @expires_in
+        @access_token = data['access_token']
+      end
+
+      def fetch_cached_token
+        cache.fetch(CACHE_KEY)
+      end
+    end
+  end
+end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -1,67 +1,75 @@
 module Bookings
   module Gitis
     class Contact
-      include ActiveModel::Model
+      include Entity
 
       attr_reader :id
-      attr_accessor :firstname, :lastname, :email, :phone
-      attr_accessor :building, :street, :town_or_city, :county, :postcode
+      entity_attributes :firstname, :lastname, :emailaddress1, :emailaddress2
+      entity_attributes :address1_line1, :address1_line2, :address1_line3
+      entity_attributes :address1_city, :address1_stateorprovince
+      entity_attributes :address1_postalcode, :phone
+
+      alias_attribute :building, :address1_line1
+      alias_attribute :town_or_city, :address1_city
+      alias_attribute :county, :address1_stateorprovince
+      alias_attribute :postcode, :address1_postalcode
 
       validates :email, presence: true, format: /\A.+@.+\..+\z/
 
       def initialize(crm_contact_data = {})
-        @crm_data     = crm_contact_data
-        @id           = @crm_data['contactid']
-        @firstname    = @crm_data['firstname']
-        @lastname     = @crm_data['lastname']
-        @email        = parse_email_from_crm(@crm_data)
-        @phone        = parse_phone_from_crm(@crm_data)
-        @building     = @crm_data['address1_line1']
-        @street       = parse_street_from_crm(@crm_data)
-        @town_or_city = @crm_data['address1_city']
-        @county       = @crm_data['address1_stateorprovince']
-        @postcode     = @crm_data['address1_postalcode']
+        @crm_data                     = crm_contact_data.stringify_keys
+        self.id                       = @crm_data['contactid']
+        self.firstname                = @crm_data['firstname']
+        self.lastname                 = @crm_data['lastname']
+        self.emailaddress1            = @crm_data['emailaddress1']
+        self.emailaddress2            = @crm_data['emailaddress2']
+        self.phone                    = parse_phone_from_crm(@crm_data)
+        self.address1_line1           = @crm_data['address1_line1']
+        self.address1_line2           = @crm_data['address1_line2']
+        self.address1_line3           = @crm_data['address1_line3']
+        self.address1_city            = @crm_data['address1_city']
+        self.address1_stateorprovince = @crm_data['address1_stateorprovince']
+        self.address1_postalcode      = @crm_data['address1_postalcode']
       end
 
       def address
-        [@building, @street, @town_or_city, @county, @postcode].compact.join(", ")
+        [building, street, town_or_city, county, postcode].compact.join(", ")
+      end
+
+      def email
+        emailaddress2.presence || emailaddress1
+      end
+
+      def email=(emailaddress)
+        if emailaddress1.blank?
+          self.emailaddress1 = emailaddress
+        elsif emailaddress1 != emailaddress
+          self.emailaddress2 = emailaddress
+        end
+      end
+
+      def street
+        [address1_line2, address1_line3].map(&:presence).compact.join(', ')
       end
 
       def id=(assigned_id)
         if @id.blank?
-          @id = assigned_id.to_s
+          @id = assigned_id
         elsif @id.to_s != assigned_id.to_s
           fail ContactIdChangedUnexpectedly
         end
       end
 
-      def crm_data
-        {} # STUBBED FOR NOW
-      end
-
       def full_name
-        "#{@firstname} #{@lastname}"
+        "#{firstname} #{lastname}"
       end
 
       class ContactIdChangedUnexpectedly < RuntimeError; end
 
     private
 
-      def parse_email_from_crm(data)
-        data['emailaddress1'].presence ||
-          data['emailaddress2'].presence ||
-          data['emailaddress3']
-      end
-
       def parse_phone_from_crm(data)
         data['mobilephone'].presence || data['telephone1']
-      end
-
-      def parse_street_from_crm(data)
-        [
-          data['address1_line2'].presence,
-          data['address1_line3'].presence
-        ].compact.join(', ')
       end
     end
   end

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -1,28 +1,40 @@
 module Bookings
   module Gitis
     class CRM
-      def initialize(token)
+      prepend FakeCrm if Rails.application.config.x.fake_crm
+
+      def initialize(token, service_url: nil, endpoint: nil)
         @token = token
+        @service_url = service_url
+        @endpoint = endpoint
       end
 
-      def find(*ids)
-        ids = normalise_ids(*ids)
+      def find(*uuids, entity_type: Contact)
+        uuids = normalise_ids(*uuids)
+        validate_ids(uuids)
 
-        validate_ids(ids)
+        # ensure we can't accidentally pull too much data
+        params = { '$top' => uuids.length }
 
-        if ids.length == 1
-          Contact.new(fake_account_data.merge('contactid' => ids[0]))
+        if uuids.length == 1
+          entity_type.new api.get("#{entity_type.entity_path}(#{uuids[0]})", params)
         else
-          ids.map do |id|
-            Contact.new(fake_account_data.merge('contactid' => id))
+          params['$filter'] = filter_pairs(entity_type.primary_key => uuids)
+
+          api.get(entity_type.entity_path, params)['value'].map do |entity_data|
+            entity_type.new entity_data
           end
         end
       end
 
       def find_by_email(address)
-        Contact.new(fake_account_data).tap do |contact|
-          contact.email = address
-        end
+        contacts = api.get("contacts", '$top' => 1, '$filter' => filter_pairs(
+          emailaddress1: address,
+          emailaddress2: address,
+          emailaddress3: address
+        ))['value']
+
+        Contact.new(contacts[0]) if contacts.any?
       end
 
       # Will return nil of it cannot match a Contact on final implementation
@@ -34,14 +46,30 @@ module Bookings
         end
       end
 
-      def write(contact)
-        raise ArgumentError unless contact.is_a?(Contact)
-        return false unless contact.valid?
+      def write(entity)
+        raise ArgumentError unless entity.class < Entity
+        return false unless entity.valid?
 
-        contact.id = write_data(contact.crm_data)
+        # Sorting to allow stubbing http requests
+        # webmock compares the request body as a serialized string
+        data = entity.changed_attributes.sort.to_h
+
+        if entity.id
+          api.patch(entity.entity_id, data)
+        else
+          entity.entity_id = api.post(entity.entity_id, data)
+        end
+
+        entity.id
       end
 
+      class InvalidApiError < RuntimeError; end
+
     private
+
+      def api
+        @api ||= API.new(@token, service_url: @service_url, endpoint: @endpoint)
+      end
 
       def normalise_ids(*ids)
         Array.wrap(ids).flatten
@@ -53,28 +81,14 @@ module Bookings
         end
       end
 
-      def fake_account_data
-        {
-          'contactid' => "d778d663-a022-4c4b-9962-e469ee179f4a",
-          'firstname' => 'Matthew',
-          'lastname' => 'Richards',
-          'mobilephone' => '07123 456789',
-          'telephone1' => '01234 567890',
-          'emailaddress1' => 'first@thisaddress.com',
-          'emailaddress2' => 'second@thisaddress.com',
-          'emailaddress3' => 'third@thisaddress.com',
-          'address1_line1' => 'First Line',
-          'address1_line2' => 'Second Line',
-          'address1_line3' => 'Third Line',
-          'address1_city' => 'Manchester',
-          'address1_stateorprovince' => 'Manchester',
-          'address1_postalcode' => 'MA1 1AM'
-        }
-      end
+      def filter_pairs(filter_data, join_with = 'or')
+        parts = filter_data.map do |key, values|
+          Array.wrap(values).map do |value|
+            "#{key} eq '#{value}'"
+          end
+        end
 
-      def write_data(crm_contact_data)
-        crm_contact_data['contactid'].presence ||
-          "75c5a32d-d603-4483-956f-236fee7c5784"
+        parts.join(" #{join_with} ")
       end
     end
   end

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -1,0 +1,87 @@
+module Bookings::Gitis
+  module Entity
+    extend ActiveSupport::Concern
+
+    included do
+      include ActiveModel::Model
+
+      class_attribute :entity_path
+      self.entity_path = derive_entity_path
+
+      class_attribute :primary_key
+      self.primary_key = derive_primary_key
+    end
+
+    def initialize
+      raise "Abstract Class - implement initialize in entity model"
+    end
+
+    def attributes
+      @attributes ||= {}
+    end
+
+    def reset
+      @attributes = @dirty_attributes = nil
+    end
+
+    def changed_attributes
+      attributes.slice(*dirty_attributes)
+    end
+
+    def reset_dirty_attributes
+      @dirty_attributes = nil
+    end
+
+    def dirty_attributes
+      @dirty_attributes ||= Set.new
+    end
+
+    def entity_id=(e_id)
+      normalised_id = e_id.to_s.downcase
+      id_match = normalised_id.match(/\A#{entity_path}\(([a-z0-9-]{36})\)\z/)
+      if id_match && id_match[1]
+        self.id = id_match[1]
+      else
+        raise InvalidEntityIdError
+      end
+    end
+
+    def entity_id
+      id ? "#{entity_path}(#{id})" : entity_path
+    end
+
+    class InvalidEntityIdError < RuntimeError; end
+
+    module ClassMethods
+    protected
+
+      def entity_attribute(attr_name)
+        define_method :"#{attr_name}" do
+          attributes[attr_name.to_s]
+        end
+
+        define_method :"#{attr_name}=" do |value|
+          unless value == send(attr_name.to_sym)
+            dirty_attributes << attr_name.to_s
+          end
+
+          attributes[attr_name.to_s] = value
+        end
+      end
+
+      def entity_attributes(*attr_names)
+        Array.wrap(attr_names).flatten.each do |attr_name|
+          entity_attribute(attr_name)
+        end
+      end
+
+      def derive_entity_path
+        model_name.to_s.underscore.split('/').last.pluralize
+      end
+
+      def derive_primary_key
+        model_name.to_s.underscore.split('/').last + 'id'
+      end
+    end
+  end
+end

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -1,0 +1,48 @@
+module Bookings::Gitis
+  module FakeCrm
+    def find(*ids)
+      ids = normalise_ids(*ids)
+      validate_ids(ids)
+
+      if ids.length == 1
+        Contact.new(fake_account_data.merge('contactid' => ids[0]))
+      else
+        ids.map do |id|
+          Contact.new(fake_account_data.merge('contactid' => id))
+        end
+      end
+    end
+
+    def find_by_email(address)
+      Contact.new(fake_account_data).tap do |contact|
+        contact.email = address
+      end
+    end
+
+  private
+
+    def write_data(crm_contact_data)
+      crm_contact_data['contactid'].presence ||
+        "75c5a32d-d603-4483-956f-236fee7c5784"
+    end
+
+    def fake_account_data
+      {
+        'contactid' => "d778d663-a022-4c4b-9962-e469ee179f4a",
+        'firstname' => 'Matthew',
+        'lastname' => 'Richards',
+        'mobilephone' => '07123 456789',
+        'telephone1' => '01234 567890',
+        'emailaddress1' => 'first@thisaddress.com',
+        'emailaddress2' => 'second@thisaddress.com',
+        'emailaddress3' => 'third@thisaddress.com',
+        'address1_line1' => 'First Line',
+        'address1_line2' => 'Second Line',
+        'address1_line3' => 'Third Line',
+        'address1_city' => 'Manchester',
+        'address1_stateorprovince' => 'Manchester',
+        'address1_postalcode' => 'MA1 1AM'
+      }
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -85,4 +85,6 @@ Rails.application.configure do
   config.x.oidc_client_id = 'schoolexperience'
   config.x.oidc_client_secret = Rails.application.credentials.dig(:dfe_pp_signin_secret)
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
+
+  config.x.fake_crm = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -129,4 +129,6 @@ Rails.application.configure do
     end
     config.x.oidc_host = ENV.fetch('DFE_SIGNIN_HOST') { 'pp-oidc.signin.education.gov.uk' }
   end
+
+  config.x.fake_crm = true
 end

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -18,4 +18,6 @@ Rails.application.configure do
   config.x.oidc_client_id = 'schoolexperience'
   config.x.oidc_client_secret = Rails.application.credentials.dig(:dfe_pp_signin_secret)
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
+
+  config.x.fake_crm = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,4 +66,6 @@ Rails.application.configure do
   config.x.oidc_client_id = 'se-test'
   config.x.oidc_client_secret = 'abc123'
   config.x.oidc_host = 'some-oidc-host.education.gov.uk'
+
+  config.x.fake_crm = false
 end

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -23,7 +23,7 @@ Feature: Viewing a booking
             | Heading             | Value                                                                |
             | Address             | First Line, Second Line, Third Line, Manchester, Manchester, MA1 1AM |
             | UK telephone number | 07123 456789                                                         |
-            | Email address       | first@thisaddress.com                                                |
+            | Email address       | second@thisaddress.com                                               |
 
     Scenario: Request details
         Given there is at least one booking

--- a/features/schools/placement_requests/index.feature
+++ b/features/schools/placement_requests/index.feature
@@ -43,7 +43,7 @@ Feature: Viewing all placement requests
 			      | Heading             | Value                           |
             | Address             | First Line, Manchester, MA1 1AM |
             | UK telephone number | 07123 456789                    |
-            | Email address       | first@thisaddress.com           |
+            | Email address       | second@thisaddress.com          |
 
     Scenario: Open request buttons
         Given there are some placement requests

--- a/features/schools/placement_requests/show.feature
+++ b/features/schools/placement_requests/show.feature
@@ -19,7 +19,7 @@ Feature: Viewing a placement request
             | Heading             | Value                                                                |
             | Address             | First Line, Second Line, Third Line, Manchester, Manchester, MA1 1AM |
             | UK telephone number | 07123 456789                                                         |
-            | Email address       | first@thisaddress.com                                                |
+            | Email address       | second@thisaddress.com                                               |
 
     Scenario: Request details
         Given there is at least one placement request

--- a/features/schools/placement_requests/upcoming.feature
+++ b/features/schools/placement_requests/upcoming.feature
@@ -41,7 +41,7 @@ Feature: Upcoming placement requests
 			| Heading             | Value                           |
             | Address             | First Line, Manchester, MA1 1AM |
             | UK telephone number | 07123 456789                    |
-            | Email address       | first@thisaddress.com           |
+            | Email address       | second@thisaddress.com          |
 
     Scenario: Open request buttons
         Given there are some placement requests

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,6 +8,8 @@ require 'cucumber/rails'
 require 'selenium/webdriver'
 require 'capybara-screenshot/cucumber'
 
+Rails.application.config.x.fake_crm = true
+
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any
 # selectors in your step definitions to use the XPath syntax.

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::PlacementRequests::CancellationsController, type: :request do
+  include_context 'stubbed out Gitis'
+
   let :notify_school_request_cancellation do
     double NotifyEmail::SchoolRequestCancellation, despatch_later!: true
   end

--- a/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }
 

--- a/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::PlacementRequests::Acceptance::PreviewConfirmationEmailController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let!(:booking_profile) { create(:bookings_profile, school: @current_user_school) }
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }

--- a/spec/controllers/schools/placement_requests/acceptance/review_and_send_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/review_and_send_email_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::PlacementRequests::Acceptance::ReviewAndSendEmailController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let!(:booking_profile) { create(:bookings_profile, school: @current_user_school) }
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementRequests::CancellationsController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementRequestsController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by! urn: urn

--- a/spec/factories/bookings/gitis/contact_factory.rb
+++ b/spec/factories/bookings/gitis/contact_factory.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :gitis_contact, class: 'Bookings::Gitis::Contact' do
     firstname { "Test" }
     sequence(:lastname) { |n| "User#{n}" }
-    sequence(:email) { |n| "testuser#{n}@testdomain.com" }
+    sequence(:emailaddress1) { |n| "testuser#{n}@testdomain.com" }
     phone { "01234 567890" }
-    building { "My Building" }
-    street { "Test Street" }
-    town_or_city { "Test Town" }
-    county { "Test County" }
-    postcode { "MA1 1AM" }
+    address1_line1 { "My Building" }
+    address1_line2 { "Test Street" }
+    address1_city { "Test Town" }
+    address1_stateorprovince { "Test County" }
+    address1_postalcode { "MA1 1AM" }
   end
 end

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateBookingConfirmation do
+  include_context "stubbed out Gitis"
+
   it_should_behave_like "email template", "29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3",
     school_name: "Springfield Elementary",
     candidate_name: "Kearney Zzyzwicz",

--- a/spec/services/bookings/gitis/api_spec.rb
+++ b/spec/services/bookings/gitis/api_spec.rb
@@ -1,0 +1,337 @@
+require 'rails_helper'
+
+describe Bookings::Gitis::API do
+  let(:token) { "My.Stub.Token" }
+  let(:service_url) { "https://my.service.com" }
+  let(:endpoint) { '/api/v1.0' }
+  let(:uuid) { '86b2839b-a009-48a7-89b6-294d2ed37bd2' }
+
+  describe ".initialize" do
+    subject do
+      described_class.new(token, service_url: service_url, endpoint: endpoint)
+    end
+
+    it "will initialize" do
+      is_expected.to be_kind_of(Bookings::Gitis::API)
+    end
+
+    it "will set the completed endpoint_url" do
+      expect(subject.endpoint_url).to eq('https://my.service.com/api/v1.0')
+    end
+  end
+
+  describe ".get" do
+    let(:api) do
+      described_class.new(token, service_url: service_url, endpoint: endpoint)
+    end
+
+    context "for valid url" do
+      before do
+        stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=1").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 200,
+            headers: {
+              'content-type' => 'application/json; odata.metadata=minimal',
+              'odata-version' => '4.0'
+            },
+            body: {
+              'contactid' => uuid,
+              'firstname' => 'test',
+              'lastname' => 'test'
+            }.to_json
+          )
+      end
+
+      subject { api.get('contacts', '$top' => 1) }
+
+      it { is_expected.to be_kind_of Hash }
+      it { is_expected.to include('contactid' => uuid) }
+      it { is_expected.to include('firstname' => 'test', 'lastname' => 'test') }
+    end
+
+    context 'for inaccessible url' do
+      before do
+        stub_request(:get, "#{service_url}#{endpoint}/contacts").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 401,
+            headers: {
+              'odata-version' => '4.0'
+            },
+            body: 'Access Denied'
+          )
+      end
+
+      it "will raise an AccessDeniedError" do
+        expect {
+          api.get('contacts')
+        }.to raise_exception(Bookings::Gitis::API::BadResponseError, /401: Access Denied/i)
+      end
+    end
+
+    context "for invalid url" do
+      before do
+        stub_request(:get, "#{service_url}#{endpoint}/contacts").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 500,
+            headers: {
+              'odata-version' => '4.0'
+            },
+            body: 'Something went wrong'
+          )
+      end
+
+      it "will raise an BadResponseError" do
+        expect {
+          api.get('contacts')
+        }.to raise_exception(Bookings::Gitis::API::BadResponseError, /500: Something went wrong/i)
+      end
+    end
+
+    context 'for absolute url' do
+      it "should raise exception" do
+        expect {
+          api.get('/contacts')
+        }.to raise_exception Bookings::Gitis::API::UnsupportedAbsoluteUrlError
+      end
+    end
+
+    context 'for unknown url' do
+      before do
+        stub_request(:get, "#{service_url}#{endpoint}/ontacts").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 404,
+            headers: {
+              'content-type' => 'application/json; odata.metadata=minimal',
+              'odata-version' => '4.0'
+            },
+            body: {
+              "error" => {
+                "code" => "0x8006088a",
+                "message" => "Resource not found for the segment 'ontacts'"
+              }
+            }.to_json
+          )
+      end
+
+      it "will raise an UnknownUrlError" do
+        expect {
+          api.get('ontacts')
+        }.to raise_exception(Bookings::Gitis::API::UnknownUrlError, /404: resource not found/i)
+      end
+    end
+  end
+
+  describe ".post" do
+    let(:api) do
+      described_class.new(token, service_url: service_url, endpoint: endpoint)
+    end
+
+    context "for valid url" do
+      before do
+        stub_request(:post, "#{service_url}#{endpoint}/contacts").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            'Content-Type' => 'application/json',
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 204,
+            headers: {
+              'odata-version' => '4.0',
+              'odata-entityid' => "#{service_url}#{endpoint}/contacts(#{uuid})"
+            },
+            body: ''
+          )
+      end
+
+      subject { api.post('contacts', 'firstname' => 'test', 'lastname' => 'user') }
+
+      it { is_expected.to eq("contacts(#{uuid})") }
+    end
+
+    context "for invalid url" do
+      before do
+        stub_request(:post, "#{service_url}#{endpoint}/contacts").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            'Content-Type' => 'application/json',
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 500,
+            headers: { 'odata-version' => '4.0' },
+            body: ''
+          )
+      end
+
+      it "will raise an BadResponseError" do
+        expect {
+          api.post('contacts', 'firstname' => 'test', 'lastname' => 'user')
+        }.to raise_exception(Bookings::Gitis::API::BadResponseError, /500:/i)
+      end
+    end
+
+    context 'for absolute url' do
+      it "should raise exception" do
+        expect {
+          api.post('/contacts', 'firstname' => 'test', 'lastname' => 'user')
+        }.to raise_exception Bookings::Gitis::API::UnsupportedAbsoluteUrlError
+      end
+    end
+
+    context 'for unknown url' do
+      before do
+        stub_request(:post, "#{service_url}#{endpoint}/ontacts").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            'Content-Type' => 'application/json',
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 404,
+            headers: {
+              'content-type' => 'application/json; odata.metadata=minimal',
+              'odata-version' => '4.0'
+            },
+            body: {
+              "error" => {
+                "code" => "0x8006088a",
+                "message" => "Resource not found for the segment 'ontacts'"
+              }
+            }.to_json
+          )
+      end
+
+      it "will raise an UnknownUrlError" do
+        expect {
+          api.post('ontacts', 'firstname' => 'test', 'lastname' => 'user')
+        }.to raise_exception(Bookings::Gitis::API::UnknownUrlError, /404: resource not found/i)
+      end
+    end
+  end
+
+  describe ".patch" do
+    let(:api) do
+      described_class.new(token, service_url: service_url, endpoint: endpoint)
+    end
+
+    context "for valid url" do
+      before do
+        stub_request(:patch, "#{service_url}#{endpoint}/contacts(#{uuid})").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            'Content-Type' => 'application/json',
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 204,
+            headers: {
+              'odata-version' => '4.0',
+              'odata-entityid' => "#{service_url}#{endpoint}/contacts(#{uuid})"
+            },
+            body: ''
+          )
+      end
+
+      subject { api.patch("contacts(#{uuid})", 'firstname' => 'test', 'lastname' => 'user') }
+
+      it { is_expected.to eq("contacts(#{uuid})") }
+    end
+
+    context "for invalid url" do
+      before do
+        stub_request(:patch, "#{service_url}#{endpoint}/contacts(#{uuid})").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            'Content-Type' => 'application/json',
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 500,
+            headers: { 'odata-version' => '4.0' },
+            body: ''
+          )
+      end
+
+      it "will raise an BadResponseError" do
+        expect {
+          api.patch("contacts(#{uuid})", 'firstname' => 'test', 'lastname' => 'user')
+        }.to raise_exception(Bookings::Gitis::API::BadResponseError, /500:/i)
+      end
+    end
+
+    context 'for absolute url' do
+      it "should raise exception" do
+        expect {
+          api.patch("/contacts(#{uuid})", 'firstname' => 'test', 'lastname' => 'user')
+        }.to raise_exception Bookings::Gitis::API::UnsupportedAbsoluteUrlError
+      end
+    end
+
+    context 'for unknown url' do
+      before do
+        stub_request(:patch, "#{service_url}#{endpoint}/ontacts(#{uuid})").
+          with(headers: {
+            'Accept' => 'application/json',
+            'Authorization' => /\ABearer #{token}/,
+            'Content-Type' => 'application/json',
+            "OData-MaxVersion" => "4.0",
+            "OData-Version" => "4.0",
+          }).
+          to_return(
+            status: 404,
+            headers: {
+              'content-type' => 'application/json; odata.metadata=minimal',
+              'odata-version' => '4.0'
+            },
+            body: {
+              "error" => {
+                "code" => "0x8006088a",
+                "message" => "Resource not found for the segment 'ontacts'"
+              }
+            }.to_json
+          )
+      end
+
+      it "will raise an UnknownUrlError" do
+        expect {
+          api.patch("ontacts(#{uuid})", 'firstname' => 'test', 'lastname' => 'user')
+        }.to raise_exception(Bookings::Gitis::API::UnknownUrlError, /404: resource not found/i)
+      end
+    end
+  end
+end

--- a/spec/services/bookings/gitis/auth_spec.rb
+++ b/spec/services/bookings/gitis/auth_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::Gitis::Auth do
+  let(:tenant_id) { SecureRandom.uuid }
+  let(:client_id) { 'client_id' }
+  let(:client_secret) { 'secret' }
+  let(:service_url) { 'https://my-service.com' }
+
+  describe '.new' do
+    subject do
+      described_class.new(
+        client_id: client_id,
+        client_secret: client_secret,
+        tenant_id: tenant_id,
+        service_url: service_url
+      )
+    end
+
+    it "will return a valid instance" do
+      is_expected.to be_kind_of Bookings::Gitis::Auth
+    end
+  end
+
+  describe "#token" do
+    let(:api) do
+      Apimock::GitisCrm.new(client_id, client_secret, tenant_id, service_url)
+    end
+
+    context "with valid credentials" do
+      before { api.stub_access_token }
+
+      subject do
+        described_class.new(
+          client_id: client_id,
+          client_secret: client_secret,
+          tenant_id: tenant_id,
+          service_url: service_url
+        )
+      end
+
+      it "returns a token" do
+        expect(subject.token).to match(/\w+\.\w+\.\w+/)
+      end
+
+      it "sets the expires" do
+        subject.token
+        expect(subject.expires_at).to be_kind_of(Time)
+        expect(subject.expires_at).to be_within(10.seconds).of(1.hour.from_now)
+      end
+    end
+
+    context "with invalid credentials" do
+      before { api.stub_invalid_access_token }
+
+      subject do
+        described_class.new(
+          client_id: client_id,
+          client_secret: 'invalid',
+          tenant_id: tenant_id,
+          service_url: service_url
+        )
+      end
+
+      it "will raise an exception" do
+        expect { subject.token }.to \
+          raise_exception Bookings::Gitis::Auth::UnableToRetrieveToken
+      end
+    end
+  end
+end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -1,6 +1,16 @@
 require 'rails_helper'
 
 describe Bookings::Gitis::Contact, type: :model do
+  describe '.entity_path' do
+    subject { described_class.entity_path }
+    it { is_expected.to eq('contacts') }
+  end
+
+  describe '.primary_key' do
+    subject { described_class.primary_key }
+    it { is_expected.to eq('contactid') }
+  end
+
   describe '.initialize' do
     context "with data" do
       before do
@@ -11,8 +21,6 @@ describe Bookings::Gitis::Contact, type: :model do
           'mobilephone' => '07123 456789',
           'telephone1' => '01234 567890',
           'emailaddress1' => 'first@thisaddress.com',
-          'emailaddress2' => 'second@thisaddress.com',
-          'emailaddress3' => 'third@thisaddress.com',
           'address1_line1' => 'First Address Line',
           'address1_line2' => 'Second Address Line',
           'address1_line3' => 'Third Address Line',
@@ -24,6 +32,11 @@ describe Bookings::Gitis::Contact, type: :model do
 
       it "will assign id" do
         expect(@contact.id).to eq "d778d663-a022-4c4b-9962-e469ee179f4a"
+      end
+
+      it "will assign entity_id" do
+        expect(@contact.entity_id).to \
+          eq("contacts(d778d663-a022-4c4b-9962-e469ee179f4a)")
       end
 
       it "will assign name" do
@@ -50,6 +63,24 @@ describe Bookings::Gitis::Contact, type: :model do
       it "will return an empty Contact" do
         expect(Bookings::Gitis::Contact.new.id).to be_nil
       end
+    end
+  end
+
+  describe "#email" do
+    context "with primary address set" do
+      subject { described_class.new(emailaddress1: 'first@test.com') }
+      it { expect(subject.email).to eql('first@test.com') }
+    end
+
+    context "with both addresses set" do
+      subject do
+        described_class.new(
+          emailaddress1: 'first@test.com',
+          emailaddress2: 'second@test.com'
+        )
+      end
+
+      it { expect(subject.email).to eql('second@test.com') }
     end
   end
 end

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -1,16 +1,27 @@
 require 'rails_helper'
+require 'apimock/gitis_crm'
 
 describe Bookings::Gitis::CRM, type: :model do
-  let(:gitis) { described_class.new('a-token') }
+  let(:client_id) { 'clientid' }
+  let(:client_secret) { 'clientsecret' }
+  let(:tenant_id) { SecureRandom.uuid }
+  let(:gitis_url) { 'https://gitis-crm.net' }
+  let(:token) { 'my.secret.token' }
+
+#  let(:api) { Bookings::Gitis::API.new('my.secret.token', service_url: gitis_url) }
+  let(:gitis) { described_class.new(token, service_url: gitis_url) }
+  let(:gitis_stub) do
+    Apimock::GitisCrm.new(client_id, client_secret, tenant_id, gitis_url)
+  end
 
   describe '.initialize' do
-    it "will succeed with access token" do
-      expect(described_class.new('something')).to \
+    it "will succeed with api object" do
+      expect(described_class.new(token)).to \
         be_instance_of(Bookings::Gitis::CRM)
     end
 
-    it "will raise an exception without an access token" do
-      expect { subject }.to raise_exception(ArgumentError)
+    it "will raise an exception without an api object" do
+      expect { described_class.new }.to raise_exception(ArgumentError)
     end
   end
 
@@ -32,37 +43,36 @@ describe Bookings::Gitis::CRM, type: :model do
     end
 
     context 'with single account_ids' do
-      before { @contacts = gitis.find(uuids[1]) }
+      before { gitis_stub.stub_contact_request(uuids[1]) }
+      subject { gitis.find(uuids[1]) }
 
       it "will return a single account" do
-        expect(@contacts).to be_instance_of Bookings::Gitis::Contact
-        expect(@contacts.id).to eq(uuids[1])
+        is_expected.to be_instance_of Bookings::Gitis::Contact
+        is_expected.to have_attributes(id: uuids[1])
       end
     end
 
     context 'with multiple account_ids' do
-      before do
-        @contacts = gitis.find(*uuids)
-      end
+      before { gitis_stub.stub_multiple_contact_request(uuids) }
+      subject { gitis.find(*uuids) }
 
       it "will return an account per id" do
-        expect(@contacts.length).to eq(3)
-        expect(@contacts).to all be_instance_of(Bookings::Gitis::Contact)
-        @contacts.each_with_index do |contact, index|
+        is_expected.to have_attributes(length: 3)
+        is_expected.to all be_instance_of(Bookings::Gitis::Contact)
+        subject.each_with_index do |contact, index|
           expect(contact.id).to eq(uuids[index])
         end
       end
     end
 
     context 'with array of account_ids' do
-      before do
-        @contacts = gitis.find(*uuids)
-      end
+      before { gitis_stub.stub_multiple_contact_request(uuids) }
+      subject { gitis.find(uuids) }
 
       it "will return an account per id" do
-        expect(@contacts.length).to eq(3)
-        expect(@contacts).to all be_instance_of(Bookings::Gitis::Contact)
-        @contacts.each_with_index do |contact, index|
+        is_expected.to have_attributes(length: 3)
+        is_expected.to all be_instance_of(Bookings::Gitis::Contact)
+        subject.each_with_index do |contact, index|
           expect(contact.id).to eq(uuids[index])
         end
       end
@@ -71,14 +81,18 @@ describe Bookings::Gitis::CRM, type: :model do
 
   describe '#find_by_email' do
     let(:email) { 'me@something.com' }
+    before { gitis_stub.stub_contact_request_by_email(email) }
+    subject { gitis.find_by_email(email) }
 
     it "will return a contact record" do
-      expect(gitis.find_by_email(email).email).to eq(email)
+      is_expected.to be_instance_of(Bookings::Gitis::Contact)
+      is_expected.to have_attributes(email: email)
     end
   end
 
   describe '#find_contact_for_signin' do
     let(:email) { 'me@something.com' }
+    before { gitis_stub.stub_contact_request_by_email(email) }
 
     subject do
       gitis.find_contact_for_signin(
@@ -94,13 +108,39 @@ describe Bookings::Gitis::CRM, type: :model do
     end
   end
 
-  describe '#write' do
-    # Note: this is just stubbed functionality for now
-    context 'with a valid contact' do
-      before { @contact = build(:gitis_contact) }
+  describe '.write' do
+    let(:contactid) { SecureRandom.uuid }
+    let(:contact_attributes) { attributes_for(:gitis_contact) }
+
+    context 'with a valid new contact' do
+      let(:contact) { build(:gitis_contact, contact_attributes) }
+
+      before do
+        sorted_attrs = contact_attributes.sort.to_h
+        gitis_stub.stub_create_contact_request(sorted_attrs, contactid)
+      end
+
+      subject { gitis.write(contact) }
+
+      it "will return the id of the inserted record" do
+        is_expected.to eq(contactid)
+      end
+    end
+
+    context 'with a valid existing contact' do
+      before do
+        @contact = build(:gitis_contact, contact_attributes.merge(id: contactid))
+        @contact.reset_dirty_attributes
+        @contact.firstname = 'Changed'
+        @contact.lastname = 'Name'
+        gitis_stub.stub_update_contact_request(
+          { 'firstname' => 'Changed', 'lastname' => 'Name' },
+          contactid
+        )
+      end
 
       it "will succeed" do
-        expect(gitis.write(@contact)).to eq("75c5a32d-d603-4483-956f-236fee7c5784")
+        expect(gitis.write(@contact)).to eq(contactid)
       end
     end
 
@@ -113,12 +153,11 @@ describe Bookings::Gitis::CRM, type: :model do
     end
 
     context 'with an invalid contact' do
-      before do
-        @contact = build(:gitis_contact, email: '')
-      end
+      let(:contact) { build(:gitis_contact, emailaddress1: '') }
+      before { gitis_stub.stub_create_contact_request(contact.attributes) }
 
       it "will return false" do
-        expect(gitis.write(@contact)).to be false
+        expect(gitis.write(contact)).to be false
       end
     end
   end

--- a/spec/services/bookings/gitis/entity_spec.rb
+++ b/spec/services/bookings/gitis/entity_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::Gitis::Entity do
+  class Stub
+    include Bookings::Gitis::Entity
+
+    attr_accessor :id
+    entity_attributes :firstname, :lastname
+
+    def initialize(data = {})
+      self.firstname = data['firstname']
+      self.lastname = data['lastname']
+    end
+  end
+
+  subject { Stub.new('firstname' => 'test', 'lastname' => 'user') }
+
+  describe ".entity_path" do
+    subject { Stub.entity_path }
+    it { is_expected.to eq('stubs') }
+  end
+
+  describe ".primary_key" do
+    subject { Stub.primary_key }
+    it { is_expected.to eq('stubid') }
+  end
+
+  describe "#attributes" do
+    it do
+      expect(subject.attributes).to \
+        eq('firstname' => 'test', 'lastname' => 'user')
+    end
+  end
+
+  describe "#reset" do
+    before { subject.reset }
+    it { expect(subject.attributes).to eq({}) }
+  end
+
+  describe "#changed_attributes" do
+    it "will use dirty tracking to return modified attributes since last reset" do
+      expect(subject.changed_attributes).to \
+        eq('firstname' => 'test', 'lastname' => 'user')
+
+      subject.reset_dirty_attributes
+      expect(subject.changed_attributes).to eq({})
+
+      subject.lastname = 'changed'
+      expect(subject.changed_attributes).to eq('lastname' => 'changed')
+    end
+  end
+
+  describe "#entity_id" do
+    let(:uuid) { SecureRandom.uuid }
+    before { subject.id = uuid }
+
+    it "will include uuid and entity_path" do
+      expect(subject).to have_attributes('entity_id' => "stubs(#{uuid})")
+    end
+  end
+
+  describe "#entity_id=" do
+    let(:uuid) { SecureRandom.uuid }
+
+    context "with expected format" do
+      before { subject.entity_id = "stubs(#{uuid})" }
+
+      it "will set the id" do
+        expect(subject.id).to eq(uuid)
+      end
+    end
+
+    context "with unexpected format" do
+      it "will raise" do
+        expect { subject.entity_id = uuid }.to \
+          raise_exception(Bookings::Gitis::Entity::InvalidEntityIdError)
+      end
+    end
+
+    context "with nil" do
+      it "will raise" do
+        expect { subject.entity_id = nil }.to \
+          raise_exception(Bookings::Gitis::Entity::InvalidEntityIdError)
+      end
+    end
+  end
+end

--- a/spec/support/stubbed_gitis.rb
+++ b/spec/support/stubbed_gitis.rb
@@ -1,0 +1,21 @@
+require 'apimock/gitis_crm'
+
+shared_context "stubbed out Gitis" do
+  let(:tenant_id) { SecureRandom.uuid }
+  let(:client_id) { 'client_id' }
+  let(:client_secret) { 'secret' }
+  let(:service_url) { 'https://my-service.com' }
+
+  let(:gitis_stubs) do
+    Apimock::GitisCrm.new(client_id, client_secret, tenant_id, service_url)
+  end
+
+  let(:gitis) do
+    Bookings::Gitis::CRM.new('a.stub.token', service_url: service_url)
+  end
+
+  before do
+    allow(Bookings::Gitis::CRM).to receive(:new).and_return(gitis)
+    gitis_stubs.stub_contact_request(1)
+  end
+end

--- a/spec_external/gitis_crm_spec.rb
+++ b/spec_external/gitis_crm_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe "The GITIS CRM Api" do
 
   it "can read the from the CRM", :read do
     # Read the first contact
-    resp = crm_get("/contacts", "$top" => "1")
+    resp = crm_get("/contacts", "$top" => "3")
 
     expect(resp.status).to eql(200)
     expect(resp.headers).to include('content-type' => 'application/json; odata.metadata=minimal')
 
     data = JSON.parse(resp.body)
-    expect(data['value'].length).to eql(1)
+    expect(data['value'].length).to eql(3)
     firstcontact = data['value'][0]
     expect(firstcontact['contactid']).not_to be_blank
 
-    # Read the contact by Id
+    # Read a single contact by Id
     resp = crm_get("/contacts(#{firstcontact['contactid']})")
 
     expect(resp.status).to eql(200)
@@ -31,6 +31,13 @@ RSpec.describe "The GITIS CRM Api" do
 
     contact = JSON.parse(resp.body)
     expect(contact['contactid']).to eql(firstcontact['contactid'])
+
+    # Read multiple contacts in a single query
+    resp = crm_get("/contacts?$top=30&$filter=contactid eq '#{data['value'][0]['contactid']}' or contactid eq '#{data['value'][1]['contactid']}' or contactid eq '#{data['value'][2]['contactid']}'")
+    contacts = JSON.parse(resp.body)
+
+    expect(contacts['value'].length).to eql(3)
+    expect(contacts['value'].pluck('contactid')).to eql(data['value'].pluck('contactid'))
   end
 
   it "can write to the CRM", :write do


### PR DESCRIPTION
# Context

We need a means of reading and writing from the CRM, this requires acquiring a token, serialising appropriate attributes and potentially a means to validate that data.

# Changes proposed in this pull request

An API object to handle accessing the service
An Auth object for requesting a token, this is cached for the life of the service
A CRM object to handle reading and writing from the Gitis CRM
An Entity module, for easily creating various Entity data types

# Guidance to review

Does this seem sane, I'm looking for opinions/review from both @peteryates and @rjlynch

One thought that occurs in moving reading/writing out into the entities, and making the CRM object a singleton so the entities can discover.

**Note:** This is a second PR since I had to roll the first out after unexpected CI failures

