### PR TITLE
Fix an error where old imported data is invalid

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -23,7 +23,7 @@ class Bookings::School < ApplicationRecord
 
   validates :availability_info,
     allow_nil: true,
-    length: { minimum: 10 }
+    length: { minimum: 3 }
 
   has_many :bookings_schools_subjects,
     class_name: "Bookings::SchoolsSubject",

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -14,7 +14,7 @@ describe Bookings::School, type: :model do
 
     context 'availability_info' do
       it { is_expected.to allow_value(nil).for(:availability_info) }
-      it { is_expected.to validate_length_of(:availability_info).is_at_least(10) }
+      it { is_expected.to validate_length_of(:availability_info).is_at_least(3) }
 
       context 'overwriting empty strings before validation' do
         subject { create(:bookings_school) }


### PR DESCRIPTION
Some schools that exist in the database were imported with data that
doesn't meet the validation critera that is currently in place,
specifically the availability_info field (existing values include things
like 'Term time' and 'TBC')

To accomodate, reduce the minimum number of characters from 10 to 3

https://sentry.io/organizations/dfe-se/issues/1064898105/events/ad7c22d2576143f68118861ac13fea60/

