### PR TITLE
Remove current academic year from start page

### DIFF
--- a/app/views/candidates/home/index.html.erb
+++ b/app/views/candidates/home/index.html.erb
@@ -12,7 +12,7 @@
 
     <p>
       School experience allows you to find out more about teaching by visiting
-      schools within the current academic year.
+      schools.
     </p>
 
     <p class="govuk-!-font-weight-bold">


### PR DESCRIPTION
The school experience service doesn’t just cover this academic year,
and so the reference to this on the start page is misleading.

### Context

### Changes proposed in this pull request

### Guidance to review

