### PR TITLE
Feature/schools cancel a booking

### DIFF
--- a/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
@@ -1,0 +1,43 @@
+module Schools
+  module ConfirmedBookings
+    module Cancellations
+      class NotificationDeliveriesController < Schools::BaseController
+        before_action :set_booking_and_placement_request
+
+        def show
+          @cancellation = @placement_request.school_cancellation
+        end
+
+        def create
+          @cancellation = @placement_request.school_cancellation
+          notify_candidate @cancellation
+          @cancellation.sent!
+          redirect_to \
+            schools_booking_cancellation_notification_delivery_path(@booking)
+        end
+
+      private
+
+        def set_booking_and_placement_request
+          @booking = current_school
+            .bookings
+            .eager_load(:bookings_placement_request)
+            .find(params[:booking_id])
+          @placement_request = @booking.bookings_placement_request
+        end
+
+        def notify_candidate(cancellation)
+        # NotifyEmail::CandidateRequestRejection.new(
+        #   to: cancellation.candidate_email,
+        #   school_name: cancellation.school_name,
+        #   candidate_name: cancellation.candidate_name,
+        #   rejection_reasons: cancellation.reason,
+        #   extra_details: cancellation.extra_details,
+        #   dates_requested: cancellation.dates_requested,
+        #   school_search_url: new_candidates_school_search_url
+        # ).despatch_later!
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
@@ -27,15 +27,15 @@ module Schools
         end
 
         def notify_candidate(cancellation)
-        # NotifyEmail::CandidateRequestRejection.new(
-        #   to: cancellation.candidate_email,
-        #   school_name: cancellation.school_name,
-        #   candidate_name: cancellation.candidate_name,
-        #   rejection_reasons: cancellation.reason,
-        #   extra_details: cancellation.extra_details,
-        #   dates_requested: cancellation.dates_requested,
-        #   school_search_url: new_candidates_school_search_url
-        # ).despatch_later!
+          NotifyEmail::CandidateBookingSchoolCancelsBooking.new(
+            to: cancellation.candidate_email,
+            school_name: cancellation.school_name,
+            candidate_name: cancellation.candidate_name,
+            rejection_reasons: cancellation.reason,
+            extra_details: cancellation.extra_details,
+            dates_requested: cancellation.dates_requested,
+            school_search_url: new_candidates_school_search_url
+          ).despatch_later!
         end
       end
     end

--- a/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
@@ -1,0 +1,57 @@
+module Schools
+  module ConfirmedBookings
+    class CancellationsController < Schools::BaseController
+      before_action :set_booking_and_placement_request
+
+      def show
+        @cancellation = @placement_request.school_cancellation
+      end
+
+      def new
+        @cancellation = @placement_request.build_school_cancellation
+      end
+
+      def edit
+        @cancellation = @placement_request.school_cancellation
+      end
+
+      def create
+        @cancellation = @placement_request.build_school_cancellation \
+          cancellation_params
+
+        if @cancellation.save
+          redirect_to schools_booking_cancellation_path \
+            @booking
+        else
+          render :new
+        end
+      end
+
+      def update
+        @cancellation = @placement_request.school_cancellation
+
+        if @cancellation.update cancellation_params
+          redirect_to schools_booking_cancellation_path \
+            @booking
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def set_booking_and_placement_request
+        @booking = current_school
+          .bookings
+          .eager_load(:bookings_placement_request)
+          .find(params[:booking_id])
+        @placement_request = @booking.bookings_placement_request
+      end
+
+      def cancellation_params
+        params.require(:bookings_placement_request_cancellation).permit \
+          :reason, :extra_details
+      end
+    end
+  end
+end

--- a/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module ConfirmedBookings
     class CancellationsController < Schools::BaseController
       before_action :set_booking_and_placement_request
+      before_action :ensure_booking_is_open
 
       def show
         @cancellation = @placement_request.school_cancellation
@@ -51,6 +52,12 @@ module Schools
       def cancellation_params
         params.require(:bookings_placement_request_cancellation).permit \
           :reason, :extra_details
+      end
+
+      def ensure_booking_is_open
+        if @placement_request.closed?
+          redirect_to schools_booking_path @booking
+        end
       end
     end
   end

--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -12,7 +12,6 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
     :school_email,
     :school_name,
     :school_admin_name,
-    :dates_requested,
     :candidate_email,
     :candidate_name,
     :requested_availability,
@@ -28,6 +27,14 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
 
   def sent?
     sent_at.present?
+  end
+
+  def dates_requested
+    if placement_request&.booking.present?
+      placement_request.booking.date.to_formatted_s(:govuk)
+    else
+      placement_request.dates_requested
+    end
   end
 
 private

--- a/app/notify/notify_email/candidate_booking_school_cancels_booking.d7e4fd68-0f01-4a9e-96f1-62a8a77a9de1.md
+++ b/app/notify/notify_email/candidate_booking_school_cancels_booking.d7e4fd68-0f01-4a9e-96f1-62a8a77a9de1.md
@@ -1,0 +1,16 @@
+# Dear ((candidate_name)),
+
+((school_name)) has cancelled your school experience for the following dates:
+* ((dates_requested))
+
+#  Your request was turned down for the following reasons:
+((rejection_reasons))
+
+#  Extra details from the school
+((extra_details))
+
+# Make a new request
+Apply for school experience at other schools - ((school_search_url))
+
+# Help and support
+If you need any further help and support getting school experience or becoming a teacher visit the Get Into Teaching website - https://getintoteaching.education.gov.uk/school-experience

--- a/app/notify/notify_email/candidate_booking_school_cancels_booking.rb
+++ b/app/notify/notify_email/candidate_booking_school_cancels_booking.rb
@@ -1,0 +1,36 @@
+class NotifyEmail::CandidateBookingSchoolCancelsBooking < Notify
+  attr_accessor :candidate_name,
+    :school_name,
+    :dates_requested,
+    :rejection_reasons,
+    :extra_details,
+    :school_search_url
+
+  def initialize(to:, candidate_name:, school_name:, dates_requested:, rejection_reasons:, extra_details:, school_search_url:)
+    self.candidate_name    = candidate_name
+    self.school_name       = school_name
+    self.dates_requested   = dates_requested
+    self.rejection_reasons = rejection_reasons
+    self.extra_details     = extra_details
+    self.school_search_url = school_search_url
+
+    super(to: to)
+  end
+
+private
+
+  def template_id
+    'd7e4fd68-0f01-4a9e-96f1-62a8a77a9de1'
+  end
+
+  def personalisation
+    {
+      candidate_name: candidate_name,
+      school_name: school_name,
+      dates_requested: dates_requested,
+      rejection_reasons: rejection_reasons,
+      extra_details: extra_details,
+      school_search_url: school_search_url
+    }
+  end
+end

--- a/app/views/schools/confirmed_bookings/_booking_table.html.erb
+++ b/app/views/schools/confirmed_bookings/_booking_table.html.erb
@@ -20,7 +20,7 @@
         <%= booking.date.to_formatted_s(:govuk) %>
       </td>
       <td class="govuk-table__cell">
-        <%= link_to "Open", schools_booking_path('abc123') %>
+        <%= link_to "Open", schools_booking_path(booking) %>
         <%= link_to 'Update', '#' %>
         <%= link_to 'Cancel', '#' %>
       </td>

--- a/app/views/schools/confirmed_bookings/_booking_table.html.erb
+++ b/app/views/schools/confirmed_bookings/_booking_table.html.erb
@@ -9,7 +9,7 @@
   </thead>
   <tbody class="govuk-table__body">
     <%- @bookings.each do |booking| -%>
-    <tr class="booking govuk-table__row <%= "booking-#{booking.id}" %>">
+    <tr class="booking govuk-table__row" data-booking="<%= booking.id %>">
       <td class="name govuk-table__cell">
         <%= booking.candidate.full_name %>
       </td>

--- a/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
@@ -1,0 +1,47 @@
+<%= link_to 'Back', schools_dashboard_path, class: 'govuk-back-link' %>
+
+<%= form_for cancellation, url: schools_booking_cancellation_path do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">
+        Review and send rejection email to candidate
+      </h1>
+
+      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p>
+            Review the following email which will be sent to the candidate. You can add extra details.
+          </p>
+
+          <%= render partial: "letter", locals: {
+            cancellation: cancellation,
+            reason: capture do
+              f.text_area :reason,
+                rows: 7,
+                placeholder: "Explain why the booking was cancelled. For example, the school is fully booked or there's no longer school experience available on the requested date",
+                label_options: { overwrite_defaults!: true, class: 'govuk-visually-hidden' }
+            end,
+            extra_details: capture do
+              f.text_area :extra_details,
+                rows: 7,
+                placeholder: "Add any extra details. For example, you may have availability on a different date or you can offer school experience in another subject",
+                label_options: { overwrite_defaults!: true, class: 'govuk-visually-hidden' }
+            end
+          } %>
+
+          <section>
+            <p>
+              <%= f.submit 'Preview rejection email' %>
+            </p>
+
+            <p>
+              <%= link_to 'Back to request', schools_placement_request_path(cancellation.placement_request) %>
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
@@ -1,0 +1,59 @@
+<section class="govuk-se-letter">
+  <section id="request-details">
+    <h2 class="govuk-heading-m">
+      Dear <%= cancellation.candidate_name %>
+    </h2>
+
+    <p>
+      <%= cancellation.school_name %> has turned down your school experience request for the following dates:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li><%= cancellation.dates_requested %></li>
+    </ul>
+  </section>
+
+  <section id="rejection-details">
+    <h3 class="govuk-heading-s">
+      Your request was turned down for the following reasons:
+    </h3>
+    <p>
+      <%= reason %>
+    </p>
+  </section>
+
+  <% if extra_details.present? %>
+    <section id="extra-details">
+      <h3 class="govuk-heading-s">
+        Extra details from the school
+      </h3>
+      <p>
+        <%= extra_details %>
+      </p>
+    </section>
+  <% end %>
+
+  <section id="Make a new request">
+    <h3 class="govuk-heading-s">
+      Make a new request
+    </h3>
+
+    <p>
+      Apply for school experience at other schools -
+      <%= link_to "Find school experience.", new_candidates_school_search_path %>
+    </p>
+  </section>
+
+  <section id="help-and-support">
+    <h3 class="govuk-heading-s">
+      Help and support
+    </h3>
+
+    <p>
+      If you need any further help and support getting school experience or
+      becoming a teacher visit the
+      <%= link_to "Get Into Teaching", 'https://getintoteaching.education.gov.uk/school-experience' %>
+      website.
+    </p>
+  </section>
+</section>

--- a/app/views/schools/confirmed_bookings/cancellations/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: { cancellation: @cancellation } %>

--- a/app/views/schools/confirmed_bookings/cancellations/new.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: { cancellation: @cancellation } %>

--- a/app/views/schools/confirmed_bookings/cancellations/notification_deliveries/show.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/notification_deliveries/show.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Your email has been sent
+      </h1>
+    </div>
+    <h2 class="govuk-heading-m">
+      What happens next
+    </h2>
+    <p>
+      We’ve sent your response to <%= @cancellation.candidate_name %>
+    </p>
+
+    <%= link_to 'Return to requests and bookings', schools_dashboard_path, class: 'govuk-button govuk-button--secondary' %>
+  </div>
+</div>

--- a/app/views/schools/confirmed_bookings/cancellations/show.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/show.html.erb
@@ -1,0 +1,43 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Send rejection email to candidate
+    </h1>
+
+    <p>
+      The following contains the wording of the rejection email which will be
+      sent to <%= @cancellation.candidate_name %>.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      Preview rejection email
+    </h2>
+
+    <%= render partial: "letter", locals: {
+      cancellation: @cancellation,
+      reason: @cancellation.reason,
+      extra_details: @cancellation.extra_details
+    } %>
+
+    <section>
+      <p>
+        By sending this email you’re confirming, to the best of your knowledge, the booking details you’re providing are correct.
+      </p>
+
+      <p>
+        <%= button_to 'Send rejection email',
+          schools_booking_cancellation_notification_delivery_path(@booking),
+          class: 'govuk-button'
+        %>
+      </p>
+
+      <p>
+        <%= link_to 'Amend the rejection email', edit_schools_booking_cancellation_path(@booking) %>
+      </p>
+
+      <p>
+        <%= link_to 'Back to booking', schools_booking_path(@booking) %>
+      </p>
+    </section>
+  </div>
+</div>

--- a/app/views/schools/confirmed_bookings/show.html.erb
+++ b/app/views/schools/confirmed_bookings/show.html.erb
@@ -138,6 +138,6 @@
   </section>
 
   <div>
-    <%= link_to 'Cancel', '#', class: 'govuk-button govuk-button--secondary' %>
+    <%= link_to 'Cancel', new_schools_booking_cancellation_path(@booking), class: 'govuk-button govuk-button--secondary' %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,10 @@ Rails.application.routes.draw do
           end
         end
         resources :confirmed_bookings, path: 'bookings', as: 'bookings' do
+          resource :cancellation, only: %i(show new create edit update), controller: 'confirmed_bookings/cancellations' do
+            resource :notification_delivery, only: %i(show create), controller: 'confirmed_bookings/cancellations/notification_deliveries'
+          end
+
           collection do
             resources :upcoming, only: :index, controller: 'confirmed_bookings/upcoming', as: 'upcoming_bookings'
           end

--- a/features/schools/confirmed_bookings/cancelling.feature
+++ b/features/schools/confirmed_bookings/cancelling.feature
@@ -1,0 +1,48 @@
+Feature: Cancelling bookings
+    So I can react to unforseen circumstances
+    As a school administrator
+    I want to be able to cancel bookings
+
+    Background:
+        Given I am logged in as a DfE user
+        And the school has subjects
+
+    Scenario: Page heading
+        Given there is at least one booking
+        When I am on the cancel booking page
+        Then the page's main heading should be 'Review and send rejection email to candidate'
+
+    Scenario: Reject information
+        Given there is at least one booking
+        When I am on the cancel booking page
+        Then the following text should be present:
+        """
+        Dear Matthew Richards
+        """
+        And the following text should be present:
+        """
+        has turned down your school experience request for the following dates:
+        """
+
+    Scenario: Reject information
+        Given there is at least one booking
+        When I am on the cancel booking page
+        Then the following text should be present:
+        """
+        Review the following email which will be sent to the candidate. You can add extra details.
+        """
+
+    Scenario: Reject form
+        Given there is at least one booking
+        When I am on the cancel booking page
+        Then there should be a 'Cancellation reasons' text area
+        And there should be a 'Extra details' text area
+        And the submit button should contain text 'Preview rejection email'
+
+    Scenario: Rejecting the requests
+        Given there is at least one booking
+        And I am on the cancel booking page
+        And I have entered a reason in the cancellation reasons text area
+        And I have entered a extra details in the extra details text area
+        When I click the 'Preview rejection email' button
+        Then I should see a preview of what I have entered

--- a/features/step_definitions/schools/bookings/cancellation_steps.rb
+++ b/features/step_definitions/schools/bookings/cancellation_steps.rb
@@ -1,0 +1,5 @@
+When("I am on the cancel booking page") do
+  path = path_for('cancel booking', booking_id: @booking_id)
+  visit(path)
+  expect(page.current_path).to eql(path)
+end

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -39,10 +39,10 @@ end
 Then("I should only see bookings belonging to my school") do
   within('table#bookings tbody') do
     @bookings.map(&:id).each do |booking_id|
-      expect(page).to have_css(".booking-#{booking_id}")
+      expect(page).to have_css(".booking[data-booking='#{booking_id}']")
     end
     @other_school_bookings.map(&:id).each do |booking_id|
-      expect(page).not_to have_css(".booking-#{booking_id}")
+      expect(page).not_to have_css(".booking[data-booking='#{booking_id}']")
     end
   end
 end
@@ -87,7 +87,8 @@ Then("every booking should contain a link to view more details") do
   within('#bookings') do
     page.all('.booking').each do |sr|
       within(sr) do
-        expect(page).to have_link('Open', href: schools_booking_path('abc123'))
+        booking_id = sr['data-booking'].to_i
+        expect(page).to have_link('Open', href: schools_booking_path(booking_id))
       end
     end
   end
@@ -121,7 +122,7 @@ end
 Then("the upcoming bookings should be listed") do
   within('table#bookings tbody') do
     @bookings.map(&:id).each do |booking_id|
-      expect(page).to have_css(".booking-#{booking_id}")
+      expect(page).to have_css(".booking[data-booking='#{booking_id}']")
     end
   end
 end
@@ -129,7 +130,7 @@ end
 Then("the non-upcoming bookings shouldn't") do
   within('table#bookings tbody') do
     @non_upcoming_bookings.map(&:id).each do |booking_id|
-      expect(page).not_to have_css(".booking-#{booking_id}")
+      expect(page).not_to have_css(".booking[data-booking='#{booking_id}']")
     end
   end
 end

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -22,6 +22,7 @@ def path_for(descriptor, school: nil, placement_date_id: nil, booking_id: nil, p
     "upcoming bookings" => [:schools_upcoming_bookings_path],
     "booking" => [:schools_booking_path, booking_id],
     "placement requests" => [:schools_placement_requests_path],
+    "cancel booking" => [:new_schools_booking_cancellation_path, booking_id],
     "upcoming requests" => [:schools_upcoming_requests_path],
     "placement request" => [:schools_placement_request_path, placement_request],
     "confirm booking" => [:new_schools_placement_request_acceptance_confirm_booking_path, placement_request],

--- a/lib/notify/notify_sync.rb
+++ b/lib/notify/notify_sync.rb
@@ -34,7 +34,7 @@ class NotifySync
       File.write(
         File.join(
           TEMPLATE_PATH,
-          [rt.name.gsub(/[\ \-]/, "").underscore, template_id, 'md'].join('.'),
+          [rt.name.gsub(/[\ ]/, "").underscore, template_id, 'md'].join('.'),
         ),
         reencode(rt.body)
       )

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -63,7 +63,7 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
           candidate_name: cancellation.candidate_name,
           rejection_reasons: cancellation.reason,
           extra_details: cancellation.extra_details,
-          dates_requested: cancellation.requested_availability,
+          dates_requested: cancellation.dates_requested,
           school_search_url: new_candidates_school_search_url
 
         expect(candidate_request_rejection_notification).to \

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesController, type: :request do
+  include_context "logged in DfE user"
+
+  let :school do
+    Bookings::School.find_by!(urn: urn).tap do |s|
+      s.subjects << FactoryBot.create_list(:bookings_subject, 5)
+    end
+  end
+
+  let :candidate_request_rejection_notification do
+    double NotifyEmail::CandidateBookingSchoolCancelsBooking,
+      despatch_later!: true
+  end
+
+  before do
+    allow(NotifyEmail::CandidateBookingSchoolCancelsBooking).to receive(:new) do
+      candidate_request_rejection_notification
+    end
+  end
+
+  context '#create' do
+    before do
+      post schools_booking_cancellation_notification_delivery_path \
+        booking
+    end
+
+    context 'when request already closed' do
+      let :placement_request do
+        create :placement_request, :cancelled_by_school, school: school
+      end
+
+      let!(:booking) do
+        create(:bookings_booking, bookings_placement_request: placement_request, bookings_school: school)
+      end
+
+      it 'redirects to the placement_show path' do
+        expect(response).to redirect_to \
+          schools_booking_cancellation_notification_delivery_path(booking)
+      end
+    end
+
+    context 'when request not already closed' do
+      let :placement_request do
+        FactoryBot.create \
+          :placement_request, :with_school_cancellation, school: school
+      end
+
+      let :cancellation do
+        placement_request.school_cancellation
+      end
+
+      let!(:booking) do
+        create(:bookings_booking, bookings_placement_request: placement_request, bookings_school: school)
+      end
+
+      it 'notifies the candidate' do
+        expect(NotifyEmail::CandidateBookingSchoolCancelsBooking).to have_received(:new).with \
+          to: cancellation.candidate_email,
+          school_name: cancellation.school_name,
+          candidate_name: cancellation.candidate_name,
+          rejection_reasons: cancellation.reason,
+          extra_details: cancellation.extra_details,
+          dates_requested: cancellation.requested_availability,
+          school_search_url: new_candidates_school_search_url
+
+        expect(candidate_request_rejection_notification).to \
+          have_received :despatch_later!
+      end
+
+      it 'updates the placement_request to closed' do
+        expect(placement_request.reload).to be_closed
+      end
+
+      it 'redirects to the show action' do
+        expect(response).to redirect_to \
+          schools_booking_cancellation_notification_delivery_path \
+            booking
+      end
+    end
+  end
+
+  context '#show' do
+    let :placement_request do
+      FactoryBot.create \
+        :placement_request, :cancelled_by_school, school: school
+    end
+
+    let!(:booking) do
+      create(:bookings_booking, bookings_placement_request: placement_request, bookings_school: school)
+    end
+
+    before do
+      get schools_booking_cancellation_notification_delivery_path \
+        booking
+    end
+
+    it 'assigns the cancellation' do
+      expect(assigns(:cancellation)).to \
+        eq placement_request.school_cancellation
+    end
+
+    it 'renders the show template' do
+      expect(response).to render_template :show
+    end
+  end
+end

--- a/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
@@ -56,7 +56,7 @@ describe Schools::ConfirmedBookings::CancellationsController, type: :request do
     end
 
     before do
-      post "/schools/placement_requests/#{placement_request.id}/cancellation",
+      post "/schools/bookings/#{booking.id}/cancellation",
         params: cancellation_params
     end
 
@@ -71,7 +71,7 @@ describe Schools::ConfirmedBookings::CancellationsController, type: :request do
 
       it 'redirects to the placement_show path' do
         expect(response).to redirect_to \
-          schools_placement_request_path(placement_request)
+          schools_booking_path(booking)
       end
     end
 
@@ -108,7 +108,7 @@ describe Schools::ConfirmedBookings::CancellationsController, type: :request do
 
         it 'redirects to the show action' do
           expect(response).to redirect_to \
-            schools_placement_request_cancellation_path(placement_request)
+            schools_booking_cancellation_path(booking)
         end
       end
     end
@@ -116,7 +116,6 @@ describe Schools::ConfirmedBookings::CancellationsController, type: :request do
 
   context '#edit' do
     before do
-      #get "/schools/placement_requests/#{placement_request.id}/cancellation/edit"
       get edit_schools_booking_cancellation_path(booking.id)
     end
 

--- a/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
@@ -1,0 +1,225 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::ConfirmedBookings::CancellationsController, type: :request do
+  include_context "logged in DfE user"
+
+  let :school do
+    Bookings::School.find_by!(urn: urn).tap do |s|
+      s.subjects << FactoryBot.create_list(:bookings_subject, 5)
+    end
+  end
+
+  let(:placement_request) do
+    create(:bookings_placement_request, school: school)
+  end
+
+  let(:booking) do
+    create(:bookings_booking, bookings_placement_request: placement_request, bookings_school: school)
+  end
+
+  context '#new' do
+    before do
+      get new_schools_booking_cancellation_path(booking)
+    end
+
+    context 'when request already closed' do
+      let :placement_request do
+        FactoryBot.create :placement_request, :cancelled, school: school
+      end
+
+      it 'redirects to the placement_show path' do
+        expect(response).to redirect_to \
+          schools_booking_path(booking)
+      end
+    end
+
+    context 'when request not already closed' do
+      let :placement_request do
+        FactoryBot.create :placement_request, school: school
+      end
+
+      it 'assigns the cancellation' do
+        expect(assigns(:cancellation).reason).to eq \
+          placement_request.build_school_cancellation.reason
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template :new
+      end
+    end
+  end
+
+  context '#create' do
+    let :cancellation_params do
+      { bookings_placement_request_cancellation: cancellation.attributes }
+    end
+
+    before do
+      post "/schools/placement_requests/#{placement_request.id}/cancellation",
+        params: cancellation_params
+    end
+
+    context 'when placement request already closed' do
+      let :placement_request do
+        FactoryBot.create :placement_request, :cancelled, school: school
+      end
+
+      let :cancellation do
+        FactoryBot.build :cancellation, placement_request: placement_request
+      end
+
+      it 'redirects to the placement_show path' do
+        expect(response).to redirect_to \
+          schools_placement_request_path(placement_request)
+      end
+    end
+
+    context 'when placement request not closed' do
+      let :placement_request do
+        FactoryBot.create :placement_request, school: school
+      end
+
+      context 'failure' do
+        let :cancellation do
+          placement_request.build_school_cancellation
+        end
+
+        it 'rerenders the new template' do
+          expect(response).to render_template :new
+        end
+
+        it "doesn't create the rejection" do
+          expect(placement_request.school_cancellation).not_to be_persisted
+        end
+      end
+
+      context 'success' do
+        let :cancellation do
+          FactoryBot.build :cancellation,
+            reason: "school's out for summer",
+            placement_request: placement_request
+        end
+
+        it 'creates the cancellation' do
+          expect(placement_request.school_cancellation.reason).to \
+            eq "school's out for summer"
+        end
+
+        it 'redirects to the show action' do
+          expect(response).to redirect_to \
+            schools_placement_request_cancellation_path(placement_request)
+        end
+      end
+    end
+  end
+
+  context '#edit' do
+    before do
+      #get "/schools/placement_requests/#{placement_request.id}/cancellation/edit"
+      get edit_schools_booking_cancellation_path(booking.id)
+    end
+
+    context 'when placement request already closed' do
+      let :placement_request do
+        FactoryBot.create :placement_request, :cancelled, school: school
+      end
+
+      it 'redirects to the placement_show path' do
+        expect(response).to redirect_to \
+          schools_booking_path(booking)
+      end
+    end
+
+    context 'when request not already closed' do
+      let :placement_request do
+        FactoryBot.create \
+          :placement_request, :with_school_cancellation, school: school
+      end
+
+      it 'assigns the cancellation' do
+        expect(assigns(:cancellation).reason).to eq \
+          placement_request.school_cancellation.reason
+      end
+
+      it 'renders the edit template' do
+        expect(response).to render_template :edit
+      end
+    end
+  end
+
+  context '#update' do
+    before do
+      patch schools_booking_cancellation_path(booking, params: cancellation_params)
+    end
+
+    let :cancellation_params do
+      { bookings_placement_request_cancellation: cancellation.attributes }
+    end
+
+    context 'when placement request already closed' do
+      let :placement_request do
+        FactoryBot.create \
+          :placement_request, :cancelled_by_school, school: school
+      end
+
+      let :cancellation do
+        FactoryBot.build :cancellation,
+          reason: "school's out for ever",
+          placement_request: placement_request
+      end
+
+      it "doesn't update the rejection" do
+        expect(placement_request.school_cancellation.reload.reason).not_to \
+          eq "school's out for ever"
+      end
+
+      it 'redirects to the placement_show path' do
+        expect(response).to redirect_to \
+          schools_booking_path(booking)
+      end
+    end
+
+    context 'when request not already closed' do
+      let :placement_request do
+        FactoryBot.create \
+          :placement_request, :with_school_cancellation, school: school
+      end
+
+      context 'failure' do
+        let :cancellation do
+          FactoryBot.build :cancellation,
+            reason: "",
+            placement_request: placement_request
+        end
+
+        it 'rerenders the edit template' do
+          expect(response).to render_template :edit
+        end
+
+        it "doesn't update the rejection" do
+          expect(placement_request.school_cancellation.reload.reason).not_to \
+            eq "school's out for ever"
+        end
+      end
+
+      context 'success' do
+        let :cancellation do
+          FactoryBot.build :cancellation,
+            reason: "school's out for ever",
+            placement_request: placement_request
+        end
+
+        it 'updates the rejection' do
+          expect(placement_request.school_cancellation.reload.reason).to \
+            eq "school's out for ever"
+        end
+
+        it 'redirects to the show action' do
+          expect(response).to redirect_to \
+            schools_booking_cancellation_path(booking)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/bookings/placement_request/cancellation_spec.rb
+++ b/spec/models/bookings/placement_request/cancellation_spec.rb
@@ -40,4 +40,23 @@ describe Bookings::PlacementRequest::Cancellation, type: :model do
       expect(subject.reload.placement_request).to be_closed
     end
   end
+
+  describe '#dates_requested' do
+    let(:placement_request) { create(:placement_request, :cancelled_by_school) }
+    subject { placement_request.school_cancellation }
+
+    context 'when the placement has been accepted' do
+      let!(:booking) { create(:bookings_booking, bookings_placement_request: placement_request) }
+
+      specify "should be the booking's date" do
+        expect(subject.dates_requested).to eql(booking.date.to_formatted_s(:govuk))
+      end
+    end
+
+    context "when the placement not has been accepted" do
+      specify 'should be the placement request availability' do
+        expect(subject.dates_requested).to eql(placement_request.dates_requested)
+      end
+    end
+  end
 end

--- a/spec/notify/notify_email/candidate_booking_school_cancels_booking_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_school_cancels_booking_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe NotifyEmail::CandidateBookingSchoolCancelsBooking do
+  it_should_behave_like "email template", "d7e4fd68-0f01-4a9e-96f1-62a8a77a9de1",
+    school_name: "Springfield Elementary School",
+    candidate_name: "James Jones",
+    rejection_reasons: "We're oversubscribed",
+    extra_details: 'Maybe try rebooking... at another school!',
+    dates_requested: 'Whenever really',
+    school_search_url: 'https://example.com/'
+end


### PR DESCRIPTION
### Context

If schools can no longer honour their commitment to provide school experience for a candidate they need to be able to cancel. Cancelling should inform the candidate via email that their placement will no longer go ahead

### Changes proposed in this pull request

Add the cancellation workflow to the booking. It builds on @rjlynch's work for placement request cancellation

### Guidance to review

Ensure everything makes sense. There is some content duplication but this was left because I can see the content for placement rejection and booking cancellation changing more.