### PR TITLE
Don't revalidate placement request on email confirm

### DIFF
--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -11,7 +11,8 @@ module Candidates
         unless registration_session.completed?
           placement_request = Bookings::PlacementRequest.create_from_registration_session! \
             registration_session,
-            cookies[:analytics_tracking_uuid]
+            cookies[:analytics_tracking_uuid],
+            context: :returning_from_confirmation_email
 
           registration_session.flag_as_completed!
 

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -39,12 +39,13 @@ module Bookings
         .where(school_cancellations_bookings_placement_requests: { sent_at: nil })
     end
 
-    def self.create_from_registration_session!(registration_session, analytics_tracking_uuid = nil)
-      self.create! \
+    def self.create_from_registration_session!(registration_session, analytics_tracking_uuid = nil, context: nil)
+      self.new(
         Candidates::Registrations::RegistrationAsPlacementRequest
           .new(registration_session)
           .attributes
           .merge(analytics_tracking_uuid: analytics_tracking_uuid)
+      ).tap { |r| r.save!(context: context) }
     end
 
     def sent_at

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -33,8 +33,6 @@ module Candidates
       end
 
       def flag_as_completed!
-        raise NotCompletedError unless all_steps_completed?
-
         @registration_session['status'] = COMPLETED_STATUS
       end
 

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -45,12 +45,9 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
     end
 
     context 'uuid found' do
-      before do
-        get "/candidates/confirm/#{uuid}"
-      end
-
       context 'registration job already enqueued' do
         before do
+          get "/candidates/confirm/#{uuid}"
           @placement_request_count = Bookings::PlacementRequest.count
           get "/candidates/confirm/#{uuid}"
         end
@@ -75,34 +72,52 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       end
 
       context 'registration job not already enqueued' do
-        let :stored_registration_session do
-          Candidates::Registrations::RegistrationStore.instance.retrieve! uuid
+        shared_examples 'a successful create' do
+          before do
+            get "/candidates/confirm/#{uuid}"
+          end
+
+          let :stored_registration_session do
+            Candidates::Registrations::RegistrationStore.instance.retrieve! uuid
+          end
+
+          it 'marks the registration as completed and re-stores it in redis' do
+            expect(stored_registration_session).to be_completed
+          end
+
+          it 'creates a bookings placement request' do
+            expect(Bookings::PlacementRequest.count).to \
+              eq @placement_request_count + 1
+            expect(Bookings::PlacementRequest.last.school).to \
+              eq stored_registration_session.school
+          end
+
+          it 'enqueues the placement request job' do
+            expect(Candidates::Registrations::PlacementRequestJob).to \
+              have_received(:perform_later).with \
+                uuid,
+                new_candidates_placement_request_cancellation_url(Bookings::PlacementRequest.last.token)
+          end
+
+          it 'redirects to placement request show' do
+            expect(response).to redirect_to \
+              candidates_school_registrations_placement_request_path(
+                school,
+                uuid: uuid
+              )
+          end
         end
 
-        it 'marks the registration as completed and re-stores it in redis' do
-          expect(stored_registration_session).to be_completed
+        context 'school has changed availability type' do
+          before do
+            school.update! availability_preference_fixed: true
+          end
+
+          it_behaves_like 'a successful create'
         end
 
-        it 'creates a bookings placement request' do
-          expect(Bookings::PlacementRequest.count).to \
-            eq @placement_request_count + 1
-          expect(Bookings::PlacementRequest.last.school).to \
-            eq stored_registration_session.school
-        end
-
-        it 'enqueues the placement request job' do
-          expect(Candidates::Registrations::PlacementRequestJob).to \
-            have_received(:perform_later).with \
-              uuid,
-              new_candidates_placement_request_cancellation_url(Bookings::PlacementRequest.last.token)
-        end
-
-        it 'redirects to placement request show' do
-          expect(response).to redirect_to \
-            candidates_school_registrations_placement_request_path(
-              school,
-              uuid: uuid
-            )
+        context 'school has not changed availability type' do
+          it_behaves_like 'a successful create'
         end
       end
     end

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -175,35 +175,18 @@ describe Candidates::Registrations::RegistrationSession do
   end
 
   context '#flag_as_completed!' do
-    context 'when not completed' do
-      let :registration_session do
-        described_class.new({})
-      end
+    include_context 'Stubbed candidates school'
 
-      it 'raises an error' do
-        expect { registration_session.flag_as_completed! }.to raise_error \
-          described_class::NotCompletedError
-      end
-
-      it "doesn't mark the session as completed" do
-        expect(registration_session).not_to be_completed
-      end
+    let :registration_session do
+      FactoryBot.build :registration_session
     end
 
-    context 'when completed' do
-      include_context 'Stubbed candidates school'
+    before do
+      registration_session.flag_as_completed!
+    end
 
-      let :registration_session do
-        FactoryBot.build :registration_session
-      end
-
-      before do
-        registration_session.flag_as_completed!
-      end
-
-      it 'marks the registration_session as completed' do
-        expect(registration_session).to be_completed
-      end
+    it 'marks the registration_session as completed' do
+      expect(registration_session).to be_completed
     end
   end
 end


### PR DESCRIPTION
If a school changes it's availability preference while there are
candidates on the email confirmation step of the placement_request
wizard this will invalidate their placement_request and throw an error
when we create! the placement_request in the database. To handle this we
won't revalidate the availability before persisting the record.
If the availability was valid at the time candidate selected it then it
should still be applicable when they come back from validating their
email address. Schools still have to set a solid date when they create a
booking from the placement requests as the placement request's
availability is just a suggestion.

### Context

### Changes proposed in this pull request

### Guidance to review
Open to suggestions for a neater way to do this.
