### PR TITLE
Redirect to school landing page on logout SE/1092

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -15,7 +15,7 @@ module Schools
     def destroy
       Rails.logger.warn("Clearing session: #{session.to_json}")
       session.clear
-      redirect_to root_path
+      redirect_to schools_path
     end
 
     def create

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,0 +1,6 @@
+class SchoolsController < ApplicationController
+  before_action :redirect_to_dashboard,
+    if: -> { current_user.present? }
+
+  def show; end
+end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,6 +1,12 @@
 class SchoolsController < ApplicationController
   before_action :redirect_to_dashboard,
-    if: -> { current_user.present? }
+    if: -> { session[:current_user].present? }
 
   def show; end
+
+private
+
+  def redirect_to_dashboard
+    redirect_to(schools_dashboard_path)
+  end
 end

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Describe your school experience availability' => nil
   }
 %>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Change how availability and dates are displayed' => nil
   }
 %>

--- a/app/views/schools/confirmed_bookings/index.html.erb
+++ b/app/views/schools/confirmed_bookings/index.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'All bookings' => nil
   }
 %>

--- a/app/views/schools/confirmed_bookings/show.html.erb
+++ b/app/views/schools/confirmed_bookings/show.html.erb
@@ -1,6 +1,6 @@
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     "All bookings" => schools_bookings_path,
     "Booking #{@booking.id}" => nil
   }

--- a/app/views/schools/confirmed_bookings/upcoming/index.html.erb
+++ b/app/views/schools/confirmed_bookings/upcoming/index.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     "All bookings" => schools_bookings_path,
     "Upcoming bookings" => nil
   }

--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     title => nil
   }
 %>

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%-
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Enter school experience admin contact details' => nil
   }
 -%>

--- a/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Enter school experience details for candidates' => nil
   }
 %>

--- a/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
@@ -1,7 +1,7 @@
 <%- self.page_title = 'Enter your school experience details' %>
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Enter your school experience details' => nil
   }
 %>

--- a/app/views/schools/on_boarding/confirmations/show.html.erb
+++ b/app/views/schools/on_boarding/confirmations/show.html.erb
@@ -1,6 +1,6 @@
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     "You've successfully set up your school experience profile" => nil
   }
 %>

--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'DBS check costs' => nil
   }
 %>

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Enter a short description of your school' => nil
   }
 %>

--- a/app/views/schools/on_boarding/experience_outlines/_form.html.erb
+++ b/app/views/schools/on_boarding/experience_outlines/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Outline experience and teacher training' => nil
   }
 %>

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Do you charge fees to cover any of the following?' => nil
   }
 %>

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Confirm number of primary key stages' => nil
   }
 %>

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -1,7 +1,7 @@
 <%- self.page_title = 'Select school experience phases' %>
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Select school experience phases' => nil
   }
 %>

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Check your answers before setting up your school experience profile' => nil
   }
 %>

--- a/app/views/schools/on_boarding/subjects/_form.html.erb
+++ b/app/views/schools/on_boarding/subjects/_form.html.erb
@@ -1,7 +1,7 @@
 <%- self.page_title = 'Select school experience subjects' %>
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Select school experience subjects' => nil
   }
 %>

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Placement dates' => schools_placement_dates_path,
     'Modify placement date' => nil
   }

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Manage fixed dates' => nil
   }
 %>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -2,7 +2,7 @@
 
 <%
   self.breadcrumbs = {
-    @current_school.name => schools_root_path,
+    @current_school.name => schools_dashboard_path,
     'Placement dates' => schools_placement_dates_path,
     'Create a placement date' => nil
   }

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,2 +1,186 @@
 <%- self.page_title = 'Manage school experience' -%>
-<h1>Manage school experience</h1>
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper">
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Manage school experience</h1>
+
+
+        <p class="govuk-body-l">
+          Use this service if you're a primary or secondary school in England and
+          want to offer and organise school experience.
+        </p>
+
+        <p>
+          To help you decide whether to offer these 'candidates' school
+          experience you'll be emailed requests including their:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>
+            full name and contact details - including address, email and UK
+            telephone number
+          </li>
+          <li>
+            individual requirements - including their school experience
+            expectations and preferred dates and subjects
+          </li>
+          <li>
+            degree status - including whether they have or are studying towards
+            a degree and the subject
+          </li>
+          <li>
+            teaching experience - including how far they've got towards
+            becoming a teacher
+          </li>
+        </ul>
+
+        <p>
+          You'll also be told if candidates have got a Disclosure and Barring
+          Service (DBS) certificate. These details will not be verified by DfE.
+        </p>
+
+        <p class="govuk-!-font-weight-bold">
+          It's your responsibility to decide if candidates comply with your
+          individual DBS and safeguarding policies and book them on experience
+          at your school.
+        </p>
+
+        <p>
+          You can charge fees to cover administration, DBS check and any other
+          school experience-related costs. You’ll need to sort out payment
+          between yourselves and individual candidates.
+        </p>
+
+        <p class="govuk-!-font-weight-bold">
+          This service is only for managing school experience in England.
+        </p>
+
+
+        <%= link_to 'Start now', schools_dashboard_path,
+          role:'button',
+          class:'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' %>
+
+        <section>
+          <h2>Before you start</h2>
+
+          <p>
+            If you’d like to manage your school experience through this
+            service, you’ll need to provide various details including:
+          </p>
+
+          <ul class="govuk-list govuk-list--bullet">
+            <li>your DBS-check and other candidate-related requirements</li>
+            <li>whether you charge candidates any fees for school experience</li>
+            <li>an outline of the kind of school experience you offer candidates</li>
+          </ul>
+
+          You’ll be asked to sign in to the service using DfE Sign-in.
+
+          <h3>Signing in with DfE Sign-in</h3>
+
+          <p>
+            Read the following advice on how to access the service using DfE
+            Sign-in.
+          </p>
+
+          <div class="govuk-accordion" data-module="accordion" id="accordion-default">
+
+            <div class="govuk-accordion__section ">
+              <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                  <span class="govuk-accordion__section-button" id="i-have-a-dfe-signin-account-heading">
+                    I have a DfE Sign-in account
+                  </span>
+                </h2>
+              </div>
+              <div id="i-have-a-dfe-signin-account-content" class="govuk-accordion__section-content" aria-labelledby="i-have-a-dfe-signin-account-heading">
+                <p class='govuk-body'>
+                  You’ll need your DfE Sign-in username and password but be aware
+                  these are not the same as your old SEP login details and does
+                  not include your URN.
+                </p>
+
+                <p>
+                  You’ll also need to ask your organisation’s ‘DfE Sign-in
+                  approver’ (often your head or deputy head) to provide you with
+                  access to ‘School Experience’ within your DfE Sign-in account.
+                </p>
+
+                <p>
+                  Your organisation’s approver details can be found in the 'My
+                  Organisations' section of your DfE Sign-in account.
+                </p>
+              </div>
+            </div>
+            <div class="govuk-accordion__section ">
+              <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                  <span class="govuk-accordion__section-button" id="i-have-no-dfe-signin-account-heading">
+                    I do not have a DfE Sign-in account
+                  </span>
+                </h2>
+              </div>
+              <div id="i-have-no-dfe-signin-account-content" class="govuk-accordion__section-content" aria-labelledby="i-have-no-dfe-signin-account-heading">
+                <p class='govuk-body'>
+                  You’ll need to ask your organisation’s ‘DfE Sign-in approver’
+                  (often your head or deputy head) to create a DfE Sign-in
+                  account for you.
+                </p>
+
+                <p>
+                  They’ll need your email address but make sure this is one
+                  that only you have access to.
+                </p>
+
+                <p>
+                  It will only be used for DfE Sign-in purposes and we won’t
+                  use it to send you anything to do with the service.
+                </p>
+
+                <p>
+                  If you don’t know who's your DfE Sign-in approver email us
+                  with your URN at <%= mail_to "organise.school-experience@education.gov.uk" %>.
+                </p>
+              </div>
+            </div>
+            <div class="govuk-accordion__section ">
+              <div class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                  <span class="govuk-accordion__section-button" id="i-have-forgotten-about-my-dfe-signin-status-heading">
+                    I cannot remember if I have a DfE Sign-in account
+                  </span>
+                </h2>
+              </div>
+              <div id="i-have-forgotten-about-my-dfe-signin-status-content" class="govuk-accordion__section-content" aria-labelledby="i-have-forgotten-about-my-dfe-signin-status-heading">
+                <p class='govuk-body'>
+                  You’ll need to fill in the following online form and ask DfE
+                  Sign-in if they can provide you with your DfE Sign-in account
+                  details.
+                </p>
+
+                <p>
+                  Submit a <%= link_to 'DfE Sign-in support request',
+                    href: "https://help.signin.education.gov.uk/contact/submit?type=create-account" %>
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      <div class="govuk-grid-column-one-third">
+        <nav>
+          <h2 class="govuk-heading-m">Related guidance</h2>
+          <ul class="govuk-list">
+            <li>
+              <%= link_to 'Manage school experience: information for schools',
+                href: 'https://www.gov.uk/government/publications/school-experience-programme-information-for-schools' %>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,0 +1,2 @@
+<%- self.page_title = 'Manage school experience' -%>
+<h1>Manage school experience</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,8 @@ Rails.application.routes.draw do
       get '/auth/insecure_callback', to: 'schools/insecure_sessions#create', as: :insecure_auth_callback
     end
 
+    resource :schools, only: :show
     namespace :schools do
-      root to: 'dashboards#show'
-
       resource :session, only: %i(show destroy)
       resource :switch, only: %i(new), controller: 'switch'
       resource :dashboard, only: :show

--- a/features/schools/availability_information/edit.feature
+++ b/features/schools/availability_information/edit.feature
@@ -14,9 +14,9 @@ Feature: Editing availability info
     Scenario: Breadcrumbs
         Given I am on the 'availability information' page
         Then I should see the following breadcrumbs:
-            | Text                                         | Link     |
-            | Some school                                  | /schools |
-            | Describe your school experience availability | None     |
+            | Text                                         | Link               |
+            | Some school                                  | /schools/dashboard |
+            | Describe your school experience availability | None               |
 
     Scenario: Page contents
         Given I am on the 'availability information' page

--- a/features/schools/availability_preferences/edit.feature
+++ b/features/schools/availability_preferences/edit.feature
@@ -14,9 +14,9 @@ Feature: Editing placement dates
     Scenario: Breadcrumbs
         Given I am on the 'availability preferences' page
         Then I should see the following breadcrumbs:
-            | Text                                            | Link     |
-            | Some school                                     | /schools |
-            | Change how availability and dates are displayed | None     |
+            | Text                                            | Link               |
+            | Some school                                     | /schools/dashboard |
+            | Change how availability and dates are displayed | None               |
 
     Scenario: Page contents
         Given I am on the 'availability preferences' page

--- a/features/schools/confirmed_bookings/index.feature
+++ b/features/schools/confirmed_bookings/index.feature
@@ -13,9 +13,9 @@ Feature: Viewing all bookings
     Scenario: Breadcrumbs
         Given I am on the 'bookings' page
         Then I should see the following breadcrumbs:
-            | Text         | Link     |
-            | Some school  | /schools |
-            | All bookings | None     |
+            | Text         | Link               |
+            | Some school  | /schools/dashboard |
+            | All bookings | None               |
 
     Scenario: List presence
         Given there are some bookings

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -11,10 +11,10 @@ Feature: Viewing a booking
         Given there is at least one booking
         When I am viewing my chosen booking
         Then I should see the following breadcrumbs:
-            | Text           | Link              |
-            | Some school    | /schools          |
-            | All bookings   | /schools/bookings |
-            | Booking        | None              |
+            | Text           | Link               |
+            | Some school    | /schools/dashboard |
+            | All bookings   | /schools/bookings  |
+            | Booking        | None               |
 
     Scenario: Personal details
         Given there is at least one booking

--- a/features/schools/confirmed_bookings/upcoming/index.feature
+++ b/features/schools/confirmed_bookings/upcoming/index.feature
@@ -13,10 +13,10 @@ Feature: Viewing upcoming bookings
     Scenario: Breadcrumbs
         Given I am on the 'upcoming bookings' page
         Then I should see the following breadcrumbs:
-            | Text              | Link              |
-            | Some school       | /schools          |
-            | All bookings      | /schools/bookings |
-            | Upcoming bookings | None              |
+            | Text              | Link               |
+            | Some school       | /schools/dashboard |
+            | All bookings      | /schools/bookings  |
+            | Upcoming bookings | None               |
 
     Scenario: List presence
         Given there are some bookings

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -10,10 +10,6 @@ Feature: The School Dashboard
         Given I am on the 'schools dashboard' page
         Then the main site header should be 'Manage school experience'
 
-    Scenario: Root redirect
-        Given I navigate to the 'schools' path
-        Then I should see the dashboard
-
     @wip
     Scenario: High priority headings
         Given I am on the 'schools dashboard' page

--- a/features/schools/landing_page.feature
+++ b/features/schools/landing_page.feature
@@ -1,0 +1,13 @@
+Feature:
+    So I can learn about managing school experience for my school
+    As a school administrator
+    I want to be able to read some useful information on the topic
+
+    Scenario: Page heading and title
+        Given I am on the 'schools' page
+        Then the page's main heading should be 'Manage school experience'
+        And the page title should be 'Manage school experience'
+
+    Scenario: Start now button
+        Given I am on the 'schools' page
+        Then there should be a 'Start now' link to the 'schools dashboard'

--- a/features/schools/onboarding/administration_fee.feature
+++ b/features/schools/onboarding/administration_fee.feature
@@ -19,9 +19,9 @@ Feature: Administration Fee
   Scenario: Breadcrumbs
     Given I am already on the 'administration costs' page
     Then I should see the following breadcrumbs:
-        | Text                 | Link     |
-        | Some school          | /schools |
-        | Administration costs | None     |
+        | Text                 | Link               |
+        | Some school          | /schools/dashboard |
+        | Administration costs | None               |
 
   Scenario: Completing the Administration costs step with error
     Given I have entered the following details into the form:

--- a/features/schools/onboarding/candidate_experience_detail.feature
+++ b/features/schools/onboarding/candidate_experience_detail.feature
@@ -24,9 +24,9 @@ Feature: Candidate experience details
   Scenario: Breadcrumbs
     Given I am already on the 'candidate experience details' page
     Then I should see the following breadcrumbs:
-        | Text                                           | Link     |
-        | Some school                                    | /schools |
-        | Enter school experience details for candidates | None     |
+        | Text                                           | Link               |
+        | Some school                                    | /schools/dashboard |
+        | Enter school experience details for candidates | None               |
 
   Scenario: Completing the step with error
     Given I am on the 'Candidate experience details' page

--- a/features/schools/onboarding/candidate_requirements.feature
+++ b/features/schools/onboarding/candidate_requirements.feature
@@ -13,9 +13,9 @@ Feature: Candidate requirements
   Scenario: Breadcrumbs
     Given I am on the 'candidate requirements' page
     Then I should see the following breadcrumbs:
-        | Text                                 | Link     |
-        | Some school                          | /schools |
-        | Enter your school experience details | None     |
+        | Text                                 | Link               |
+        | Some school                          | /schools/dashboard |
+        | Enter your school experience details | None               |
 
   @javascript
   Scenario: Completing step

--- a/features/schools/onboarding/dbs_fee.feature
+++ b/features/schools/onboarding/dbs_fee.feature
@@ -19,9 +19,9 @@ Feature: DBS Fee
   Scenario: Breadcrumbs
     Given I am on the 'dbs check costs' page
     Then I should see the following breadcrumbs:
-        | Text            | Link     |
-        | Some school     | /schools |
-        | DBS check costs | None     |
+        | Text            | Link               |
+        | Some school     | /schools/dashboard |
+        | DBS check costs | None               |
 
   Scenario: Completing the DBS costs step with error
     Given I have entered the following details into the form:

--- a/features/schools/onboarding/descriptions.feature
+++ b/features/schools/onboarding/descriptions.feature
@@ -23,9 +23,9 @@ Feature: Description
   Scenario: Breadcrumbs
     Given I am already on the 'description' page
     Then I should see the following breadcrumbs:
-        | Text                                     | Link     |
-        | Some school                              | /schools |
-        | Enter a short description of your school | None     |
+        | Text                                     | Link               |
+        | Some school                              | /schools/dashboard |
+        | Enter a short description of your school | None               |
 
   Scenario: Completing the step with description
     Given I am on the 'Description' page

--- a/features/schools/onboarding/experience_outline.feature
+++ b/features/schools/onboarding/experience_outline.feature
@@ -21,9 +21,9 @@ Feature: Experience Outline
   Scenario: Breadcrumbs
     Given I am on the 'Experience Outline' page
     Then I should see the following breadcrumbs:
-        | Text                                    | Link     |
-        | Some school                             | /schools |
-        | Outline experience and teacher training | None     |
+        | Text                                    | Link               |
+        | Some school                             | /schools/dashboard |
+        | Outline experience and teacher training | None               |
 
   Scenario: Page title
     Given I am on the 'Experience Outline' page

--- a/features/schools/onboarding/fees.feature
+++ b/features/schools/onboarding/fees.feature
@@ -17,9 +17,9 @@ Feature: Fees
   Scenario: Breadcrumbs
     Given I am already on the 'fees charged' page
     Then I should see the following breadcrumbs:
-        | Text                                              | Link     |
-        | Some school                                       | /schools |
-        | Do you charge fees to cover any of the following? | None     |
+        | Text                                              | Link               |
+        | Some school                                       | /schools/dashboard |
+        | Do you charge fees to cover any of the following? | None               |
 
   Scenario: Completing step choosing Adminsitration costs only
     Given I am on the 'fees charged' page

--- a/features/schools/onboarding/other_fee.feature
+++ b/features/schools/onboarding/other_fee.feature
@@ -19,9 +19,9 @@ Feature: Other Fee
   Scenario: Breadcrumbs
     Given I am already on the 'other costs' page
     Then I should see the following breadcrumbs:
-        | Text        | Link     |
-        | Some school | /schools |
-        | Other costs | None     |
+        | Text        | Link               |
+        | Some school | /schools/dashboard |
+        | Other costs | None               |
 
   Scenario: Completing the Other costs step with error
     Given I have entered the following details into the form:

--- a/features/schools/onboarding/phases.feature
+++ b/features/schools/onboarding/phases.feature
@@ -20,9 +20,9 @@ Feature: Phases
   Scenario: Breadcrumbs
     Given I am on the 'phases' page
     Then I should see the following breadcrumbs:
-        | Text                            | Link     |
-        | Some school                     | /schools |
-        | Select school experience phases | None     |
+        | Text                            | Link               |
+        | Some school                     | /schools/dashboard |
+        | Select school experience phases | None               |
 
   Scenario: Completing step choosing Primary phase only
     Given I am already on the 'phases' page

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -29,9 +29,9 @@ Feature: School Profile
   Scenario: Breadcrumbs
     Given I am on the 'Profile' page
     Then I should see the following breadcrumbs:
-        | Text                                                                | Link     |
-        | Some school                                                         | /schools |
-        | Check your answers before setting up your school experience profile | None     |
+        | Text                                                                | Link               |
+        | Some school                                                         | /schools/dashboard |
+        | Check your answers before setting up your school experience profile | None               |
 
 
   Scenario: Viewing the profile

--- a/features/schools/onboarding/secondary_subjects.feature
+++ b/features/schools/onboarding/secondary_subjects.feature
@@ -22,9 +22,9 @@ Feature: Subjects
   Scenario: Breadcrumbs
     Given I am already on the 'Subjects' page
     Then I should see the following breadcrumbs:
-        | Text                              | Link     |
-        | Some school                       | /schools |
-        | Select school experience subjects | None     |
+        | Text                              | Link               |
+        | Some school                       | /schools/dashboard |
+        | Select school experience subjects | None               |
 
   Scenario: Completing the step choosing no subjects
     Given I am on the 'Subjects' page

--- a/features/schools/placement_dates/edit.feature
+++ b/features/schools/placement_dates/edit.feature
@@ -14,7 +14,7 @@ Feature: Editing placement dates
         Given I am on the edit page for my placement
         Then I should see the following breadcrumbs:
             | Text                  | Link                     |
-            | Some school           | /schools                 |
+            | Some school           | /schools/dashboard       |
             | Placement dates       | /schools/placement_dates |
             | Modify placement date | None                     |
 

--- a/features/schools/placement_dates/index.feature
+++ b/features/schools/placement_dates/index.feature
@@ -13,9 +13,9 @@ Feature: Listing placement dates
   Scenario: Breadcrumbs
     Given I am on the 'placement dates' page
     Then I should see the following breadcrumbs:
-        | Text               | Link     |
-        | Some school        | /schools |
-        | Manage fixed dates | None     |
+        | Text               | Link               |
+        | Some school        | /schools/dashboard |
+        | Manage fixed dates | None               |
 
     Scenario: List contents
         Given my school has 5 placement dates

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -14,7 +14,7 @@ Feature: Creating new placement dates
     Given I am on the 'new placement date' page
     Then I should see the following breadcrumbs:
         | Text                    | Link                     |
-        | Some school             | /schools                 |
+        | Some school             | /schools/dashboard       |
         | Placement dates         | /schools/placement_dates |
         | Create a placement date | None                     |
 

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -16,7 +16,7 @@ def path_for(descriptor, school: nil, placement_date_id: nil, booking_id: nil, p
     "cancel placement request" => [:new_candidates_placement_request_cancellation_path, placement_request&.token],
 
     #school paths
-    "schools" => [:schools_root_path],
+    "schools" => [:schools_path],
     "schools dashboard" => [:schools_dashboard_path],
     "bookings" => [:schools_bookings_path],
     "upcoming bookings" => [:schools_upcoming_bookings_path],

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -122,7 +122,7 @@ describe Schools::SessionsController, type: :request do
     end
 
     specify "should redirect to the homepage" do
-      expect(subject).to redirect_to(root_path)
+      expect(subject).to redirect_to(schools_path)
     end
   end
 end

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -1,7 +1,31 @@
-describe SchoolsController do
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe SchoolsController, type: :request do
   describe 'redirecting logged-in users to the dashboard' do
+    context 'when a user is logged in' do
+      include_context "logged in DfE user"
+      before { get '/schools' }
+
+      specify 'should be redirected to the dashboard' do
+        expect(response).to redirect_to(schools_dashboard_path)
+      end
+    end
+
+    context 'when no user is logged in' do
+      before { get '/schools' }
+
+      specify 'should not be redirected anywhere' do
+        expect(response).to render_template :show
+      end
+    end
   end
 
   describe '#show' do
+    before { get '/schools' }
+
+    specify 'should render the correct template' do
+      expect(response).to render_template :show
+    end
   end
 end

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -1,0 +1,7 @@
+describe SchoolsController do
+  describe 'redirecting logged-in users to the dashboard' do
+  end
+
+  describe '#show' do
+  end
+end


### PR DESCRIPTION
### Context

Logging out as a school redirects to the root path which is candidate specific

### Changes proposed in this pull request

Now, as per #563, we have a school landing page with general information about the service, we can redirect here instead

### Guidance to review

Ensure everything works as intended.

