### PR TITLE
Se 1162/candidate/bookings/add cancellation link to booking confirmation email

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
@@ -27,7 +27,7 @@ module Schools
 
         def candidate_booking_notification(booking)
           NotifyEmail::CandidateBookingConfirmation
-            .from_booking(booking.candidate.email, booking)
+            .from_booking(booking.candidate.email, booking, candidates_cancel_url(booking.token))
         end
 
         def set_placement_request

--- a/app/notify/notify_email/candidate_booking_confirmation.29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3.md
+++ b/app/notify/notify_email/candidate_booking_confirmation.29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3.md
@@ -23,6 +23,8 @@ UK telephone number: ((school_teacher_telephone))
 
 You can also contact them if you have any questions about your actual placement.
 
+To cancel your placement use the the following link ((cancellation_url)).
+
 # Placement details
 
 ((placement_details))

--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -15,7 +15,8 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     :school_teacher_email,
     :school_teacher_telephone,
     :placement_details,
-    :placement_fee
+    :placement_fee,
+    :cancellation_url
 
   def initialize(
     to:,
@@ -35,7 +36,8 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     school_teacher_email:,
     school_teacher_telephone:,
     placement_details:,
-    placement_fee:
+    placement_fee:,
+    cancellation_url:
   )
 
     self.school_name = school_name
@@ -55,11 +57,12 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     self.school_teacher_telephone = school_teacher_telephone
     self.placement_details = placement_details
     self.placement_fee = placement_fee
+    self.cancellation_url = cancellation_url
 
     super(to: to)
   end
 
-  def self.from_booking(to, booking)
+  def self.from_booking(to, booking, cancellation_url)
     school = booking.bookings_school
     placement_request = booking.bookings_placement_request
     candidate = placement_request.candidate
@@ -96,7 +99,8 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
       placement_details: booking.placement_details,
-      placement_fee: 'REMOVE' # FIXME
+      placement_fee: 'REMOVE', # FIXME
+      cancellation_url: cancellation_url
     )
   end
 
@@ -124,7 +128,8 @@ private
       school_teacher_email: school_teacher_email,
       school_teacher_telephone: school_teacher_telephone,
       placement_details: placement_details,
-      placement_fee: placement_fee
+      placement_fee: placement_fee,
+      cancellation_url: cancellation_url
     }
   end
 end

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -20,7 +20,8 @@ describe NotifyEmail::CandidateBookingConfirmation do
     school_teacher_email: "ednak@springfield.co.uk",
     school_teacher_telephone: "01234 234 1245",
     placement_details: "You will shadow a teacher and assist with lesson planning",
-    placement_fee: 30
+    placement_fee: 30,
+    cancellation_url: 'https://example.com/candiates/cancel/abc-123'
 
   describe ".from_booking" do
     before do
@@ -45,7 +46,9 @@ describe NotifyEmail::CandidateBookingConfirmation do
       )
     end
 
-    subject { described_class.from_booking(to, booking) }
+    let!(:cancellation_url) { "https://example.com/candidates/cancel/#{booking.token}" }
+
+    subject { described_class.from_booking(to, booking, cancellation_url) }
 
     it { is_expected.to be_a(described_class) }
 
@@ -120,6 +123,10 @@ describe NotifyEmail::CandidateBookingConfirmation do
       specify 'placement_fee is correctly-assigned'
       #  expect(subject.placement_fee).to eql('REMOVE')
       #end
+
+      specify 'cancellation_url is correctly-assigned' do
+        expect(subject.cancellation_url).to eql(cancellation_url)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
Adds a link to allow candidates to cancel a booking from the booking confirmation email confirmation

### Changes proposed in this pull request

### Guidance to review
Review after [SE-1108](https://github.com/DFE-Digital/schools-experience/pull/548
) has been merged
