### PR TITLE
Added Feature checking model

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,0 +1,37 @@
+class Feature
+  include Singleton
+
+  delegate :only_phase, :from_phase, :until_phase, to: :instance
+  delegate :only, :from, :until, to: :instance
+
+  def only_phase(phase_to_test)
+    return false unless Integer(phase_to_test) == current_phase
+
+    block_given? ? yield : true
+  end
+  alias_method :only, :only_phase
+
+  def from_phase(phase_to_test)
+    return false unless Integer(phase_to_test) >= current_phase
+
+    block_given? ? yield : true
+  end
+  alias_method :from, :from_phase
+
+  def until_phase(phase_to_test)
+    return false unless Integer(phase_to_test) <= current_phase
+
+    block_given? ? yield : true
+  end
+  alias_method :until, :until_phase
+
+  def current_phase
+    @current_phase ||= Integer(Rails.application.config.x.phase)
+  end
+  alias_method :current, :current_phase
+
+  def current_phase=(phase)
+    @current_phase = phase.nil? ? nil : Integer(phase)
+  end
+  alias_method :current=, :current_phase=
+end

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+describe Feature do
+  class Tester
+    def self.hello
+      'world'
+    end
+  end
+
+  before { Feature.instance.current_phase = 10 }
+  after { Feature.instance.current_phase = nil }
+  subject { Feature.instance }
+
+  describe '#from_phase' do
+    it { expect(subject.from_phase(3)).to be false }
+    it { expect(subject.from_phase(10)).to be true }
+    it { expect(subject.from_phase(12)).to be true }
+
+    context 'and earlier phase' do
+      before { expect(Tester).not_to receive(:hello) }
+
+      it "will not run the block" do
+        subject.from_phase(3) { Tester.hello }
+      end
+    end
+
+    context 'and active phase' do
+      before { expect(Tester).to receive(:hello) }
+
+      it "will run the block" do
+        subject.from_phase(10) { Tester.hello }
+      end
+    end
+
+    context 'and later phase' do
+      before { expect(Tester).to receive(:hello) }
+
+      it "will run the block" do
+        subject.from_phase(12) { Tester.hello }
+      end
+    end
+  end
+
+  describe '#from' do
+    it { expect(subject.from_phase(3)).to be false }
+    it { expect(subject.from_phase(10)).to be true }
+    it { expect(subject.from_phase(12)).to be true }
+  end
+
+  describe '#until_phase' do
+    it { expect(subject.until_phase(3)).to be true }
+    it { expect(subject.until_phase(10)).to be true }
+    it { expect(subject.until_phase(12)).to be false }
+
+    context 'with block' do
+      context 'and earlier phase' do
+        before { expect(Tester).to receive(:hello) }
+
+        it "will run the block" do
+          subject.until_phase(3) { Tester.hello }
+        end
+      end
+
+      context 'and active phase' do
+        before { expect(Tester).to receive(:hello) }
+
+        it "will run the block" do
+          subject.until_phase(10) { Tester.hello }
+        end
+      end
+
+      context 'and later phase' do
+        before { expect(Tester).not_to receive(:hello) }
+
+        it "will not run the block" do
+          subject.until_phase(12) { Tester.hello }
+        end
+      end
+    end
+  end
+
+  describe '#until' do
+    it { expect(subject.until_phase(3)).to be true }
+    it { expect(subject.until_phase(10)).to be true }
+    it { expect(subject.until_phase(12)).to be false }
+  end
+
+  describe '#only_phase' do
+    it { expect(subject.only_phase(3)).to be false }
+    it { expect(subject.only_phase(10)).to be true }
+    it { expect(subject.only_phase(12)).to be false }
+
+    context 'with block' do
+      context 'and earlier phase' do
+        before { expect(Tester).not_to receive(:hello) }
+
+        it "will not run the block" do
+          subject.only_phase(3) { Tester.hello }
+        end
+      end
+
+      context 'and active phase' do
+        before { expect(Tester).to receive(:hello) }
+
+        it "will run the block" do
+          subject.only_phase(10) { Tester.hello }
+        end
+      end
+
+      context 'and later phase' do
+        before { expect(Tester).not_to receive(:hello) }
+
+        it "will not run the block" do
+          subject.only_phase(12) { Tester.hello }
+        end
+      end
+    end
+  end
+
+  describe '#only' do
+    it { expect(subject.only_phase(3)).to be false }
+    it { expect(subject.only_phase(10)).to be true }
+    it { expect(subject.only_phase(12)).to be false }
+  end
+end


### PR DESCRIPTION
### Context

Currently we're repeating `Rails.application.config.x.phase >= X` all over the place, this isn't very DRY and is needlessly verbose.

### Changes proposed in this pull request

1. Adds a helper model to do the check with `Feature.only(phase)`,`Feature.until(phase)` and `Feature.from(phase)`
2. Each helper can optionally take a block which will get run and the result returned, if not block is given then `true` is returned

eg

```erb
<% if Feature.from_phase(3) %>
<p>My Big New Feature</p>
<% end %>
```

or 

```erb
<% Feature.from(3) do %>
<p>My Big New Feature</p>
<% end %>
```

or

```ruby
resource :dashboard if Feature.until(5)
```

### Guidance to review
Sanity checking - note, converting the code base to use this will be a separate PR

