### PR TITLE
Update DBS Check costs page to match prototype

### DIFF
--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -15,9 +15,16 @@
 
     <%= form_for @dbs_fee, url: schools_on_boarding_dbs_fee_path do |f| %>
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
-      <%= f.pounds_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.99 %>
-      <%= f.text_area :description, rows: 4, width: 20 %>
-      <%= f.text_area :payment_method, rows: 4, width: 20, label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
+      <%= f.pounds_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.99, label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } %>
+
+      <%= f.text_area :description, rows: 4, width: 'full', label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
+        <span class="govuk-hint">
+          For example, ‘The fee covers the cost of carrying out your DBS check’
+          or ‘We won’t charge you a fee if you have an enhanced DBS certificate
+          which is less than 2 years old’
+        </span>
+      <% end %>
+      <%= f.text_area :payment_method, rows: 4, width: 'full', label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
         <span class="govuk-hint">
           For example, by bank transfer, in cash or via PayPal.
         </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -376,6 +376,7 @@ en:
       schools_on_boarding_dbs_fee:
         <<: *schools_on_boarding_school_fee_labels
         payment_method: 'Explain how the fee is paid.'
+        description: 'Add extra details'
       schools_on_boarding_other_fee:
         <<: *schools_on_boarding_school_fee_labels
       schools_on_boarding_phases_list:

--- a/features/schools/onboarding/dbs_fee.feature
+++ b/features/schools/onboarding/dbs_fee.feature
@@ -25,15 +25,15 @@ Feature: DBS Fee
 
   Scenario: Completing the DBS costs step with error
     Given I have entered the following details into the form:
-      | Explain what the fee covers. | Background checks |
-      | Explain how the fee is paid. | Ethereum          |
+      | Add extra details           | Background checks |
+      | Explain how the fee is paid | Ethereum          |
     When I submit the form
     Then I should see a validation error message
 
   Scenario: Completing the DBS costs step with error
     Given I have entered the following details into the form:
-      | Enter the number of pounds.  | 200               |
-      | Explain what the fee covers. | Background checks |
-      | Explain how the fee is paid. | Ethereum          |
+      | Enter the number of pounds  | 200               |
+      | Add extra details           | Background checks |
+      | Explain how the fee is paid | Ethereum          |
     When I submit the form
     Then I should be on the 'Phases' page


### PR DESCRIPTION
Update text on the DBS screen to match prototype. Also, to further match the prototype, make the text boxes a bit wider.

Prototype on left, app on right:

![Screenshot 2019-06-17 at 12 06 21](https://user-images.githubusercontent.com/128088/59601445-e124ff00-90fb-11e9-8c67-4f373c936fed.png)
