### PR TITLE
SE-1176 Record token confirmation

### DIFF
--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -7,11 +7,22 @@ class Bookings::Candidate < ApplicationRecord
   validates :gitis_uuid, presence: true, format: { with: UUID_V4_FORMAT }
   validates :gitis_uuid, uniqueness: { case_sensitive: false }
 
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
+  scope :unconfirmed, -> { where(confirmed_at: nil) }
+
   def generate_session_token!
     session_tokens.create!
   end
 
   def expire_session_tokens!
     session_tokens.expire_all!
+  end
+
+  def confirmed?
+    confirmed_at?
+  end
+
+  def last_signed_in_at
+    confirmed_at || session_tokens.confirmed.maximum(:confirmed_at)
   end
 end

--- a/app/models/candidates/session.rb
+++ b/app/models/candidates/session.rb
@@ -20,7 +20,7 @@ class Candidates::Session
     token = Candidates::SessionToken.valid.find_by(token: token_string)
     return unless token
 
-    token.candidate.tap(&:expire_session_tokens!)
+    token.confirm!.candidate
   end
 
   def initialize(gitis, *args)

--- a/db/migrate/20190617135043_candidates_session_tokens.rb
+++ b/db/migrate/20190617135043_candidates_session_tokens.rb
@@ -1,0 +1,6 @@
+class CandidatesSessionTokens < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_candidates, :confirmed_at, :datetime, index: true
+    add_column :candidates_session_tokens, :confirmed_at, :datetime, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_07_140934) do
+ActiveRecord::Schema.define(version: 2019_06_17_135043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,13 +23,13 @@ ActiveRecord::Schema.define(version: 2019_06_07_140934) do
     t.integer "bookings_school_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "duration", default: 1, null: false
     t.text "placement_details"
     t.string "contact_name"
     t.string "contact_number"
     t.string "contact_email"
     t.text "location"
     t.string "candidate_instructions"
-    t.integer "duration", default: 1, null: false
     t.datetime "accepted_at"
     t.index ["bookings_placement_request_id"], name: "index_bookings_bookings_on_bookings_placement_request_id", unique: true
     t.index ["bookings_school_id"], name: "index_bookings_bookings_on_bookings_school_id"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2019_06_07_140934) do
     t.string "gitis_uuid", limit: 36, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "confirmed_at"
     t.index ["gitis_uuid"], name: "index_bookings_candidates_on_gitis_uuid", unique: true
   end
 
@@ -89,8 +90,8 @@ ActiveRecord::Schema.define(version: 2019_06_07_140934) do
     t.text "availability"
     t.integer "bookings_placement_date_id"
     t.integer "bookings_school_id"
-    t.string "token"
     t.uuid "analytics_tracking_uuid"
+    t.string "token"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
     t.index ["bookings_school_id"], name: "index_bookings_placement_requests_on_bookings_school_id"
     t.index ["token"], name: "index_bookings_placement_requests_on_token", unique: true
@@ -223,6 +224,7 @@ ActiveRecord::Schema.define(version: 2019_06_07_140934) do
     t.datetime "expired_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "confirmed_at"
     t.index ["candidate_id"], name: "index_candidates_session_tokens_on_candidate_id"
     t.index ["token"], name: "index_candidates_session_tokens_on_token", unique: true
   end

--- a/spec/factories/bookings/candidates_factory.rb
+++ b/spec/factories/bookings/candidates_factory.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :candidate, class: 'Bookings::Candidate' do
     gitis_uuid { SecureRandom.uuid }
+
+    trait :confirmed do
+      confirmed_at { 5.minutes.ago }
+    end
   end
 end

--- a/spec/factories/candidates/session_token_factory.rb
+++ b/spec/factories/candidates/session_token_factory.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     trait :auto_expired do
       created_at { Time.zone.now - 1.minute - Candidates::SessionToken::AUTO_EXPIRE }
     end
+
+    trait :confirmed do
+      confirmed_at { 5.minutes.ago }
+    end
   end
 end


### PR DESCRIPTION
### Context

We will need to invalidate a candidates sign in if they update their email address in the future

### Changes proposed in this pull request

1. Record when a token is confirmed
2. Record when a candidate is confirmed via a token
3. Allow de-confirming a candidate
4. Auto expire other tokens when confirming a token

### Guidance to review

Does it look sane

