### PR TITLE
Feature/make test env use redis for session

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,6 +46,10 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  # Use Redis for Session and cache
+  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
+  config.session_store :cache_store, key: 'schoolex-test-session'
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -73,6 +73,10 @@ RSpec.configure do |config|
     ])
   end
 
+  config.before :each do
+    Rails.cache.clear
+  end
+
   config.before :suite do
     Webpacker.compile
   end


### PR DESCRIPTION
### Context

There are some differences in the way objects are serialised and
deserialised between Redis and memory-based sessions which came to light
when accessing the `OpenIDConnect::ResponseObject::UserInfo` objects that
were being retrieved as `Hash`es.

### Changes proposed in this pull request

Switch to using Redis for the cache in the test environment. Cache is cleared before every spec.

### Guidance to review

Ensure everything still works as expected
