### PR TITLE
Adds back link to privacy page

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,5 +1,10 @@
 <div class="govuk-grid-row">
   <div class="gov-grid-column-full">
+
+  <%= link_to 'Back', :back,
+              class: 'govuk-back-link',
+              data: {controller: 'back-link'} %>
+
     <h1 class="govuk-heading-l">Privacy notice for the School Experience Service</h1>
     <section>
       <h2 class="govuk-heading-m">


### PR DESCRIPTION
### Context
Privacy policy needed a back link to prevent users becoming trapped

### Changes proposed in this pull request
Adds a back link to privacy policy

### Guidance to review
Privacy policy should have a back link

