### PR TITLE
Use FakeCrm in tests by default

### DIFF
--- a/app/services/bookings/gitis/fake_auth.rb
+++ b/app/services/bookings/gitis/fake_auth.rb
@@ -1,9 +1,17 @@
 module Bookings::Gitis
   module FakeAuth
-    def initialize(client_id: nil, client_secret: nil, tenant_id: nil, service_url: nil); end
+    def initialize(client_id: nil, client_secret: nil, tenant_id: nil, service_url: nil)
+      Rails.application.config.x.fake_crm || super
+    end
 
     def token
-      'my.stub.token'
+      stubbed? ? 'my.fake.token' : super
+    end
+
+  private
+
+    def stubbed?
+      Rails.application.config.x.fake_crm
     end
   end
 end

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -1,6 +1,8 @@
 module Bookings::Gitis
   module FakeCrm
     def find(*ids)
+      return super unless stubbed?
+
       ids = normalise_ids(*ids)
       validate_ids(ids)
 
@@ -14,6 +16,8 @@ module Bookings::Gitis
     end
 
     def find_by_email(address)
+      return super unless stubbed?
+
       Contact.new(fake_account_data).tap do |contact|
         contact.email = address
       end
@@ -43,6 +47,10 @@ module Bookings::Gitis
         'address1_stateorprovince' => 'Manchester',
         'address1_postalcode' => 'MA1 1AM'
       }
+    end
+
+    def stubbed?
+      Rails.application.config.x.fake_crm
     end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   config.x.oidc_client_secret = 'abc123'
   config.x.oidc_host = 'some-oidc-host.education.gov.uk'
 
-  config.x.fake_crm = false
+  config.x.fake_crm = true
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 end

--- a/spec/services/bookings/gitis/auth_spec.rb
+++ b/spec/services/bookings/gitis/auth_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Bookings::Gitis::Auth do
+  include_context 'bypass fake Gitis'
+
   let(:tenant_id) { SecureRandom.uuid }
   let(:client_id) { 'client_id' }
   let(:client_secret) { 'secret' }

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 require 'apimock/gitis_crm'
 
 describe Bookings::Gitis::CRM, type: :model do
+  include_context 'bypass fake Gitis'
+
   let(:client_id) { 'clientid' }
   let(:client_secret) { 'clientsecret' }
   let(:tenant_id) { SecureRandom.uuid }
   let(:gitis_url) { 'https://gitis-crm.net' }
   let(:token) { 'my.secret.token' }
 
-#  let(:api) { Bookings::Gitis::API.new('my.secret.token', service_url: gitis_url) }
   let(:gitis) { described_class.new(token, service_url: gitis_url) }
   let(:gitis_stub) do
     Apimock::GitisCrm.new(client_id, client_secret, tenant_id, gitis_url)

--- a/spec/support/bypass_fake_gitis.rb
+++ b/spec/support/bypass_fake_gitis.rb
@@ -1,0 +1,4 @@
+shared_context "bypass fake Gitis" do
+  before { Rails.application.config.x.fake_crm = false }
+  after { Rails.application.config.x.fake_crm = true }
+end

--- a/spec/support/bypass_fake_gitis.rb
+++ b/spec/support/bypass_fake_gitis.rb
@@ -1,4 +1,3 @@
 shared_context "bypass fake Gitis" do
-  before { Rails.application.config.x.fake_crm = false }
-  after { Rails.application.config.x.fake_crm = true }
+  before { allow(Rails.application.config.x).to receive(:fake_crm).and_return(false) }
 end

--- a/spec/support/stubbed_gitis.rb
+++ b/spec/support/stubbed_gitis.rb
@@ -1,6 +1,8 @@
 require 'apimock/gitis_crm'
 
 shared_context "stubbed out Gitis" do
+  include_context 'bypass fake Gitis'
+
   let(:tenant_id) { SecureRandom.uuid }
   let(:client_id) { 'client_id' }
   let(:client_secret) { 'secret' }


### PR DESCRIPTION
### Context

Master is currently broken because previously we used the FakeCRM in tests, and have subsequently switched to using stubbed.

### Changes proposed in this pull request

1. Swap back to using FakeCRM in tests by default
2. Allow enabling/disabling FakeCRM at runtime for those tests which require stubbing API requests instead.

