### PR TITLE
Add stubbing Gitis to confirmed booking controllers

### DIFF
--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::ConfirmedBookings::CancellationsController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|


### PR DESCRIPTION
Some specs failed when subsets were run, ie. running
`rspec spec/controllers` but didn't when the entire suite was run.