### PR TITLE
Fetch Gitis Contact in controllers

### DIFF
--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -17,7 +17,7 @@ module Candidates
           placement_request_params
 
         if @cancellation.save
-          @placement_request.gitis_contact = find_contact(@placement_request)
+          @placement_request.fetch_gitis_contact gitis_crm
 
           notify_school @cancellation
           notify_candidate @cancellation
@@ -104,10 +104,6 @@ module Candidates
           candidate_name: cancellation.candidate_name,
           requested_availability: cancellation.dates_requested
         ).despatch_later!
-      end
-
-      def find_contact(req)
-        gitis_crm.find(req.contact_uuid)
       end
     end
   end

--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -1,6 +1,7 @@
 module Candidates
   module PlacementRequests
     class CancellationsController < ApplicationController
+      include GitisAccess
       before_action :ensure_placement_request_is_open, except: :show
 
       def show
@@ -16,6 +17,8 @@ module Candidates
           placement_request_params
 
         if @cancellation.save
+          @placement_request.gitis_contact = find_contact(@placement_request)
+
           notify_school @cancellation
           notify_candidate @cancellation
           @cancellation.sent!
@@ -101,6 +104,10 @@ module Candidates
           candidate_name: cancellation.candidate_name,
           requested_availability: cancellation.dates_requested
         ).despatch_later!
+      end
+
+      def find_contact(req)
+        gitis_crm.find(req.contact_uuid)
       end
     end
   end

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -3,6 +3,7 @@ module Schools
   class MissingURN < StandardError; end
 
   class BaseController < ApplicationController
+    include GitisAccess
     include DFEAuthentication
     before_action :require_auth
     before_action :set_current_school

--- a/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
@@ -6,10 +6,12 @@ module Schools
 
         def show
           @cancellation = @placement_request.school_cancellation
+          @placement_request.fetch_gitis_contact gitis_crm
         end
 
         def create
           @cancellation = @placement_request.school_cancellation
+          @placement_request.fetch_gitis_contact gitis_crm
           notify_candidate @cancellation
           @cancellation.sent!
           redirect_to \

--- a/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
@@ -6,6 +6,7 @@ module Schools
 
       def show
         @cancellation = @placement_request.school_cancellation
+        @placement_request.fetch_gitis_contact gitis_crm
       end
 
       def new

--- a/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
@@ -10,10 +10,12 @@ module Schools
 
       def new
         @cancellation = @placement_request.build_school_cancellation
+        @placement_request.fetch_gitis_contact gitis_crm
       end
 
       def edit
         @cancellation = @placement_request.school_cancellation
+        @placement_request.fetch_gitis_contact gitis_crm
       end
 
       def create
@@ -24,6 +26,7 @@ module Schools
           redirect_to schools_booking_cancellation_path \
             @booking
         else
+          @placement_request.fetch_gitis_contact gitis_crm
           render :new
         end
       end
@@ -35,6 +38,7 @@ module Schools
           redirect_to schools_booking_cancellation_path \
             @booking
         else
+          @placement_request.fetch_gitis_contact gitis_crm
           render :edit
         end
       end

--- a/app/controllers/schools/confirmed_bookings/upcoming_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/upcoming_controller.rb
@@ -7,6 +7,8 @@ module Schools
           .upcoming
           .eager_load(:bookings_subject, :bookings_placement_request)
           .all
+
+        assign_gitis_contacts @bookings
       end
     end
   end

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -6,7 +6,7 @@ module Schools
         .eager_load(:bookings_subject, :bookings_placement_request)
         .all
 
-      assign_gitis_contacts(@bookings)
+      assign_gitis_contacts @bookings
     end
 
     def show

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -5,6 +5,8 @@ module Schools
         .bookings
         .eager_load(:bookings_subject, :bookings_placement_request)
         .all
+
+      assign_gitis_contacts(@bookings)
     end
 
     def show
@@ -12,6 +14,21 @@ module Schools
         .bookings
         .eager_load(:bookings_subject)
         .find(params[:id])
+
+      @booking.bookings_placement_request.fetch_gitis_contact gitis_crm
+    end
+
+  private
+
+    def assign_gitis_contacts(bookings)
+      return bookings if bookings.empty?
+
+      contacts = gitis_crm.find(bookings.map(&:contact_uuid)).index_by(&:id)
+
+      bookings.each do |booking|
+        booking.bookings_placement_request.gitis_contact = \
+          contacts[booking.contact_uuid]
+      end
     end
   end
 end

--- a/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
@@ -11,18 +11,23 @@ module Schools
             date: @placement_request.placement_date&.date,
             placement_details: @current_school&.profile&.experience_details
           )
+          @placement_request.fetch_gitis_contact gitis_crm
         end
 
         def create
           @confirm_booking = Schools::PlacementRequests::ConfirmBooking.new(confirm_booking_params)
 
-          return render :new if @confirm_booking.invalid?
+          if @confirm_booking.invalid?
+            @placement_request.fetch_gitis_contact gitis_crm
+            return render :new
+          end
 
           booking = find_or_create_booking(@placement_request)
 
           if booking.save
             redirect_to new_schools_placement_request_acceptance_add_more_details_path(@placement_request.id)
           else
+            @placement_request.fetch_gitis_contact gitis_crm
             Rails.logger.warn("ConfirmBooking was valid but Booking wasn't: #{params}")
             render :new
           end

--- a/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
@@ -3,6 +3,7 @@ module Schools
     module Acceptance
       class PreviewConfirmationEmailController < Schools::BaseController
         before_action :set_placement_request
+        before_action :fetch_gitis_contact_for_placement_request
         before_action :ensure_previous_step_complete
 
         def new; end
@@ -27,13 +28,17 @@ module Schools
 
         def candidate_booking_notification(booking)
           NotifyEmail::CandidateBookingConfirmation
-            .from_booking(booking.candidate.email, booking)
+            .from_booking(booking.candidate_email, booking.candidate_name, booking)
         end
 
         def set_placement_request
           @placement_request = @current_school
             .bookings_placement_requests
             .find(params[:placement_request_id])
+        end
+
+        def fetch_gitis_contact_for_placement_request
+          @placement_request.fetch_gitis_contact gitis_crm
         end
       end
     end

--- a/app/controllers/schools/placement_requests/acceptance/review_and_send_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/review_and_send_email_controller.rb
@@ -3,6 +3,7 @@ module Schools
     module Acceptance
       class ReviewAndSendEmailController < Schools::BaseController
         before_action :set_placement_request
+        before_action :fetch_gitis_contact_for_placement_request
         before_action :ensure_previous_step_complete
 
         def new
@@ -37,6 +38,10 @@ module Schools
           @placement_request = @current_school
             .bookings_placement_requests
             .find(params[:placement_request_id])
+        end
+
+        def fetch_gitis_contact_for_placement_request
+          @placement_request.fetch_gitis_contact gitis_crm
         end
       end
     end

--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -7,6 +7,7 @@ module Schools
 
         def show
           @cancellation = @placement_request.school_cancellation
+          @placement_request.fetch_gitis_contact gitis_crm
         end
 
         def create

--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -3,11 +3,11 @@ module Schools
     module Cancellations
       class NotificationDeliveriesController < Schools::BaseController
         before_action :set_placement_request
+        before_action :fetch_gitis_contact_for_placement_request
         before_action :ensure_placement_request_is_open, except: :show
 
         def show
           @cancellation = @placement_request.school_cancellation
-          @placement_request.fetch_gitis_contact gitis_crm
         end
 
         def create
@@ -23,6 +23,10 @@ module Schools
         def set_placement_request
           @placement_request = \
             current_school.placement_requests.find params[:placement_request_id]
+        end
+
+        def fetch_gitis_contact_for_placement_request
+          @placement_request.fetch_gitis_contact gitis_crm
         end
 
         def ensure_placement_request_is_open

--- a/app/controllers/schools/placement_requests/cancellations_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations_controller.rb
@@ -6,6 +6,7 @@ module Schools
 
       def show
         @cancellation = @placement_request.school_cancellation
+        @placement_request.fetch_gitis_contact gitis_crm
       end
 
       def new

--- a/app/controllers/schools/placement_requests/cancellations_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations_controller.rb
@@ -10,14 +10,14 @@ module Schools
 
       def new
         @cancellation = @placement_request.build_school_cancellation
-        attach_contact @placement_request
+        @placement_request.fetch_gitis_contact gitis_crm
       end
 
       def create
         @cancellation = @placement_request.build_school_cancellation \
           cancellation_params
 
-        attach_contact(@placement_request)
+        @placement_request.fetch_gitis_contact gitis_crm
 
         if @cancellation.save
           redirect_to schools_placement_request_cancellation_path \
@@ -29,7 +29,7 @@ module Schools
 
       def edit
         @cancellation = @placement_request.school_cancellation
-        attach_contact @placement_request
+        @placement_request.fetch_gitis_contact gitis_crm
       end
 
       def update
@@ -39,7 +39,7 @@ module Schools
           redirect_to schools_placement_request_cancellation_path \
             @placement_request
         else
-          attach_contact @placement_request
+          @placement_request.fetch_gitis_contact gitis_crm
           render :edit
         end
       end
@@ -60,14 +60,6 @@ module Schools
       def cancellation_params
         params.require(:bookings_placement_request_cancellation).permit \
           :reason, :extra_details
-      end
-
-      def find_contact(req)
-        gitis_crm.find(req.contact_uuid)
-      end
-
-      def attach_contact(req)
-        req.gitis_contact = find_contact(req)
       end
     end
   end

--- a/app/controllers/schools/placement_requests/cancellations_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations_controller.rb
@@ -10,11 +10,14 @@ module Schools
 
       def new
         @cancellation = @placement_request.build_school_cancellation
+        attach_contact @placement_request
       end
 
       def create
         @cancellation = @placement_request.build_school_cancellation \
           cancellation_params
+
+        attach_contact(@placement_request)
 
         if @cancellation.save
           redirect_to schools_placement_request_cancellation_path \
@@ -26,6 +29,7 @@ module Schools
 
       def edit
         @cancellation = @placement_request.school_cancellation
+        attach_contact @placement_request
       end
 
       def update
@@ -35,6 +39,7 @@ module Schools
           redirect_to schools_placement_request_cancellation_path \
             @placement_request
         else
+          attach_contact @placement_request
           render :edit
         end
       end
@@ -55,6 +60,14 @@ module Schools
       def cancellation_params
         params.require(:bookings_placement_request_cancellation).permit \
           :reason, :extra_details
+      end
+
+      def find_contact(req)
+        gitis_crm.find(req.contact_uuid)
+      end
+
+      def attach_contact(req)
+        req.gitis_contact = find_contact(req)
       end
     end
   end

--- a/app/controllers/schools/placement_requests/upcoming_controller.rb
+++ b/app/controllers/schools/placement_requests/upcoming_controller.rb
@@ -3,6 +3,7 @@ module Schools
     class UpcomingController < PlacementRequestsController
       def index
         @placement_requests = placement_requests.open
+        assign_gitis_contacts @placement_requests
       end
     end
   end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -22,15 +22,13 @@ module Schools
     end
 
     def assign_gitis_contacts(reqs)
-      return [] if reqs.empty?
+      return reqs if reqs.empty?
 
       contacts = gitis_crm.find(reqs.map(&:contact_uuid)).index_by(&:id)
 
       reqs.each do |req|
         req.gitis_contact = contacts[req.contact_uuid]
       end
-
-      reqs
     end
   end
 end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -2,10 +2,12 @@ module Schools
   class PlacementRequestsController < Schools::BaseController
     def index
       @placement_requests = placement_requests
+      assign_gitis_contacts(@placement_requests)
     end
 
     def show
       @placement_request = placement_request
+      @gitis_contact = gitis_crm.find(placement_request.contact_uuid)
     end
 
   private
@@ -17,6 +19,18 @@ module Schools
 
     def placement_request
       current_school.placement_requests.find params[:id]
+    end
+
+    def assign_gitis_contacts(reqs)
+      return [] if reqs.empty?
+
+      contacts = gitis_crm.find(reqs.map(&:contact_uuid)).index_by(&:id)
+
+      reqs.each do |req|
+        req.gitis_contact = contacts[req.contact_uuid]
+      end
+
+      reqs
     end
   end
 end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -30,7 +30,10 @@ module Bookings
       :build_candidate_cancellation,
       :closed?,
       :received_on,
-      :candidate,
+      :gitis_contact,
+      :contact_uuid,
+      :candidate_email,
+      :candidate_name,
       to: :bookings_placement_request
 
     scope :upcoming, -> { where(arel_table[:date].between(Time.now..2.weeks.from_now)) }
@@ -50,6 +53,10 @@ module Bookings
 
     def placement_start_date_with_duration
       [date.to_formatted_s(:govuk), duration_days].join(' ')
+    end
+
+    def received_on
+      bookings_placement_request.created_at.to_date
     end
 
     def duration_days

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -55,10 +55,6 @@ module Bookings
       [date.to_formatted_s(:govuk), duration_days].join(' ')
     end
 
-    def received_on
-      bookings_placement_request.created_at.to_date
-    end
-
     def duration_days
       duration.to_s + ' day'.pluralize(duration)
     end

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -4,6 +4,11 @@ module Bookings
       class_name: 'Bookings::School',
       foreign_key: 'bookings_school_id'
 
+    has_many :placement_requests,
+      class_name: 'Bookings::PlacementRequest',
+      inverse_of: :placement_date,
+      foreign_key: :bookings_placement_date_id
+
     validates :bookings_school, presence: true
     validates :duration,
       presence: true,

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -15,7 +15,8 @@ module Bookings
 
     has_one :booking,
       class_name: 'Bookings::Booking',
-      foreign_key: 'bookings_placement_request_id'
+      foreign_key: 'bookings_placement_request_id',
+      inverse_of: :bookings_placement_request
 
     belongs_to :placement_date,
       class_name: 'Bookings::PlacementDate',

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -64,11 +64,6 @@ module Bookings
       !closed?
     end
 
-    # FIXME SE-1095 update this model to belong_to a candidate
-#    def candidate
-#      @candidate ||= Bookings::Gitis::CRM.new('abc123').find(1)
-#    end
-
     def contact_uuid
       1
     end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -63,8 +63,12 @@ module Bookings
     end
 
     # FIXME SE-1095 update this model to belong_to a candidate
-    def candidate
-      @candidate ||= Bookings::Gitis::CRM.new('abc123').find(1)
+#    def candidate
+#      @candidate ||= Bookings::Gitis::CRM.new('abc123').find(1)
+#    end
+
+    def contact_uuid
+      1
     end
 
     def dates_requested
@@ -108,14 +112,6 @@ module Bookings
 
     def school_admin_name
       school.admin_contact_name
-    end
-
-    def candidate_email
-      candidate.email
-    end
-
-    def candidate_name
-      candidate.full_name
     end
 
     def cancellation

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -127,6 +127,10 @@ module Bookings
       candidate_cancellation || school_cancellation
     end
 
+    def load_gitis_contact(crm)
+      self.gitis_contact = crm.find(contact_uuid)
+    end
+
   private
 
     def cancelled?

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -25,12 +25,14 @@ module Bookings
       -> { where cancelled_by: 'candidate' },
       class_name: 'Bookings::PlacementRequest::Cancellation',
       foreign_key: 'bookings_placement_request_id',
+      inverse_of: :placement_request,
       dependent: :destroy
 
     has_one :school_cancellation,
       -> { where cancelled_by: 'school' },
       class_name: 'Bookings::PlacementRequest::Cancellation',
       foreign_key: 'bookings_placement_request_id',
+      inverse_of: :placement_request,
       dependent: :destroy
 
     scope :open, -> do

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -2,6 +2,7 @@
 # registration
 module Bookings
   class PlacementRequest < ApplicationRecord
+    attr_accessor :gitis_contact
     include Candidates::Registrations::Behaviours::PlacementPreference
     include Candidates::Registrations::Behaviours::SubjectPreference
     include Candidates::Registrations::Behaviours::BackgroundCheck
@@ -112,6 +113,14 @@ module Bookings
 
     def school_admin_name
       school.admin_contact_name
+    end
+
+    def candidate_email
+      gitis_contact.email
+    end
+
+    def candidate_name
+      gitis_contact.full_name
     end
 
     def cancellation

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -127,7 +127,7 @@ module Bookings
       candidate_cancellation || school_cancellation
     end
 
-    def load_gitis_contact(crm)
+    def fetch_gitis_contact(crm)
       self.gitis_contact = crm.find(contact_uuid)
     end
 

--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -59,16 +59,14 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     super(to: to)
   end
 
-  def self.from_booking(to, booking)
+  def self.from_booking(to, candidate_name, booking)
     school = booking.bookings_school
-    placement_request = booking.bookings_placement_request
-    candidate = placement_request.candidate
     profile = school.profile
 
     new(
       to: to,
       school_name: school.name,
-      candidate_name: [candidate.firstname, candidate.lastname].join(' '),
+      candidate_name: candidate_name,
       placement_start_date: booking.date,
       placement_finish_date: 'FIXME',
       school_address: [

--- a/app/views/schools/confirmed_bookings/_booking_table.html.erb
+++ b/app/views/schools/confirmed_bookings/_booking_table.html.erb
@@ -11,7 +11,7 @@
     <%- @bookings.each do |booking| -%>
     <tr class="booking govuk-table__row" data-booking="<%= booking.id %>">
       <td class="name govuk-table__cell">
-        <%= booking.candidate.full_name %>
+        <%= booking.candidate_name %>
       </td>
       <td class="subject govuk-table__cell">
         <%= booking.bookings_subject.name %>

--- a/app/views/schools/confirmed_bookings/show.html.erb
+++ b/app/views/schools/confirmed_bookings/show.html.erb
@@ -6,7 +6,7 @@
   }
 %>
 
-<h1>Booking by <%= @booking.candidate.full_name %></h1>
+<h1>Booking by <%= @booking.candidate_name %></h1>
 
 <div class="booking">
   <section id="booking-details">
@@ -113,7 +113,7 @@
           Address
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @booking.candidate.address %>
+          <%= @booking.gitis_contact.address %>
         </dd>
       </div>
 
@@ -122,7 +122,7 @@
           UK telephone number
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @booking.candidate.phone %>
+          <%= @booking.gitis_contact.phone %>
         </dd>
       </div>
 
@@ -131,7 +131,7 @@
           Email address
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @booking.candidate.email %>
+          <%= @booking.candidate_email %>
         </dd>
       </div>
     </dl>

--- a/app/views/schools/placement_requests/_placement_request.html.erb
+++ b/app/views/schools/placement_requests/_placement_request.html.erb
@@ -1,5 +1,5 @@
 <div class="placement-request" data-placement-request="<%= placement_request.id %>" data-urn="<%= placement_request.urn %>">
-  <h2 class="govuk-heading-m">Request from <%= placement_request.candidate.full_name %></h2>
+  <h2 class="govuk-heading-m">Request from <%= placement_request.gitis_contact.full_name %></h2>
 
   <dl class="placement-details govuk-summary-list">
     <div class="date-requested govuk-summary-list__row">
@@ -41,9 +41,9 @@
                   Address
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <%= placement_request.candidate.building %>,
-                  <%= placement_request.candidate.town_or_city %>,
-                  <%= placement_request.candidate.postcode %>
+                  <%= placement_request.gitis_contact.building %>,
+                  <%= placement_request.gitis_contact.town_or_city %>,
+                  <%= placement_request.gitis_contact.postcode %>
                 </dd>
               </div>
 
@@ -52,7 +52,7 @@
                   UK telephone number
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <%= placement_request.candidate.phone %>
+                  <%= placement_request.gitis_contact.phone %>
                 </dd>
               </div>
 
@@ -61,7 +61,7 @@
                   Email address
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  <%= placement_request.candidate.email %>
+                  <%= placement_request.gitis_contact.email %>
                 </dd>
               </div>
 

--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -3,7 +3,7 @@
     <h1>Confirm booking</h1>
 
     <h3>
-      Confirm the booking for <%= [@placement_request.candidate.firstname, @placement_request.candidate.lastname].join(" ") %>.
+      Confirm the booking for <%= @placement_request.candidate_name %>.
     </h3>
 
     <dl id="placement-request-details" class="govuk-summary-list govuk-summary-list--no-border">

--- a/app/views/schools/placement_requests/acceptance/preview_confirmation_email/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/preview_confirmation_email/new.html.erb
@@ -4,12 +4,12 @@
 
     <p>
       The following contains the wording of the confirmation email which will be
-      sent to <%= @placement_request.candidate.firstname %> <%= @placement_request.candidate.lastname %>
+      sent to <%= @placement_request.candidate_name %>
       to confirm their booking.
     </p>
 
     <div class="email-preview">
-      <p>Dear <%= @placement_request.candidate.firstname %> <%= @placement_request.candidate.lastname %>,</p>
+      <p>Dear <%= @placement_request.candidate_name %>,</p>
 
       <p>Here are the details about your school experience at <%= @placement_request.school.name %>.</p>
 

--- a/app/views/schools/placement_requests/acceptance/review_and_send_email/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/review_and_send_email/new.html.erb
@@ -9,7 +9,7 @@
     <%= form_for @review_and_send_email, url: schools_placement_request_acceptance_review_and_send_email_path, method: 'post' do |form| %>
       <div class="email-preview">
 
-        <p>Dear <%= @placement_request.candidate.firstname %> <%= @placement_request.candidate.lastname %>,</p>
+        <p>Dear <%= @placement_request.candidate_name %>,</p>
 
         <p>Here are the details about your school experience at <%= @placement_request.school.name %>.</p>
 

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -1,6 +1,6 @@
 <%= link_to 'Back', schools_upcoming_requests_path, class: 'govuk-back-link' %>
 
-<h1>Request from <%= @placement_request.candidate.full_name %></h1>
+<h1>Request from <%= @gitis_contact.full_name %></h1>
 
 <div class="school-request">
   <section id="request-details">
@@ -105,7 +105,7 @@
           Address
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @placement_request.candidate.address %>
+          <%= @gitis_contact.address %>
         </dd>
       </div>
 
@@ -114,7 +114,7 @@
           UK telephone number
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @placement_request.candidate.phone %>
+          <%= @gitis_contact.phone %>
         </dd>
       </div>
 
@@ -123,7 +123,7 @@
           Email address
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @placement_request.candidate.email %>
+          <%= @gitis_contact.email %>
         </dd>
       </div>
     </dl>

--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -26,8 +26,8 @@ When("I am on the {string} page for my fixed placement request") do |identifier|
 end
 
 Then("the subheading should be {string} followed by the candidate's name") do |subheading|
-  candidate = @placement_request.candidate
-  candidate_name = [candidate.firstname, candidate.lastname].join(' ')
+  gitis = Bookings::Gitis::CRM.new('a.fake.token')
+  candidate_name = @placement_request.fetch_gitis_contact(gitis).full_name
   expect(page).to have_css('h3', text: "#{subheading} #{candidate_name}.")
 end
 

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe Candidates::PlacementRequests::CancellationsController, type: :request do
-  include_context 'stubbed out Gitis'
-
   let :notify_school_request_cancellation do
     double NotifyEmail::SchoolRequestCancellation, despatch_later!: true
   end
@@ -154,11 +152,15 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
             FactoryBot.build :cancellation, placement_request: placement_request
           end
 
+          let :gitis_contact do
+            Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+          end
+
           it 'notifies the school' do
             expect(NotifyEmail::SchoolRequestCancellation).to have_received(:new).with \
               to: cancellation.school_email,
               school_name: cancellation.school_name,
-              candidate_name: cancellation.candidate_name,
+              candidate_name: gitis_contact.full_name,
               cancellation_reasons: cancellation.reason,
               requested_availability: cancellation.dates_requested,
               placement_request_url: schools_placement_request_url(cancellation.placement_request)
@@ -169,9 +171,9 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
 
           it 'notifies the candidate' do
             expect(NotifyEmail::CandidateRequestCancellation).to have_received(:new).with \
-              to: cancellation.candidate_email,
+              to: gitis_contact.email,
               school_name: cancellation.school_name,
-              candidate_name: cancellation.candidate_name,
+              candidate_name: gitis_contact.full_name,
               requested_availability: cancellation.dates_requested
 
             expect(notify_candidate_request_cancellation).to \
@@ -228,11 +230,15 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
             FactoryBot.build :cancellation, placement_request: placement_request
           end
 
+          let :gitis_contact do
+            Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+          end
+
           it 'notifies the school' do
             expect(NotifyEmail::SchoolBookingCancellation).to have_received(:new).with \
               to: cancellation.school_email,
               school_name: cancellation.school_name,
-              candidate_name: cancellation.candidate_name,
+              candidate_name: gitis_contact.full_name,
               placement_start_date_with_duration: cancellation.booking.placement_start_date_with_duration
 
             expect(notify_school_booking_cancellation).to \
@@ -241,9 +247,9 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
 
           it 'notifies the candidate' do
             expect(NotifyEmail::CandidateBookingCancellation).to have_received(:new).with \
-              to: cancellation.candidate_email,
+              to: gitis_contact.email,
               school_name: cancellation.school_name,
-              candidate_name: cancellation.candidate_name,
+              candidate_name: gitis_contact.full_name,
               placement_start_date_with_duration: cancellation.booking.placement_start_date_with_duration
 
             expect(notify_candidate_booking_cancellation).to \

--- a/spec/controllers/candidates/sessions_controller_spec.rb
+++ b/spec/controllers/candidates/sessions_controller_spec.rb
@@ -13,9 +13,10 @@ RSpec.describe Candidates::SessionsController, type: :request do
   end
 
   describe "POST #create" do
-    before { NotifyFakeClient.reset_deliveries! }
-    before { queue_adapter.perform_enqueued_jobs = true }
-    after { queue_adapter.perform_enqueued_jobs = nil }
+    before do
+      NotifyFakeClient.reset_deliveries!
+      allow(queue_adapter).to receive(:perform_enqueued_jobs).and_return(true)
+    end
 
     let(:valid_creds) do
       {

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -56,11 +56,15 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
         create(:bookings_booking, bookings_placement_request: placement_request, bookings_school: school)
       end
 
+      let(:gitis_contact) do
+        Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+      end
+
       it 'notifies the candidate' do
         expect(NotifyEmail::CandidateBookingSchoolCancelsBooking).to have_received(:new).with \
-          to: cancellation.candidate_email,
+          to: gitis_contact.email,
           school_name: cancellation.school_name,
-          candidate_name: cancellation.candidate_name,
+          candidate_name: gitis_contact.full_name,
           rejection_reasons: cancellation.reason,
           extra_details: cancellation.extra_details,
           dates_requested: cancellation.dates_requested,

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -49,11 +49,15 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
         placement_request.school_cancellation
       end
 
+      let :gitis_contact do
+        Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+      end
+
       it 'notifies the candidate' do
         expect(NotifyEmail::CandidateRequestRejection).to have_received(:new).with \
-          to: cancellation.candidate_email,
+          to: gitis_contact.email,
           school_name: cancellation.school_name,
-          candidate_name: cancellation.candidate_name,
+          candidate_name: gitis_contact.full_name,
           rejection_reasons: cancellation.reason,
           extra_details: cancellation.extra_details,
           dates_requested: cancellation.dates_requested,

--- a/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
@@ -3,7 +3,6 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementRequests::CancellationsController, type: :request do
   include_context "logged in DfE user"
-  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -3,7 +3,6 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementRequestsController, type: :request do
   include_context "logged in DfE user"
-  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by! urn: urn
@@ -21,6 +20,8 @@ describe Schools::PlacementRequestsController, type: :request do
 
     it 'assigns the placement_requests belonging to the school' do
       expect(assigns(:placement_requests)).to eq school.placement_requests
+      expect(assigns(:placement_requests).map(&:gitis_contact)).to all \
+        be_kind_of Bookings::Gitis::Contact
     end
 
     it 'renders the index template' do

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -8,7 +8,7 @@ describe Bookings::PlacementDate, type: :model do
     it { is_expected.to have_db_column(:active).of_type(:boolean) }
   end
 
-  describe 'Valiation' do
+  describe 'Validation' do
     subject { described_class.new }
 
     context '#date' do
@@ -66,8 +66,8 @@ describe Bookings::PlacementDate, type: :model do
   end
 
   describe 'Relationships' do
-    subject { described_class.new }
-    it { expect(subject).to belong_to(:bookings_school) }
+    it { is_expected.to belong_to(:bookings_school) }
+    it { is_expected.to have_many(:placement_requests) }
   end
 
   describe 'Scopes' do

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -454,4 +454,16 @@ describe Bookings::PlacementRequest, type: :model do
       end
     end
   end
+
+  describe '#fetch_gitis_contact' do
+    let(:gitis) { Bookings::Gitis::CRM.new('a.fake.token') }
+    subject { FactoryBot.create :placement_request }
+
+    it "will assign contact" do
+      expect(subject.fetch_gitis_contact(gitis)).to \
+        be_kind_of(Bookings::Gitis::Contact)
+
+      expect(subject.gitis_contact).to be_kind_of(Bookings::Gitis::Contact)
+    end
+  end
 end

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -119,6 +119,7 @@ describe Bookings::PlacementRequest, type: :model do
   end
 
   context 'attributes' do
+    it { is_expected.to respond_to :gitis_contact }
     it { is_expected.to respond_to :urn }
     it { is_expected.to respond_to :degree_stage }
     it { is_expected.to respond_to :degree_stage_explaination }

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -35,6 +35,7 @@ describe NotifyEmail::CandidateBookingConfirmation do
     let!(:school) { create(:bookings_school, urn: 11048) }
     let!(:profile) { create(:bookings_profile, school: school) }
     let(:to) { "morris.szyslak@moes.net" }
+    let(:candidate_name) { "morris.szyslak" }
 
     let!(:pr) { create(:bookings_placement_request, school: school) }
     let!(:booking) do
@@ -45,13 +46,13 @@ describe NotifyEmail::CandidateBookingConfirmation do
       )
     end
 
-    subject { described_class.from_booking(to, booking) }
+    subject { described_class.from_booking(to, candidate_name, booking) }
 
     it { is_expected.to be_a(described_class) }
 
     context 'correctly assigning attributes' do
       specify 'candidate_name is correctly-assigned' do
-        expect(subject.candidate_name).to eql([pr.candidate.firstname, pr.candidate.lastname].join(' '))
+        expect(subject.candidate_name).to eql(candidate_name)
       end
 
       specify 'placement_start_date is correctly-assigned' do


### PR DESCRIPTION
### Context

As part of SE-1095, I need to add a Candidate relationship to Placement Requests. There is already a stubbed method there which always does api requests.

Refactored this to control the API requests at the controller level, and free up the candidate method for the future association.

### Changes proposed in this pull request

1. Stub out a method to associate a Placement Requests Candidate record with a Contact in Gitis CRM
2. Add a manual trigger to do an API request to get a Contact associated with a Placement Request
3. Change various controllers to trigger this request, and fixed up tests accordingly
