### PR TITLE
Feature/modify disabling and enabling behaviour for onboarded schools se 1158

### DIFF
--- a/app/assets/stylesheets/school-dashboard.scss
+++ b/app/assets/stylesheets/school-dashboard.scss
@@ -72,6 +72,15 @@ article#dashboard {
     &.requests-and-bookings {
     }
   }
+
+  .govuk-se-warning {
+    border: 5px solid $govuk-error-colour;
+    padding: 1rem;
+
+    a.govuk-se-warning__link {
+      color: $govuk-error-colour;
+    }
+  }
 }
 
 .govuk-hint.govuk-hint__indented {

--- a/app/assets/stylesheets/school-dashboard.scss
+++ b/app/assets/stylesheets/school-dashboard.scss
@@ -72,15 +72,6 @@ article#dashboard {
     &.requests-and-bookings {
     }
   }
-
-  .govuk-se-warning {
-    border: 5px solid $govuk-error-colour;
-    padding: 1rem;
-
-    a.govuk-se-warning__link {
-      color: $govuk-error-colour;
-    }
-  }
 }
 
 .govuk-hint.govuk-hint__indented {

--- a/app/controllers/concerns/schools/restrict_access_unless_onboarded.rb
+++ b/app/controllers/concerns/schools/restrict_access_unless_onboarded.rb
@@ -1,0 +1,22 @@
+module Schools
+  module RestrictAccessUnlessOnboarded
+    extend ActiveSupport::Concern
+
+    included do
+      before_action :ensure_onboarded
+    end
+
+  private
+
+    def ensure_onboarded
+      unless @current_school.private_beta?
+        Rails.logger.warn("%<school_name>s tried to access %<page>s before completing profile" % {
+          school_name: @current_school.name,
+          page: request.path
+        })
+
+        redirect_to schools_dashboard_path
+      end
+    end
+  end
+end

--- a/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module ConfirmedBookings
     module Cancellations
       class NotificationDeliveriesController < Schools::BaseController
+        include Schools::RestrictAccessUnlessOnboarded
         before_action :set_booking_and_placement_request
 
         def show

--- a/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
@@ -1,6 +1,8 @@
 module Schools
   module ConfirmedBookings
     class CancellationsController < Schools::BaseController
+      include Schools::RestrictAccessUnlessOnboarded
+
       before_action :set_booking_and_placement_request
       before_action :ensure_booking_is_open
 

--- a/app/controllers/schools/confirmed_bookings/upcoming_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/upcoming_controller.rb
@@ -1,6 +1,8 @@
 module Schools
   module ConfirmedBookings
     class UpcomingController < ConfirmedBookingsController
+      include Schools::RestrictAccessUnlessOnboarded
+
       def index
         @bookings = current_school
           .bookings

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -1,5 +1,7 @@
 module Schools
   class ConfirmedBookingsController < Schools::BaseController
+    include Schools::RestrictAccessUnlessOnboarded
+
     def index
       @bookings = current_school
         .bookings

--- a/app/controllers/schools/placement_requests/acceptance/add_more_details_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/add_more_details_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class AddMoreDetailsController < Schools::BaseController
+        include Schools::RestrictAccessUnlessOnboarded
         before_action :set_placement_request
         before_action :ensure_previous_step_complete
 

--- a/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class ConfirmBookingController < Schools::BaseController
+        include Schools::RestrictAccessUnlessOnboarded
         before_action :set_placement_request, :set_available_subjects
 
         def new

--- a/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class PreviewConfirmationEmailController < Schools::BaseController
+        include Schools::RestrictAccessUnlessOnboarded
         before_action :set_placement_request
         before_action :ensure_previous_step_complete
 

--- a/app/controllers/schools/placement_requests/acceptance/review_and_send_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/review_and_send_email_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class ReviewAndSendEmailController < Schools::BaseController
+        include Schools::RestrictAccessUnlessOnboarded
         before_action :set_placement_request
         before_action :ensure_previous_step_complete
 

--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module PlacementRequests
     module Cancellations
       class NotificationDeliveriesController < Schools::BaseController
+        include Schools::RestrictAccessUnlessOnboarded
         before_action :set_placement_request
         before_action :ensure_placement_request_is_open, except: :show
 

--- a/app/controllers/schools/placement_requests/cancellations_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations_controller.rb
@@ -1,6 +1,7 @@
 module Schools
   module PlacementRequests
     class CancellationsController < Schools::BaseController
+      include Schools::RestrictAccessUnlessOnboarded
       before_action :set_placement_request
       before_action :ensure_placement_request_is_open
 

--- a/app/controllers/schools/placement_requests/upcoming_controller.rb
+++ b/app/controllers/schools/placement_requests/upcoming_controller.rb
@@ -1,6 +1,8 @@
 module Schools
   module PlacementRequests
     class UpcomingController < PlacementRequestsController
+      include Schools::RestrictAccessUnlessOnboarded
+
       def index
         @placement_requests = placement_requests.open
       end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -1,5 +1,7 @@
 module Schools
   class PlacementRequestsController < Schools::BaseController
+    include Schools::RestrictAccessUnlessOnboarded
+
     def index
       @placement_requests = placement_requests
     end

--- a/app/controllers/schools/toggle_enabled_controller.rb
+++ b/app/controllers/schools/toggle_enabled_controller.rb
@@ -1,5 +1,6 @@
 module Schools
   class ToggleEnabledController < Schools::BaseController
+    include Schools::RestrictAccessUnlessOnboarded
     before_action :set_school
 
     def edit; end

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -1,4 +1,12 @@
 module Schools::DashboardsHelper
+  def not_onboarded_warning
+    if @current_school.placement_requests.any?
+      "You profile isn't complete"
+    else
+      "You have school experience requests waiting"
+    end
+  end
+
   def numbered_circle(number, id: nil, colour: 'red', width: 26, height: 30, font_size: "16px", circle_size: 13)
     content_tag(:svg, id: id, width: width, height: height) do
       safe_join([

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -1,7 +1,7 @@
 module Schools::DashboardsHelper
-  def not_onboarded_warning
-    if @current_school.placement_requests.any?
-      "You profile isn't complete"
+  def not_onboarded_warning(school)
+    if school.placement_requests.any?
+      "Your profile isn't complete"
     else
       "You have school experience requests waiting"
     end

--- a/app/views/schools/dashboards/_full_dashboard.html.erb
+++ b/app/views/schools/dashboards/_full_dashboard.html.erb
@@ -12,17 +12,20 @@
         <%= render partial: 'update_your_school_profile' %>
       <% end %>
 
-      <section class="upcoming-bookings">
-        <header class="dashboard-medium-priority">
-          <%= link_to "View upcoming bookings", "#" %>
-        </header>
-      </section>
-
       <section class="other-tasks">
         <ul class="govuk-list dashboard-low-priority">
           <li>
             <%= link_to "Read about service updates and changes", "#" %>
           </li>
+          <%- if @current_school.private_beta? -%>
+            <li>
+              <%= link_to "Turn requests on / off", edit_schools_enabled_path %>
+              <span class="govuk-hint">
+                Choose to stop / start receiving requests from candidates.
+                Requests are currently <strong><%= school_enabled_description(@current_school) %></strong>.
+              </span>
+            </li>
+          <%- end -%>
           <li>
             <%= link_to "Edit school profile", "#" %>
           </li>

--- a/app/views/schools/dashboards/_full_dashboard.html.erb
+++ b/app/views/schools/dashboards/_full_dashboard.html.erb
@@ -5,35 +5,11 @@
     <article id="dashboard">
 
       <section class="managing-requests">
-
-        <section class="requests-and-bookings">
-          <div class="subsection requests">
-            <header class="dashboard-high-priority">
-              <%= link_to "Accept and reject requests", schools_upcoming_requests_path %>
-              <%= numbered_circle(@new_requests, id: 'new-requests-counter') %>
-            </header>
-            <p class="govuk-hint">Candidates have requested school experience</p>
-          </div>
-
-          <div class="subsection bookings">
-            <header class="dashboard-high-priority">
-              <%= link_to "Accept and reject bookings", "#" %>
-              <%= numbered_circle(@new_bookings, id: 'new-bookings-counter') %>
-            </header>
-            <p class="govuk-hint">A candidate has asked to change a booking</p>
-          </div>
-        </section>
-
-        <section class="candidate-attendance">
-          <header class="dashboard-medium-priority">
-            <%= link_to "Confirm candidate attendance", "#" %>
-            <%= numbered_circle(@candidate_attendances, id: 'candidate-attendances-counter') %>
-          </header>
-          <p class="govuk-hint">
-            Confirm the attendance of candidates who've been on school experience
-          </p>
-        </section>
-
+        <% if @current_school.private_beta? %>
+          <%= render partial: 'new_requests_and_bookings' %>
+        <% else %>
+          <%= render partial: 'update_your_school_profile' %>
+        <% end %>
       </section>
 
       <section class="upcoming-bookings">

--- a/app/views/schools/dashboards/_full_dashboard.html.erb
+++ b/app/views/schools/dashboards/_full_dashboard.html.erb
@@ -3,32 +3,37 @@
     <h1 class="govuk-heading-l">Manage school experience at <%= @current_school.name %></h1>
 
     <article id="dashboard">
-      <section class="requests-and-bookings">
-        <div class="subsection requests">
-          <header class="dashboard-high-priority">
-            <%= link_to "Accept and reject requests", schools_upcoming_requests_path %>
-            <%= numbered_circle(@new_requests, id: 'new-requests-counter') %>
-          </header>
-          <p class="govuk-hint">Candidates have requested school experience</p>
-        </div>
 
-        <div class="subsection bookings">
-          <header class="dashboard-high-priority">
-            <%= link_to "Accept and reject bookings", "#" %>
-            <%= numbered_circle(@new_bookings, id: 'new-bookings-counter') %>
-          </header>
-          <p class="govuk-hint">A candidate has asked to change a booking</p>
-        </div>
-      </section>
+      <section class="managing-requests">
 
-      <section class="candidate-attendance">
-        <header class="dashboard-medium-priority">
-          <%= link_to "Confirm candidate attendance", "#" %>
-          <%= numbered_circle(@candidate_attendances, id: 'candidate-attendances-counter') %>
-        </header>
-        <p class="govuk-hint">
-          Confirm the attendance of candidates who've been on school experience
-        </p>
+        <section class="requests-and-bookings">
+          <div class="subsection requests">
+            <header class="dashboard-high-priority">
+              <%= link_to "Accept and reject requests", schools_upcoming_requests_path %>
+              <%= numbered_circle(@new_requests, id: 'new-requests-counter') %>
+            </header>
+            <p class="govuk-hint">Candidates have requested school experience</p>
+          </div>
+
+          <div class="subsection bookings">
+            <header class="dashboard-high-priority">
+              <%= link_to "Accept and reject bookings", "#" %>
+              <%= numbered_circle(@new_bookings, id: 'new-bookings-counter') %>
+            </header>
+            <p class="govuk-hint">A candidate has asked to change a booking</p>
+          </div>
+        </section>
+
+        <section class="candidate-attendance">
+          <header class="dashboard-medium-priority">
+            <%= link_to "Confirm candidate attendance", "#" %>
+            <%= numbered_circle(@candidate_attendances, id: 'candidate-attendances-counter') %>
+          </header>
+          <p class="govuk-hint">
+            Confirm the attendance of candidates who've been on school experience
+          </p>
+        </section>
+
       </section>
 
       <section class="upcoming-bookings">

--- a/app/views/schools/dashboards/_full_dashboard.html.erb
+++ b/app/views/schools/dashboards/_full_dashboard.html.erb
@@ -4,13 +4,13 @@
 
     <article id="dashboard">
 
-      <section class="managing-requests">
-        <% if @current_school.private_beta? %>
+      <% if @current_school.private_beta? %>
+        <section class="managing-requests">
           <%= render partial: 'new_requests_and_bookings' %>
-        <% else %>
-          <%= render partial: 'update_your_school_profile' %>
-        <% end %>
-      </section>
+        </section>
+      <% else %>
+        <%= render partial: 'update_your_school_profile' %>
+      <% end %>
 
       <section class="upcoming-bookings">
         <header class="dashboard-medium-priority">

--- a/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
@@ -1,0 +1,27 @@
+<section class="new-requests-and-bookings">
+  <div class="subsection requests">
+    <header class="dashboard-high-priority">
+      <%= link_to "Accept and reject requests", schools_upcoming_requests_path %>
+      <%= numbered_circle(@new_requests, id: 'new-requests-counter') %>
+    </header>
+    <p class="govuk-hint">Candidates have requested school experience</p>
+  </div>
+
+  <div class="subsection bookings">
+    <header class="dashboard-high-priority">
+      <%= link_to "Accept and reject bookings", "#" %>
+      <%= numbered_circle(@new_bookings, id: 'new-bookings-counter') %>
+    </header>
+    <p class="govuk-hint">A candidate has asked to change a booking</p>
+  </div>
+</section>
+
+<section class="candidate-attendance">
+  <header class="dashboard-medium-priority">
+    <%= link_to "Confirm candidate attendance", "#" %>
+    <%= numbered_circle(@candidate_attendances, id: 'candidate-attendances-counter') %>
+  </header>
+  <p class="govuk-hint">
+    Confirm the attendance of candidates who've been on school experience
+  </p>
+</section>

--- a/app/views/schools/dashboards/_update_your_school_profile.html.erb
+++ b/app/views/schools/dashboards/_update_your_school_profile.html.erb
@@ -1,6 +1,6 @@
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+<div class="govuk-error-summary" role="alert" tabindex="-1" data-module="error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
-    <%= not_onboarded_warning %>
+    <%= not_onboarded_warning(@current_school) %>
   </h2>
   <div class="govuk-error-summary__body">
     <p>

--- a/app/views/schools/dashboards/_update_your_school_profile.html.erb
+++ b/app/views/schools/dashboards/_update_your_school_profile.html.erb
@@ -1,19 +1,19 @@
-<div class="govuk-se-warning">
-
-  <div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-      You have school experience requests waiting
-    </strong>
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    <%= not_onboarded_warning %>
+  </h2>
+  <div class="govuk-error-summary__body">
+    <p>
+      Before you can view and deal with these requests you need to answer some
+      questions to update your school profile.
+    </p>
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <%= link_to 'Update your school profile',
+          schools_on_boarding_profile_path,
+          class: 'govuk-se-warning__link govuk-!-font-weight-bold'
+        %>
+      </li>
+    </ul>
   </div>
-
-  <p>
-    Before you can view and deal with these requests you need to answer some
-    questions to update your school profile.
-  </p>
-
-  <%= link_to 'Update your school profile',
-    schools_on_boarding_profile_path,
-    class: 'govuk-se-warning__link govuk-!-font-weight-bold'
-  %>
 </div>

--- a/app/views/schools/dashboards/_update_your_school_profile.html.erb
+++ b/app/views/schools/dashboards/_update_your_school_profile.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-se-warning">
+
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      You have school experience requests waiting
+    </strong>
+  </div>
+
+  <p>
+    Before you can view and deal with these requests - you need to answer some
+    questions to update your school profile.
+  </p>
+
+  <%= link_to 'Update your school profile',
+    schools_on_boarding_profile_path,
+    class: 'govuk-se-warning__link govuk-!-font-weight-bold'
+  %>
+</div>

--- a/app/views/schools/dashboards/_update_your_school_profile.html.erb
+++ b/app/views/schools/dashboards/_update_your_school_profile.html.erb
@@ -8,7 +8,7 @@
   </div>
 
   <p>
-    Before you can view and deal with these requests - you need to answer some
+    Before you can view and deal with these requests you need to answer some
     questions to update your school profile.
   </p>
 

--- a/db/migrate/20190620082850_set_bookings_school_enabled_default_to_false.rb
+++ b/db/migrate/20190620082850_set_bookings_school_enabled_default_to_false.rb
@@ -1,0 +1,5 @@
+class SetBookingsSchoolEnabledDefaultToFalse < ActiveRecord::Migration[5.2]
+  def change
+    change_column :bookings_schools, :enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_07_140934) do
+ActiveRecord::Schema.define(version: 2019_06_20_082850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -188,7 +188,7 @@ ActiveRecord::Schema.define(version: 2019_06_07_140934) do
     t.text "primary_key_stage_info"
     t.text "availability_info"
     t.string "teacher_training_website"
-    t.boolean "enabled", default: true, null: false
+    t.boolean "enabled", default: false, null: false
     t.boolean "availability_preference_fixed", default: false, null: false
     t.index ["coordinates"], name: "index_bookings_schools_on_coordinates", using: :gist
     t.index ["name"], name: "index_bookings_schools_on_name"

--- a/features/schools/confirmed_bookings/cancelling.feature
+++ b/features/schools/confirmed_bookings/cancelling.feature
@@ -5,6 +5,7 @@ Feature: Cancelling bookings
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
         And the school has subjects
 
     Scenario: Page heading

--- a/features/schools/confirmed_bookings/index.feature
+++ b/features/schools/confirmed_bookings/index.feature
@@ -5,6 +5,7 @@ Feature: Viewing all bookings
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
 
     Scenario: Page title
         Given I am on the 'bookings' page

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -5,6 +5,7 @@ Feature: Viewing a booking
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
         And the scheduled booking date is '02 October 2019'
 
     Scenario: Breadcrumbs

--- a/features/schools/confirmed_bookings/upcoming/index.feature
+++ b/features/schools/confirmed_bookings/upcoming/index.feature
@@ -5,6 +5,7 @@ Feature: Viewing upcoming bookings
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
 
     Scenario: Page title
         Given I am on the 'upcoming bookings' page

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -10,6 +10,17 @@ Feature: The School Dashboard
         Given I am on the 'schools dashboard' page
         Then the main site header should be 'Manage school experience'
 
+    Scenario: Hiding the managing requests section when schools haven't onboarded
+        Given my school has not yet fully-onboarded
+        When I am on the 'schools dashboard' page
+        Then I should see a warning informing me that I need to complete my profile before continuing
+        And I should see a 'Update your school profile' link to the 'profile' page
+
+    Scenario: Displaying the managing requests section when schools have onboarded
+        Given my school has fully-onboarded
+        When I am on the 'schools dashboard' page
+        Then I should see the managing requests section
+
     @wip
     Scenario: High priority headings
         Given I am on the 'schools dashboard' page

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -21,6 +21,16 @@ Feature: The School Dashboard
         When I am on the 'schools dashboard' page
         Then I should see the managing requests section
 
+    Scenario: Hide the enable/disable link if schools not onboarded
+        Given my school has not yet fully-onboarded
+        When I am on the 'schools dashboard' page
+        Then there should be no 'Turn requests on / off' link
+
+    Scenario: Show the enable/disable link when schools are onboarded
+        Given my school has fully-onboarded
+        When I am on the 'schools dashboard' page
+        Then I should see a 'Turn requests on / off' link to the 'toggle requests' page
+
     @wip
     Scenario: High priority headings
         Given I am on the 'schools dashboard' page

--- a/features/schools/placement_requests/cancelling.feature
+++ b/features/schools/placement_requests/cancelling.feature
@@ -5,6 +5,7 @@ Feature: Rejecting placement requests
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
         And the school has subjects
 
     Scenario: Back link

--- a/features/schools/placement_requests/index.feature
+++ b/features/schools/placement_requests/index.feature
@@ -5,6 +5,7 @@ Feature: Viewing all placement requests
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
         And the school has subjects
 
     Scenario: Page title

--- a/features/schools/placement_requests/show.feature
+++ b/features/schools/placement_requests/show.feature
@@ -5,6 +5,7 @@ Feature: Viewing a placement request
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
         And the school has subjects
 
     Scenario: Back link

--- a/features/schools/toggle_enabling_and_disabling.feature
+++ b/features/schools/toggle_enabling_and_disabling.feature
@@ -5,6 +5,7 @@ Feature: Toggling being enabled and disabled
 
     Background:
         Given I am logged in as a DfE user
+        And my school is fully-onboarded
 
     Scenario: Page title
         Given I am on the 'toggle requests' page

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -38,7 +38,7 @@ Given("my school has not yet fully-onboarded") do
 end
 
 Then("I should see a warning informing me that I need to complete my profile before continuing") do
-  within('.govuk-se-warning') do
+  within('.govuk-error-summary') do
     expect(page).to have_content('you need to answer some questions to update your school profile')
   end
 end

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -50,3 +50,7 @@ end
 Then("I should see the managing requests section") do
   expect(page).to have_css('.managing-requests')
 end
+
+Then("there should be no {string} link") do |link_text|
+  expect(page).not_to have_link(link_text)
+end

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -32,3 +32,21 @@ end
 Then("the {string} should be {int}") do |string, int|
   expect(page).to have_css("svg#%<id>s" % { id: string.tr(' ', '-') }, text: int.to_s)
 end
+
+Given("my school has not yet fully-onboarded") do
+  # do nothing
+end
+
+Then("I should see a warning informing me that I need to complete my profile before continuing") do
+  within('.govuk-se-warning') do
+    expect(page).to have_content('you need to answer some questions to update your school profile')
+  end
+end
+
+Given("my school has fully-onboarded") do
+  FactoryBot.create(:bookings_profile, school: @school)
+end
+
+Then("I should see the managing requests section") do
+  expect(page).to have_css('.managing-requests')
+end

--- a/features/step_definitions/schools/dfe_signin_steps.rb
+++ b/features/step_definitions/schools/dfe_signin_steps.rb
@@ -2,3 +2,9 @@ Given("I am logged in as a DfE user") do
   visit insecure_auth_callback_path
   @school = Bookings::School.find_by(urn: 123456)
 end
+
+Given("my school is fully-onboarded") do
+  if @school.profile.blank?
+    FactoryBot.create(:bookings_profile, school: @school)
+  end
+end

--- a/features/step_definitions/schools/toggle_requests_steps.rb
+++ b/features/step_definitions/schools/toggle_requests_steps.rb
@@ -1,9 +1,9 @@
 Given("my school is enabled") do
+  @school.update(enabled: true)
   expect(@school).to be_enabled
 end
 
 Given("my school is disabled") do
-  @school.update(enabled: false)
   expect(@school).to be_disabled
 end
 

--- a/spec/controllers/concerns/schools/restrict_access_unless_onboarded_spec.rb
+++ b/spec/controllers/concerns/schools/restrict_access_unless_onboarded_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::RestrictAccessUnlessOnboarded, type: :request do
+  include_context "logged in DfE user"
+  subject { Schools::ConfirmedBookings::CancellationsController }
+
+  context 'when the school is not onboarded' do
+    before { get "/schools/placement_requests/1/cancellation/new" }
+
+    specify 'controller should include the restrict access module' do
+      expect(subject.ancestors).to include(Schools::RestrictAccessUnlessOnboarded)
+    end
+
+    specify 'should redirect to the dashboard' do
+      expect(subject).to redirect_to(schools_dashboard_path)
+    end
+  end
+end

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -8,6 +8,7 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|
       s.subjects << FactoryBot.create_list(:bookings_subject, 5)
+      create(:bookings_profile, school: s)
     end
   end
 

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
@@ -8,6 +8,7 @@ describe Schools::ConfirmedBookings::CancellationsController, type: :request do
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|
       s.subjects << FactoryBot.create_list(:bookings_subject, 5)
+      create(:bookings_profile, school: s)
     end
   end
 

--- a/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 describe Schools::ConfirmedBookings::CancellationsController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::ConfirmedBookings::CancellationsController, type: :request do
   include_context "logged in DfE user"
+  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/placement_requests/acceptance/add_more_details_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/add_more_details_controller_spec.rb
@@ -15,6 +15,10 @@ describe Schools::PlacementRequests::Acceptance::AddMoreDetailsController, type:
     )
   end
 
+  let!(:profile) do
+    create(:bookings_profile, school: @current_user_school)
+  end
+
   context '#new' do
     before do
       get new_schools_placement_request_acceptance_add_more_details_path(pr.id)

--- a/spec/controllers/schools/placement_requests/acceptance/add_more_details_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/add_more_details_controller_spec.rb
@@ -3,6 +3,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::PlacementRequests::Acceptance::AddMoreDetailsController, type: :request do
   include_context "logged in DfE user"
+  include_context "restricted unless school onboarded"
 
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }
   let!(:booking) do

--- a/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }
   before { create(:bookings_profile, school: @current_user_school) }

--- a/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
@@ -6,6 +6,7 @@ describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type:
   include_context "stubbed out Gitis"
 
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }
+  before { create(:bookings_profile, school: @current_user_school) }
 
   context '#new' do
     before do

--- a/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 describe Schools::PlacementRequests::Acceptance::PreviewConfirmationEmailController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let!(:booking_profile) { create(:bookings_profile, school: @current_user_school) }
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }

--- a/spec/controllers/schools/placement_requests/acceptance/review_and_send_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/review_and_send_email_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 describe Schools::PlacementRequests::Acceptance::ReviewAndSendEmailController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let!(:booking_profile) { create(:bookings_profile, school: @current_user_school) }
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -8,6 +8,7 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|
       s.subjects << FactoryBot.create_list(:bookings_subject, 5)
+      FactoryBot.create(:bookings_profile, school: s)
     end
   end
 

--- a/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 describe Schools::PlacementRequests::CancellationsController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
@@ -8,6 +8,7 @@ describe Schools::PlacementRequests::CancellationsController, type: :request do
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|
       s.subjects << FactoryBot.create_list(:bookings_subject, 5)
+      FactoryBot.create(:bookings_profile, school: s)
     end
   end
 

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -9,6 +9,10 @@ describe Schools::PlacementRequestsController, type: :request do
     Bookings::School.find_by! urn: urn
   end
 
+  let! :profile do
+    create(:bookings_profile, school: school)
+  end
+
   before do
     school.subjects << FactoryBot.create_list(:bookings_subject, 5)
   end

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -4,6 +4,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 describe Schools::PlacementRequestsController, type: :request do
   include_context "logged in DfE user"
   include_context "stubbed out Gitis"
+  include_context "restricted unless school onboarded"
 
   let :school do
     Bookings::School.find_by! urn: urn

--- a/spec/controllers/schools/toggle_enabled_controller_spec.rb
+++ b/spec/controllers/schools/toggle_enabled_controller_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+require_relative 'session_context'
+
+describe Schools::ToggleEnabledController, type: :request do
+  include_context "restricted unless school onboarded"
+end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     sequence(:contact_email) { |n| "admin#{n}@school.org" }
     availability_info { 'We can offer placements throughout June and July for the remainder of this academic year (up to the 21st July).' }
     availability_preference_fixed { false }
+    enabled { true }
 
     trait :onboarded do
       association :profile, factory: :bookings_profile

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
     availability_info { 'We can offer placements throughout June and July for the remainder of this academic year (up to the 21st July).' }
     availability_preference_fixed { false }
 
+    trait :onboarded do
+      association :profile, factory: :bookings_profile
+    end
+
     trait :disabled do
       enabled { false }
     end

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -162,4 +162,21 @@ describe Schools::DashboardsHelper, type: 'helper' do
       end
     end
   end
+
+  context '#not_onboarded_warning' do
+    let(:school) { create(:bookings_school) }
+    context 'when the school has placement requests' do
+      let!(:pr) { create(:bookings_placement_request, school: school) }
+
+      specify 'should return message "You profile isn\'t complete"' do
+        expect(not_onboarded_warning(school)).to eql("Your profile isn't complete")
+      end
+    end
+
+    context 'when the school has no placement requests' do
+      specify 'should return message "You have school experience requests waiting"' do
+        expect(not_onboarded_warning(school)).to eql("You have school experience requests waiting")
+      end
+    end
+  end
 end

--- a/spec/support/schools/restricted_unless_school_onboarded.rb
+++ b/spec/support/schools/restricted_unless_school_onboarded.rb
@@ -1,0 +1,5 @@
+shared_context 'restricted unless school onboarded' do |path_to_test|
+  specify 'should include concern RestrictAccessUnlessOnboarded' do
+    expect(subject).is_a?(Schools::RestrictAccessUnlessOnboarded)
+  end
+end

--- a/spec/support/schools/restricted_unless_school_onboarded.rb
+++ b/spec/support/schools/restricted_unless_school_onboarded.rb
@@ -1,4 +1,4 @@
-shared_context 'restricted unless school onboarded' do |path_to_test|
+shared_context 'restricted unless school onboarded' do
   specify 'should include concern RestrictAccessUnlessOnboarded' do
     expect(subject).is_a?(Schools::RestrictAccessUnlessOnboarded)
   end


### PR DESCRIPTION
### Context

If schools try to accept a Placement Request before they've fully-onboarded the email sending stage will blow up because we don't have all the required information to populate the email

### Changes proposed in this pull request

Prevent new schools from enabling themselves until they've onboarded, the default value for the `enabled` flag is now `false`.

### Guidance to review

Ensure changes make sense.
