### PR TITLE
Finalise booking confirmation email text

### DIFF
--- a/app/notify/notify_email/candidate_booking_confirmation.29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3.md
+++ b/app/notify/notify_email/candidate_booking_confirmation.29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3.md
@@ -1,31 +1,35 @@
 Dear ((candidate_name)),
 
-Here are some details about your school experience placement at ((school_name)).
+Here are the main details about your school experience at ((school_name)).
 
 * School or college: ((school_name))
 * Address: ((school_address))
-* Placement dates: ((placement_start_date)) to ((placement_finish_date))
-* Start and finish times: ((school_start_time)) to ((school_finish_time))
+* Experience dates: ((placement_schedule))
+* Experience start and finish times: ((school_start_time)) to ((school_finish_time))
 * Dress code: ((school_dress_code))
 * Parking: ((school_parking))
 
-If you have any questions about your bookings:
+# School experience contacts
+
+If you have any questions about your booking:
 
 Name: ((school_admin_name))
 Email address: ((school_admin_email))
 UK telephone number: ((school_admin_telephone))
 
-On the day of your school experience placement you'll need to report to:
+On the day of your school experience, you'll need to report to:
 
 Name: ((school_teacher_name))
 Email address: ((school_teacher_email))
 UK telephone number: ((school_teacher_telephone))
 
-You can also contact them if you have any questions about your actual placement.
+You can also contact them if you have any questions about your experience.
+
+To cancel your school experience use the following link ((cancellation_url)).
 
 To cancel your placement use the the following link ((cancellation_url)).
 
-# Placement details
+# School experience details
 
 ((placement_details))
 

--- a/app/notify/notify_email/candidate_booking_confirmation.29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3.md
+++ b/app/notify/notify_email/candidate_booking_confirmation.29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3.md
@@ -27,12 +27,6 @@ You can also contact them if you have any questions about your experience.
 
 To cancel your school experience use the following link ((cancellation_url)).
 
-To cancel your placement use the the following link ((cancellation_url)).
-
 # School experience details
 
 ((placement_details))
-
-# Remember to bring
-* your DBS certificate
-* your £((placement_fee)) placement fee

--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -14,7 +14,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     :school_teacher_email,
     :school_teacher_telephone,
     :placement_details,
-    :placement_fee,
     :cancellation_url
 
   def initialize(
@@ -34,7 +33,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     school_teacher_email:,
     school_teacher_telephone:,
     placement_details:,
-    placement_fee:,
     cancellation_url:
   )
 
@@ -53,7 +51,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     self.school_teacher_email = school_teacher_email
     self.school_teacher_telephone = school_teacher_telephone
     self.placement_details = placement_details
-    self.placement_fee = placement_fee
     self.cancellation_url = cancellation_url
 
     super(to: to)
@@ -93,7 +90,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
       placement_details: booking.placement_details,
-      placement_fee: 'REMOVE', # FIXME
       cancellation_url: cancellation_url
     )
   end
@@ -121,7 +117,6 @@ private
       school_teacher_email: school_teacher_email,
       school_teacher_telephone: school_teacher_telephone,
       placement_details: placement_details,
-      placement_fee: placement_fee,
       cancellation_url: cancellation_url
     }
   end

--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -1,8 +1,7 @@
 class NotifyEmail::CandidateBookingConfirmation < Notify
   attr_accessor :school_name,
     :candidate_name,
-    :placement_start_date,
-    :placement_finish_date,
+    :placement_schedule,
     :school_address,
     :school_start_time,
     :school_finish_time,
@@ -22,8 +21,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     to:,
     school_name:,
     candidate_name:,
-    placement_start_date:,
-    placement_finish_date:,
+    placement_schedule:,
     school_address:,
     school_start_time:,
     school_finish_time:,
@@ -42,8 +40,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
 
     self.school_name = school_name
     self.candidate_name = candidate_name
-    self.placement_start_date = placement_start_date
-    self.placement_finish_date = placement_finish_date
+    self.placement_schedule = placement_schedule
     self.school_address = school_address
     self.school_start_time = school_start_time
     self.school_finish_time = school_finish_time
@@ -70,8 +67,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
       to: to,
       school_name: school.name,
       candidate_name: candidate_name,
-      placement_start_date: booking.date,
-      placement_finish_date: 'FIXME',
+      placement_schedule: booking.placement_start_date_with_duration,
       school_address: [
         school.address_1,
         school.address_2,
@@ -112,8 +108,7 @@ private
     {
       school_name: school_name,
       candidate_name: candidate_name,
-      placement_start_date: placement_start_date,
-      placement_finish_date: placement_finish_date,
+      placement_schedule: placement_schedule,
       school_address: school_address,
       school_start_time: school_start_time,
       school_finish_time: school_finish_time,

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -6,8 +6,7 @@ describe NotifyEmail::CandidateBookingConfirmation do
   it_should_behave_like "email template", "29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3",
     school_name: "Springfield Elementary",
     candidate_name: "Kearney Zzyzwicz",
-    placement_start_date: "2022-01-01",
-    placement_finish_date: "2022-02-01",
+    placement_schedule: "2022-03-04 for 3 days",
     school_address: "123 Main Street, Springfield, M2 3JF",
     school_start_time: "08:40",
     school_finish_time: "15:30",
@@ -58,13 +57,9 @@ describe NotifyEmail::CandidateBookingConfirmation do
         expect(subject.candidate_name).to eql(candidate_name)
       end
 
-      specify 'placement_start_date is correctly-assigned' do
-        expect(subject.placement_start_date).to eql(booking.date)
+      specify 'placement_schedule is correctly-assigned' do
+        expect(subject.placement_schedule).to eql(booking.placement_start_date_with_duration)
       end
-
-      specify 'placement_finish_date is correctly-assigned'
-      #  expect(subject.placement_finish_date).to eql('FIXME')
-      #end
 
       specify 'school_address is correctly-assigned' do
         expect(subject.school_address).to eql(

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -19,7 +19,6 @@ describe NotifyEmail::CandidateBookingConfirmation do
     school_teacher_email: "ednak@springfield.co.uk",
     school_teacher_telephone: "01234 234 1245",
     placement_details: "You will shadow a teacher and assist with lesson planning",
-    placement_fee: 30,
     cancellation_url: 'https://example.com/candiates/cancel/abc-123'
 
   describe ".from_booking" do
@@ -115,10 +114,6 @@ describe NotifyEmail::CandidateBookingConfirmation do
       specify 'placement_details is correctly-assigned' do
         expect(subject.placement_details).to eql(booking.placement_details)
       end
-
-      specify 'placement_fee is correctly-assigned'
-      #  expect(subject.placement_fee).to eql('REMOVE')
-      #end
 
       specify 'cancellation_url is correctly-assigned' do
         expect(subject.cancellation_url).to eql(cancellation_url)


### PR DESCRIPTION
### Context

Some _extra_ and unnecessary fields remained in the confirm booking template that are no longer needed, namely `placement_fee` and `placement_finish_date`.

### Changes proposed in this pull request

Remove the unnecessary fields and sync the remaining content with the master copy on Notify

### Guidance to review

Ensure the email makes sense
