### PR TITLE
Register new candidates

### DIFF
--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -14,7 +14,7 @@ module Candidates
             registration_session,
             current_contact
 
-          placement_request = Bookings::PlacementRequest.create_from_registration_session! \
+          placement_request = current_candidate.placement_requests.create_from_registration_session! \
             registration_session,
             cookies[:analytics_tracking_uuid],
             context: :returning_from_confirmation_email

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -9,6 +9,11 @@ module Candidates
         registration_session = RegistrationStore.instance.retrieve! params[:uuid]
 
         unless registration_session.completed?
+          self.current_candidate = Bookings::Candidate.create_or_update_from_registration_session! \
+            gitis_crm,
+            registration_session,
+            current_contact
+
           placement_request = Bookings::PlacementRequest.create_from_registration_session! \
             registration_session,
             cookies[:analytics_tracking_uuid],

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -1,5 +1,7 @@
 module Candidates
   class RegistrationsController < ApplicationController
+    include GitisAuthentication
+
     rescue_from Registrations::RegistrationSession::StepNotFound do |error|
       Rails.logger.warn "Step not found: #{error.inspect}"
       redirect_to next_step_path(current_registration)

--- a/app/controllers/concerns/gitis_authentication.rb
+++ b/app/controllers/concerns/gitis_authentication.rb
@@ -29,11 +29,13 @@ protected
     return nil unless current_contact
 
     @current_candidate ||=
-      Bookings::Candidate.find_by!(gitis_uuid: current_contact.id)
+      Bookings::Candidate.find_by_gitis_contact!(current_contact)
   end
 
   def current_candidate=(candidate)
-    self.current_contact = gitis_crm.find(candidate.gitis_uuid)
+    self.current_contact = candidate.gitis_contact ||
+      candidate.fetch_gitis_contact(gitis_crm)
+
     @current_candidate = candidate
   end
 

--- a/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
@@ -23,7 +23,7 @@ module Schools
         def set_booking_and_placement_request
           @booking = current_school
             .bookings
-            .eager_load(:bookings_placement_request)
+            .eager_load(bookings_placement_request: :candidate)
             .find(params[:booking_id])
           @placement_request = @booking.bookings_placement_request
         end

--- a/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
@@ -49,7 +49,7 @@ module Schools
       def set_booking_and_placement_request
         @booking = current_school
           .bookings
-          .eager_load(:bookings_placement_request)
+          .eager_load(bookings_placement_request: :candidate)
           .find(params[:booking_id])
         @placement_request = @booking.bookings_placement_request
       end

--- a/app/controllers/schools/confirmed_bookings/upcoming_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/upcoming_controller.rb
@@ -5,7 +5,7 @@ module Schools
         @bookings = current_school
           .bookings
           .upcoming
-          .eager_load(:bookings_subject, :bookings_placement_request)
+          .eager_load(:bookings_subject, bookings_placement_request: :candidate)
           .all
 
         assign_gitis_contacts @bookings

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -3,7 +3,7 @@ module Schools
     def index
       @bookings = current_school
         .bookings
-        .eager_load(:bookings_subject, :bookings_placement_request)
+        .eager_load(:bookings_subject, bookings_placement_request: :candidate)
         .all
 
       assign_gitis_contacts @bookings
@@ -26,7 +26,7 @@ module Schools
       contacts = gitis_crm.find(bookings.map(&:contact_uuid)).index_by(&:id)
 
       bookings.each do |booking|
-        booking.bookings_placement_request.gitis_contact = \
+        booking.bookings_placement_request.candidate.gitis_contact = \
           contacts[booking.contact_uuid]
       end
     end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -7,14 +7,14 @@ module Schools
 
     def show
       @placement_request = placement_request
-      @gitis_contact = gitis_crm.find(placement_request.contact_uuid)
+      @gitis_contact = placement_request.fetch_gitis_contact(gitis_crm)
     end
 
   private
 
     def placement_requests
       current_school.placement_requests
-        .eager_load(:candidate_cancellation, :school_cancellation, :placement_date)
+        .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date)
     end
 
     def placement_request
@@ -27,7 +27,7 @@ module Schools
       contacts = gitis_crm.find(reqs.map(&:contact_uuid)).index_by(&:id)
 
       reqs.each do |req|
-        req.gitis_contact = contacts[req.contact_uuid]
+        req.candidate.gitis_contact = contacts[req.contact_uuid]
       end
     end
   end

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -1,9 +1,19 @@
 class Bookings::Candidate < ApplicationRecord
   UUID_V4_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/.freeze
+  attr_accessor :gitis_contact
+  alias_method :contact, :gitis_contact
 
-  # delete_all used since there may be a lot of tokens, and the tokens don't have any real logic
-  has_many :session_tokens, class_name: 'Candidates::SessionToken', dependent: :delete_all
-  has_many :placement_requests, class_name: 'Bookings::PlacementRequest', dependent: :destroy
+  # delete_all used since there may be a lot of tokens
+  # and the tokens don't have any real logic
+  has_many :session_tokens,
+              class_name: 'Candidates::SessionToken',
+              dependent: :delete_all
+
+  has_many :placement_requests,
+              class_name: 'Bookings::PlacementRequest',
+              inverse_of: :candidate,
+              dependent: :destroy
+
   has_many :bookings, through: :placement_requests
 
   validates :gitis_uuid, presence: true, format: { with: UUID_V4_FORMAT }
@@ -27,4 +37,12 @@ class Bookings::Candidate < ApplicationRecord
   def last_signed_in_at
     confirmed_at || session_tokens.confirmed.maximum(:confirmed_at)
   end
+
+  def fetch_gitis_contact(crm)
+    raise NoGitisUuid unless gitis_uuid?
+
+    self.gitis_contact = crm.find(gitis_uuid)
+  end
+
+  class NoGitisUuid < RuntimeError; end
 end

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -16,7 +16,7 @@ class Bookings::Candidate < ApplicationRecord
 
   has_many :bookings, through: :placement_requests
 
-  validates :gitis_uuid, presence: true, format: { with: UUID_V4_FORMAT }
+  validates :gitis_uuid, presence: true, format: { with: Bookings::Gitis::Entity::ID_FORMAT }
   validates :gitis_uuid, uniqueness: { case_sensitive: false }
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -22,6 +22,8 @@ class Bookings::Candidate < ApplicationRecord
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :unconfirmed, -> { where(confirmed_at: nil) }
 
+  delegate :full_name, :email, to: :gitis_contact
+
   class << self
     def find_or_create_from_gitis_contact!(contact)
       find_or_create_by!(gitis_uuid: contact.id).tap do |c|

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -3,6 +3,8 @@ class Bookings::Candidate < ApplicationRecord
 
   # delete_all used since there may be a lot of tokens, and the tokens don't have any real logic
   has_many :session_tokens, class_name: 'Candidates::SessionToken', dependent: :delete_all
+  has_many :placement_requests, class_name: 'Bookings::PlacementRequest', dependent: :destroy
+  has_many :bookings, through: :placement_requests
 
   validates :gitis_uuid, presence: true, format: { with: UUID_V4_FORMAT }
   validates :gitis_uuid, uniqueness: { case_sensitive: false }

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -29,6 +29,12 @@ class Bookings::Candidate < ApplicationRecord
       end
     end
 
+    def find_by_gitis_contact!(contact)
+      find_by!(gitis_uuid: contact.id).tap do |c|
+        c.gitis_contact = contact
+      end
+    end
+
     def create_or_update_from_registration_session!(crm, registration, contact)
       if contact
         find_or_create_from_gitis_contact!(contact) \

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -23,10 +23,16 @@ class Bookings::Candidate < ApplicationRecord
   scope :unconfirmed, -> { where(confirmed_at: nil) }
 
   class << self
+    def find_or_create_from_gitis_contact!(contact)
+      find_or_create_by!(gitis_uuid: contact.id).tap do |c|
+        c.gitis_contact = contact
+      end
+    end
+
     def create_or_update_from_registration_session!(crm, registration, contact)
       if contact
-        find_or_create_by!(gitis_uuid: contact.id).
-          update_from_registration_session!(crm, registration)
+        find_or_create_from_gitis_contact!(contact) \
+          .update_from_registration_session!(crm, registration)
       else
         create_from_registration_session!(crm, registration)
       end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -9,6 +9,8 @@ module Bookings
 
     has_secure_token
 
+    validates_presence_of :candidate, unless: :pre_phase3_record?
+
     belongs_to :school,
       class_name: 'Bookings::School',
       foreign_key: :bookings_school_id
@@ -141,6 +143,12 @@ module Bookings
     def completed?
       # FIXME SE-1096 determine from booking
       false
+    end
+
+    def pre_phase3_record?
+      return true if Rails.application.config.x.phase < 3
+
+      persisted? && candidate_id_was.nil?
     end
   end
 end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -49,6 +49,8 @@ module Bookings
         .where(school_cancellations_bookings_placement_requests: { sent_at: nil })
     end
 
+    default_scope { where.not(candidate_id: nil) }
+
     delegate :gitis_contact, :fetch_gitis_contact, to: :candidate
 
     def self.create_from_registration_session!(registration_session, analytics_tracking_uuid = nil, context: nil)

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -2,7 +2,6 @@
 # registration
 module Bookings
   class PlacementRequest < ApplicationRecord
-    attr_accessor :gitis_contact
     include Candidates::Registrations::Behaviours::PlacementPreference
     include Candidates::Registrations::Behaviours::SubjectPreference
     include Candidates::Registrations::Behaviours::BackgroundCheck
@@ -50,6 +49,8 @@ module Bookings
         .where(school_cancellations_bookings_placement_requests: { sent_at: nil })
     end
 
+    delegate :gitis_contact, :fetch_gitis_contact, to: :candidate
+
     def self.create_from_registration_session!(registration_session, analytics_tracking_uuid = nil, context: nil)
       self.new(
         Candidates::Registrations::RegistrationAsPlacementRequest
@@ -72,7 +73,7 @@ module Bookings
     end
 
     def contact_uuid
-      1
+      candidate.gitis_uuid
     end
 
     def dates_requested
@@ -119,19 +120,15 @@ module Bookings
     end
 
     def candidate_email
-      gitis_contact.email
+      candidate.email
     end
 
     def candidate_name
-      gitis_contact.full_name
+      candidate.full_name
     end
 
     def cancellation
       candidate_cancellation || school_cancellation
-    end
-
-    def fetch_gitis_contact(crm)
-      self.gitis_contact = crm.find(contact_uuid)
     end
 
   private

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -13,6 +13,11 @@ module Bookings
       class_name: 'Bookings::School',
       foreign_key: :bookings_school_id
 
+    belongs_to :candidate,
+      class_name: 'Bookings::Candidate',
+      foreign_key: :candidate_id,
+      optional: true
+
     has_one :booking,
       class_name: 'Bookings::Booking',
       foreign_key: 'bookings_placement_request_id',

--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -1,0 +1,29 @@
+module Bookings
+  class RegistrationContactMapper
+    attr_reader :registration_session, :gitis_contact
+
+    delegate :personal_information, :contact_information, :subject_preference,
+      :placement_preference, :background_check, to: :registration_session
+
+
+    def initialize(registration_session, gitis_contact)
+      @registration_session = registration_session
+      @gitis_contact = gitis_contact
+    end
+
+    def registration_to_contact
+      gitis_contact.first_name = personal_information.first_name
+      gitis_contact.last_name = personal_information.last_name
+      gitis_contact.email = personal_information.email
+
+      gitis_contact.phone = contact_information.phone
+      gitis_contact.building = contact_information.building
+      gitis_contact.street = contact_information.street
+      gitis_contact.town_or_city = contact_information.town_or_city
+      gitis_contact.county = contact_information.county
+      gitis_contact.postcode = contact_information.postcode
+
+      gitis_contact
+    end
+  end
+end

--- a/app/models/candidates/session.rb
+++ b/app/models/candidates/session.rb
@@ -53,7 +53,7 @@ private
   end
 
   def find_or_create_candidate
-    @candidate = Bookings::Candidate.find_or_create_by!(gitis_uuid: contact.id)
+    @candidate = Bookings::Candidate.find_or_create_from_gitis_contact!(contact)
   end
 
   def generate_session_token

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -10,6 +10,8 @@ module Bookings
       entity_attributes :address1_city, :address1_stateorprovince
       entity_attributes :address1_postalcode, :phone
 
+      alias_attribute :first_name, :firstname
+      alias_attribute :last_name, :lastname
       alias_attribute :building, :address1_line1
       alias_attribute :town_or_city, :address1_city
       alias_attribute :county, :address1_stateorprovince
@@ -47,6 +49,11 @@ module Bookings
         elsif emailaddress1 != emailaddress
           self.emailaddress2 = emailaddress
         end
+      end
+
+      def street=(line_2and3)
+        self.address1_line2 = line_2and3
+        self.address1_line3 = ""
       end
 
       def street

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -55,9 +55,9 @@ module Bookings
         data = entity.changed_attributes.sort.to_h
 
         if entity.id
-          api.patch(entity.entity_id, data)
+          update_entity(entity.entity_id, data)
         else
-          entity.entity_id = api.post(entity.entity_id, data)
+          entity.entity_id = create_entity(entity.entity_id, data)
         end
 
         entity.id
@@ -89,6 +89,14 @@ module Bookings
         end
 
         parts.join(" #{join_with} ")
+      end
+
+      def create_entity(entity_id, data)
+        api.post(entity_id, data)
+      end
+
+      def update_entity(entity_id, data)
+        api.patch(entity_id, data)
       end
     end
   end

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -19,13 +19,9 @@ module Bookings
         params = { '$top' => uuids.length }
 
         if multiple_ids
-          params['$filter'] = filter_pairs(entity_type.primary_key => uuids)
-
-          api.get(entity_type.entity_path, params)['value'].map do |entity_data|
-            entity_type.new entity_data
-          end
+          find_many(entity_type, uuids, params)
         else
-          entity_type.new api.get("#{entity_type.entity_path}(#{uuids[0]})", params)
+          find_one(entity_type, uuids[0], params)
         end
       end
 
@@ -107,6 +103,18 @@ module Bookings
 
       def update_entity(entity_id, data)
         api.patch(entity_id, data)
+      end
+
+      def find_one(entity_type, uuid, params)
+        entity_type.new api.get("#{entity_type.entity_path}(#{uuid})", params)
+      end
+
+      def find_many(entity_type, uuids, params)
+        params['$filter'] = filter_pairs(entity_type.primary_key => uuids)
+
+        api.get(entity_type.entity_path, params)['value'].map do |entity_data|
+          entity_type.new entity_data
+        end
       end
     end
   end

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -3,6 +3,7 @@ module Bookings::Gitis
 
   module Entity
     extend ActiveSupport::Concern
+    ID_FORMAT = /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/.freeze
 
     included do
       include ActiveModel::Model

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -1,21 +1,5 @@
 module Bookings::Gitis
   module FakeCrm
-    def find(ids)
-      return super unless stubbed?
-
-      multiple_ids = ids.is_a? Array
-      ids = normalise_ids(ids)
-      validate_ids(ids)
-
-      if multiple_ids
-        ids.map do |id|
-          Contact.new(fake_contact_data.merge('contactid' => id))
-        end
-      else
-        Contact.new(fake_contact_data.merge('contactid' => ids[0]))
-      end
-    end
-
     def find_by_email(address)
       return super unless stubbed?
 
@@ -63,6 +47,22 @@ module Bookings::Gitis
 
     def stubbed?
       Rails.application.config.x.fake_crm
+    end
+
+    # only Contacts are mocked for now
+    def find_one(_entity_type, uuid, params)
+      return super unless stubbed?
+
+      Contact.new(fake_contact_data.merge('contactid' => uuid))
+    end
+
+    # only Contacts are mocked for now
+    def find_many(entity_type, uuids, params)
+      return super unless stubbed?
+
+      uuids.map do |uuid|
+        find_one(entity_type, uuid, params)
+      end
     end
   end
 end

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -1,17 +1,18 @@
 module Bookings::Gitis
   module FakeCrm
-    def find(*ids)
+    def find(ids)
       return super unless stubbed?
 
-      ids = normalise_ids(*ids)
+      multiple_ids = ids.is_a? Array
+      ids = normalise_ids(ids)
       validate_ids(ids)
 
-      if ids.length == 1
-        Contact.new(fake_contact_data.merge('contactid' => ids[0]))
-      else
+      if multiple_ids
         ids.map do |id|
           Contact.new(fake_contact_data.merge('contactid' => id))
         end
+      else
+        Contact.new(fake_contact_data.merge('contactid' => ids[0]))
       end
     end
 

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -25,9 +25,16 @@ module Bookings::Gitis
 
   private
 
-    def write_data(crm_contact_data)
-      crm_contact_data['contactid'].presence ||
-        "75c5a32d-d603-4483-956f-236fee7c5784"
+    def create_entity(entity_id, _data)
+      return super unless stubbed?
+
+      "#{entity_id}(#{SecureRandom.uuid})"
+    end
+
+    def update_entity(entity_id, _data)
+      return super unless stubbed?
+
+      entity_id
     end
 
     def fake_account_data

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -7,10 +7,10 @@ module Bookings::Gitis
       validate_ids(ids)
 
       if ids.length == 1
-        Contact.new(fake_account_data.merge('contactid' => ids[0]))
+        Contact.new(fake_contact_data.merge('contactid' => ids[0]))
       else
         ids.map do |id|
-          Contact.new(fake_account_data.merge('contactid' => id))
+          Contact.new(fake_contact_data.merge('contactid' => id))
         end
       end
     end
@@ -18,7 +18,7 @@ module Bookings::Gitis
     def find_by_email(address)
       return super unless stubbed?
 
-      Contact.new(fake_account_data).tap do |contact|
+      Contact.new(fake_contact_data).tap do |contact|
         contact.email = address
       end
     end
@@ -28,7 +28,7 @@ module Bookings::Gitis
     def create_entity(entity_id, _data)
       return super unless stubbed?
 
-      "#{entity_id}(#{SecureRandom.uuid})"
+      "#{entity_id}(#{fake_contact_id})"
     end
 
     def update_entity(entity_id, _data)
@@ -37,9 +37,13 @@ module Bookings::Gitis
       entity_id
     end
 
-    def fake_account_data
+    def fake_contact_id
+      SecureRandom.uuid
+    end
+
+    def fake_contact_data
       {
-        'contactid' => "d778d663-a022-4c4b-9962-e469ee179f4a",
+        'contactid' => fake_contact_id,
         'firstname' => 'Matthew',
         'lastname' => 'Richards',
         'mobilephone' => '07123 456789',

--- a/db/migrate/20190618152627_add_candidate_id_to_bookings_placement_requests.rb
+++ b/db/migrate/20190618152627_add_candidate_id_to_bookings_placement_requests.rb
@@ -1,0 +1,6 @@
+class AddCandidateIdToBookingsPlacementRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :bookings_placement_requests, :candidate, index: true
+    add_foreign_key :bookings_placement_requests, :bookings_candidates, column: :candidate_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_17_135043) do
+ActiveRecord::Schema.define(version: 2019_06_18_152627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,8 +92,10 @@ ActiveRecord::Schema.define(version: 2019_06_17_135043) do
     t.integer "bookings_school_id"
     t.uuid "analytics_tracking_uuid"
     t.string "token"
+    t.bigint "candidate_id"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
     t.index ["bookings_school_id"], name: "index_bookings_placement_requests_on_bookings_school_id"
+    t.index ["candidate_id"], name: "index_bookings_placement_requests_on_candidate_id"
     t.index ["token"], name: "index_bookings_placement_requests_on_token", unique: true
   end
 
@@ -315,6 +317,7 @@ ActiveRecord::Schema.define(version: 2019_06_17_135043) do
   add_foreign_key "bookings_bookings", "bookings_subjects"
   add_foreign_key "bookings_placement_dates", "bookings_schools"
   add_foreign_key "bookings_placement_request_cancellations", "bookings_placement_requests"
+  add_foreign_key "bookings_placement_requests", "bookings_candidates", column: "candidate_id"
   add_foreign_key "bookings_placement_requests", "bookings_placement_dates"
   add_foreign_key "bookings_placement_requests", "bookings_schools"
   add_foreign_key "bookings_profiles", "bookings_schools", column: "school_id"

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Candidates::PlacementRequests::CancellationsController, type: :request do
+  include_context 'fake gitis'
+
   let :notify_school_request_cancellation do
     double NotifyEmail::SchoolRequestCancellation, despatch_later!: true
   end
@@ -153,7 +155,7 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
           end
 
           let :gitis_contact do
-            Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+            fake_gitis.find placement_request.contact_uuid
           end
 
           it 'notifies the school' do
@@ -231,7 +233,7 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
           end
 
           let :gitis_contact do
-            Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+            fake_gitis.find placement_request.contact_uuid
           end
 
           it 'notifies the school' do

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -43,6 +43,8 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
     end
 
     context 'when request not already closed' do
+      include_context 'fake gitis'
+
       let :placement_request do
         FactoryBot.create \
           :placement_request, :with_school_cancellation, school: school
@@ -57,7 +59,7 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
       end
 
       let(:gitis_contact) do
-        Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+        fake_gitis.find placement_request.contact_uuid
       end
 
       it 'notifies the candidate' do

--- a/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
@@ -3,7 +3,6 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type: :request do
   include_context "logged in DfE user"
-  include_context "stubbed out Gitis"
 
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }
 

--- a/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
@@ -3,7 +3,6 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::PlacementRequests::Acceptance::PreviewConfirmationEmailController, type: :request do
   include_context "logged in DfE user"
-  include_context "stubbed out Gitis"
 
   let!(:booking_profile) { create(:bookings_profile, school: @current_user_school) }
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }

--- a/spec/controllers/schools/placement_requests/acceptance/review_and_send_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/review_and_send_email_controller_spec.rb
@@ -3,7 +3,6 @@ require Rails.root.join('spec', 'controllers', 'schools', 'session_context')
 
 describe Schools::PlacementRequests::Acceptance::ReviewAndSendEmailController, type: :request do
   include_context "logged in DfE user"
-  include_context "stubbed out Gitis"
 
   let!(:booking_profile) { create(:bookings_profile, school: @current_user_school) }
   let!(:pr) { create(:bookings_placement_request, school: @current_user_school) }

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -3,7 +3,6 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesController, type: :request do
   include_context "logged in DfE user"
-  include_context "stubbed out Gitis"
 
   let :school do
     Bookings::School.find_by!(urn: urn).tap do |s|

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -40,6 +40,8 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
     end
 
     context 'when request not already closed' do
+      include_context 'fake gitis'
+
       let :placement_request do
         FactoryBot.create \
           :placement_request, :with_school_cancellation, school: school
@@ -50,7 +52,7 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
       end
 
       let :gitis_contact do
-        Bookings::Gitis::CRM.new('a.fake.token').find placement_request.contact_uuid
+        fake_gitis.find placement_request.contact_uuid
       end
 
       it 'notifies the candidate' do

--- a/spec/factories/bookings/candidates_factory.rb
+++ b/spec/factories/bookings/candidates_factory.rb
@@ -5,5 +5,10 @@ FactoryBot.define do
     trait :confirmed do
       confirmed_at { 5.minutes.ago }
     end
+
+    trait :with_gitis_contact do
+      gitis_contact { build(:gitis_contact, :persisted) }
+      gitis_uuid { gitis_contact.id }
+    end
   end
 end

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
       urn: 11048,
       subject_count: 2
 
+    association :candidate
+
     after :build do |placement_request|
       placement_request.subject_first_choice = placement_request.school.subjects.first.name
       placement_request.subject_second_choice = placement_request.school.subjects.second&.name || "I don't have a second subject"

--- a/spec/factories/bookings/placement_requests_factory.rb
+++ b/spec/factories/bookings/placement_requests_factory.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :bookings_placement_request, class: 'Bookings::PlacementRequest' do
+    association :candidate
+
     objectives { "I want to be a teacher" }
     degree_stage { "Final year" }
     degree_subject { "Bioscience" }

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe Bookings::Candidate, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many :session_tokens }
+    it { is_expected.to have_many :placement_requests }
+    it { is_expected.to have_many :bookings }
   end
 
   describe 'scopes' do

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Bookings::Candidate, type: :model do
 
   describe 'associations' do
     it { is_expected.to have_many :session_tokens }
-    it { is_expected.to have_many :placement_requests }
+    it { is_expected.to have_many(:placement_requests).inverse_of :candidate }
     it { is_expected.to have_many :bookings }
   end
 
@@ -103,6 +103,19 @@ RSpec.describe Bookings::Candidate, type: :model do
       it "will return last confirmed token timestamp" do
         expect(first.candidate.last_signed_in_at.to_i).to eql(second.confirmed_at.to_i)
       end
+    end
+  end
+
+  describe '#fetch_gitis_contact' do
+    let(:gitis) { Bookings::Gitis::CRM.new('a.fake.token') }
+    subject { FactoryBot.create :candidate }
+
+    it "will assign contact" do
+      expect(subject.fetch_gitis_contact(gitis)).to \
+        be_kind_of(Bookings::Gitis::Contact)
+
+      expect(subject.gitis_contact).to be_kind_of(Bookings::Gitis::Contact)
+      expect(subject.contact).to be_kind_of(Bookings::Gitis::Contact)
     end
   end
 end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -107,11 +107,11 @@ RSpec.describe Bookings::Candidate, type: :model do
   end
 
   describe '#fetch_gitis_contact' do
-    let(:gitis) { Bookings::Gitis::CRM.new('a.fake.token') }
+    include_context 'fake gitis'
     subject { FactoryBot.create :candidate }
 
     it "will assign contact" do
-      expect(subject.fetch_gitis_contact(gitis)).to \
+      expect(subject.fetch_gitis_contact(fake_gitis)).to \
         be_kind_of(Bookings::Gitis::Contact)
 
       expect(subject.gitis_contact).to be_kind_of(Bookings::Gitis::Contact)

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -295,4 +295,13 @@ RSpec.describe Bookings::Candidate, type: :model do
       expect(subject.contact).to be_kind_of(Bookings::Gitis::Contact)
     end
   end
+
+  describe "contact accessor attributes" do
+    subject { build :candidate, :with_gitis_contact }
+    it "will be delegated to gitis contact" do
+      is_expected.to have_attributes \
+        full_name: subject.gitis_contact.full_name,
+        email: subject.gitis_contact.email
+    end
+  end
 end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -56,6 +56,34 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
   end
 
+  describe '.find_by_gitis_contact!' do
+    let(:gitis_contact) { build(:gitis_contact, :persisted) }
+
+    context 'with existing Candidate' do
+      let!(:candidate) { create(:candidate, gitis_uuid: gitis_contact.id) }
+
+      subject do
+        Bookings::Candidate.find_or_create_from_gitis_contact! gitis_contact
+      end
+
+      it "return existing candidate" do
+        is_expected.to eql candidate
+      end
+
+      it "will assign gitis_contact" do
+        is_expected.to have_attributes(gitis_contact: gitis_contact)
+      end
+    end
+
+    context 'without existing Candidate' do
+      it "raise record not found" do
+        expect {
+          Bookings::Candidate.find_by_gitis_contact! gitis_contact
+        }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
   describe '.find_or_create_from_gitis_contact!' do
     let(:gitis_contact) { build(:gitis_contact, :persisted) }
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -16,6 +16,7 @@ describe Bookings::PlacementRequest, type: :model do
   it { is_expected.to have_db_column(:availability).of_type(:text).with_options null: true }
   it { is_expected.to have_db_column(:bookings_placement_date_id).of_type(:integer).with_options null: true }
   it { is_expected.to have_db_column(:analytics_tracking_uuid).of_type(:uuid).with_options null: true }
+  it { is_expected.to have_db_column(:candidate_id).of_type(:integer).with_options null: true }
 
   it { is_expected.to have_secure_token }
 
@@ -37,6 +38,8 @@ describe Bookings::PlacementRequest, type: :model do
     it { is_expected.to belong_to(:school).class_name('Bookings::School').with_foreign_key(:bookings_school_id) }
     it { is_expected.to have_one(:booking).class_name('Bookings::Booking').with_foreign_key(:bookings_placement_request_id) }
     it { is_expected.to belong_to(:placement_date).class_name('Bookings::PlacementDate').with_foreign_key(:bookings_placement_date_id).optional }
+
+    it { is_expected.to belong_to(:candidate).class_name('Bookings::Candidate').with_foreign_key(:candidate_id).optional }
   end
 
   it { is_expected.to respond_to :sent_at }

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -459,11 +459,11 @@ describe Bookings::PlacementRequest, type: :model do
   end
 
   describe '#fetch_gitis_contact' do
-    let(:gitis) { Bookings::Gitis::CRM.new('a.fake.token') }
+    include_context 'fake gitis'
     subject { FactoryBot.create :placement_request }
 
     it "will assign contact" do
-      expect(subject.fetch_gitis_contact(gitis)).to \
+      expect(subject.fetch_gitis_contact(fake_gitis)).to \
         be_kind_of(Bookings::Gitis::Contact)
 
       expect(subject.gitis_contact).to be_kind_of(Bookings::Gitis::Contact)

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -20,6 +20,22 @@ describe Bookings::PlacementRequest, type: :model do
 
   it { is_expected.to have_secure_token }
 
+  describe 'candidate requirement' do
+    it { is_expected.to validate_presence_of :candidate }
+
+    context 'with legacy record' do
+      subject { create(:placement_request) }
+      before { subject.update_columns(candidate_id: nil) }
+      before { subject.reload }
+      it { is_expected.to be_valid }
+    end
+
+    context 'before phase3' do
+      before { allow(Rails.application.config.x).to receive(:phase).and_return(2) }
+      it { is_expected.not_to validate_presence_of :candidate }
+    end
+  end
+
   context 'relationships' do
     it do
       is_expected.to \
@@ -39,7 +55,10 @@ describe Bookings::PlacementRequest, type: :model do
     it { is_expected.to have_one(:booking).class_name('Bookings::Booking').with_foreign_key(:bookings_placement_request_id) }
     it { is_expected.to belong_to(:placement_date).class_name('Bookings::PlacementDate').with_foreign_key(:bookings_placement_date_id).optional }
 
-    it { is_expected.to belong_to(:candidate).class_name('Bookings::Candidate').with_foreign_key(:candidate_id).optional }
+    it do
+      is_expected.to belong_to(:candidate).class_name('Bookings::Candidate').\
+        with_foreign_key(:candidate_id).without_validating_presence
+    end
   end
 
   it { is_expected.to respond_to :sent_at }
@@ -71,6 +90,8 @@ describe Bookings::PlacementRequest, type: :model do
   end
 
   context '.create_from_registration_session' do
+    let(:candidate) { create(:candidate) }
+
     context 'invalid session' do
       let :invalid_session do
         Candidates::Registrations::RegistrationSession.new \
@@ -83,7 +104,8 @@ describe Bookings::PlacementRequest, type: :model do
 
       it 'raises a validation error' do
         expect {
-          described_class.create_from_registration_session! invalid_session
+          candidate.placement_requests.create_from_registration_session! \
+            invalid_session
         }.to raise_error ActiveRecord::RecordInvalid
       end
     end
@@ -97,7 +119,8 @@ describe Bookings::PlacementRequest, type: :model do
 
       it 'creates the placement request' do
         expect {
-          described_class.create_from_registration_session! registration_session
+          candidate.placement_requests.create_from_registration_session! \
+            registration_session
         }.to change { described_class.count }.by 1
       end
     end
@@ -112,7 +135,8 @@ describe Bookings::PlacementRequest, type: :model do
       end
 
       subject do
-        described_class.create_from_registration_session! registration_session, analytics_tracking_uuid
+        candidate.placement_requests.create_from_registration_session! \
+          registration_session, analytics_tracking_uuid
       end
 
       specify 'it stores the analytics_tracking_uuid correctly if supplied' do

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::RegistrationContactMapper do
+  describe ".new" do
+    let(:registration) { build(:registration_session) }
+    let(:contact) { Bookings::Gitis::Contact.new }
+    subject { described_class.new(registration, contact) }
+
+    it { is_expected.to have_attributes(registration_session: registration) }
+    it { is_expected.to have_attributes(gitis_contact: contact) }
+  end
+
+  describe "#registration_to_contact" do
+    let(:registration) { build(:registration_session) }
+    let(:contact) { Bookings::Gitis::Contact.new }
+    let(:mapper) { described_class.new(registration, contact) }
+    subject { mapper.registration_to_contact }
+
+    it { is_expected.to have_attributes(firstname: registration.personal_information.first_name) }
+    it { is_expected.to have_attributes(lastname: registration.personal_information.last_name) }
+    it { is_expected.to have_attributes(email: registration.personal_information.email) }
+    it "needs to compare date of birth when that is merged in"
+    it { is_expected.to have_attributes(phone: registration.contact_information.phone) }
+    it { is_expected.to have_attributes(building: registration.contact_information.building) }
+    it { is_expected.to have_attributes(street: registration.contact_information.street) }
+    it { is_expected.to have_attributes(town_or_city: registration.contact_information.town_or_city) }
+    it { is_expected.to have_attributes(county: registration.contact_information.county) }
+    it { is_expected.to have_attributes(postcode: registration.contact_information.postcode) }
+    it "should copy more attributes over"
+  end
+
+  describe "#contact_to_registration" do
+    it "will be written"
+  end
+end

--- a/spec/models/candidates/session_spec.rb
+++ b/spec/models/candidates/session_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Candidates::Session, type: :model do
-  let(:gitis) { Bookings::Gitis::CRM.new('a-token') }
+  include_context 'fake gitis'
   let(:candidate) { create(:candidate) }
   let(:attrs) do
     {
@@ -23,7 +23,7 @@ RSpec.describe Candidates::Session, type: :model do
 
   describe '.new' do
     context 'with crm instance' do
-      subject { described_class.new(gitis) }
+      subject { described_class.new(fake_gitis) }
       it "will return instance" do
         is_expected.to be_kind_of Candidates::Session
       end
@@ -37,7 +37,7 @@ RSpec.describe Candidates::Session, type: :model do
   end
 
   describe 'validates' do
-    subject { described_class.new(gitis) }
+    subject { described_class.new(fake_gitis) }
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_presence_of(:firstname) }
     it { is_expected.to validate_presence_of(:lastname) }
@@ -73,14 +73,14 @@ RSpec.describe Candidates::Session, type: :model do
   end
 
   describe '#create_signin_token' do
-    subject { described_class.new(gitis, login_attrs) }
+    subject { described_class.new(fake_gitis, login_attrs) }
 
     context 'with known candidate' do
       let(:existing_attrs) { attrs.merge('contactid' => candidate.gitis_uuid) }
       let(:existing_contact) { Bookings::Gitis::Contact.new(existing_attrs) }
 
       before do
-        expect(gitis).to receive(:find_contact_for_signin).and_return(existing_contact)
+        expect(fake_gitis).to receive(:find_contact_for_signin).and_return(existing_contact)
         @token = subject.create_signin_token
       end
 
@@ -99,7 +99,7 @@ RSpec.describe Candidates::Session, type: :model do
 
       context 'who exists in Gitis' do
         before do
-          expect(gitis).to receive(:find_contact_for_signin).and_return(new_contact)
+          expect(fake_gitis).to receive(:find_contact_for_signin).and_return(new_contact)
           @token = subject.create_signin_token
         end
 
@@ -115,7 +115,7 @@ RSpec.describe Candidates::Session, type: :model do
 
       context 'who does not exist in Gitis' do
         before do
-          expect(gitis).to receive(:find_contact_for_signin).and_return(false)
+          expect(fake_gitis).to receive(:find_contact_for_signin).and_return(false)
           @token = subject.create_signin_token
         end
 

--- a/spec/models/candidates/session_token_spec.rb
+++ b/spec/models/candidates/session_token_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Candidates::SessionToken, type: :model do
   describe 'database structure' do
     it { is_expected.to have_db_column(:token).of_type(:string).with_options(null: false) }
     it { is_expected.to have_db_index(:token).unique }
+    it { is_expected.to have_secure_token }
   end
 
   describe 'associations' do

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateBookingConfirmation do
-  include_context "stubbed out Gitis"
-
   it_should_behave_like "email template", "29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3",
     school_name: "Springfield Elementary",
     candidate_name: "Kearney Zzyzwicz",

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -53,19 +53,6 @@ describe Bookings::Gitis::CRM, type: :model do
       end
     end
 
-    context 'with multiple account_ids' do
-      before { gitis_stub.stub_multiple_contact_request(uuids) }
-      subject { gitis.find(*uuids) }
-
-      it "will return an account per id" do
-        is_expected.to have_attributes(length: 3)
-        is_expected.to all be_instance_of(Bookings::Gitis::Contact)
-        subject.each_with_index do |contact, index|
-          expect(contact.id).to eq(uuids[index])
-        end
-      end
-    end
-
     context 'with array of account_ids' do
       before { gitis_stub.stub_multiple_contact_request(uuids) }
       subject { gitis.find(uuids) }

--- a/spec/support/fake_gitis.rb
+++ b/spec/support/fake_gitis.rb
@@ -6,4 +6,16 @@ shared_context "fake gitis" do
 
     Bookings::Gitis::CRM.new('a.fake.token')
   end
+
+  before { allow(Bookings::Gitis::CRM).to receive(:new).and_return(fake_gitis) }
+end
+
+shared_context "fake gitis with known uuid" do
+  include_context 'fake gitis'
+
+  let(:fake_gitis_uuid) { SecureRandom.uuid }
+
+  before do
+    allow(fake_gitis).to receive(:fake_contact_id).and_return(fake_gitis_uuid)
+  end
 end

--- a/spec/support/fake_gitis.rb
+++ b/spec/support/fake_gitis.rb
@@ -1,0 +1,9 @@
+shared_context "fake gitis" do
+  let(:fake_gitis) do
+    unless Bookings::Gitis::CRM < Bookings::Gitis::FakeCrm
+      raise "Not running with FakeCrm"
+    end
+
+    Bookings::Gitis::CRM.new('a.fake.token')
+  end
+end


### PR DESCRIPTION
### Context

The Candidate Journey with unknown Candidates should create Candidate records and associate the PlacementRequest with them.

### Changes proposed in this pull request

1. If not logged in, create a new Contact in Gitis CRM
2. Create a Candidate pointing to that Gitis entity
3. Made Placement Requests require a Candidate
4. Made candidates responsible for loading in Gitis Contact data

### Guidance to review
1. Walk through the candidate journey, this should be possible without anything clever since the dev environment will rely upon FakeCrm
2. General code review the code, eg logic errors, style errors
3. Last commit may be controversial - I'm setting a `default_scope` on PlacementRequest - open to opinions on this. My take is there's no reason to access the legacy data at this point but the alternative is a scope and updating Schools::PlacementRequests controller to use it. Feels like something someone may miss in the future though.

Note - I've merged in the Candidate associate branch since I'd needed those changes in this, hence why they're showing up again in the diff 