### PR TITLE
Update copy, replace 'reject' with 'cancel'

### DIFF
--- a/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">
-        Review and send rejection email to candidate
+        Review and send cancellation email to candidate
       </h1>
 
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
@@ -33,11 +33,11 @@
 
           <section>
             <p>
-              <%= f.submit 'Preview rejection email' %>
+              <%= f.submit 'Preview cancellation email' %>
             </p>
 
             <p>
-              <%= link_to 'Back to request', schools_placement_request_path(cancellation.placement_request) %>
+              <%= link_to 'Back to booking', schools_booking_path(@booking) %>
             </p>
           </section>
         </div>

--- a/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
@@ -5,7 +5,7 @@
     </h2>
 
     <p>
-      <%= cancellation.school_name %> has turned down your school experience request for the following dates:
+      <%= cancellation.school_name %> has cancelled your school experience booking for the following dates:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
@@ -15,7 +15,7 @@
 
   <section id="rejection-details">
     <h3 class="govuk-heading-s">
-      Your request was turned down for the following reasons:
+      Your booking was cancelled for the following reasons:
     </h3>
     <p>
       <%= reason %>
@@ -39,7 +39,7 @@
     </h3>
 
     <p>
-      Apply for school experience at other schools -
+      Request school experience at other schools -
       <%= link_to "Find school experience.", new_candidates_school_search_path %>
     </p>
   </section>

--- a/app/views/schools/confirmed_bookings/cancellations/notification_deliveries/show.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/notification_deliveries/show.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        Your email has been sent
+        Your cancellation email has been sent
       </h1>
     </div>
     <h2 class="govuk-heading-m">

--- a/app/views/schools/confirmed_bookings/cancellations/show.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/show.html.erb
@@ -1,16 +1,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Send rejection email to candidate
+      Review and send cancellation email to candidate
     </h1>
 
     <p>
-      The following contains the wording of the rejection email which will be
+      The following contains the wording of the cancellation email which will be
       sent to <%= @cancellation.candidate_name %>.
     </p>
 
     <h2 class="govuk-heading-m">
-      Preview rejection email
+      Preview cancellation email
     </h2>
 
     <%= render partial: "letter", locals: {
@@ -25,14 +25,14 @@
       </p>
 
       <p>
-        <%= button_to 'Send rejection email',
+        <%= button_to 'Send cancellation email',
           schools_booking_cancellation_notification_delivery_path(@booking),
           class: 'govuk-button'
         %>
       </p>
 
       <p>
-        <%= link_to 'Amend the rejection email', edit_schools_booking_cancellation_path(@booking) %>
+        <%= link_to 'Edit cancellation email', edit_schools_booking_cancellation_path(@booking) %>
       </p>
 
       <p>

--- a/features/schools/confirmed_bookings/cancelling.feature
+++ b/features/schools/confirmed_bookings/cancelling.feature
@@ -10,7 +10,7 @@ Feature: Cancelling bookings
     Scenario: Page heading
         Given there is at least one booking
         When I am on the cancel booking page
-        Then the page's main heading should be 'Review and send rejection email to candidate'
+        Then the page's main heading should be 'Review and send cancellation email to candidate'
 
     Scenario: Reject information
         Given there is at least one booking
@@ -21,7 +21,7 @@ Feature: Cancelling bookings
         """
         And the following text should be present:
         """
-        has turned down your school experience request for the following dates:
+        has cancelled your school experience booking for the following dates:
         """
 
     Scenario: Reject information
@@ -37,12 +37,17 @@ Feature: Cancelling bookings
         When I am on the cancel booking page
         Then there should be a 'Cancellation reasons' text area
         And there should be a 'Extra details' text area
-        And the submit button should contain text 'Preview rejection email'
+        And the submit button should contain text 'Preview cancellation email'
 
     Scenario: Rejecting the requests
         Given there is at least one booking
         And I am on the cancel booking page
         And I have entered a reason in the cancellation reasons text area
         And I have entered a extra details in the extra details text area
-        When I click the 'Preview rejection email' button
+        When I click the 'Preview cancellation email' button
         Then I should see a preview of what I have entered
+
+    Scenario: Sending the email
+        Given I have progressed to the cancellation email preview page
+        When I click the 'Send cancellation email' submit button
+        Then I should see a 'Your cancellation email has been sent' confirmation

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -114,6 +114,10 @@ When("I enter {string} into the {string} text area") do |value, label|
   fill_in label, with: value
 end
 
+When("I click the {string} submit button") do |string|
+  page.find("input[value='#{string}']").click
+end
+
 LABEL_SELECTORS = %w(.govuk-label legend label).freeze
 def get_form_group(page, label_text)
   selector = LABEL_SELECTORS.detect do |s|

--- a/features/step_definitions/schools/bookings/cancellation_steps.rb
+++ b/features/step_definitions/schools/bookings/cancellation_steps.rb
@@ -3,3 +3,21 @@ When("I am on the cancel booking page") do
   visit(path)
   expect(page.current_path).to eql(path)
 end
+
+Given("I have progressed to the cancellation email preview page") do
+  steps %(
+    Given there is at least one booking
+    And I am on the cancel booking page
+    And I have entered a reason in the cancellation reasons text area
+    And I have entered a extra details in the extra details text area
+    When I click the 'Preview cancellation email' button
+    Then I should see a preview of what I have entered
+  )
+end
+
+Then("I should see a {string} confirmation") do |string|
+  expect(page).to have_css(
+    '.govuk-panel.govuk-panel--confirmation',
+    text: string
+  )
+end


### PR DESCRIPTION
### Context

Booking cancellation screens used the wrong wording, 'rejection' instead of 'cancellation'

### Changes proposed in this pull request

Replace incorrect words, plus add a couple of extra tests

### Guidance to review

Ensure everything looks sensible
