### PR TITLE
Feature/add placement request acceptance confirmation page se 1244

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance.rb
+++ b/app/controllers/schools/placement_requests/acceptance.rb
@@ -1,0 +1,22 @@
+module Schools
+  module PlacementRequests
+    module Acceptance
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :set_placement_request
+        before_action :fetch_gitis_contact_for_placement_request
+      end
+
+      def set_placement_request
+        @placement_request = @current_school
+          .bookings_placement_requests
+          .find(params[:placement_request_id])
+      end
+
+      def fetch_gitis_contact_for_placement_request
+        @placement_request.fetch_gitis_contact gitis_crm
+      end
+    end
+  end
+end

--- a/app/controllers/schools/placement_requests/acceptance/add_more_details_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/add_more_details_controller.rb
@@ -2,7 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class AddMoreDetailsController < Schools::BaseController
-        before_action :set_placement_request
+        include Acceptance
         before_action :ensure_previous_step_complete
 
         def new
@@ -31,12 +31,6 @@ module Schools
         end
 
       private
-
-        def set_placement_request
-          @placement_request = @current_school
-            .bookings_placement_requests
-            .find(params[:placement_request_id])
-        end
 
         def ensure_previous_step_complete
           unless @placement_request.booking.booking_confirmed?

--- a/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
@@ -2,7 +2,8 @@ module Schools
   module PlacementRequests
     module Acceptance
       class ConfirmBookingController < Schools::BaseController
-        before_action :set_placement_request, :set_available_subjects
+        include Acceptance
+        before_action :set_available_subjects
 
         def new
           subject_id = Bookings::Subject.find_by(name: @placement_request.subject_first_choice).id
@@ -46,12 +47,6 @@ module Schools
           params
             .require(:schools_placement_requests_confirm_booking)
             .permit(:bookings_subject_id, :date, :placement_details)
-        end
-
-        def set_placement_request
-          @placement_request = @current_school
-            .bookings_placement_requests
-            .find(params[:placement_request_id])
         end
 
         def set_available_subjects

--- a/app/controllers/schools/placement_requests/acceptance/email_sent_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/email_sent_controller.rb
@@ -1,0 +1,31 @@
+module Schools
+  module PlacementRequests
+    module Acceptance
+      class EmailSentController < Schools::BaseController
+        before_action :set_placement_request
+        before_action :fetch_gitis_contact_for_placement_request
+        before_action :ensure_previous_step_complete
+
+        def show; end
+
+      private
+
+        def ensure_previous_step_complete
+          unless @placement_request.booking.accepted?
+            redirect_to new_schools_placement_request_acceptance_review_and_send_email_path(@placement_request.id)
+          end
+        end
+
+        def set_placement_request
+          @placement_request = @current_school
+            .bookings_placement_requests
+            .find(params[:placement_request_id])
+        end
+
+        def fetch_gitis_contact_for_placement_request
+          @placement_request.fetch_gitis_contact gitis_crm
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/schools/placement_requests/acceptance/email_sent_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/email_sent_controller.rb
@@ -2,8 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class EmailSentController < Schools::BaseController
-        before_action :set_placement_request
-        before_action :fetch_gitis_contact_for_placement_request
+        include Acceptance
         before_action :ensure_previous_step_complete
 
         def show; end
@@ -14,16 +13,6 @@ module Schools
           unless @placement_request.booking.accepted?
             redirect_to new_schools_placement_request_acceptance_review_and_send_email_path(@placement_request.id)
           end
-        end
-
-        def set_placement_request
-          @placement_request = @current_school
-            .bookings_placement_requests
-            .find(params[:placement_request_id])
-        end
-
-        def fetch_gitis_contact_for_placement_request
-          @placement_request.fetch_gitis_contact gitis_crm
         end
       end
     end

--- a/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
@@ -12,7 +12,7 @@ module Schools
           booking = @placement_request.booking
 
           if booking.update(accepted_at: Time.now) && candidate_booking_notification(booking).despatch_later!
-            redirect_to schools_placement_requests_path
+            redirect_to schools_placement_request_acceptance_email_sent_path(@placement_request.id)
           else
             render :new
           end

--- a/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
@@ -2,8 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class PreviewConfirmationEmailController < Schools::BaseController
-        before_action :set_placement_request
-        before_action :fetch_gitis_contact_for_placement_request
+        include Acceptance
         before_action :ensure_previous_step_complete
 
         def new; end
@@ -29,16 +28,6 @@ module Schools
         def candidate_booking_notification(booking)
           NotifyEmail::CandidateBookingConfirmation
             .from_booking(booking.candidate_email, booking.candidate_name, booking, candidates_cancel_url(booking.token))
-        end
-
-        def set_placement_request
-          @placement_request = @current_school
-            .bookings_placement_requests
-            .find(params[:placement_request_id])
-        end
-
-        def fetch_gitis_contact_for_placement_request
-          @placement_request.fetch_gitis_contact gitis_crm
         end
       end
     end

--- a/app/controllers/schools/placement_requests/acceptance/review_and_send_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/review_and_send_email_controller.rb
@@ -2,8 +2,7 @@ module Schools
   module PlacementRequests
     module Acceptance
       class ReviewAndSendEmailController < Schools::BaseController
-        before_action :set_placement_request
-        before_action :fetch_gitis_contact_for_placement_request
+        include Acceptance
         before_action :ensure_previous_step_complete
 
         def new
@@ -32,16 +31,6 @@ module Schools
           unless @placement_request.booking.more_details_added?
             redirect_to new_schools_placement_request_acceptance_add_more_details_path(@placement_request.id)
           end
-        end
-
-        def set_placement_request
-          @placement_request = @current_school
-            .bookings_placement_requests
-            .find(params[:placement_request_id])
-        end
-
-        def fetch_gitis_contact_for_placement_request
-          @placement_request.fetch_gitis_contact gitis_crm
         end
       end
     end

--- a/app/views/schools/placement_requests/acceptance/email_sent/show.html.erb
+++ b/app/views/schools/placement_requests/acceptance/email_sent/show.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Your email has been sent
+      </h1>
+    </div>
+    <div>
+      <h3>What happens next</h3>
+
+      <p>
+        We’ve sent your confirmation to
+        <%= @placement_request.gitis_contact.full_name %>
+      </p>
+      <p>
+        They’ve been told to arrive at your school on the date and time you
+        specified.
+      </p>
+
+      <%= link_to 'Return to requets and bookings', schools_dashboard_path, class: 'govuk-button govuk-button--secondary' %>
+    </div>
+  </div>
+</div>

--- a/app/views/schools/placement_requests/acceptance/email_sent/show.html.erb
+++ b/app/views/schools/placement_requests/acceptance/email_sent/show.html.erb
@@ -17,7 +17,7 @@
         specified.
       </p>
 
-      <%= link_to 'Return to requets and bookings', schools_dashboard_path, class: 'govuk-button govuk-button--secondary' %>
+      <%= link_to 'Return to requests and bookings', schools_dashboard_path, class: 'govuk-button govuk-button--secondary' %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Rails.application.routes.draw do
             resource :preview_confirmation_email,
               only: [:new, :create],
               controller: '/schools/placement_requests/acceptance/preview_confirmation_email'
+            resource :email_sent,
+              only: [:show],
+              controller: '/schools/placement_requests/acceptance/email_sent'
           end
           collection do
             resources :upcoming, only: :index, controller: 'placement_requests/upcoming', as: 'upcoming_requests'

--- a/features/schools/placement_requests/acceptance/email_sent.feature
+++ b/features/schools/placement_requests/acceptance/email_sent.feature
@@ -1,0 +1,18 @@
+Feature: Viewing my sent receipt
+    So I can be confident that my email has been sent
+    As a school administrator
+    I want to see a receipt stating that it was successful
+
+    Background:
+        Given I am logged in as a DfE user
+        And the subjects 'Biology' and 'Chemistry' exist
+        And there is a new placement request
+        And I have completed the 'confirm booking' page
+        And I have completed the 'add more details' page
+        And I have completed the 'review and send email' page
+        And I have completed the 'preview confirmation email' page
+
+    Scenario: Page contents
+        Given I have progressed to the 'email sent' page for my chosen placement request
+        Then I should see a panel stating 'Your email has been sent'
+        And there should be a 'Return to requests and bookings' link to the 'schools dashboard'

--- a/features/schools/placement_requests/acceptance/preview_confirmation_email.feature
+++ b/features/schools/placement_requests/acceptance/preview_confirmation_email.feature
@@ -59,5 +59,5 @@ Feature: Accepting placement requests
         Given I have progressed to the 'preview confirmation email' page for my chosen placement request
         And I think the email looks good
         When I click the 'Send confirmation email' button
-        Then I should be on the 'placement requests' page
+        Then I should be on the 'email sent' page for my chosen placement request
         And the placement request should be accepted

--- a/features/step_definitions/schools/placement_requests/email_sent_steps.rb
+++ b/features/step_definitions/schools/placement_requests/email_sent_steps.rb
@@ -1,0 +1,9 @@
+Given("I have completed the 'preview confirmation email' page") do
+  click_button 'Send confirmation email'
+end
+
+Then("I should see a panel stating {string}") do |string|
+  within('.govuk-panel') do
+    expect(page).to have_content(string)
+  end
+end

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -29,6 +29,7 @@ def path_for(descriptor, school: nil, placement_date_id: nil, booking_id: nil, p
     "add more details" => [:new_schools_placement_request_acceptance_add_more_details_path, placement_request],
     "review and send email" => [:new_schools_placement_request_acceptance_review_and_send_email_path, placement_request],
     "preview confirmation email" => [:new_schools_placement_request_acceptance_preview_confirmation_email_path, placement_request],
+    "email sent" => [:schools_placement_request_acceptance_email_sent_path, placement_request],
     "reject placement request" => [:new_schools_placement_request_cancellation_path, placement_request&.id],
     "candidate requirements" => [:new_schools_on_boarding_candidate_requirement_path],
     "fees charged" => [:new_schools_on_boarding_fees_path],

--- a/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
@@ -53,7 +53,7 @@ describe Schools::PlacementRequests::Acceptance::PreviewConfirmationEmailControl
     end
 
     specify 'should be redirected to the placement requests index' do
-      expect(response).to redirect_to schools_placement_requests_path
+      expect(response).to redirect_to schools_placement_request_acceptance_email_sent_path(pr.id)
     end
   end
 end


### PR DESCRIPTION
### Context

The email sent screen was missing from the original placement request acceptance flow

### Changes proposed in this pull request

Add the missing screen!

### Guidance to review

Ensure everything looks sensible.
