### PR TITLE
Hide the bookings table if no bookings for school

### DIFF
--- a/app/views/schools/confirmed_bookings/index.html.erb
+++ b/app/views/schools/confirmed_bookings/index.html.erb
@@ -19,18 +19,25 @@
       You'll need to refer to <strong>your own records</strong> for any bookings made before this date.
     </p>
 
-    <div class="pagination-info higher">
-      <div class="pagination-slice">
-        <%= page_entries_info @bookings %>
+    <% if @bookings.any? %>
+      <div class="pagination-info higher">
+        <div class="pagination-slice">
+          <%= page_entries_info @bookings %>
+        </div>
+        <%= paginate @bookings %>
       </div>
-      <%= paginate @bookings %>
-    </div>
 
-    <%= render partial: 'schools/confirmed_bookings/booking_table', locals: { bookings: @bookings } %>
+      <%= render partial: 'schools/confirmed_bookings/booking_table', locals: { bookings: @bookings } %>
 
-    <div class="pagination-info lower">
-      <%= paginate @bookings %>
-    </div>
+      <div class="pagination-info lower">
+        <%= paginate @bookings %>
+      </div>
+
+    <% else %>
+      <p>
+        There are no bookings.
+      </p>
+    <% end %>
 
     <div>
       <%= link_to "Return to requests and bookings", schools_dashboard_path, class: 'govuk-button govuk-button--secondary' %>

--- a/features/schools/confirmed_bookings/index.feature
+++ b/features/schools/confirmed_bookings/index.feature
@@ -41,3 +41,9 @@ Feature: Viewing all bookings
         Given there are some bookings
         When I am on the 'bookings' page
         Then every booking should contain a link to view more details
+
+    Scenario:
+        Given there are no bookings
+        When I am on the 'bookings' page
+        Then I should see the text 'There are no bookings'
+        And I should not see the bookings table

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -134,3 +134,15 @@ Then("the non-upcoming bookings shouldn't") do
     end
   end
 end
+
+Given("there are no bookings") do
+  # do nothing
+end
+
+Then("I should see the text {string}") do |string|
+  expect(page).to have_text string
+end
+
+Then("I should not see the bookings table") do
+  expect(page).not_to have_css('table#bookings')
+end


### PR DESCRIPTION
### Context
Showing the table when there are no bookings looks odd

### Changes proposed in this pull request
Hide the table when the school has no bookings

### Guidance to review
Table should be hidden when there are no bookings.
