### PR TITLE
Removed use of class vars for controlling Notify client

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -5,23 +5,11 @@ class Notify
 
   class RetryableError < ArgumentError; end
 
-  # rubocop:disable Style/ClassVars
-  # Rubocop complains about classvars as they're inherited by subclasses,
-  # in this case that is the behaviour we want.
   class << self
     def notification_class
-      if class_variable_defined?(:@@notification_class) && @@notification_class
-        @@notification_class
-      else
-        Notifications::Client
-      end
-    end
-
-    def notification_class=(klass)
-      @@notification_class = klass
+      Rails.application.config.x.notify_client || Notifications::Client
     end
   end
-  # rubocop:enable Style/ClassVars
 
   def initialize(to:)
     self.to = to

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # Override production environment settings here
 
   # Don't actually attempt to delivery emails in Staging environment
-  Notify.notification_class = NotifyFakeClient
+  config.x.notify_client = NotifyFakeClient
 
   # default to true but allow overriding in CI
   config.force_ssl = !ENV['SKIP_FORCE_SSL'].present?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,7 +58,7 @@ Rails.application.configure do
   end
 
   # Don't actually attempt to delivery emails during tests
-  Notify.notification_class = NotifyFakeClient
+  config.x.notify_client = NotifyFakeClient
 
   config.x.phase = 10000
 

--- a/spec/notify/notify_spec.rb
+++ b/spec/notify/notify_spec.rb
@@ -24,10 +24,8 @@ describe Notify do
 
   describe 'Initialization' do
     before do
-      @orig_notification_class = Notify.notification_class
-      Notify.notification_class = nil
+      allow(Rails.application.config.x).to receive(:notify_client).and_return nil
     end
-    after { Notify.notification_class = @orig_notification_class }
 
     specify 'should assign email address' do
       expect(subject.to).to eql(to)
@@ -81,11 +79,10 @@ describe Notify do
     end
 
     before do
-      Notify.notification_class = NotifyFakeClient
+      allow(Rails.application.config.x).to receive(:notify_client).and_return NotifyFakeClient
+
       NotifyFakeClient.reset_deliveries!
     end
-
-    after { Notify.notification_class = nil }
 
     describe '#despatch!' do
       subject { StubNotification.new(to: 'test@user.com', name: 'Test User') }


### PR DESCRIPTION
### Context

Configuring the fake notify client has been triggering some odd behaviour in tests launched via Spring, easiest solution seems to be to use `Rails.application.config` and move the configuration aspect
entirely outside the class.

### Changes proposed in this pull request

Use `Rails.application.config.x.notify_client` to control the class used for sending messages via Notify

### Guidance to review

Does it seem like a good idea? Does it cause issues for anyone else. Seems to be more reliable for me.

