### PR TITLE
Fixed bug in notify refactor

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -7,7 +7,7 @@ class Notify
 
   class << self
     def notification_class
-      Rails.application.config.x.notify_client || Notifications::Client
+      Rails.application.config.x.notify_client.presence || Notifications::Client
     end
   end
 


### PR DESCRIPTION
### Context

Notify client access is broken in `development` and `production` (unreleased so far)

### Changes proposed in this pull request

Didn't allow for Rails.config.x returning a hash when unset instead of a Nil


