### PR TITLE
Assign default value for channel creation

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -3,8 +3,8 @@ module Bookings
     class Contact
       include Entity
 
-      # Call pot in Gitis to instert the record into
-      CHANNEL_CREATION = ENV.fetch('CRM_CHANNEL_CREATION', nil)
+      # Call pot in Gitis to insert the record into
+      CHANNEL_CREATION = ENV['CRM_CHANNEL_CREATION'].presence || 0
 
       # Status of record within Gitis
       STATE_CODE = 0


### PR DESCRIPTION
### Context

The epic branch is currently broken because `DEFAULT_CHANNEL_CREATION` is not getting set to anything.

### Changes proposed in this pull request

1. Set it to an arbitrary default value of 0



