### PR TITLE
Updated Personal Information and Sign In screen content

### DIFF
--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -15,7 +15,7 @@
           <%= f.text_field :first_name, autocomplete: 'given-name' %>
           <%= f.text_field :last_name, autocomplete: 'family-name' %>
           <%= f.email_field :email, autocomplete: 'on' %>
-          <%= f.date_field :date_of_birth, autocomplete: 'bday', heading: true %>
+          <%= f.date_field :date_of_birth, heading: true %>
 
           <%= f.submit 'Continue' %>
         <% end %>

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -2,12 +2,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Enter your personal details</h1>
+    <h1 class="govuk-heading-l">Check if we already have your details</h1>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
-          Your details will be used by schools to contact you about school
-          experience once you’ve sent them a request.
+          Provide the following information so we can check if we already have your details.
         </p>
 
         <%= form_for personal_information, url: candidates_school_registrations_personal_information_path do |f| %>

--- a/app/views/candidates/sessions/new.html.erb
+++ b/app/views/candidates/sessions/new.html.erb
@@ -16,7 +16,7 @@
       <%= f.email_field :email, autocomplete: 'on', class: 'govuk-input govuk-input--width-30' %>
       <%= f.text_field :firstname, autocomplete: 'given-name', class: 'govuk-input govuk-input--width-20' %>
       <%= f.text_field :lastname, autocomplete: 'family-name', class: 'govuk-input govuk-input--width-20' %>
-      <%= f.date_field :date_of_birth %>
+      <%= f.date_field :date_of_birth, autocomplete: 'bday', heading: true %>
 
       <%= f.submit 'Sign in' %>
     <% end %>

--- a/app/views/candidates/sessions/new.html.erb
+++ b/app/views/candidates/sessions/new.html.erb
@@ -16,7 +16,7 @@
       <%= f.email_field :email, autocomplete: 'on', class: 'govuk-input govuk-input--width-30' %>
       <%= f.text_field :firstname, autocomplete: 'given-name', class: 'govuk-input govuk-input--width-20' %>
       <%= f.text_field :lastname, autocomplete: 'family-name', class: 'govuk-input govuk-input--width-20' %>
-      <%= f.date_field :date_of_birth, autocomplete: 'bday', heading: true %>
+      <%= f.date_field :date_of_birth, heading: true %>
 
       <%= f.submit 'Sign in' %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -295,6 +295,8 @@ en:
       phases: Select all that apply
       max_fee: Schools may charge
       subjects: Select all that apply
+      candidates_registrations_personal_information:
+        date_of_birth: This will only be used to identify you and won’t be shared with any schools. For example, 12 11 2007
       candidates_registrations_subject_preference:
         degree_subject: Select the nearest or equivalent subject.
       candidates_registrations_placement_preference:
@@ -311,6 +313,8 @@ en:
         objectives:
           - Provide a short explanation about what you want to gain from your placement.
           - This will help the school see if it can offer you the kind of placement you’re looking for.
+      candidates_session:
+        date_of_birth: This will only be used to identify you and won’t be shared with any schools. For example, 12 11 2007
       schools_on_boarding_candidate_experience_detail:
         disabled_facilities: 'For example, disabled parking spaces and support for autistic spectrum disorders, dyslexia and hearing impairments'
       schools_on_boarding_experience_outline:

--- a/features/candidates/registrations/personal_information.feature
+++ b/features/candidates/registrations/personal_information.feature
@@ -5,8 +5,8 @@ Feature: Personal Information
 
     Scenario: Page contents
         Given I am on the 'Enter your personal details' page for my school of choice
-        Then the page's main header should be 'Enter your personal details'
-        And I should see a paragraph informing me that my details will be used by schools to contact me
+        Then the page's main header should be 'Check if we already have your details'
+        And I should see a paragraph informing me that my details will be used to identify me
 
     Scenario: Form contents
         Given I am on the 'Enter your personal details' page for my school of choice

--- a/features/step_definitions/candidates/registrations/personal_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/personal_information_steps.rb
@@ -1,0 +1,6 @@
+Then("I should see a paragraph informing me that my details will be used to identify me") do
+  within('#main-content') do
+    expect(page).to have_content \
+      "Provide the following information so we can check if we already have your details."
+  end
+end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -128,7 +128,7 @@ feature 'Candidate Registrations', type: :feature do
   def complete_personal_information_step
     # Begin wizard journey
     visit "/candidates/schools/#{school_urn}/registrations/personal_information/new"
-    expect(page).to have_text 'Enter your personal details'
+    expect(page).to have_text 'Check if we already have your details'
 
     # Submit personal information form with errors
     fill_in 'First name', with: 'testy'


### PR DESCRIPTION
### Context

Some of the content on the Personal Information screen needs to make clear how the information will be used

### Changes proposed in this pull request

1. Updated the content on the Personal Information step
2. Updated the content on the Sign In screen


