### PR TITLE
SE-1257 Feature flag phase3 work

### DIFF
--- a/app/controllers/candidates/registrations/confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/confirmation_emails_controller.rb
@@ -13,7 +13,7 @@ module Candidates
         if @privacy_policy.not_accepted?
           @application_preview = ApplicationPreview.new current_registration
           render 'candidates/registrations/application_previews/show'
-        elsif candidate_signed_in?
+        elsif gitis_integration? && candidate_signed_in?
           RegistrationStore.instance.store! current_registration
           redirect_to candidates_confirm_path uuid: current_registration.uuid
         else

--- a/app/controllers/candidates/registrations/contact_informations_controller.rb
+++ b/app/controllers/candidates/registrations/contact_informations_controller.rb
@@ -7,6 +7,7 @@ module Candidates
 
       def create
         @contact_information = ContactInformation.new contact_information_params
+
         if @contact_information.valid?
           persist @contact_information
           redirect_to new_candidates_school_registrations_subject_preference_path

--- a/app/controllers/candidates/registrations/personal_informations_controller.rb
+++ b/app/controllers/candidates/registrations/personal_informations_controller.rb
@@ -11,7 +11,7 @@ module Candidates
 
         persist @personal_information
 
-        if candidate_signed_in?
+        if skip_gitis_integration? || candidate_signed_in?
           redirect_to new_candidates_school_registrations_contact_information_path
         else
           token = @personal_information.create_signin_token(gitis_crm)

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -9,15 +9,22 @@ module Candidates
         registration_session = RegistrationStore.instance.retrieve! params[:uuid]
 
         unless registration_session.completed?
-          self.current_candidate = Bookings::Candidate.create_or_update_from_registration_session! \
-            gitis_crm,
-            registration_session,
-            current_contact
+          if gitis_integration?
+            self.current_candidate = Bookings::Candidate.create_or_update_from_registration_session! \
+              gitis_crm,
+              registration_session,
+              current_contact
 
-          placement_request = current_candidate.placement_requests.create_from_registration_session! \
-            registration_session,
-            cookies[:analytics_tracking_uuid],
-            context: :returning_from_confirmation_email
+            placement_request = current_candidate.placement_requests.create_from_registration_session! \
+              registration_session,
+              cookies[:analytics_tracking_uuid],
+              context: :returning_from_confirmation_email
+          else
+            placement_request = Bookings::PlacementRequest.create_from_registration_session! \
+              registration_session,
+              cookies[:analytics_tracking_uuid],
+              context: :returning_from_confirmation_email
+          end
 
           registration_session.flag_as_completed!
 

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -35,5 +35,13 @@ module Candidates
 
       Bookings::RegistrationContactMapper.new(registration_session, gitis_contact)
     end
+
+    def gitis_integration?
+      Rails.application.config.x.phase >= 3
+    end
+
+    def skip_gitis_integration?
+      !gitis_integration?
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,7 @@ Rails.application.routes.draw do
       end
     end
 
-    if Rails.application.config.x.phase >= 4
+    if Rails.application.config.x.phase >= 5
       get 'signin', to: 'sessions#new'
       post 'signin', to: 'sessions#create'
       get 'signin/:authtoken', to: 'sessions#update', as: 'signin_confirmation'

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -47,6 +47,26 @@ feature 'Candidate Registrations', type: :feature do
   end
 
   feature 'Candidate Registration' do
+    context "running under Phase 2" do
+      include_context 'bypass fake Gitis'
+      let(:email_address) { 'person@example.com' }
+
+      before do
+        allow(Rails.application.config.x).to receive(:phase).and_return(2)
+      end
+
+      scenario "completing the Journey" do
+        complete_personal_information_step
+        complete_contact_information_step
+        complete_subject_preference_step
+        complete_placement_preference_step
+        complete_background_step
+        complete_application_preview_step
+        complete_email_confirmation_step
+        view_request_acknowledgement_step
+      end
+    end
+
     context 'for unknown Contact' do
       let(:email_address) { 'unknown@example.com' }
 
@@ -113,7 +133,6 @@ feature 'Candidate Registrations', type: :feature do
 
       scenario "completing the Journey" do
         sign_in_via_dashboard(token.token)
-
         complete_personal_information_step
         complete_contact_information_step
         complete_subject_preference_step

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,3 +95,7 @@ Shoulda::Matchers.configure do |config|
     with.library :action_controller
   end
 end
+
+# Ensure load time injection of FakeCRM happens early enough
+require_dependency 'bookings/gitis/auth'
+require_dependency 'bookings/gitis/crm'


### PR DESCRIPTION
### Context

We need to continue to be able to run the Candidate Journey in Phase 3 mode

### Changes proposed in this pull request

1. Avoid interacting with Gitis if in Phase 2 mode
2. Dont associate placement requests with candidates if running in Phase 2 mode

### Guidance to review

1. Code review
2. Real test - set .env
```
PHASE=2
FAKE_CRM=false
```
