### PR TITLE
Se 1031/acessibility/form builder fixes

### DIFF
--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -21,7 +21,8 @@
             rows: 5,
             maxwords: { count: 150 },
             placeholder: t('.availability_placeholder'),
-            label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
+            'aria-describedby': 'candidates_registrations_placement_preference_availability_label',
+            label_options: { overwrite_defaults!: true, class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_availability_label' } do %>
 
             <p>
               We need a few details so we can forward your experience requirements to the school.
@@ -67,7 +68,8 @@
           :objectives,
           rows: 5,
           maxwords: { count: 150 },
-          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
+          'aria-describedby': 'candidates_registrations_placement_preference_objectives_label',
+          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_objectives_label' } do %>
           <p>
             Provide a short explanation. For example:
           </p>

--- a/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements/_form.html.erb
@@ -20,7 +20,12 @@
         <% f.object.dbs_requirements.each do |requirement| %>
           <% if f.object.policy_explanation_required? requirement %>
             <%= fieldset.radio_input requirement do %>
-              <%= fieldset.text_area_with_maxwords :dbs_policy, maxwords: { count: 50 }, class: 'govuk-!-width-two-thirds', rows: 7 %>
+              <%= fieldset.text_area_with_maxwords :dbs_policy,
+                maxwords: { count: 50 },
+                class: 'govuk-!-width-two-thirds',
+                label_options: { id: 'schools_on_boarding_candidate_requirement_dbs_policy_label' },
+                'aria-describedby': 'schools_on_boarding_candidate_requirement_dbs_policy_label',
+                rows: 7 %>
             <% end %>
           <% else %>
             <%= fieldset.radio_input requirement %>

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -22,7 +22,7 @@
   <%= form.number_field :duration, width: 3, required: true %>
 
   <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
+    <fieldset class="govuk-fieldset">
       <%= form.check_box_input :active %>
     </fieldset>
   </div>


### PR DESCRIPTION
Fix textarea_with_maxwords

govuk-frontend/all.js CharacterCount.prototype.createCountMessage
appends a reference to the word count span to the textarea's
aria-describedby attribute. If this attribute is not set on the textarea
the govukjs sets it to `'null' + ' ' + <id-of-word-count-span>` causing an
error to be shown in waves.

### Context

### Changes proposed in this pull request

### Guidance to review
Visit 
/candidates/schools/:urn/registrations/placement_preference/new
/schools/onboarding/candidate_requirement/new
/schools/placement_dates/:id/edit
Expect not to see any errors in waves

I looked into baking this into form builder, but it would require substantial work as generating ids for the label tags is tricky. Something to consider for formbuilder 2

