### PR TITLE
Stop cancelled flag disappearing

### DIFF
--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -1,0 +1,11 @@
+module Schools::PlacementRequestsHelper
+  def placement_request_status(placement_request)
+    text = if placement_request.cancelled?
+             'Cancelled'
+           elsif !placement_request.viewed?
+             'New'
+           end
+
+    tag.span(text, class: 'govuk-tag') if text
+  end
+end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -160,11 +160,11 @@ module Bookings
       candidate_cancellation || school_cancellation
     end
 
-  private
-
     def cancelled?
       cancellation&.sent?
     end
+
+  private
 
     def completed?
       # FIXME SE-1096 determine from booking

--- a/app/views/schools/placement_requests/_placement_request.html.erb
+++ b/app/views/schools/placement_requests/_placement_request.html.erb
@@ -3,11 +3,7 @@
     <%= placement_request.gitis_contact.full_name %>
   </td>
   <td class="govuk-table__cell">
-    <% if !placement_request.viewed? %>
-      <span class="govuk-tag">
-        <%= placement_request.status %>
-      </span>
-    <% end %>
+    <%= placement_request_status(placement_request) %>
   </td>
   <td class="govuk-table__cell">
     <%= placement_request.subject_first_choice %>

--- a/features/schools/placement_requests/index.feature
+++ b/features/schools/placement_requests/index.feature
@@ -34,3 +34,18 @@ Feature: Viewing all placement requests
         Given there are some placement requests
         When I am on the 'placement requests' page
         Then every request should contain a link to view more details
+
+    Scenario: Cancelled placement requests
+        Given there are some cancelled placement requests
+        When I am on the 'placement requests' page
+        Then the cancelled requests should have a status of 'Cancelled'
+
+    Scenario: Unviewed placement requests
+        Given there are some unviewed placement requests
+        When I am on the 'placement requests' page
+        Then the unviewed requests should have a status of 'New'
+
+    Scenario: Viewed placement requests
+        Given there are some viewed placement requests
+        When I am on the 'placement requests' page
+        Then the viewed requests should have no status

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -68,10 +68,10 @@ Then("I fill in the date field {string} with {int}-{int}-{int}") do |field, day,
   # Some of the designs call for the field name to be styled as a heading
   date_field_set = \
     begin
-     page.find '.govuk-label', text: field
-   rescue Capybara::ElementNotFound
-     page.find '.govuk-fieldset__heading', text: field
-   end
+      page.find '.govuk-label', text: field
+    rescue Capybara::ElementNotFound
+      page.find '.govuk-fieldset__heading', text: field
+    end
 
   within(date_field_set.ancestor('.govuk-form-group')) do
     fill_in 'Day',   with: day

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -149,3 +149,47 @@ Then("I should see a table with the following headings:") do |table|
     expect(page).to have_css('thead th', text: heading)
   end
 end
+
+Given("there are some cancelled placement requests") do
+  @cancelled_placement_requests_count = 3
+  @cancelled_placement_requests = FactoryBot.create_list \
+    :placement_request,
+    @cancelled_placement_requests_count,
+    :cancelled,
+    school: @school
+end
+
+Then("the cancelled requests should have a status of {string}") do |status|
+  within('table#placement-requests') do
+    expect(page).to have_css('.govuk-tag', text: status, count: @cancelled_placement_requests_count)
+  end
+end
+
+Given("there are some unviewed placement requests") do
+  @unviewed_placement_requests_count = 3
+  @unviewed_placement_requests = FactoryBot.create_list \
+    :placement_request,
+    @unviewed_placement_requests_count,
+    school: @school
+end
+
+Then("the unviewed requests should have a status of {string}") do |status|
+  within('table#placement-requests') do
+    expect(page).to have_css('.govuk-tag', text: status, count: @unviewed_placement_requests_count)
+  end
+end
+
+Given("there are some viewed placement requests") do
+  @viewed_placement_requests_count = 3
+  @viewed_placement_requests = FactoryBot.create_list \
+    :placement_request,
+    @viewed_placement_requests_count,
+    school: @school,
+    viewed_at: 3.minutes.ago
+end
+
+Then("the viewed requests should have no status") do
+  within('table#placement-requests') do
+    expect(page).not_to have_css('.govuk-tag')
+  end
+end


### PR DESCRIPTION
### Context

Cancelled labels were being hidden once placement requests are viewed

### Changes proposed in this pull request

Move the status logic to a helper

### Guidance to review

Ensure it looks sensible and works
