### PR TITLE
Made failing features match govuk tags case-insensitively

### DIFF
--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -161,7 +161,7 @@ end
 
 Then("the cancelled requests should have a status of {string}") do |status|
   within('table#placement-requests') do
-    expect(page).to have_css('.govuk-tag', text: status, count: @cancelled_placement_requests_count)
+    expect(page).to have_css('.govuk-tag', text: /#{status}/i, count: @cancelled_placement_requests_count)
   end
 end
 
@@ -175,7 +175,7 @@ end
 
 Then("the unviewed requests should have a status of {string}") do |status|
   within('table#placement-requests') do
-    expect(page).to have_css('.govuk-tag', text: status, count: @unviewed_placement_requests_count)
+    expect(page).to have_css('.govuk-tag', text: /#{status}/i, count: @unviewed_placement_requests_count)
   end
 end
 


### PR DESCRIPTION
### Context

Master is broken, this is caused by features in cucumber failing to match the text of gov-uk tags because the CSS upcases them

### Changes proposed in this pull request

make the specs match case insensitively

### Guidance to review

broader fix is probably to change the tag names but this is the lower risk fix for now

