### PR TITLE
Feature/prevent enabling school until onboarded se 1158

### DIFF
--- a/app/views/schools/dashboards/_full_dashboard.html.erb
+++ b/app/views/schools/dashboards/_full_dashboard.html.erb
@@ -61,6 +61,7 @@
           </span>
         </div>
 
+        <%- if @current_school.private_beta? -%>
         <div id="manage-requests" class="subection">
           <header class="dashboard-medium-priority">
             <%= link_to "Turn requests on / off", edit_schools_enabled_path %>
@@ -70,6 +71,7 @@
             Requests are currently <strong><%= school_enabled_description(@current_school) %></strong>.
           </span>
         </div>
+        <%- end -%>
       </section>
 
       <section id="help-and-support" class="medium-priority">

--- a/db/migrate/20190628082805_set_bookings_schools_enabeld_flag_to_false_by_default.rb
+++ b/db/migrate/20190628082805_set_bookings_schools_enabeld_flag_to_false_by_default.rb
@@ -1,0 +1,5 @@
+class SetBookingsSchoolsEnabeldFlagToFalseByDefault < ActiveRecord::Migration[5.2]
+  def change
+    change_column :bookings_schools, :enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_18_152627) do
+ActiveRecord::Schema.define(version: 2019_06_28_082805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,7 +192,7 @@ ActiveRecord::Schema.define(version: 2019_06_18_152627) do
     t.text "primary_key_stage_info"
     t.text "availability_info"
     t.string "teacher_training_website"
-    t.boolean "enabled", default: true, null: false
+    t.boolean "enabled", default: false, null: false
     t.boolean "availability_preference_fixed", default: false, null: false
     t.index ["coordinates"], name: "index_bookings_schools_on_coordinates", using: :gist
     t.index ["name"], name: "index_bookings_schools_on_name"

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -61,6 +61,16 @@ Feature: The School Dashboard
         When I am on the 'schools dashboard' page
         Then the 'new bookings counter' should be 3
 
+    Scenario: Hide the enable/disable link if schools not onboarded
+        Given my school has not yet fully-onboarded
+        When I am on the 'schools dashboard' page
+        Then there should be no 'Turn requests on / off' link
+
+    Scenario: Show the enable/disable link when schools are onboarded
+        Given my school has fully-onboarded
+        When I am on the 'schools dashboard' page
+        Then I should see a 'Turn requests on / off' link to the 'toggle requests' page
+
     @wip
     Scenario: Candidate attendances counter
         Given there are 4 new candidate attendances

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -54,3 +54,7 @@ end
 Then("I should see the managing requests section") do
   expect(page).to have_css('.managing-requests')
 end
+
+Then("there should be no {string} link") do |link_text|
+  expect(page).not_to have_link(link_text)
+end

--- a/features/step_definitions/schools/toggle_requests_steps.rb
+++ b/features/step_definitions/schools/toggle_requests_steps.rb
@@ -1,9 +1,9 @@
 Given("my school is enabled") do
+  @school.update(enabled: true)
   expect(@school).to be_enabled
 end
 
 Given("my school is disabled") do
-  @school.update(enabled: false)
   expect(@school).to be_disabled
 end
 

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     sequence(:contact_email) { |n| "admin#{n}@school.org" }
     availability_info { 'We can offer placements throughout June and July for the remainder of this academic year (up to the 21st July).' }
     availability_preference_fixed { false }
+    enabled { true }
 
     trait :onboarded do
       association :profile, factory: :bookings_profile


### PR DESCRIPTION
### Context

Non-onboarded schools shouldn't be able to enable themselves.

### Changes proposed in this pull request

Toggling is already blocked at the controller level but this change actually flips the column default and hides the option from the dashboard unless the school has onboarded

### Guidance to review

Ensure the changes look sensible and it works

