### PR TITLE
Withold booked placement requests from listing

### DIFF
--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -17,7 +17,9 @@ module Schools
     def placement_requests
       current_school
         .placement_requests
+        .unbooked
         .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date)
+        .order(created_at: 'desc')
     end
 
     def placement_request

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -17,8 +17,11 @@ describe Schools::PlacementRequestsController, type: :request do
   end
 
   context '#index' do
-    before do
+    let(:placement_requests) do
       FactoryBot.create_list :placement_request, 5, school: school
+    end
+
+    before do
       get '/schools/placement_requests'
     end
 
@@ -30,6 +33,19 @@ describe Schools::PlacementRequestsController, type: :request do
 
     it 'renders the index template' do
       expect(response).to render_template :index
+    end
+
+    context 'after placement requests have been accepted' do
+      let(:booked) { placement_requests.last }
+      before do
+        create(:bookings_booking, bookings_placement_request: booked, bookings_school: school)
+      end
+
+      before { get '/schools/placement_requests' }
+
+      specify 'they should be omitted' do
+        expect(assigns(:placement_requests)).to eq(school.placement_requests - Array.wrap(booked))
+      end
     end
   end
 


### PR DESCRIPTION
### Context

Booked placement requests were appearing in the placement requests index, they should 'move' to the Bookings list instead.

### Changes proposed in this pull request

Prevent booked placement requests from appearing in the placement requests index.

Also, order the placement requests by their creation date, newest first.

### Guidance to review

Ensure it looks sensible
