### PR TITLE
Default to Real CRM in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -130,5 +130,5 @@ Rails.application.configure do
     config.x.oidc_host = ENV.fetch('DFE_SIGNIN_HOST') { 'pp-oidc.signin.education.gov.uk' }
   end
 
-  config.x.fake_crm = true
+  config.x.fake_crm = ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s)
 end


### PR DESCRIPTION
### Context

We should be running with a Real CRM instance in production

### Changes proposed in this pull request

1. Default to using the Real CRM in production environments
2. Allow configuring the Fake CRM for use in production environments



