### PR TITLE
Updated Personal Information screen text

### DIFF
--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -6,8 +6,21 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">
-          Provide the following information so we can check if we already have your details.
+          Provide the following information so we can check if we already have
+          your details.
         </p>
+
+        <%- if Rails.application.config.x.phase >= 3 -%>
+        <p>
+          If we already have your details - we'll automatically add them to your
+          school experience request.
+        </p>
+
+        <p>
+          If we don’t - we’ll register them with DfE’s Get Into Teaching service
+          so you can get help and advice about becoming a teacher.
+        </p>
+        <%- end -%>
 
         <%= form_for personal_information, url: candidates_school_registrations_personal_information_path do |f| %>
           <%= GovukElementsErrorsHelper.error_summary personal_information, 'There is a problem', '' %>


### PR DESCRIPTION
### Context

Changes from Fred to clarify how we use the candidates personal information

### Changes proposed in this pull request

1. Added additional explanation text to personal information screen - only shown conditionally for Phase 3 since it only applies from Phase 3 onwards

### Guidance to review

