### PR TITLE
Feature/updating privacy policies se 1250

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -29,10 +29,10 @@
         We receive your personal data when you fill in and submit an online request for a school experience.
       </p>
       <p>
-        This data is passed onto staff (who work at and for schools and manage school experience at the school where you’re requested school experience) processing and review.
+        This data is passed onto staff (who work at and for schools and manage school experience at the school where you're requested school experience) processing and review.
       </p>
       <p>
-        As part of the service we’ll use the contact information you’ve provided to send out notifications, reminders and feedback questionnaires relating to the service.
+        As part of the service we'll use the contact information you've provided to send out notifications, reminders and feedback questionnaires relating to the service.
       </p>
     </section>
 
@@ -96,7 +96,7 @@
         We sometimes need to make personal data available to other organisations.
       </p>
       <p>
-        These might include contracted partners (who we’ve employed to process your personal data on our behalf) and / or other organisations (with whom we need to share your personal data for specific purposes).
+        These might include contracted partners (who we've employed to process your personal data on our behalf) and / or other organisations (with whom we need to share your personal data for specific purposes).
       </p>
 
       <p>
@@ -115,7 +115,7 @@
         <h2 class="govuk-heading-s">The private company Engine Group uses your data:</h2>
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            user research to help develop the service - where you’ve shared your name, email address and / or phone number for this purpose
+            user research to help develop the service - where you've shared your name, email address and / or phone number for this purpose
           </li>
           <li>
             security purposes to protect the service - for example, parts of the IP addresses of website visitors are collected to block continuous direct denial of service attacks from an IP address range
@@ -181,7 +181,7 @@
       </p>
 
       <p>
-        Further information about your data protection rights can be found on the on the <%= link_to "Information Commissioner’s Office (ICO)", "https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" %> website.
+        Further information about your data protection rights can be found on the on the <%= link_to "Information Commissioner's Office (ICO)", "https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" %> website.
       </p>
     </section>
 
@@ -196,7 +196,7 @@
         If you change your mind or you are unhappy with our use of your personal data please email us at <%= mail_to 'organise.schoolexperience@education.gov.uk' %>.
       </p>
       <p>
-        Alternatively, you have the right to raise any concerns via the <%= link_to "Information Commissioner’s Office (ICO)", 'https://ico.org.uk/concerns/' %> website.
+        Alternatively, you have the right to raise any concerns via the <%= link_to "Information Commissioner's Office (ICO)", 'https://ico.org.uk/concerns/' %> website.
       </p>
     </section>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -5,16 +5,19 @@
               class: 'govuk-back-link',
               data: {controller: 'back-link'} %>
 
-    <h1 class="govuk-heading-l">Privacy notice for the School Experience Service</h1>
+    <h1 class="govuk-heading-l">Privacy policy for the get school experience</h1>
     <section>
       <h2 class="govuk-heading-m">
         Who we are
       </h2>
       <p>
-        This work is being carried out by Education Standards which is a part of the Department for Education (DfE). DfE has engaged the private companies Engine Group and Teleperformance UK (TPUK) to help provide and improve the service.
+        This work is being carried out by Education Standards which is a part of the Department for Education (DfE).
       </p>
       <p>
-        For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of School Experience Service.
+        DfE has engaged the private companies Engine Group and Teleperformance UK (TPUK) to help provide and improve the service.
+      </p>
+      <p>
+        For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of the service.
       </p>
     </section>
 
@@ -23,10 +26,13 @@
         How we'll use your information
       </h2>
       <p>
-        We receive your personal data from when you fill in and submit an online request for a school experience. This data is passed onto staff, who work at / for schools and manage school experience at the school you've selected, for processing and review.
+        We receive your personal data when you fill in and submit an online request for a school experience.
       </p>
       <p>
-        As part of the service we'll use the contact information you've provided to send out notifications, reminders and feedback questionnaires relating to the School Experience Service.
+        This data is passed onto staff (who work at and for schools and manage school experience at the school where you’re requested school experience) processing and review.
+      </p>
+      <p>
+        As part of the service we’ll use the contact information you’ve provided to send out notifications, reminders and feedback questionnaires relating to the service.
       </p>
     </section>
 
@@ -35,7 +41,7 @@
         The nature of your personal data we'll be using
       </h2>
       <p>
-        Personal data will be collected when you fill in and submit a webform. The fields required on the webform ask for personal information such as:
+        Personal data will be collected when you fill in and submit a webform. The fields required on the webform ask personal information such as:
       </p>
       <ul class="govuk-list govuk-list--bullet">
         <li>
@@ -48,7 +54,7 @@
           address
         </li>
         <li>
-          telephone number
+          UK telephone number
         </li>
         <li>
           degree subject
@@ -62,10 +68,11 @@
         <li>
           teaching subject preferences
         </li>
-        <li>
-          IP address
-        </li>
       </ul>
+
+      <p>
+        We also use Google Analytics to collect your IP address while you fill in and submit the webform.
+      </p>
     </section>
 
     <section>
@@ -73,7 +80,11 @@
         Why our use of your personal data is lawful
       </h2>
       <p>
-        In order to lawfully use your personal data, we need to meet 1 (or more) conditions in the data protection legislation. For the purpose of this project, your consent forms the basis of this as stated under GDPR Article 6 (1)(a).
+        In order to lawfully use your personal data, we need to meet 1 (or more) conditions in the data protection legislation.
+      </p>
+
+      <p>
+        For the purpose of this project, your consent forms the basis of this as stated under GDPR Article 6 (1)(a).
       </p>
     </section>
 
@@ -82,23 +93,35 @@
         Who we'll make your personal data available to
       </h2>
       <p>
-        We sometimes need to make your personal data available to other organisations. These might include contracted partners (who we've employed to process your personal data on our behalf) and / or other organisations (with whom we need to share your personal data for specific purposes).
+        We sometimes need to make personal data available to other organisations.
       </p>
       <p>
-        Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation. We share specific types of personal data with Engine Group, who have been contracted by DfE to manage the delivery of the digital service and TPUK, who have been contracted by DfE to support the administration of the service.
+        These might include contracted partners (who we’ve employed to process your personal data on our behalf) and / or other organisations (with whom we need to share your personal data for specific purposes).
+      </p>
+
+      <p>
+        Where we need to share your personal data with others, we ensure that this data sharing complies with data protection legislation.
+      </p>
+
+      <p>
+        We share specific types of personal data with Engine Group, who have been contracted by DfE to manage the delivery of the digital service and TPUK, who have been contracted by DfE to support the administration of the service.
+      </p>
+
+      <p>
+        The private company Engine Group uses your data for:
       </p>
 
       <section>
         <h2 class="govuk-heading-s">The private company Engine Group uses your data:</h2>
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            for user research - to help develop the School Experience Service, where you've shared your name, email address and / or telephone number for this purpose
+            user research to help develop the service - where you’ve shared your name, email address and / or phone number for this purpose
           </li>
           <li>
-            for security purposes - to protect the School Experience Service, parts of the IP addresses of website visitors are collected (for example, to block continuous direct denial of service attacks from an IP address range)
+            security purposes to protect the service - for example, parts of the IP addresses of website visitors are collected to block continuous direct denial of service attacks from an IP address range
           </li>
           <li>
-            for communication purposes - to help you use the School Experience Service and receive updates the email addresses of individuals requesting school experience are collected
+            for communications purposes - to help you use and receive updates about the service individual email addresses are collected
           </li>
         </ul>
       </section>
@@ -107,7 +130,7 @@
         <h2 class="govuk-heading-s">The private company TPUK uses your data:</h2>
         <ul class="govuk-list govuk-list--bullet">
           <li>
-            to cancel, amend and manage booking requests on your behalf
+            to cancel, manage and update your requests and bookings on your behalf
           </li>
         </ul>
       </section>
@@ -118,10 +141,10 @@
         How long we'll keep your personal data
       </h2>
       <p>
-        DfE, Engine Group or TPUK will only keep your personal data for as long as we need it for the purposes of their work, after which it will be securely destroyed. If this is longer than 6 years your data will be deleted.
+        DfE, Engine Group or TPUK will only keep your personal data for as long as we need it for the purposes of their work, after which point it will be securely destroyed. If this is longer than 6 years your data will be deleted.
       </p>
       <p>
-        Please note, under Data Protection legislation and in compliance with the relevant data processing conditions, personal data can be kept for longer periods of time when processed purely for archiving purposes in the public interest, statistical purposes and historical or scientific research.
+        Note: under Data Protection legislation, and in compliance with the relevant data processing conditions, personal data can be kept for longer periods of time when processed purely for archiving purposes in the public interest, statistical purposes and historical or scientific research.
       </p>
     </section>
 
@@ -182,7 +205,7 @@
         Last updated
       </h2>
       <p>
-        We may need to update this privacy notice periodically and recommend you revisit this information from time to time. This version was last updated on 6 March 2019.
+        We may need to update this privacy notice periodically and recommend you revisit this information from time to time. This version was last updated on 27 June 2019.
       </p>
     </section>
 

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -5,7 +5,7 @@
               class: 'govuk-back-link',
               data: {controller: 'back-link'} %>
 
-    <h1 class="govuk-heading-l">Privacy policy for the get school experience</h1>
+    <h1 class="govuk-heading-l">Privacy policy for get school experience</h1>
     <section>
       <h2 class="govuk-heading-m">
         Who we are

--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -58,7 +58,7 @@
       </p>
 
       <p>
-        As part of the service we’ll use the contact information you’ve
+        As part of the service we'll use the contact information you've
         provided to send out notifications, reminders and feedback
         questionnaires relating to the service.
       </p>
@@ -83,7 +83,7 @@
       </h2>
 
       <p>
-        These might include contracted partners (who we’ve employed to process
+        These might include contracted partners (who we've employed to process
         your personal data on our behalf) and / or other organisations (with whom
         we need to share your personal data for specific purposes).
       </p>
@@ -106,7 +106,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          user research to help develop the service - where you’ve shared your
+          user research to help develop the service - where you've shared your
           name, email address and / or phone number for this purpose
         </li>
 
@@ -201,7 +201,7 @@
 
       <p>
         Further information about your data protection rights can be found on
-        the on the <%= link_to "Information Commissioner’s Office (ICO)", "https://ico.org.uk/" %>
+        the on the <%= link_to "Information Commissioner's Office (ICO)", "https://ico.org.uk/" %>
         website.
       </p>
     </section>
@@ -224,7 +224,7 @@
 
       <p>
         Alternatively, you have the right to raise any concerns via the
-        <%= link_to "Information Commissioner’s Office (ICO)", "https://ico.org.uk/concerns/" %>
+        <%= link_to "Information Commissioner's Office (ICO)", "https://ico.org.uk/concerns/" %>
         website.
       </p>
     </section>

--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-full">
 
     <h1 class="govuk-heading-l">
-      Privacy notice for the School Experience Service
+      Privacy policy for manage school experience
     </h1>
 
     <section>
@@ -15,16 +15,18 @@
       </h2>
 
       <p>
-        This work is being carried out by Education Standards which is a part
-        of the Department for Education (DfE). DfE has engaged the private 
-        companies Engine Group and Teleperformance UK (TPUK) to help provide
-        and improve the service.
+        This work is being carried out by Education Standards which is a part of
+        the Department for Education (DfE).
+      </p>
+
+      <p>
+        DfE has engaged the private companies Engine Group and Teleperformance UK
+        (TPUK) to help provide and improve the service.
       </p>
 
       <p>
         For the purpose of data protection legislation, the DfE is the data
-        controller for the personal data processed as part of School Experience
-        Service.
+        controller for the personal data processed as part of the service.
       </p>
     </section>
 
@@ -34,40 +36,32 @@
       </h2>
 
       <p>
-        We receive your personal data from when you fill in and submit an
-        online request for a school experience. This data is passed onto staff,
-        who work at / for schools and manage school experience at the school
-        you've selected, for processing and review.
+        To facilitate school experience we collect the following details and data
+        about school staff who manage the service when the school they work for
+        or at signs up to the service:
       </p>
 
-      <p>
-        As part of the service we'll use the contact information you've
-        provided to send out notifications, reminders and feedback questionnaires
-        relating to the School Experience Service.
-      </p>
-    </section>
-
-    <section>
-      <h2 class="govuk-heading-m">
-        The nature of your personal data we'll be using
-      </h2>
-
-      <p>
-        Personal data will be collected when you fill in and submit a webform.
-        The fields required on the webform ask for personal information such as:
-      </p>
-
-      <ul class="govuk-list govuk-list--bullet">
+      <ul>
         <li>name</li>
         <li>email address</li>
-        <li>address</li>
-        <li>telephone number</li>
-        <li>degree subject</li>
-        <li>stage of degree</li>
-        <li>degree class (predicted / achieved)</li>
-        <li>teaching subject preferences</li>
-        <li>IP address</li> 
+        <li>UK telephone number</li>
       </ul>
+
+      <p>
+        These details are then shared with a candidate once their school
+        experience request has been confirmed by the relevant school.
+      </p>
+
+      <p>
+        School staff can delete or update their contact details at any time in
+        the service.
+      </p>
+
+      <p>
+        As part of the service we’ll use the contact information you’ve
+        provided to send out notifications, reminders and feedback
+        questionnaires relating to the service.
+      </p>
     </section>
 
     <section>
@@ -79,7 +73,7 @@
         In order to lawfully use your personal data, we need to meet 1 (or more)
         conditions in the data protection legislation. For the purpose of this
         project, your consent forms the basis of this as stated under GDPR
-        Article 6 (1)(a). 
+        Article 6 (1)(a).
       </p>
     </section>
 
@@ -89,43 +83,42 @@
       </h2>
 
       <p>
-        We sometimes need to make your personal data available to other
-        organisations. These might include contracted partners (who we've
-        employed to process your personal data on our behalf) and / or other
-        organisations (with whom we need to share your personal data for
-        specific purposes).
+        These might include contracted partners (who we’ve employed to process
+        your personal data on our behalf) and / or other organisations (with whom
+        we need to share your personal data for specific purposes).
       </p>
 
       <p>
         Where we need to share your personal data with others, we ensure that
-        this data sharing complies with data protection legislation. We share
-        specific types of personal data with Engine Group, who have been
+        this data sharing complies with data protection legislation.
+      </p>
+
+      <p>
+        We share specific types of personal data with Engine Group, who have been
         contracted by DfE to manage the delivery of the digital service and TPUK,
-        who have been contracted by DfE to support the administration of the service.
+        who have been contracted by DfE to support the administration of the
+        service.
       </p>
 
       <h3 class="govuk-heading-s">
-        The private company Engine Group uses your data:
+        The private company Engine Group uses your data for:
       </h3>
 
       <ul class="govuk-list govuk-list--bullet">
         <li>
-          for user research - to help develop the School Experience Service,
-          where you've shared your name, email address and / or telephone
-          number for this purpose
+          user research to help develop the service - where you’ve shared your
+          name, email address and / or phone number for this purpose
         </li>
 
         <li>
-          for security purposes - to protect the School Experience Service,
-          parts of the IP addresses of website visitors are collected (for
-          example, to block continuous direct denial of service attacks from an
-          IP address range)
+          security purposes to protect the service - for example, parts of the
+          IP addresses of website visitors are collected to block continuous
+          direct denial of service attacks from an IP address range
         </li>
 
         <li>
-          for communication purposes - to help you use the School Experience
-          Service and receive updates the email addresses of individuals
-          requesting school experience are collected
+          communications purposes - to help you use and receive updates
+          about the service individual email addresses are collected
         </li>
       </ul>
 
@@ -146,18 +139,18 @@
       </h2>
 
       <p>
-        DfE, Engine Group or TPUK will only keep your personal data for as
-        long as we need it for the purposes of their work, after which it will
-        be securely destroyed. If this is longer than 6 years your data will
-        be deleted.
+        DfE, Engine Group or TPUK will only keep your personal data for as long
+        as we need it for the purposes of their work, after which point it will
+        be securely destroyed. If this is longer than 6 years your data will be
+        deleted.
       </p>
 
       <p>
-        Please note, under Data Protection legislation and in compliance with
-        the relevant data processing conditions, personal data can be kept for
+        Note: under Data Protection legislation, and in compliance with the
+        relevant data processing conditions, personal data can be kept for
         longer periods of time when processed purely for archiving purposes in
         the public interest, statistical purposes and historical or scientific
-        research. 
+        research.
       </p>
     </section>
 
@@ -209,7 +202,7 @@
       <p>
         Further information about your data protection rights can be found on
         the on the <%= link_to "Information Commissioner’s Office (ICO)", "https://ico.org.uk/" %>
-        website. 
+        website.
       </p>
     </section>
 
@@ -232,7 +225,7 @@
       <p>
         Alternatively, you have the right to raise any concerns via the
         <%= link_to "Information Commissioner’s Office (ICO)", "https://ico.org.uk/concerns/" %>
-        website. 
+        website.
       </p>
     </section>
 
@@ -244,7 +237,7 @@
       <p>
         We may need to update this privacy notice periodically and recommend
         you revisit this information from time to time. This version was last
-        updated on 6 March 2019. 
+        updated on 27 June 2019.
       </p>
     </section>
 


### PR DESCRIPTION
### Context

The privacy policies for candidates and schools have been updated

### Changes proposed in this pull request

Add the updated content to the templates.

### Guidance to review

They should now match the [candiadte](https://school-experience-rolling.herokuapp.com/register/privacy-policy) and [school](https://school-experience-rolling.herokuapp.com/register/privacy-policy-school) policies on the prototype. There are a couple of intentional minor differences to preserve grammar and make the page work
