### PR TITLE
Reorder sections on placementrequest show

### DIFF
--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -3,6 +3,39 @@
 <h1>Request from <%= @gitis_contact.full_name %></h1>
 
 <div class="school-request">
+  <section id="personal-details">
+    <h2>Personal details</h2>
+
+    <dl class="placement-details govuk-summary-list">
+      <div class="address govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Address
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @gitis_contact.address %>
+        </dd>
+      </div>
+
+      <div class="phone-number govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          UK telephone number
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @gitis_contact.phone %>
+        </dd>
+      </div>
+
+      <div class="email-address govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Email address
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @gitis_contact.email %>
+        </dd>
+      </div>
+    </dl>
+  </section>
+
   <section id="request-details">
     <h2>Request details</h2>
 
@@ -93,39 +126,6 @@
         </dd>
       </div>
 
-    </dl>
-  </section>
-
-  <section id="personal-details">
-    <h2>Personal details</h2>
-
-    <dl class="placement-details govuk-summary-list">
-      <div class="address govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Address
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @gitis_contact.address %>
-        </dd>
-      </div>
-
-      <div class="phone-number govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          UK telephone number
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @gitis_contact.phone %>
-        </dd>
-      </div>
-
-      <div class="email-address govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Email address
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @gitis_contact.email %>
-        </dd>
-      </div>
     </dl>
   </section>
 


### PR DESCRIPTION
The ordering of sections on placement request show doesn't match
the prototype, looks like this got mixed up when fixing a conflicting
merge

### Context

### Changes proposed in this pull request

### Guidance to review

