### PR TITLE
DOB field fixes

### DIFF
--- a/app/views/candidates/sessions/new.html.erb
+++ b/app/views/candidates/sessions/new.html.erb
@@ -11,7 +11,7 @@
     </p>
 
     <%= form_for @candidates_session, url: candidates_signin_path, html: {novalidate: true} do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary @session, 'There is a problem', '' %>
+      <%= GovukElementsErrorsHelper.error_summary @candidates_session, 'There is a problem', '' %>
 
       <%= f.email_field :email, autocomplete: 'on', class: 'govuk-input govuk-input--width-30' %>
       <%= f.text_field :firstname, autocomplete: 'given-name', class: 'govuk-input govuk-input--width-20' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
             full_name:
               blank: "Enter your full name"
             date_of_birth:
+              blank: "Enter your date of birth"
               inclusion: "Enter a valid date of birth. You must be at least 18 years old"
 
         candidates/registrations/placement_preference:

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to have_attributes(firstname: registration.personal_information.first_name) }
     it { is_expected.to have_attributes(lastname: registration.personal_information.last_name) }
     it { is_expected.to have_attributes(email: registration.personal_information.email) }
-    it "needs to compare date of birth when that is merged in"
+    it { is_expected.to have_attributes(date_of_birth: registration.personal_information.date_of_birth) }
     it { is_expected.to have_attributes(phone: registration.contact_information.phone) }
     it { is_expected.to have_attributes(building: registration.contact_information.building) }
     it { is_expected.to have_attributes(street: registration.contact_information.street) }
@@ -38,6 +38,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to include('first_name' => contact.first_name) }
     it { is_expected.to include('last_name' => contact.last_name) }
     it { is_expected.to include('email' => contact.email) }
+    it { is_expected.to include('date_of_birth' => contact.date_of_birth) }
   end
 
   describe "#contact_to_contact_information" do


### PR DESCRIPTION
### Context

Minor fixes to issues with the Date of Birth field on the Personal Information page

### Changes proposed in this pull request

1. Improved the error message when the Date of Birth is not set
2. Added specs to ensure the Date of Birth gets prepopulated when it should

