### PR TITLE
SE-1261 Record gitis record creation

### DIFF
--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -62,7 +62,7 @@ class Bookings::Candidate < ApplicationRecord
       contact = mapper.registration_to_contact
       crm.write contact
 
-      create!(gitis_uuid: contact.id, confirmed_at: Time.zone.now).tap do |candidate|
+      create!(gitis_uuid: contact.id, confirmed_at: Time.zone.now, created_in_gitis: true).tap do |candidate|
         candidate.gitis_contact = contact
       end
     end

--- a/db/migrate/20190628133753_add_created_in_gitis_to_bookings_candidates.rb
+++ b/db/migrate/20190628133753_add_created_in_gitis_to_bookings_candidates.rb
@@ -1,0 +1,5 @@
+class AddCreatedInGitisToBookingsCandidates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_candidates, :created_in_gitis, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_28_082805) do
+ActiveRecord::Schema.define(version: 2019_06_28_133753) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2019_06_28_082805) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "confirmed_at"
+    t.boolean "created_in_gitis", default: false
     t.index ["gitis_uuid"], name: "index_bookings_candidates_on_gitis_uuid", unique: true
   end
 

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -178,6 +178,10 @@ RSpec.describe Bookings::Candidate, type: :model do
           firstname: registration_session.personal_information.first_name,
           lastname: registration_session.personal_information.last_name
       end
+
+      it "will mark as already existing in gitis" do
+        is_expected.to have_attributes(created_in_gitis: false)
+      end
     end
 
     context 'with an existing contact but not candidate' do
@@ -201,6 +205,10 @@ RSpec.describe Bookings::Candidate, type: :model do
         expect(subject.gitis_contact).to have_attributes \
           firstname: registration_session.personal_information.first_name,
           lastname: registration_session.personal_information.last_name
+      end
+
+      it "will mark as already existing in gitis" do
+        is_expected.to have_attributes(created_in_gitis: false)
       end
     end
 
@@ -227,6 +235,10 @@ RSpec.describe Bookings::Candidate, type: :model do
         expect(subject.gitis_contact).to have_attributes \
           firstname: registration_session.personal_information.first_name,
           lastname: registration_session.personal_information.last_name
+      end
+
+      it "will mark as newly created in gitis" do
+        is_expected.to have_attributes(created_in_gitis: true)
       end
     end
   end


### PR DESCRIPTION
### Context

Currently we need to query Gitis to find whether Candidate already existed or was created by us. This prevents us using it as part of our Analytics

### Changes proposed in this pull request

1. When we create a Candidate in our database, include whether it already existed in Gitis when we created it.


