### PR TITLE
Breakage on `master` on landing page

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,7 +59,6 @@ steps:
   - script: |
       docker run --name=selenium-chrome -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-chrome
       docker run --rm --link postgres:postgres --link=redis:redis --link selenium-chrome:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'),eq(variables['Build.SourceBranch'], 'refs/heads/phase2'))
     displayName: Run Cucumber via Selenium Chrome
 
   - script: |

--- a/features/step_definitions/candidates/landing_page_steps.rb
+++ b/features/step_definitions/candidates/landing_page_steps.rb
@@ -1,5 +1,5 @@
 Then("the leading paragraph should provide me with a summary of the service") do
-  within('div > p:first') do
+  within('div > p:first-of-type') do
     [
       'interested in becoming a teacher',
       'find and request school experience',


### PR DESCRIPTION
### Context

I've broken master with an Invalid CSS selector - passes on Rack::Test but not with Chrome

### Changes proposed in this pull request

1. Fix CSS Selector
2. Switch to run against Chrome in addition to Rack::Test when on branches - this should catch issues before they get merged to master

### Guidance to review

