### PR TITLE
push a latest tag to docker hub repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,7 @@ steps:
       docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(dockerRegistry)/$(imageName):latest
       docker push $(dockerRegistry)/$(imageName):latest
       docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(DOCKER_HUB_REPO):$(imageTag)
+      docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(DOCKER_HUB_REPO):latest
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
     displayName: 'Push Docker image (built from master)'
 
@@ -90,6 +91,15 @@ steps:
       repository: $(DOCKER_HUB_REPO)
       command: push
       tags: $(imageTag)
+
+  - task: Docker@2
+    displayName: 'push to docker hub'
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    inputs:
+      containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
+      repository: $(DOCKER_HUB_REPO)
+      command: push
+      tags: latest
 
   - task: CopyFiles@2
     inputs:


### PR DESCRIPTION
### Context

We assume an up to date latest tag in our Azure Container Registry based repos (for the various release jobs that execute rake tasks that disable, enable, enrich etc. via Docker).

Therefore prior to switching off ACR we need to have a latest tagged image in Docker Hub.

### Changes proposed in this pull request

Create a latest tag and push that to the docker hub repo

### Guidance to review

This will only be verified once pushed to master due to the conditions on the tasks.

