### PR TITLE
Marked PersonalInformation#email as read only

### DIFF
--- a/app/controllers/candidates/registrations/personal_informations_controller.rb
+++ b/app/controllers/candidates/registrations/personal_informations_controller.rb
@@ -7,6 +7,7 @@ module Candidates
 
       def create
         @personal_information = PersonalInformation.new personal_information_params
+        @personal_information.read_only_email = candidate_signed_in?
         render(:new) && return unless @personal_information.valid?
 
         persist @personal_information
@@ -32,6 +33,7 @@ module Candidates
       def update
         @personal_information = current_registration.personal_information
         @personal_information.assign_attributes personal_information_params
+        @personal_information.read_only_email = candidate_signed_in?
 
         if @personal_information.valid?
           persist @personal_information

--- a/app/controllers/candidates/registrations/sign_ins_controller.rb
+++ b/app/controllers/candidates/registrations/sign_ins_controller.rb
@@ -16,9 +16,13 @@ module Candidates
       end
 
       def update
+        personal_information = current_registration.personal_information
         candidate = Candidates::Session.signin!(params[:token])
 
         if candidate
+          personal_information.read_only_email = true
+          persist personal_information
+
           self.current_candidate = candidate
           redirect_to new_candidates_school_registrations_contact_information_path
         else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,7 +43,7 @@ module ApplicationHelper
   end
 
   def summary_row(key, value, change_path = nil, id: nil)
-    action = change_path ? link_to('Change', change_path) : nil
+    action = change_path ? link_to('Change', change_path) : ""
 
     render \
       partial: "shared/list_row",

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -12,6 +12,7 @@ module Candidates
         :last_name,
         :full_name,
         :email,
+        :read_only_email,
         to: :@personal_information
 
       delegate \

--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -12,6 +12,7 @@ module Candidates
       attribute :last_name
       attribute :email
       attribute :date_of_birth, :date
+      attribute :read_only_email, :boolean, default: false
 
       validates :first_name, presence: true
       validates :last_name, presence: true
@@ -28,6 +29,10 @@ module Candidates
 
       def create_signin_token(gitis_crm)
         build_candidate_session(gitis_crm).create_signin_token
+      end
+
+      def email=(email_address)
+        read_only_email ? email : super
       end
 
     private

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -38,12 +38,16 @@
           anchor: 'candidates_registrations_contact_information_phone_container'
         ) %>
 
-      <%= summary_row \
-        'Email address',
-        @application_preview.email_address,
-        edit_candidates_school_registrations_personal_information_path(
-          anchor: 'candidates_registrations_personal_information_email_container'
-        ) %>
+      <%- if @application_preview.read_only_email -%>
+        <%= summary_row 'Email address', @application_preview.email_address %>
+      <%- else -%>
+        <%= summary_row \
+          'Email address',
+          @application_preview.email_address,
+          edit_candidates_school_registrations_personal_information_path(
+            anchor: 'candidates_registrations_personal_information_email_container'
+          ) %>
+      <%- end -%>
 
       <h2 class="govuk-heading-m">Request details</h2>
 

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -27,7 +27,7 @@
 
           <%= f.text_field :first_name, autocomplete: 'given-name' %>
           <%= f.text_field :last_name, autocomplete: 'family-name' %>
-          <%= f.email_field :email, autocomplete: 'on' %>
+          <%= f.email_field :email, autocomplete: 'on', readonly: personal_information.read_only_email %>
           <%= f.date_field :date_of_birth, heading: true %>
 
           <%= f.submit 'Continue' %>

--- a/app/views/shared/_list_row.html.erb
+++ b/app/views/shared/_list_row.html.erb
@@ -5,7 +5,7 @@
   <dd class="govuk-summary-list__value">
     <%= value %>
   </dd>
-  <% if action.present? %>
+  <% if action %>
     <dd class="govuk-summary-list__actions">
       <%= action %>
     </dd>

--- a/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
@@ -117,7 +117,7 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
 
       context 'already signed in' do
         let :personal_information do
-          FactoryBot.build :personal_information
+          FactoryBot.build :personal_information, read_only_email: true
         end
 
         let(:candidate) { create(:candidate, :confirmed) }

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
         {
           'first_name' => 'Testy',
           'last_name' => 'McTest',
-          'email' => 'testy@mctest.com'
+          'email' => 'testy@mctest.com',
+          'date_of_birth' => Date.parse('1980-01-01')
         }
     )
   end
@@ -28,6 +29,7 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
 
   describe 'GET #update' do
     let(:token) { create(:candidate_session_token) }
+    let(:personal_info) { registration_session.personal_information }
 
     context 'with valid token' do
       before do
@@ -42,6 +44,10 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
       it "will have confirmed candidate" do
         expect(token.candidate.reload).to be_confirmed
       end
+
+      it "will have marked the email address read only" do
+        expect(personal_info).to have_attributes read_only_email: true
+      end
     end
 
     context 'with invalid token' do
@@ -52,6 +58,10 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
 
       it "will show error screen" do
         expect(response).to have_http_status(:success)
+      end
+
+      it "will not have marked the email address read only" do
+        expect(personal_info).to have_attributes read_only_email: false
       end
     end
   end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -122,7 +122,8 @@ feature 'Candidate Registrations', type: :feature do
     context 'for known Candidate already signed in' do
       include_context 'fake gitis with known uuid'
 
-      let(:email_address) { 'test@example.com' }
+      # Contact gets default email address after reload via token lookup
+      let(:email_address) { fake_gitis.send(:fake_contact_data)['emailaddress2'] }
       let!(:candidate) { create(:candidate, :confirmed, gitis_uuid: fake_gitis_uuid) }
       let(:token) { create(:candidate_session_token, candidate: candidate) }
 

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -8,6 +8,8 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     it { is_expected.to respond_to :first_name }
     it { is_expected.to respond_to :last_name }
     it { is_expected.to respond_to :email }
+    it { is_expected.to respond_to :read_only_email }
+    it { is_expected.to have_attributes read_only_email: false }
   end
 
   context 'validations' do
@@ -152,6 +154,28 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
       it 'returns false' do
         expect(pinfo.create_signin_token(gitis)).to be false
       end
+    end
+  end
+
+  describe '.email=' do
+    before { subject.email = 'second@test.com' }
+
+    context 'with unvalidate emails' do
+      subject do
+        build(:personal_information, email: 'first@test.com',
+          read_only_email: false)
+      end
+
+      it { is_expected.to have_attributes email: 'second@test.com' }
+    end
+
+    context 'with validated emails' do
+      subject do
+        build(:personal_information, email: 'first@test.com',
+          read_only_email: true)
+      end
+
+      it { is_expected.to have_attributes email: 'first@test.com' }
     end
   end
 end


### PR DESCRIPTION
### Context

1. Once the user has validated their email address we shouldn't let them update it.

### Changes proposed in this pull request

1. Added a read_only_email attribute which defaults to false
2. Only allow assigning the email address if read_only_email isn't assigned
3. Mark the address as Read Only at sign in

### Guidance to review

1. Code review and Sanity Checking
2. Check that after sign in, returning to the Personal Info page shows the email address marked readonly

