### PR TITLE
Ensure the duration is set properly when the placement request has an associated date

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
@@ -37,9 +37,12 @@ module Schools
       private
 
         def find_or_create_booking(placement_request)
+          duration = placement_request&.placement_date&.duration
+
           placement_request.booking || Bookings::Booking.from_confirm_booking(@confirm_booking).tap do |booking|
             booking.bookings_placement_request = placement_request
             booking.bookings_school = @current_school
+            (booking.duration = duration) if duration
           end
         end
 

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -62,7 +62,7 @@ module Bookings
     end
 
     def placement_start_date_with_duration
-      [date.to_formatted_s(:govuk), duration_days].join(' ')
+      [date.to_formatted_s(:govuk), 'for', duration_days].join(' ')
     end
 
     def duration_days

--- a/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
@@ -18,36 +18,54 @@ describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type:
   end
 
   context '#create' do
-    before { post schools_placement_request_acceptance_confirm_booking_path(pr.id, params: params) }
+    let(:params) do
+      {
+        schools_placement_requests_confirm_booking: {
+          bookings_subject_id: bookings_subject.id,
+          date: date,
+          placement_details: placement_details
+        }
+      }
+    end
+
+    subject { post schools_placement_request_acceptance_confirm_booking_path(pr.id, params: params) }
 
     let(:bookings_subject) { create(:bookings_subject) }
     let(:date) { 3.weeks.from_now.to_date }
     let(:placement_details) { "you'll get to try out teaching" }
 
     context 'with valid params' do
-      let(:params) do
-        {
-          schools_placement_requests_confirm_booking: {
-            bookings_subject_id: bookings_subject.id,
-            date: date,
-            placement_details: placement_details
-          }
-        }
-      end
+      before { subject }
 
-      specify 'should create a new booking' do
-        expect(pr.booking).to be_a(Bookings::Booking)
-      end
+      context 'when the placement request does not belong to a placement date' do
+        specify 'should create a new booking' do
+          expect(pr.booking).to be_a(Bookings::Booking)
+        end
 
-      specify 'should redirect to the add more details page' do
-        expect(response).to redirect_to(new_schools_placement_request_acceptance_add_more_details_path(pr.id))
-      end
+        specify 'should redirect to the add more details page' do
+          expect(response).to redirect_to(new_schools_placement_request_acceptance_add_more_details_path(pr.id))
+        end
 
-      specify 'should set up the booking with the correct values' do
+        specify 'should set up the booking with the correct values' do
+          pr.booking.tap do |b|
+            expect(b.date).to eql(date)
+            expect(b.bookings_subject).to eql(bookings_subject)
+            expect(b.placement_details).to eql(placement_details)
+          end
+        end
+      end
+    end
+
+    context 'when the placement request belongs to a placement date' do
+      let(:duration) { 3 }
+      let(:pd) { create(:bookings_placement_date, duration: duration, bookings_school: @current_user_school) }
+      let!(:pr) { create(:bookings_placement_request, school: @current_user_school, bookings_placement_date_id: pd.id) }
+
+      before { subject }
+
+      specify 'should set the booking from the placement date' do
         pr.booking.tap do |b|
-          expect(b.date).to eql(date)
-          expect(b.bookings_subject).to eql(bookings_subject)
-          expect(b.placement_details).to eql(placement_details)
+          expect(b.duration).to eql(duration)
         end
       end
     end
@@ -62,6 +80,8 @@ describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type:
           }
         }
       end
+
+      before { subject }
 
       specify 'should not create a new booking' do
         expect(pr.booking).to be_nil

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -253,7 +253,7 @@ describe Bookings::Booking do
 
     specify 'should return a descriptive string' do
       expect(subject.placement_start_date_with_duration).to eq \
-        "#{date.to_formatted_s(:govuk)} 2 days"
+        "#{date.to_formatted_s(:govuk)} for 2 days"
     end
   end
 


### PR DESCRIPTION
### Context

For fixed date placement requests the `duration` wasn't being carried over to the newly-created booking

### Changes proposed in this pull request

Update the #find_or_create_booking method so that if there's a placement request present with a placement date it uses the booking, and ignores it if there isn't (allowing the booking to revert to its default of `1`)

An additional change was to improve the formatting of the date formatting so it includes the word 'for'.

### Guidance to review

Ensure changes look sensible

