### PR TITLE
Remove empty address parts before combining

### DIFF
--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -72,13 +72,13 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
         school.town,
         school.county,
         school.postcode
-      ].join(', '),
+      ].reject(&:blank?).join(', '),
       school_start_time: profile.start_time,
       school_finish_time: profile.end_time,
       school_dress_code: [
         profile.dress_code,
         profile.dress_code_other_details,
-      ].join(', '),
+      ].reject(&:blank?).join(', '),
       school_parking: [
         profile.parking_provided ? 'Yes' : 'No',
         profile.parking_details

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -61,7 +61,7 @@ describe NotifyEmail::CandidateBookingConfirmation do
       specify 'school_address is correctly-assigned' do
         expect(subject.school_address).to eql(
           [school.address_1, school.address_2, school.address_3,
-           school.town, school.county, school.postcode].join(", ")
+           school.town, school.county, school.postcode].reject(&:blank?).join(", ")
         )
       end
 
@@ -75,7 +75,7 @@ describe NotifyEmail::CandidateBookingConfirmation do
 
       specify 'school_dress_code is correctly-assigned' do
         expect(subject.school_dress_code).to eql(
-          [profile.dress_code, profile.dress_code_other_details].join(", ")
+          [profile.dress_code, profile.dress_code_other_details].reject(&:blank?).join(", ")
         )
       end
 


### PR DESCRIPTION
### Context

The booking confirmation email had a badly-formatted address like: "Street, , , Postcode"

### Changes proposed in this pull request

Remove any 'blank' address parts before joining

### Guidance to review

Ensure the fix looks sensible
