### PR TITLE
Notifies slack and sentry on Notify error

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -24,6 +24,8 @@ class Notify
         personalisation: personalisation
       )
     rescue Notifications::Client::ServerError => e
+      ExceptionNotifier.notify_exception(e)
+      Raven.capture_exception(e)
       raise RetryableError, e.message
     end
   end

--- a/spec/support/notify_erroring_client.rb
+++ b/spec/support/notify_erroring_client.rb
@@ -1,0 +1,8 @@
+class NotifyErroringClient
+  def initialize(api_key = nil); end
+
+  def send_email(*_args)
+    raise Notifications::Client::ServerError,
+      OpenStruct.new(body: 'Missing template param', code: 500)
+  end
+end


### PR DESCRIPTION
We weren't receiving slack notifications for Notify errors.
This commit notifies slack if a notification fails to send before the
jobs has expired it's retires.

### Context

### Changes proposed in this pull request

### Guidance to review

