### PR TITLE
SE-1256 Cancel registrations if current contact switches

### DIFF
--- a/app/controllers/concerns/gitis_authentication.rb
+++ b/app/controllers/concerns/gitis_authentication.rb
@@ -22,7 +22,8 @@ protected
     raise InvalidContact unless contact.is_a?(Bookings::Gitis::Contact)
 
     if current_contact && current_contact.contactid != contact.contactid
-      Rails.logger.warn("Signed in Candidate was overwritten")
+      Rails.logger.warn \
+        "Signed in Candidate overwritten - #{current_contact.contactid} to #{contact.contactid}"
       delete_registration_sessions!
     end
 

--- a/app/controllers/concerns/gitis_authentication.rb
+++ b/app/controllers/concerns/gitis_authentication.rb
@@ -21,6 +21,11 @@ protected
   def current_contact=(contact)
     raise InvalidContact unless contact.is_a?(Bookings::Gitis::Contact)
 
+    if current_contact && current_contact.contactid != contact.contactid
+      Rails.logger.warn("Signed in Candidate was overwritten")
+      delete_registration_sessions!
+    end
+
     contact.tap do |c|
       session[:gitis_contact] = c.attributes
     end
@@ -48,5 +53,9 @@ protected
 
   def authenticate_user!
     current_candidate || fail(UnauthorizedCandidate)
+  end
+
+  def delete_registration_sessions!
+    Candidates::Registrations::SchoolSession.delete_all_registrations session
   end
 end

--- a/app/services/candidates/registrations/school_session.rb
+++ b/app/services/candidates/registrations/school_session.rb
@@ -3,6 +3,14 @@
 module Candidates
   module Registrations
     class SchoolSession
+      class << self
+        def delete_all_registrations(session)
+          session.keys.grep(%r{\Aschools/[^/]+/registrations\z}).each do |key|
+            session.delete key
+          end
+        end
+      end
+
       def initialize(urn, session)
         @school_session = session["schools/#{urn}/registrations"] ||= {}
         @school_session.merge! 'urn' => urn

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
         expect(response).to have_http_status(:success)
       end
     end
+
+    context 'when already signed in' do
+      include_context 'candidate signin'
+
+      before do
+        expect_any_instance_of(described_class).to \
+          receive(:delete_registration_sessions!)
+
+        get candidates_registration_verify_path(school_id, token)
+      end
+
+      it "will redirect_to ContactInformation step" do
+        expect(response).to \
+          redirect_to new_candidates_school_registrations_contact_information_path(school_id)
+      end
+    end
   end
 
   describe 'POST #create' do

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -161,6 +161,10 @@ feature 'Candidate Registrations', type: :feature do
         complete_personal_information_step
         complete_contact_information_step
         sign_in_via_dashboard(newtoken.token)
+        swap_back_to_subject_preference_step
+        complete_subject_preference_step
+        complete_placement_preference_step
+        complete_background_step
         get_bounced_to_personal_information_step
       end
     end
@@ -324,8 +328,12 @@ feature 'Candidate Registrations', type: :feature do
     expect(page.current_path).to eq "/candidates/dashboard"
   end
 
-  def get_bounced_to_personal_information_step
+  def swap_back_to_subject_preference_step
     visit "/candidates/schools/#{school_urn}/registrations/subject_preference/new"
+  end
+
+  def get_bounced_to_personal_information_step
+    visit "/candidates/schools/#{school_urn}/registrations/application_preview"
     expect(page.current_path).to eq \
       "/candidates/schools/#{school_urn}/registrations/personal_information/new"
   end

--- a/spec/services/candidates/registrations/school_session_spec.rb
+++ b/spec/services/candidates/registrations/school_session_spec.rb
@@ -21,6 +21,42 @@ describe Candidates::Registrations::SchoolSession do
     {}
   end
 
+  context '.destroy_all_registrations' do
+    let :session do
+      {
+        'schools/100/registrations' => {
+          'personal_information' => {
+            'first_name'    => 'One',
+            'last_name'     => 'Test',
+            'email'         => 'one@test.one',
+            'date_of_birth' => Date.parse('1980-01-01')
+          }
+        },
+        'schools/200/registrations' => {
+          'personal_information' => {
+            'first_name'    => 'Two',
+            'last_name'     => 'Test',
+            'email'         => 'two@test.two',
+            'date_of_birth' => Date.parse('1980-01-01')
+          },
+        },
+        'some-other-key' => 'test'
+      }
+    end
+
+    before { described_class.delete_all_registrations session }
+    subject { session }
+
+    it "will remove the registrations keys" do
+      is_expected.not_to include('schools/100/registrations')
+      is_expected.not_to include('schools/200/registrations')
+    end
+
+    it "will leave the other keys" do
+      is_expected.to include('some-other-key' => 'test')
+    end
+  end
+
   context '#current_registration' do
     context '1 school' do
       subject do


### PR DESCRIPTION
### Context

If the signed in candidate switches, then we should not allow the new candidate to access the prior candidates information.

### Changes proposed in this pull request

1. Remove all existing registration sessions, if the signed in candidates changes - Note: this doesn't affect candidates signing in when no one was already signed in

### Guidance to review

1. You can replicate the process by using Fake CRM, completing the journey to after the verification process
2. Then opening a separate browser window and going to `/candidates/dashboard`, signing in their with different details
3. Swap back to the original window and continue the process
4. At the point you'd expect to see the application preview, you should be bounced back to the Personal Information step since those details have now been removed from the session.
5. The form should be prefilled with details from the Candidates Dashboard sign in account.

