### PR TITLE
Added Notify client which just writes to the Logger

### DIFF
--- a/app/notify/notify_to_logger.rb
+++ b/app/notify/notify_to_logger.rb
@@ -1,0 +1,11 @@
+class NotifyToLogger
+  def initialize(api_key = nil)
+    @api_key = api_key
+  end
+
+  def send_email(template_id:, email_address:, personalisation:)
+    Rails.logger.info \
+      "Notify message to '#{email_address}', template_id: #{template_id}"
+    Rails.logger.info personalisation.to_yaml
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -87,4 +87,8 @@ Rails.application.configure do
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
 
   config.x.fake_crm = ['true', '1', 'yes'].include?(String(ENV.fetch('FAKE_CRM') { true }))
+
+  if ENV['NOTIFY_CLIENT'] && ENV['NOTIFY_CLIENT'] != ''
+    Rails.application.config.x.notify_client = ENV['NOTIFY_CLIENT'].constantize
+  end
 end


### PR DESCRIPTION
### Context

Its useful to see the information being sent in an email actually needing to send the email via notify.

### Changes proposed in this pull request

1. Allow the notify client to be controlled by an environment variable in `development.rb`
2. Added Notify client which just writes to the Logger

### Guidance to review

1. Would like to add a more fully fleshed option which leverages letter_opener, but we're not there yet and this suffices.
2. This is quite subjective, and is just some code I've had knocking around on my machine so feel free to knock back if it doesn't seem like a good idea

