### PR TITLE
Add duration to acceptance screens SE-1330

### DIFF
--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -28,6 +28,17 @@
           <%- end -%>
         </dd>
       </div>
+
+      <%- if @placement_request.placement_date.present? -%>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Duration
+        </dt>
+        <dd class="govuk-summary-list__value availability-requested-date">
+          <%= pluralize(@placement_request.placement_date.duration, 'day') %>
+        </dd>
+      </div>
+      <%- end -%>
     </dl>
 
     <%= form_for @confirm_booking, url: schools_placement_request_acceptance_confirm_booking_path do |form| %>

--- a/app/views/schools/placement_requests/acceptance/email_preview_sections/_school_experience_details.html.erb
+++ b/app/views/schools/placement_requests/acceptance/email_preview_sections/_school_experience_details.html.erb
@@ -2,6 +2,7 @@
   <h3>School experience details</h3>
 
   <ul class="govuk-list govuk-list--bullet">
+    <li class="govuk-list__item">Dates: <%= @placement_request.booking.placement_start_date_with_duration %></li>
     <li class="govuk-list__item">Subject: <%= @placement_request.booking.bookings_subject.name %></li>
     <li class="govuk-list__item">Experience details: <%= @placement_request.booking.placement_details %></li>
   </ul>

--- a/features/schools/placement_requests/acceptance/confirm_booking.feature
+++ b/features/schools/placement_requests/acceptance/confirm_booking.feature
@@ -40,6 +40,11 @@ Feature: Accepting placement requests
         Then the date should be pre-populated
         And the original date should be listed on the page
 
+    Scenario: Displaying the duration when the school has fixed dates
+        Given my school is set to use 'fixed' dates
+        When I am on the 'confirm booking' page for my fixed placement request
+        Then I should see the placement request's duration
+
     Scenario: Entering an invalid date
         Given my school is set to use 'fixed' dates
         When I am on the 'confirm booking' page for my fixed placement request

--- a/features/schools/placement_requests/acceptance/preview_confirmation_email.feature
+++ b/features/schools/placement_requests/acceptance/preview_confirmation_email.feature
@@ -22,6 +22,7 @@ Feature: Accepting placement requests
             | School experience contacts    |
             | School experience details     |
             | Help and support              |
+        And I should see the booking date and duration displayed
 
     Scenario: Email preview - school details
         Given I have progressed to the 'preview confirmation email' page for my chosen placement request

--- a/features/schools/placement_requests/acceptance/review_and_send_email.feature
+++ b/features/schools/placement_requests/acceptance/review_and_send_email.feature
@@ -26,6 +26,7 @@ Feature: Accepting placement requests
             | School experience details     |
             | Extra details from the school |
             | Help and support              |
+        And I should see the booking date and duration displayed
 
     Scenario: Email preview - school details
         Given I have progressed to the 'review and send email' page for my chosen placement request

--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -90,3 +90,7 @@ Given("I enter three weeks from now as the date") do
   date = 3.weeks.from_now.strftime('%d-%m-%Y')
   step "I fill in the date field 'Confirm experience date' with #{date}"
 end
+
+Then("I should see the placement request's duration") do
+  expect(page).to have_css('dd', text: "1 day")
+end

--- a/features/step_definitions/schools/placement_requests/review_and_send_email_steps.rb
+++ b/features/step_definitions/schools/placement_requests/review_and_send_email_steps.rb
@@ -78,3 +78,9 @@ end
 Then("the candidate instructions should have been saved") do
   expect(@placement_request.booking.candidate_instructions).to eql(@candidate_instructions)
 end
+
+Then("I should see the booking date and duration displayed") do
+  within('#school-experience-details') do
+    expect(page).to have_content(@placement_request.booking.placement_start_date_with_duration)
+  end
+end


### PR DESCRIPTION
### Context

Add duration to placement request acceptance wizard, it was missing from the accept placement request and both screens with email previews

### Changes proposed in this pull request

Add the booking date to the relevant parts

### Guidance to review

Ensure it looks ok. Note that the date/duration summary will be improved by #667 

