### PR TITLE
Use fetch to retrieve state from session

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -19,7 +19,10 @@ module Schools
     end
 
     def create
-      check_state(session[:state], params[:state])
+      # using fetch rather than :[] so it'll blow up
+      # here if it's retrieiving the state from the session that's
+      # the problem rather than the comparison
+      check_state(session.fetch(:state), params[:state])
 
       client                    = get_oidc_client
       client.authorization_code = params[:code]


### PR DESCRIPTION
This is an attempt to work out why the state mismatch errors are
frequently happening. Rich speculated that it might be the retrieval of
the state from Redis that's causing the issue rather than comparing the
retrieved value to the one provided in params.

Fetch will blow up if it can't find `:state`, potentially highlighting the
issue