### PR TITLE
SE-1331 Write to tel1 and email1

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -10,9 +10,12 @@ module Bookings
       STATE_CODE = 0
 
       UPDATE_BLACKLIST = %w{
-        dfe_channelcreation statecode emailaddress1 telephone1 mobilephone
-        address1_telephone1
+        dfe_channelcreation statecode mobilephone address1_telephone1
       }.freeze
+
+      UPDATE_BLACKLIST_OTHER_RECORDS = (
+        UPDATE_BLACKLIST + %w{telephone1 emailaddress1}
+      ).freeze
 
       entity_id_attribute :contactid
 
@@ -64,6 +67,10 @@ module Bookings
         end
       end
 
+      def created_by_us?
+        dfe_channelcreation.to_s == CHANNEL_CREATION.to_s
+      end
+
       def address
         [building, street, town_or_city, county, postcode].compact.join(", ")
       end
@@ -73,7 +80,7 @@ module Bookings
       end
 
       def email=(emailaddress)
-        if emailaddress1.blank?
+        if emailaddress1.blank? || created_by_us?
           self.emailaddress1 = emailaddress
         end
 
@@ -99,6 +106,7 @@ module Bookings
 
       def phone=(phonenumber)
         self.telephone2 = phonenumber&.strip
+        self.telephone1 = self.telephone2 if created_by_us?
       end
 
       def date_of_birth

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -65,6 +65,26 @@ describe Bookings::Gitis::Contact, type: :model do
     end
   end
 
+  describe '#created_by_us?' do
+    context 'with our record' do
+      subject do
+        build :gitis_contact, \
+          dfe_channelcreation: described_class::CHANNEL_CREATION
+      end
+
+      it { is_expected.to be_created_by_us }
+    end
+
+    context 'with existing gitis record' do
+      subject do
+        build :gitis_contact, \
+          dfe_channelcreation: described_class::CHANNEL_CREATION + 1
+      end
+
+      it { is_expected.not_to be_created_by_us }
+    end
+  end
+
   describe "#email" do
     context "with primary address set" do
       subject { described_class.new(emailaddress1: 'first@test.com') }
@@ -146,37 +166,78 @@ describe Bookings::Gitis::Contact, type: :model do
 
     describe "#attributes_for_update" do
       let(:attrs) do
-        attributes_for :gitis_contact, :persisted, dfe_channelcreation: nil
+        attributes_for :gitis_contact, :persisted, dfe_channelcreation: channel
       end
 
       let(:contact) { Bookings::Gitis::Contact.new attrs }
       subject { contact.attributes_for_update }
 
-      context 'when unmodified' do
-        it { is_expected.not_to include('contactid') }
-        it { is_expected.not_to include('statecode') }
-        it { is_expected.not_to include('dfe_channelcreation') }
-        it { is_expected.not_to include('firstname') }
-        it { is_expected.not_to include('lastname') }
-        it { is_expected.to include('telephone2') }
-        it { is_expected.to include('emailaddress2') }
-      end
+      context 'with records we created' do
+        let(:channel) { described_class::CHANNEL_CREATION }
 
-      context 'when modified' do
-        before do
-          contact.firstname = 'Different'
-          contact.lastname = 'Different'
-          contact.email = 'new@fictional-address.com'
-          contact.phone = '0712345679'
+        context 'when unmodified' do
+          it { is_expected.not_to include('contactid') }
+          it { is_expected.not_to include('statecode') }
+          it { is_expected.not_to include('dfe_channelcreation') }
+          it { is_expected.not_to include('firstname') }
+          it { is_expected.not_to include('lastname') }
+          it { is_expected.to include('telephone2') }
+          it { is_expected.to include('emailaddress2') }
         end
 
-        it { is_expected.not_to include('contactid') }
-        it { is_expected.not_to include('statecode') }
-        it { is_expected.not_to include('dfe_channelcreation') }
-        it { is_expected.to include('firstname') }
-        it { is_expected.to include('lastname') }
-        it { is_expected.to include('emailaddress2') }
-        it { is_expected.to include('telephone2') }
+        context 'when modified' do
+          before do
+            contact.firstname = 'Different'
+            contact.lastname = 'Different'
+            contact.email = 'new@fictional-address.com'
+            contact.phone = '0712345679'
+          end
+
+          it { is_expected.not_to include('contactid') }
+          it { is_expected.not_to include('statecode') }
+          it { is_expected.not_to include('dfe_channelcreation') }
+          it { is_expected.to include('firstname') }
+          it { is_expected.to include('lastname') }
+          it { is_expected.to include('emailaddress1') }
+          it { is_expected.to include('emailaddress2') }
+          it { is_expected.to include('telephone1') }
+          it { is_expected.to include('telephone2') }
+        end
+      end
+
+      context "with other gitis records" do
+        let(:channel) { described_class::CHANNEL_CREATION + 1 }
+
+        context 'when unmodified' do
+          it { is_expected.not_to include('contactid') }
+          it { is_expected.not_to include('statecode') }
+          it { is_expected.not_to include('dfe_channelcreation') }
+          it { is_expected.not_to include('firstname') }
+          it { is_expected.not_to include('lastname') }
+          it { is_expected.not_to include('emailaddress1') }
+          it { is_expected.to include('emailaddress2') }
+          it { is_expected.not_to include('telephone1') }
+          it { is_expected.to include('telephone2') }
+        end
+
+        context 'when modified' do
+          before do
+            contact.firstname = 'Different'
+            contact.lastname = 'Different'
+            contact.email = 'new@fictional-address.com'
+            contact.phone = '0712345679'
+          end
+
+          it { is_expected.not_to include('contactid') }
+          it { is_expected.not_to include('statecode') }
+          it { is_expected.not_to include('dfe_channelcreation') }
+          it { is_expected.to include('firstname') }
+          it { is_expected.to include('lastname') }
+          it { is_expected.not_to include('emailaddress1') }
+          it { is_expected.to include('emailaddress2') }
+          it { is_expected.not_to include('telephone1') }
+          it { is_expected.to include('telephone2') }
+        end
       end
     end
   end


### PR DESCRIPTION
### Context

Following on from conversations with the CRM team - its been requested we update telephone1 and emailaddress1 when its our own records in the CRM

### Changes proposed in this pull request

1. Added method to detect when they are 'our own records'
2. Use that to determine which fields to update when assigning email and phone on the Contact entity
3. Tests to check for the above

### Guidance to review
1. Code review
2. CRM interactions are now written to the log, prefixed with [CRM] - this includes the fields written but not values

