### PR TITLE
De-emphasise resend link button

### DIFF
--- a/app/views/candidates/registrations/sign_ins/update.html.erb
+++ b/app/views/candidates/registrations/sign_ins/update.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <p>
-      <%= button_to 'Send a new link', @resend_link, class: 'govuk-button' %>
+      <%= button_to 'Send a new link', @resend_link, class: 'govuk-button govuk-button--secondary' %>
     </p>
   </div>
 </div>


### PR DESCRIPTION
### Context

Button should be a secondary button

### Changes proposed in this pull request

1. Made it a secondary button



