### PR TITLE
Rename 'open' scope to 'uprocessed'

### DIFF
--- a/app/controllers/schools/dashboards_controller.rb
+++ b/app/controllers/schools/dashboards_controller.rb
@@ -5,7 +5,7 @@ module Schools
     def show
       @school = current_school
 
-      @new_requests = current_school.placement_requests.open.count
+      @new_requests = current_school.placement_requests.unprocessed.count
       @new_bookings = current_school.bookings.upcoming.count
       @candidate_attendances = 4
     end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -45,8 +45,8 @@ module Bookings
 
     UPCOMING_TIMEFRAME = 2.weeks
 
-    scope :open, -> { joins(:bookings_placement_request).merge(PlacementRequest.not_cancelled) }
-    scope :upcoming, -> { open.where(arel_table[:date].between(Time.now..UPCOMING_TIMEFRAME.from_now)) }
+    scope :unprocessed, -> { joins(:bookings_placement_request).merge(PlacementRequest.not_cancelled) }
+    scope :upcoming, -> { unprocessed.where(arel_table[:date].between(Time.now..UPCOMING_TIMEFRAME.from_now)) }
     scope :accepted, -> { where.not(accepted_at: nil) }
 
     def self.from_confirm_booking(confirm_booking)

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -43,7 +43,7 @@ module Bookings
       inverse_of: :placement_request,
       dependent: :destroy
 
-    scope :open, -> do
+    scope :unprocessed, -> do
       not_cancelled.merge unbooked
     end
 

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -110,7 +110,7 @@ describe Bookings::Booking do
       end
     end
 
-    describe '.open' do
+    describe '.unprocessed' do
       let! :open_booking do
         FactoryBot.create :bookings_booking
       end
@@ -123,7 +123,7 @@ describe Bookings::Booking do
         FactoryBot.create :bookings_booking, :cancelled_by_candidate
       end
 
-      subject { described_class.open }
+      subject { described_class.unprocessed }
 
       it { is_expected.to match_array [open_booking] }
     end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -111,7 +111,7 @@ describe Bookings::Booking do
     end
 
     describe '.unprocessed' do
-      let! :open_booking do
+      let! :unprocessed_bookings do
         FactoryBot.create :bookings_booking
       end
 
@@ -125,7 +125,7 @@ describe Bookings::Booking do
 
       subject { described_class.unprocessed }
 
-      it { is_expected.to match_array [open_booking] }
+      it { is_expected.to match_array [unprocessed_bookings] }
     end
   end
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -90,8 +90,8 @@ describe Bookings::PlacementRequest, type: :model do
       FactoryBot.create :placement_request, school: school
     end
 
-    context '.open' do
-      subject { described_class.open }
+    context '.unprocessed' do
+      subject { described_class.unprocessed }
       it do
         is_expected.to match_array [
           placement_request_open,


### PR DESCRIPTION
'open' conflicts with a built in Ruby method

### Context

### Changes proposed in this pull request

### Guidance to review

