### PR TITLE
Adds validation message for unselected fees

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,11 +134,11 @@ en:
         schools/on_boarding/fees:
           attributes:
             administration_fees:
-              inclusion: 'Select an opiton'
+              inclusion: 'Select Yes or No for Administration costs'
             dbs_fees:
-              inclusion: 'Select an opiton'
+              inclusion: 'Select Yes or No for DBS check costs'
             other_fees:
-              inclusion: 'Select an opiton'
+              inclusion: 'Select Yes or No for Other costs'
         schools/on_boarding/administration_fee:
           <<: *schools_on_boarding_school_fee_errors
         schools/on_boarding/dbs_fee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,6 +131,14 @@ en:
               inclusion: 'Select whether you have requirements for school experience candidates'
             requirements_details:
               blank: 'Details required'
+        schools/on_boarding/fees:
+          attributes:
+            administration_fees:
+              inclusion: 'Select an opiton'
+            dbs_fees:
+              inclusion: 'Select an opiton'
+            other_fees:
+              inclusion: 'Select an opiton'
         schools/on_boarding/administration_fee:
           <<: *schools_on_boarding_school_fee_errors
         schools/on_boarding/dbs_fee:


### PR DESCRIPTION
### Context
Schools on boarding wizard fee radio buttons were missing validations messages when no fee was selected

### Changes proposed in this pull request
Adds validation errors when no fees are selected.

### Guidance to review

