### PR TITLE
Add /schools$ to the whitelist

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /$
+Allow: /schools$
 Disallow: /*


### PR DESCRIPTION
### Context

Google currently can't index the schools landing page, only the candidate one

### Changes proposed in this pull request

Add `/schools$` to the whitelist

### Guidance to review

It's a pretty minimal change! `$` denotes the end of a URL
