### PR TITLE
Make later pipeline steps dependent upon earlier pipeline steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ steps:
   - script: |
       docker run --name=selenium-firefox -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-firefox
       docker run --rm --link postgres:postgres --link=redis:redis --link selenium-firefox:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e CUC_DRIVER=firefox -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(dockerRegistry)/$(imageName):$(imageTag) cucumber
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'),eq(variables['Build.SourceBranch'], 'refs/heads/phase2'))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'),eq(variables['Build.SourceBranch'], 'refs/heads/debug')))
     displayName: Run Cucumber via Selenium Firefox
 
   - script: |
@@ -73,11 +73,11 @@ steps:
       docker push $(dockerRegistry)/$(imageName):latest
       docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(DOCKER_HUB_REPO):$(imageTag)
       docker tag $(dockerRegistry)/$(imageName):$(imageTag) $(DOCKER_HUB_REPO):latest
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: 'Push Docker image (built from master)'
 
   - task: Docker@2
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: login
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
@@ -85,7 +85,7 @@ steps:
 
   - task: Docker@2
     displayName: 'push to docker hub'
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
       repository: $(DOCKER_HUB_REPO)
@@ -94,7 +94,7 @@ steps:
 
   - task: Docker@2
     displayName: 'push to docker hub'
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
       repository: $(DOCKER_HUB_REPO)


### PR DESCRIPTION
### Context

Currently within the CI pipeline, any steps with conditions will be running irrespective of whether the prior step succeeded. This is because we override the default condition which is to depend upon the earlier step

### Changes proposed in this pull request

1. Make any steps with conditions first check the earlier step succeeded

### Guidance to review
1. Sanity checking
