### PR TITLE
Added nosniff header for static assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,6 +23,9 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.headers = {
+    'X-Content-Type-Options' => 'nosniff'
+  }
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
### Context

We are triggering warnings from Pen Test tools because we don't set the `X-Content-Type-Options` header to `nosniff`

### Changes proposed in this pull request

1. Explicitly set the header for static assets served by Puma

### Guidance to review

Run the app in production, verify the header is present on the CSS/JS files and matches the header setting on the main html file.

Note this requires

1. Assets to be precompiled
2. `RAILS_SERVE_STATIC_FILES=true` set in `.env`
3. `config.force_ssl`  set to false in `production.rb`
