### PR TITLE
Fix for incorrectly formatted date in Cancellation email

### DIFF
--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -83,7 +83,7 @@ module Candidates
           school_name: cancellation.school_name,
           candidate_name: cancellation.candidate_name,
           cancellation_reasons: cancellation.reason,
-          requested_on: cancellation.created_at.to_formatted_s(:govuk),
+          requested_on: cancellation.placement_request.requested_on.to_formatted_s(:govuk),
           placement_request_url: schools_placement_request_url(cancellation.placement_request)
         ).despatch_later!
       end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -164,6 +164,10 @@ module Bookings
       cancellation&.sent?
     end
 
+    def requested_on
+      created_at&.to_date
+    end
+
   private
 
     def completed?

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -164,7 +164,7 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
               school_name: cancellation.school_name,
               candidate_name: gitis_contact.full_name,
               cancellation_reasons: cancellation.reason,
-              requested_on: cancellation.placement_request.created_at.to_formatted_s(:govuk),
+              requested_on: cancellation.placement_request.requested_on.to_formatted_s(:govuk),
               placement_request_url: schools_placement_request_url(cancellation.placement_request)
 
             expect(notify_school_request_cancellation).to \

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -44,7 +44,8 @@ describe Schools::PlacementRequestsController, type: :request do
       before { get '/schools/placement_requests' }
 
       specify 'they should be omitted' do
-        expect(assigns(:placement_requests)).to eq(school.placement_requests - Array.wrap(booked))
+        expect(assigns(:placement_requests).sort_by(&:id)).to \
+          eq((school.placement_requests - Array.wrap(booked)).sort_by(&:id))
       end
     end
   end

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -199,6 +199,9 @@ describe Bookings::PlacementRequest, type: :model do
     it { is_expected.to respond_to :teaching_stage }
     it { is_expected.to respond_to :subject_first_choice }
     it { is_expected.to respond_to :subject_second_choice }
+    it { is_expected.to respond_to :availability }
+    it { is_expected.to respond_to :objectives }
+    it { is_expected.to respond_to :bookings_placement_date_id }
   end
 
   context 'validations' do
@@ -336,14 +339,7 @@ describe Bookings::PlacementRequest, type: :model do
     Date.today
   end
 
-  context 'attributes' do
-    it { is_expected.to respond_to :urn }
-    it { is_expected.to respond_to :availability }
-    it { is_expected.to respond_to :objectives }
-    it { is_expected.to respond_to :bookings_placement_date_id }
-  end
-
-  context 'validations' do
+  context 'validations for placement preferences' do
     before :each do
       placement_preference.validate
     end
@@ -566,5 +562,10 @@ describe Bookings::PlacementRequest, type: :model do
 
       expect(subject.gitis_contact).to be_kind_of(Bookings::Gitis::Contact)
     end
+  end
+
+  describe '#requested_on' do
+    subject { create :placement_request }
+    it { is_expected.to have_attributes(requested_on: subject.created_at.to_date) }
   end
 end


### PR DESCRIPTION
### Context

Whilst investigate a couple of flaky test failures, I also found the format of the cancellation email sent to schools when Candidates cancel a booking is in an incorrect format, including the time of placement request.

### Changes proposed in this pull request

1. Change the Cancellation email to show the date without the time.
2. A fix a flaky test in the test suite which was assuming records were created by FactoryBot were created in a specific order.

### Guidance to review

1. Sanity checking

