### PR TITLE
Changed heading on Personal Information screen for Phase 2

### DIFF
--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -2,7 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Check if we already have your details</h1>
+    <h1 class="govuk-heading-l">
+      <%- if Rails.application.config.x.phase >= 3 -%>
+      Check if we already have your details
+      <%- else -%>
+      Enter your details
+      <%- end -%>
+    </h1>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -56,7 +56,7 @@ feature 'Candidate Registrations', type: :feature do
       end
 
       scenario "completing the Journey" do
-        complete_personal_information_step
+        complete_personal_information_step 'Enter your details'
         complete_contact_information_step
         complete_subject_preference_step
         complete_placement_preference_step
@@ -145,10 +145,10 @@ feature 'Candidate Registrations', type: :feature do
     end
   end
 
-  def complete_personal_information_step
+  def complete_personal_information_step(expected_heading = nil)
     # Begin wizard journey
     visit "/candidates/schools/#{school_urn}/registrations/personal_information/new"
-    expect(page).to have_text 'Check if we already have your details'
+    expect(page).to have_text expected_heading || 'Check if we already have your details'
 
     # Submit personal information form with errors
     fill_in 'First name', with: 'testy'


### PR DESCRIPTION
### Context

Heading on the Personal Information needs to be corrected for runnning in Phase 2, ie no CRM

### Changes proposed in this pull request

1. Change the title
2. Update the phase2 feature spec

### Guidance to review

1. Sanity check
