### PR TITLE
Feature/diagnose state mismatch errors se 1356

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -19,6 +19,8 @@ module Schools
     end
 
     def create
+      return redirect_to schools_dashboard_path if user_signed_in?
+
       # using fetch rather than :[] so it'll blow up
       # here if it's retrieiving the state from the session that's
       # the problem rather than the comparison

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,13 +1,5 @@
 class SchoolsController < ApplicationController
   include DFEAuthentication
 
-  before_action :redirect_to_dashboard, if: :user_signed_in?
-
   def show; end
-
-private
-
-  def redirect_to_dashboard
-    redirect_to(schools_dashboard_path)
-  end
 end

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -3,10 +3,10 @@ require_relative 'session_context'
 
 describe Schools::SessionsController, type: :request do
   context '#create' do
-    context 'redirection' do
-      let(:return_url) { '/schools/dashboard' }
+    let(:return_url) { '/schools/dashboard' }
+    let(:state) { 'd18ce84b-423e-4696-bee4-b74caa47163e' }
 
-      let(:state) { 'd18ce84b-423e-4696-bee4-b74caa47163e' }
+    context 'when the user is not yet signed in' do
       let(:code) { 'OTA4MTU0ZTgtMjBhZC00YmNmLThmMmQtOGZiZDhmNTYxMTA2vLY8wh-MpR-WR3vsn4C2J_oBkN-KGjD9-XVcDFS8UyADwt5DrIrYe0Gjgsj2gpvAt5L2cka5n8ZZmiojr6zgWg' }
       let(:session_state) { '652b5afc63d7c4875c42de4231f66e4940226f840b2a7ea02441544751ea0a2a.h3bd7bc2438a84dc' }
       let(:access_token) { 'abc123' }
@@ -109,6 +109,23 @@ describe Schools::SessionsController, type: :request do
             expect(response.status).to eql 302
           end
         end
+      end
+    end
+
+    context 'when the user is already logged in' do
+      before do
+        allow_any_instance_of(ActionDispatch::Request)
+          .to receive(:session).and_return(
+            return_url: return_url,
+            state: state,
+            current_user: { name: 'Milhouse' }
+        )
+      end
+
+      subject { get auth_callback_path }
+
+      specify 'should redirect to the dashboard' do
+        expect(subject).to redirect_to(schools_dashboard_path)
       end
     end
   end

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -3,15 +3,6 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe SchoolsController, type: :request do
   describe 'redirecting logged-in users to the dashboard' do
-    context 'when a user is logged in' do
-      include_context "logged in DfE user"
-      before { get '/schools' }
-
-      specify 'should be redirected to the dashboard' do
-        expect(response).to redirect_to(schools_dashboard_path)
-      end
-    end
-
     context 'when no user is logged in' do
       before { get '/schools' }
 


### PR DESCRIPTION
### Context

We're still seeing quite a number of state mismatch errors in production and a potential cause might be users clicking 'back' after logging in (in an attempt to change school).

This fails because after the user has been redirected to the dashboard controller after they've been boucned back from DfE Signin (via the `SessionsController#create`) their query string has been lost, hence the session mismatch.

### Changes proposed in this pull request

Now, if users are logged in (on the dashboard) and they click back, they'll be immediately redirected back to the dashboard. If they want to 'go back' to select another school on DfE Signin they'll have to click 'Change School' in the app.

### Guidance to review

Ensure the process works correctly and clicking back after having logged in doesn't result in a state mismatch error
