### PR TITLE
SE-1312 add Content Security Policy

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -2,7 +2,7 @@ class Candidates::SchoolsController < ApplicationController
   include AnalyticsTracking
   EXPANDED_SEARCH_RADIUS = 50
 
-  content_security_policy do |policy|
+  content_security_policy(only: :show) do |policy| # Allow bing maps
     policy.connect_src :self, 'https://www.bing.com'
     policy.script_src :self, :data, "'unsafe-inline'", "'unsafe-eval'", 'https://www.bing.com', 'https://*.virtualearth.net'
     policy.font_src :self, :data

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -2,6 +2,14 @@ class Candidates::SchoolsController < ApplicationController
   include AnalyticsTracking
   EXPANDED_SEARCH_RADIUS = 50
 
+  content_security_policy do |policy|
+    policy.connect_src :self, 'https://www.bing.com'
+    policy.script_src :self, :data, "'unsafe-inline'", "'unsafe-eval'", 'https://www.bing.com', 'https://*.virtualearth.net'
+    policy.font_src :self, :data
+    policy.img_src :self, :data, 'https://www.bing.com', 'https://*.virtualearth.net'
+    policy.style_src :self, "'unsafe-inline'", 'https://www.bing.com'
+  end
+
   def index
     return redirect_to new_candidates_school_search_path unless location_present?
 

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -3,11 +3,17 @@ class Candidates::SchoolsController < ApplicationController
   EXPANDED_SEARCH_RADIUS = 50
 
   content_security_policy(only: :show) do |policy| # Allow bing maps
-    policy.connect_src :self, 'https://www.bing.com'
-    policy.script_src :self, :data, "'unsafe-inline'", "'unsafe-eval'", 'https://www.bing.com', 'https://*.virtualearth.net'
+    policy.connect_src :self, 'https://www.bing.com', "https://*.visualstudio.com"
     policy.font_src :self, :data
-    policy.img_src :self, :data, 'https://www.bing.com', 'https://*.virtualearth.net'
+    policy.img_src :self, :data, 'https://www.bing.com', 'https://*.virtualearth.net', "https://www.google-analytics.com"
     policy.style_src :self, "'unsafe-inline'", 'https://www.bing.com'
+    policy.script_src :self, :data, "'unsafe-inline'",
+      "'unsafe-eval'",
+      'https://www.bing.com',
+      'https://*.virtualearth.net',
+      "https://www.googletagmanager.com",
+      "https://www.google-analytics.com",
+      "https://*.vo.msecnd.net"
   end
 
   def index

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,8 +26,11 @@
 
  Rails.application.config.content_security_policy do |policy|
    policy.default_src :self
-   if ENV['GA_TRACKING_ID'].present?
-     policy.img_src :self, "https://www.google-analytics.com"
-     policy.script_src :self, "'unsafe-inline'", "https://www.googletagmanager.com", "https://www.google-analytics.com"
-   end
+
+   policy.connect_src :self, "https://*.visualstudio.com"
+   policy.img_src :self, "https://www.google-analytics.com"
+   policy.script_src :self, "'unsafe-inline'",
+     "https://www.googletagmanager.com",
+     "https://www.google-analytics.com",
+     "https://*.vo.msecnd.net"
  end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -30,10 +30,4 @@
      policy.img_src :self, "https://www.google-analytics.com"
      policy.script_src :self, "'unsafe-inline'", "https://www.googletagmanager.com", "https://www.google-analytics.com"
    end
-
-   # Specify URI for violation reports
-#   policy.report_uri "/csp-violation-report-endpoint"
  end
-
-Rails.application.config.content_security_policy_report_only = \
-  %w{1 true yes}.include?(ENV['CSP_REPORT_ONLY'].to_s)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,3 +23,13 @@
 # For further information see the following documentation:
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 # Rails.application.config.content_security_policy_report_only = true
+
+ Rails.application.config.content_security_policy do |policy|
+   policy.default_src :self
+
+   # Specify URI for violation reports
+#   policy.report_uri "/csp-violation-report-endpoint"
+ end
+
+Rails.application.config.content_security_policy_report_only = \
+  %w{1 true yes}.include?(ENV['CSP_REPORT_ONLY'].to_s)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -26,6 +26,10 @@
 
  Rails.application.config.content_security_policy do |policy|
    policy.default_src :self
+   if ENV['GA_TRACKING_ID'].present?
+     policy.img_src :self, "https://www.google-analytics.com"
+     policy.script_src :self, "'unsafe-inline'", "https://www.googletagmanager.com", "https://www.google-analytics.com"
+   end
 
    # Specify URI for violation reports
 #   policy.report_uri "/csp-violation-report-endpoint"


### PR DESCRIPTION
### Context

The lack of content security policy was raised as a concern in the internal Pen Test performed by @petenorth 

### Changes proposed in this pull request

1. Added a generic CSP granting access for google analytics and app insights
2. Added a specialised CSP for the show school profile page, which also allows bing maps to run

### Guidance to review
1. Check various pages, including the search for schools -> show school page, with the javascript console open looking for any errors
2. Ensure Google Analytics, Bing Maps and App Insights are all enabled

