### PR TITLE
Remove capturing school admin (name from UI)

### DIFF
--- a/app/controllers/schools/on_boarding/admin_contacts_controller.rb
+++ b/app/controllers/schools/on_boarding/admin_contacts_controller.rb
@@ -35,7 +35,7 @@ module Schools
 
       def admin_contact_params
         params.require(:schools_on_boarding_admin_contact).permit \
-          :full_name, :phone, :email
+          :phone, :email
       end
     end
   end

--- a/app/forms/schools/on_boarding/admin_contact.rb
+++ b/app/forms/schools/on_boarding/admin_contact.rb
@@ -1,18 +1,16 @@
 module Schools
   module OnBoarding
     class AdminContact < Step
-      attribute :full_name, :string
       attribute :phone, :string
       attribute :email, :string
 
-      validates :full_name, presence: true
       validates :phone, presence: true
       validates :phone, phone: true, if: -> { phone.present? }
       validates :email, presence: true
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
 
-      def self.compose(full_name, email, phone)
-        new full_name: full_name, email: email, phone: phone
+      def self.compose(email, phone)
+        new email: email, phone: phone
       end
     end
   end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -144,10 +144,6 @@ module Bookings
       school.name
     end
 
-    def school_admin_name
-      school.admin_contact_name
-    end
-
     def candidate_email
       candidate.email
     end

--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -11,7 +11,6 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
   delegate \
     :school_email,
     :school_name,
-    :school_admin_name,
     :candidate_email,
     :candidate_name,
     :dates_requested,

--- a/app/models/bookings/profile.rb
+++ b/app/models/bookings/profile.rb
@@ -6,8 +6,14 @@ class Bookings::Profile < ApplicationRecord
   FIELDS_TO_NILIFY = %i{dbs_policy teacher_training_info teacher_training_url}.freeze
 
   FIELDS_TO_STRIP = %i{
-    start_time end_time admin_contact_full_name admin_contact_email admin_contact_phone
+    start_time end_time admin_contact_email admin_contact_phone
   }.freeze
+
+  # Temporary while we're in the process of removing the admin_full_name
+  # attribute as the column has a not null constraint
+  before_save do
+    self.admin_contact_full_name = 'NOT-SET'
+  end
 
   belongs_to :school, class_name: 'Bookings::School'
   validates :school_id, uniqueness: true
@@ -46,7 +52,6 @@ class Bookings::Profile < ApplicationRecord
 
   validates :teacher_training_url, format: URI::regexp(%w{http https}), if: :teacher_training_url
 
-  validates :admin_contact_full_name, presence: true
   validates :admin_contact_email, presence: true
   validates :admin_contact_email, format: EMAIL_FORMAT, allow_blank: true
   validates :admin_contact_phone, presence: true

--- a/app/models/bookings/profile_attributes_convertor.rb
+++ b/app/models/bookings/profile_attributes_convertor.rb
@@ -74,14 +74,8 @@ module Bookings
     end
 
     def convert_admin_details
-      output[:admin_contact_full_name] = input[:admin_contact_full_name].presence
-
-      if output[:admin_contact_full_name].present?
-        output[:admin_contact_email] = input[:admin_contact_email]
-        output[:admin_contact_phone] = input[:admin_contact_phone]
-      else
-        output[:admin_contact_email] = output[:admin_contact_phone] = nil
-      end
+      output[:admin_contact_email] = input[:admin_contact_email].presence
+      output[:admin_contact_phone] = output[:admin_contact_email].presence && input[:admin_contact_phone].presence
     end
 
     def copy_phases

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -149,10 +149,6 @@ class Bookings::School < ApplicationRecord
     end
   end
 
-  def admin_contact_name
-    profile ? profile.admin_contact_full_name : contact_email
-  end
-
   def admin_contact_phone
     profile&.admin_contact_phone
   end

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -167,7 +167,6 @@ module Schools
       :admin_contact,
       class_name: 'Schools::OnBoarding::AdminContact',
       mapping: [
-        %w(admin_contact_full_name full_name),
         %w(admin_contact_email email),
         %w(admin_contact_phone phone)
       ],

--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -7,7 +7,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     :school_finish_time,
     :school_dress_code,
     :school_parking,
-    :school_admin_name,
     :school_admin_email,
     :school_admin_telephone,
     :school_teacher_name,
@@ -26,7 +25,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     school_finish_time:,
     school_dress_code:,
     school_parking:,
-    school_admin_name:,
     school_admin_email:,
     school_admin_telephone:,
     school_teacher_name:,
@@ -44,7 +42,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     self.school_finish_time = school_finish_time
     self.school_dress_code = school_dress_code
     self.school_parking = school_parking
-    self.school_admin_name = school_admin_name
     self.school_admin_email = school_admin_email
     self.school_admin_telephone = school_admin_telephone
     self.school_teacher_name = school_teacher_name
@@ -83,7 +80,6 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
         profile.parking_provided ? 'Yes' : 'No',
         profile.parking_details
       ].join(', '),
-      school_admin_name: profile.admin_contact_full_name,
       school_admin_email: profile.admin_contact_email,
       school_admin_telephone: profile.admin_contact_phone,
       school_teacher_name: booking.contact_name,
@@ -97,7 +93,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
 private
 
   def template_id
-    '29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3'
+    'b9882e65-b644-4c52-871e-0e5922f27d7e'
   end
 
   def personalisation
@@ -110,7 +106,6 @@ private
       school_finish_time: school_finish_time,
       school_dress_code: school_dress_code,
       school_parking: school_parking,
-      school_admin_name: school_admin_name,
       school_admin_email: school_admin_email,
       school_admin_telephone: school_admin_telephone,
       school_teacher_name: school_teacher_name,

--- a/app/notify/notify_email/candidate_booking_confirmation_withoutadmincontactname.b9882e65-b644-4c52-871e-0e5922f27d7e.md
+++ b/app/notify/notify_email/candidate_booking_confirmation_withoutadmincontactname.b9882e65-b644-4c52-871e-0e5922f27d7e.md
@@ -1,0 +1,30 @@
+Dear ((candidate_name)),
+
+Here are the main details about your school experience at ((school_name)):
+
+* Address: ((school_address))
+* Experience dates: ((placement_schedule))
+* Experience start and finish times: ((school_start_time)) to ((school_finish_time))
+* Dress code: ((school_dress_code))
+* Parking: ((school_parking))
+
+# School experience contacts
+
+If you have any questions about your booking:
+
+Email address: ((school_admin_email))
+UK telephone number: ((school_admin_telephone))
+
+On the day of your school experience, you'll need to report to:
+
+Name: ((school_teacher_name))
+Email address: ((school_teacher_email))
+UK telephone number: ((school_teacher_telephone))
+
+You can also contact them if you have any questions about your experience.
+
+To cancel your school experience use the following link ((cancellation_url)).
+
+# School experience details
+
+((placement_details))

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -208,10 +208,6 @@ module Schools
         end
       end
 
-      def admin_contact_full_name
-        @school_profile.admin_contact.full_name
-      end
-
       def admin_contact_phone
         @school_profile.admin_contact.phone
       end

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -46,7 +46,6 @@
         Provide admin contact details
       </h2>
 
-      <%= f.text_field :full_name %>
       <%= f.text_field :phone %>
       <%= f.text_field :email %>
       <%= f.submit 'Continue' %>

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -51,7 +51,6 @@
 
       <h2 class="ogvuk-heading-m">Admin contact details</h2>
       <dl class="govuk-summary-list">
-        <%= summary_row 'Full name', @profile.admin_contact_full_name, edit_schools_on_boarding_admin_contact_path %>
         <%= summary_row 'UK telephone number', @profile.admin_contact_phone, edit_schools_on_boarding_admin_contact_path %>
         <%= summary_row 'Email address', @profile.admin_contact_email, edit_schools_on_boarding_admin_contact_path %>
       </dl>

--- a/app/views/schools/placement_requests/acceptance/email_preview_sections/_help_and_support.html.erb
+++ b/app/views/schools/placement_requests/acceptance/email_preview_sections/_help_and_support.html.erb
@@ -4,7 +4,6 @@
   <p>If you have any questions about your booking contact:</p>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li class="govuk-list__item">Name: <%= @placement_request.school&.profile&.admin_contact_full_name %></li>
     <li class="govuk-list__item">Email address: <%= @placement_request.school&.profile&.admin_contact_email %></li>
     <li class="govuk-list__item">UK telephone number: <%= @placement_request.school&.profile&.admin_contact_phone %></li>
   </ul>

--- a/features/schools/onboarding/admin_contact.feature
+++ b/features/schools/onboarding/admin_contact.feature
@@ -26,14 +26,12 @@ Feature: Admin contact
 
   Scenario: Completing the step with error
     Given I am on the 'Admin contact' page
-    And I enter 'Gary Chalmers' into the 'Full name' text area
     And I enter '01234567890' into the 'UK telephone number' text area
     When I submit the form
     Then I should see a validation error message
 
   Scenario: Completing the step with error
     Given I am on the 'Admin contact' page
-    And I enter 'Gary Chalmers' into the 'Full name' text area
     And I enter '01234567890' into the 'UK telephone number' text area
     And I enter 'g.chalmers@springfield.edu' into the 'Email address' text area
     When I submit the form

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -37,7 +37,7 @@ Feature: School Profile
   Scenario: Viewing the profile
     Given I am on the 'Profile' page
     Then the page should have the following summary list information:
-      | Full name                   | school 1                                                    |
+      | Full name                   | Some school                                                 |
       | Address                     | \d{1,} something street, M\d{1,} 2JJ                        |
       | UK telephone number         | 01234567890                                                 |
       | Email address               | school1@example.com                                         |
@@ -56,6 +56,5 @@ Feature: School Profile
       | Start time                  | 8:15 am                                                     |
       | Finish time                 | 4:30 pm                                                     |
       | Flexible on times           | No                                                          |
-      | Full name                   | Gary Chalmers                                               |
       | UK telephone number         | 01234567890                                                 |
       | Email address               | g.chalmers@springfield.edu                                  |

--- a/features/schools/placement_requests/acceptance/preview_confirmation_email.feature
+++ b/features/schools/placement_requests/acceptance/preview_confirmation_email.feature
@@ -51,7 +51,6 @@ Feature: Accepting placement requests
     Scenario: Email preview - help and support
         Given I have progressed to the 'preview confirmation email' page for my chosen placement request
         Then in the 'Help and support' section I should see the following items:
-            | Name                |
             | Email address       |
             | UK telephone number |
         And the help and support section should contain the relevant information

--- a/features/schools/placement_requests/acceptance/review_and_send_email.feature
+++ b/features/schools/placement_requests/acceptance/review_and_send_email.feature
@@ -55,7 +55,6 @@ Feature: Accepting placement requests
     Scenario: Email preview - help and support
         Given I have progressed to the 'review and send email' page for my chosen placement request
         Then in the 'Help and support' section I should see the following items:
-            | Name                |
             | Email address       |
             | UK telephone number |
         And the help and support section should contain the relevant information

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -135,7 +135,6 @@ end
 Given "I have completed the Admin contact step" do
   steps %(
     Given I am on the 'Admin contact' page
-    And I enter 'Gary Chalmers' into the 'Full name' text area
     And I enter '01234567890' into the 'UK telephone number' text area
     And I enter 'g.chalmers@springfield.edu' into the 'Email address' text area
     When I submit the form

--- a/features/step_definitions/schools/placement_requests/review_and_send_email_steps.rb
+++ b/features/step_definitions/schools/placement_requests/review_and_send_email_steps.rb
@@ -66,7 +66,6 @@ end
 Then("the help and support section should contain the relevant information") do
   within('section#help-and-support') do
     [
-      @profile.admin_contact_full_name,
       @profile.admin_contact_email,
       @profile.admin_contact_phone
     ].each do |item|

--- a/spec/factories/schools/on_boarding/admin_contact_factory.rb
+++ b/spec/factories/schools/on_boarding/admin_contact_factory.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :admin_contact, class: Schools::OnBoarding::AdminContact do
-    full_name { 'Gary Chalmers' }
     email { 'g.chalmers@springfield.edu' }
     phone { '+441234567890' }
   end

--- a/spec/forms/schools/on_boarding/admin_contact_spec.rb
+++ b/spec/forms/schools/on_boarding/admin_contact_spec.rb
@@ -2,13 +2,11 @@ require 'rails_helper'
 
 describe Schools::OnBoarding::AdminContact, type: :model do
   context 'attributes' do
-    it { is_expected.to respond_to :full_name }
     it { is_expected.to respond_to :phone }
     it { is_expected.to respond_to :email }
   end
 
   context 'validations' do
-    it { is_expected.to validate_presence_of :full_name }
     it { is_expected.to validate_presence_of :phone }
     it { is_expected.to validate_presence_of :email }
 

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       it { is_expected.to include(dress_code_remove_piercings: true) }
       it { is_expected.to include(dress_code_smart_casual: true) }
       it { is_expected.to include(dress_code_other_details: 'Must have nice hat') }
-      it { is_expected.to include(admin_contact_full_name: 'Gary Chalmers') }
       it { is_expected.to include(admin_contact_email: 'g.chalmers@springfield.edu') }
       it { is_expected.to include(admin_contact_phone: '+441234567890') }
       it { is_expected.to include(primary_phase: true) }
@@ -63,7 +62,7 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
         model.description_details = ' '
         model.candidate_experience_detail_disabled_facilities = false
         model.candidate_experience_detail_other_dress_requirements = false
-        model.admin_contact_full_name = ' '
+        model.admin_contact_email = ' '
         model.phases_list_primary = false
         model.phases_list_secondary = false
         model.phases_list_college = true
@@ -88,7 +87,6 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       it { is_expected.to include(description_details: nil) }
       it { is_expected.to include(disabled_facilities: nil) }
       it { is_expected.to include(dress_code_other_details: nil) }
-      it { is_expected.to include(admin_contact_full_name: nil) }
       it { is_expected.to include(admin_contact_email: nil) }
       it { is_expected.to include(admin_contact_phone: nil) }
       it { is_expected.to include(primary_phase: false) }

--- a/spec/models/bookings/profile_spec.rb
+++ b/spec/models/bookings/profile_spec.rb
@@ -247,10 +247,6 @@ RSpec.describe Bookings::Profile, type: :model do
       end
     end
 
-    describe "admin_contact_full_name" do
-      it { is_expected.to validate_presence_of :admin_contact_full_name }
-    end
-
     describe "admin_contact_email" do
       it { is_expected.to allow_value('me@you.com').for :admin_contact_email }
       it { is_expected.to allow_value('me.test@you.co.uk').for :admin_contact_email }

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -464,7 +464,7 @@ describe Schools::SchoolProfile, type: :model do
         model.admin_contact = form_model
       end
 
-      %i(full_name phone email).each do |attribute|
+      %i(phone email).each do |attribute|
         it "sets #{attribute} correctly" do
           expect(model.send("admin_contact_#{attribute}")).to \
             eq form_model.send attribute

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateBookingConfirmation do
-  it_should_behave_like "email template", "29ed44bd-dc79-4fb3-bf8e-6e0ff18365b3",
+  it_should_behave_like "email template", "b9882e65-b644-4c52-871e-0e5922f27d7e",
     school_name: "Springfield Elementary",
     candidate_name: "Kearney Zzyzwicz",
     placement_schedule: "2022-03-04 for 3 days",
@@ -10,7 +10,6 @@ describe NotifyEmail::CandidateBookingConfirmation do
     school_finish_time: "15:30",
     school_dress_code: "Smart casual, elbow patches",
     school_parking: "There is a car park on the school grounds",
-    school_admin_name: "Seymour Skinner",
     school_admin_email: "sskinner@springfield.co.uk",
     school_admin_telephone: "01234 123 1234",
     school_teacher_name: "Edna Krabappel",
@@ -83,10 +82,6 @@ describe NotifyEmail::CandidateBookingConfirmation do
         expect(subject.school_parking).to eql(
           ['No', profile.parking_details].join(', ')
         )
-      end
-
-      specify 'school_admin_name is correctly-assigned' do
-        expect(subject.school_admin_name).to eql(profile.admin_contact_full_name)
       end
 
       specify 'school_admin_email is correctly-assigned' do

--- a/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
@@ -388,16 +388,6 @@ describe Schools::OnBoarding::SchoolProfilePresenter do
     end
   end
 
-  context '#admin_contact_full_name' do
-    let :profile do
-      FactoryBot.build :school_profile, :with_admin_contact
-    end
-
-    it "returns the admin contact's name" do
-      expect(subject.admin_contact_full_name).to eq 'Gary Chalmers'
-    end
-  end
-
   context '#admin_contact_email' do
     let :profile do
       FactoryBot.build :school_profile, :with_admin_contact


### PR DESCRIPTION
### Context
Removing this field to avoid capturing unnecessary pii.

### Changes proposed in this pull request
Removes the school admin name from the app, leaves the column name in the db.

### Guidance to review
should be no instances of school admin name.
I've added a new notify template for candidate booking confirmation, will want to remove the old template once this code is deployed to staging.