### PR TITLE
Bugfix/replace failing feature with spec se 1392

### DIFF
--- a/features/schools/placement_requests/acceptance/confirm_booking.feature
+++ b/features/schools/placement_requests/acceptance/confirm_booking.feature
@@ -45,6 +45,9 @@ Feature: Accepting placement requests
         When I am on the 'confirm booking' page for my fixed placement request
         Then I should see the placement request's duration
 
+    # This scenario fails in CI using the Firefox driver, seeminly it's
+    # ok everywhere else. See SE-1392
+    @wip
     Scenario: Entering an invalid date
         Given my school is set to use 'fixed' dates
         When I am on the 'confirm booking' page for my fixed placement request

--- a/features/schools/placement_requests/acceptance/confirm_booking.feature
+++ b/features/schools/placement_requests/acceptance/confirm_booking.feature
@@ -45,18 +45,6 @@ Feature: Accepting placement requests
         When I am on the 'confirm booking' page for my fixed placement request
         Then I should see the placement request's duration
 
-    # This scenario fails in CI using the Firefox driver, seeminly it's
-    # ok everywhere else. See SE-1392
-    @wip
-    Scenario: Entering an invalid date
-        Given my school is set to use 'fixed' dates
-        When I am on the 'confirm booking' page for my fixed placement request
-        And I select 'Chemistry' from the 'Confirm subject' select box
-        And I enter "It's a really exciting day" into the "Confirm experience details" text area
-        And I fill in the 'Confirm experience date' date field with an invalid date of 31st September next year
-        And I submit the form
-        Then I should see an error message stating 'not a valid date'
-
     Scenario: The date should be blank when the school has flexible dates
         Given my school is set to use 'flexible' dates
         When I am on the 'confirm booking' page for my flexible placement request

--- a/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
@@ -70,12 +70,12 @@ describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type:
       end
     end
 
-    context 'with invalid params' do
+    context 'with an invalid date' do
       let(:params) do
         {
           schools_placement_requests_confirm_booking: {
             bookings_subject_id: create(:bookings_subject).id,
-            # date: '2019-07-03',
+            date: '2019-09-31',
             placement_details: "you'll get to try out teaching"
           }
         }
@@ -89,6 +89,10 @@ describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type:
 
       specify 'should rerender the new template' do
         expect(response).to render_template(:new)
+      end
+
+      specify "should include an 'invalid date' error" do
+        expect(response.body).to match(/not a valid date/)
       end
     end
   end


### PR DESCRIPTION
### Context

A feature (`features/schools/placement_requests/acceptance/confirm_booking.feature:48`) was failing in CI when run with Firefox. It passed locally with Firefox and locally and on CI with Chrome. I don't know why, yet but there's a ticket (SE-1392) to diagnose it. 

### Changes proposed in this pull request

Replace the failing feature with an equivalent spec

### Guidance to review

Ensure the change makes sense and the same functionality was covered by both
