### PR TITLE
Added App Insights cookies to the policy

### DIFF
--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -200,6 +200,53 @@
           </tbody>
         </table>
       </section>
+      <section>
+        <h3 class="govuk-heading-m">Microsoft Application Insights</h3>
+        <p>
+          Used to track visits to help us improve the quality of our service.
+        </p>
+        <table class="govuk-table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">
+                Name
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Purpose
+              </th>
+              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                Expires
+              </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong>ai_session</strong>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                Used by Microsoft Application Insights to collect statistics and
+                telemetry information during a single visit to the site
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                30 minutes
+              </td>
+            </tr>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong>ai_user</strong>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                Used by Microsoft Application Insights to link more than a
+                single visit to the site
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                1 year
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
     </section>
 
     <br>


### PR DESCRIPTION
### Context 🍪

Before we turn on App Insights client-side reporting we need to inform users that they'll receive some additional cookies 

### Changes proposed in this pull request

Add a new section to the cookies policy covering `ai_session` and `ai_user` cookies

### Guidance to review

Ensure it makes sense. Copy reviewed already by @fredbrenton 

