### PR TITLE
running functional tests in parallel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,3 @@
-pool:
-  vmImage: 'ubuntu-16.04'
-
 variables:
   imageTag: v$(Build.BuildId)
   POSTGRES_IMAGE: mdillon/postgis:11-alpine
@@ -12,9 +9,16 @@ variables:
   REDIS_IMAGE: redis:5-alpine
   REDIS_URL: redis://redis:6379/1
   CUCUMBER_PROFILE: continuous_integration
+  APP_URL: http://school-experience:3000
 
-steps:
+jobs:
+- job: BuildAndNonBrowserTesting
+  pool:
+    vmImage: 'ubuntu-16.04'
 
+  steps:
+
+  - script: echo $(Build.Reason)
   - script: docker run --name=postgres -e POSTGRES_PASSWORD -d $(POSTGRES_IMAGE)
     displayName: Launch Postgres # done early to give it time to boot
   - script: docker run --name=redis -d $(REDIS_IMAGE)
@@ -51,28 +55,17 @@ steps:
   - script: docker run --rm --link postgres:postgres --link redis:redis -e DATABASE_URL -e REDIS_URL -e RAILS_ENV=test $(DOCKER_HUB_REPO):$(imageTag) govuk-lint-ruby app lib spec
     displayName: Run the GovUK Lint check
 
-  - script: |
-      docker run --name=selenium-chrome -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-chrome
-      docker run --rm --link postgres:postgres --link=redis:redis --link selenium-chrome:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(DOCKER_HUB_REPO):$(imageTag) cucumber
-    displayName: Run Cucumber via Selenium Chrome
-
-  - script: |
-      docker run --name=selenium-firefox -d --link smoketest:school-experience -v /dev/shm:/dev/shm selenium/standalone-firefox
-      docker run --rm --link postgres:postgres --link=redis:redis --link selenium-firefox:selenium --link smoketest:school-experience -e DATABASE_URL="$WEB_URL" -e REDIS_URL -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium -e CUC_DRIVER=firefox -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e CUC_PAGE_DELAY=0 -e APP_URL='http://school-experience:3000' $(DOCKER_HUB_REPO):$(imageTag) cucumber
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'),eq(variables['Build.SourceBranch'], 'refs/heads/debug')))
-    displayName: Run Cucumber via Selenium Firefox
-
-  - script: |
-      docker tag $(DOCKER_HUB_REPO):$(imageTag) $(DOCKER_HUB_REPO):latest
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-    displayName: 'Push Docker image (built from master)'
-
   - task: Docker@2
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     displayName: login
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
       command: login
+
+  - script: |
+      docker tag $(DOCKER_HUB_REPO):$(imageTag) $(DOCKER_HUB_REPO):latest
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    displayName: 'Push Docker image (built from master)'
 
   - task: Docker@2
     displayName: 'push to docker hub'
@@ -91,6 +84,41 @@ steps:
       repository: $(DOCKER_HUB_REPO)
       command: push
       tags: latest
+
+  - task: Bash@3
+    name: mtrx
+    displayName: 'set up functional test matrix variable'
+    inputs:
+      targetType: filePath
+      filePath: ./script/generate_matrix.sh
+
+- job: FunctionalTesting
+  pool:
+    vmImage: 'ubuntu-16.04'
+  dependsOn: BuildAndNonBrowserTesting
+  strategy:
+    maxParallel: 5
+    matrix: $[ dependencies.BuildAndNonBrowserTesting.outputs['mtrx.legs'] ]
+
+  steps:
+
+  - script: |
+      docker pull $(DOCKER_HUB_REPO):latest || true
+      docker build -f Dockerfile --cache-from=$(DOCKER_HUB_REPO):latest -t school-experience:latest .
+      docker-compose -f docker-compose.yml -f docker-compose-selenium.yml up -d 
+      sleep 15
+      echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
+      docker-compose -f docker-compose.yml -f docker-compose-selenium.yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
+    displayName: Run Cucumber Tests
+    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['browser'],'chrome')))
+
+- job: PublishArtifacts
+  pool:
+    vmImage: 'ubuntu-16.04'
+  dependsOn:
+  - FunctionalTesting
+
+  steps:
 
   - task: CopyFiles@2
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,10 +105,10 @@ jobs:
   - script: |
       docker pull $(DOCKER_HUB_REPO):latest || true
       docker build -f Dockerfile --cache-from=$(DOCKER_HUB_REPO):latest -t school-experience:latest .
-      docker-compose -f docker-compose.yml -f docker-compose-selenium.yml up -d 
+      docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml up -d 
       sleep 15
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
-      docker-compose -f docker-compose.yml -f docker-compose-selenium.yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
+      docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
     displayName: Run Cucumber Tests
     condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['browser'],'chrome')))
 

--- a/docker-compose-chrome.yml
+++ b/docker-compose-chrome.yml
@@ -1,0 +1,8 @@
+version: '3.3'
+
+services:
+
+   selenium-chrome:
+     image: selenium/standalone-chrome
+     volumes:
+       - /dev/shm:/dev/shm

--- a/docker-compose-firefox.yml
+++ b/docker-compose-firefox.yml
@@ -1,11 +1,6 @@
 version: '3.3'
-
+  
 services:
-
-   selenium-chrome:
-     image: selenium/standalone-chrome
-     volumes:
-       - /dev/shm:/dev/shm
 
    selenium-firefox:
      image: selenium/standalone-firefox

--- a/docker-compose-selenium.yml
+++ b/docker-compose-selenium.yml
@@ -1,55 +1,6 @@
 version: '3.3'
 
 services:
-   school-experience:
-     image: school-experience:latest
-     ports:
-       - "3000:3000"
-     restart: always
-     healthcheck:
-       disable: true
-     environment:
-       - RAILS_ENV=servertest
-       - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
-       - REDIS_URL=redis://redis:6379/1
-       - SECRET_KEY_BASE=stubbed
-       - SKIP_FORCE_SSL=true
-       - WEB_URL=postgis://postgres:secret@postgres/school_experience
-     depends_on:
-       - create-db
-
-   delayed-jobs:
-     image: school-experience:latest
-     command: rake jobs:work
-     restart: always
-     healthcheck:
-       disable: true
-     environment:
-       - RAILS_ENV=servertest
-       - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
-       - REDIS_URL=redis://redis:6379/1
-       - SECRET_KEY_BASE=stubbed
-       - SKIP_FORCE_SSL=true
-       - WEB_URL=postgis://postgres:secret@postgres/school_experience
-     depends_on:
-       - create-db
-  
-   create-db:
-     image: school-experience:latest
-     command: rake db:create db:schema:load
-     restart: on-failure
-     healthcheck:
-       disable: true
-     environment:
-       - RAILS_ENV=test
-       - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
-       - REDIS_URL=redis://redis:6379/1
-       - SECRET_KEY_BASE=stubbed
-       - SKIP_FORCE_SSL=true
-       - WEB_URL=postgis://postgres:secret@postgres/school_experience
-     depends_on:
-       - postgres
-       - redis
 
    selenium-chrome:
      image: selenium/standalone-chrome
@@ -60,9 +11,3 @@ services:
      image: selenium/standalone-firefox
      volumes:
        - /dev/shm:/dev/shm
-
-   postgres:
-     image: mdillon/postgis:11-alpine
-     
-   redis:
-     image: redis:5-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
        - "3000:3000"
      restart: always
      healthcheck:
-       disable: true
+       disable: false
      environment:
        - RAILS_ENV=servertest
        - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
@@ -16,14 +16,14 @@ services:
        - SKIP_FORCE_SSL=true
        - WEB_URL=postgis://postgres:secret@postgres/school_experience
      depends_on:
-       - create-db
+       - db-tasks
 
    delayed-jobs:
      image: school-experience:latest
      command: rake jobs:work
      restart: always
      healthcheck:
-       disable: true
+       disable: false
      environment:
        - RAILS_ENV=servertest
        - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
@@ -32,9 +32,9 @@ services:
        - SKIP_FORCE_SSL=true
        - WEB_URL=postgis://postgres:secret@postgres/school_experience
      depends_on:
-       - create-db
+       - db-tasks
   
-   create-db:
+   db-tasks:
      image: school-experience:latest
      command: rake db:create db:schema:load
      restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
        - "3000:3000"
      restart: always
      healthcheck:
-       disable: false
+       disable: true
      environment:
        - RAILS_ENV=servertest
        - DATABASE_URL=postgis://postgres:secret@postgres/school_experience
@@ -23,7 +23,7 @@ services:
      command: rake jobs:work
      restart: always
      healthcheck:
-       disable: false
+       disable: true
      environment:
        - RAILS_ENV=servertest
        - DATABASE_URL=postgis://postgres:secret@postgres/school_experience

--- a/script/generate_matrix.sh
+++ b/script/generate_matrix.sh
@@ -1,0 +1,29 @@
+find . -type f -name "*.feature" > features.txt
+
+split -n r/5 features.txt
+
+ls -l
+
+index=1
+matrix="{"
+for browser in chrome firefox
+do
+  for filename in x*; do
+    data=$(
+    while read line
+    do
+      echo -n " ${line}"
+    done < $filename)
+    if [ $index -ne 1 ]
+    then
+      matrix+=","
+    fi
+    matrix+="'${browser}${index}':{'browser':'${browser}', 'features':'${data}'}"
+    echo $index $data
+    ((index++))
+  done
+done
+matrix+="}"
+echo $matrix
+
+echo "##vso[task.setVariable variable=legs;isOutput=true]${matrix}"


### PR DESCRIPTION
### Context

The functional tests take a long time to execute in CI . These functional tests can be run in parallel as long as each process accesses a dedicated application instance.

### Changes proposed in this pull request

Utilise the Docker Compose file to spin up the dedicated application instance.

Note the use of Docker Compose has been limited to the functional tests.

Since the dedicated application instance is running in a separate agent it needs a Docker image that has not yet been pushed. For this reason the docker image is rebuilt in each agent. The image that is pushed will still be functionally tested in CD .

### Guidance to review

The duration of a feature branch build is reduced by roughly 10 mins i.e. 26 mins down to 16 mins. I imagine the reduction in the master branch builds will be c. 20 mins i.e. 50 mins down to 30 mins.



