### PR TITLE
Remove PII from active job logs

### DIFF
--- a/config/initializers/filter_active_job_logging.rb
+++ b/config/initializers/filter_active_job_logging.rb
@@ -1,0 +1,14 @@
+require 'active_job/logging'
+
+if !Rails.env.development?
+  class ActiveJob::Logging::LogSubscriber
+    # activejob-5.2.3/lib/active_job/logging.rb
+    private def args_info(job)
+      if job.arguments.any?
+        ' with arguments: ' + job.arguments.first.to_s # Log the job class only
+      else
+        ''
+      end
+    end
+  end
+end


### PR DESCRIPTION
When enqueuing a notify job the personalisation and email address were
being stored in the logs, this commit removes this information from
activejob logging.

### Context

### Changes proposed in this pull request

### Guidance to review
Original method is here:
https://github.com/rails/rails/blob/661cf57906743a0965edc31443a28181cee348d6/activejob/lib/active_job/logging.rb#L97

