### PR TITLE
Make analytics cookie httponly SE-1310

### DIFF
--- a/app/controllers/concerns/analytics_tracking.rb
+++ b/app/controllers/concerns/analytics_tracking.rb
@@ -8,7 +8,7 @@ module AnalyticsTracking
 
     def set_analytics_tracking_uuid
       if cookies[:analytics_tracking_uuid].blank?
-        cookies[:analytics_tracking_uuid] = SecureRandom.uuid
+        cookies[:analytics_tracking_uuid] = { value: SecureRandom.uuid, httponly: true }
       end
     end
   end

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -89,6 +89,10 @@ RSpec.describe Candidates::SchoolsController, type: :request do
           expect(parts).to all(match(/[0-9a-f]/))
         end
       end
+
+      specify 'should be HTTP-only' do
+        expect(cookies.get_cookie("analytics_tracking_uuid")).to be_http_only
+      end
     end
   end
 


### PR DESCRIPTION
### Context

The analytics tracking cookie was not marked as _httponly_. This [increases the risk of cookies being revealed to third parties](https://www.owasp.org/index.php/HttpOnly#What_is_HttpOnly.3F).

### Changes proposed in this pull request

Make the `analytics_tracking_uuid` cookie _httponly_.

### Guidance to review

The change is very minimal, covered by specs and tested locally:

<img width="425" alt="Screenshot 2019-07-15 at 09 30 25" src="https://user-images.githubusercontent.com/128088/61205024-d9e71600-a6e6-11e9-87a6-f964e1912298.png">

