### PR TITLE
SE-1177 Restrict crm fields queried

### DIFF
--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -18,6 +18,9 @@ module Bookings::Gitis
 
       class_attribute :primary_key
       self.primary_key = derive_primary_key
+
+      class_attribute :entity_attribute_names
+      self.entity_attribute_names = Set.new
     end
 
     def initialize(*_args)
@@ -112,6 +115,8 @@ module Bookings::Gitis
 
           attributes[attr_name.to_s] = value
         end
+
+        self.entity_attribute_names << attr_name.to_s
       end
 
       def entity_attributes(*attr_names)

--- a/lib/apimock/gitis_crm.rb
+++ b/lib/apimock/gitis_crm.rb
@@ -10,7 +10,7 @@ module Apimock
     end
 
     def stub_contact_request(uuid, return_params = {})
-      stub_request(:get, "#{service_url}#{endpoint}/contacts(#{uuid})?$top=1").
+      stub_request(:get, "#{service_url}#{endpoint}/contacts(#{uuid})?$top=1&$select=#{contact_attributes}").
         with(headers: get_headers).
         to_return(
           status: 200,
@@ -27,7 +27,7 @@ module Apimock
     def stub_multiple_contact_request(uuids, return_params = {})
       uuidfilter = uuids.map { |id| "contactid eq '#{id}'" }.join(' or ')
 
-      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=#{uuids.length}&$filter=#{uuidfilter}").
+      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=#{uuids.length}&$filter=#{uuidfilter}&$select=#{contact_attributes}").
         with(headers: get_headers).
         to_return(
           status: 200,
@@ -51,7 +51,7 @@ module Apimock
         contact_data.merge('emailaddress1' => email).merge(stringified_params)
       ]
 
-      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=1&$filter=emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'").
+      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=1&$filter=emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'&$select=#{contact_attributes}").
         with(headers: get_headers).
         to_return(
           status: 200,
@@ -72,7 +72,7 @@ module Apimock
           .merge(contactdata.stringify_keys)
       end
 
-      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=20&$filter=emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'&$orderby=createdon desc").
+      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=20&$filter=emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'&$select=#{contact_attributes}&$orderby=createdon desc").
         with(headers: get_headers).
         to_return(
           status: 200,
@@ -297,6 +297,10 @@ module Apimock
         'statecode' => 0,
         'dfe_channelcreation' => 222750021
       }
+    end
+
+    def contact_attributes
+      Bookings::Gitis::Contact.entity_attribute_names.to_a.join(',')
     end
   end
 end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -78,7 +78,7 @@ describe Bookings::Gitis::Contact, type: :model do
     context 'with existing gitis record' do
       subject do
         build :gitis_contact, \
-          dfe_channelcreation: described_class::CHANNEL_CREATION + 1
+          dfe_channelcreation: described_class::CHANNEL_CREATION.to_s + '1'
       end
 
       it { is_expected.not_to be_created_by_us }
@@ -206,7 +206,7 @@ describe Bookings::Gitis::Contact, type: :model do
       end
 
       context "with other gitis records" do
-        let(:channel) { described_class::CHANNEL_CREATION + 1 }
+        let(:channel) { described_class::CHANNEL_CREATION.to_s + '1' }
 
         context 'when unmodified' do
           it { is_expected.not_to include('contactid') }

--- a/spec/services/bookings/gitis/entity_spec.rb
+++ b/spec/services/bookings/gitis/entity_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe Bookings::Gitis::Entity do
     it { is_expected.to eq('stubid') }
   end
 
+  describe ".entity_attribute_names" do
+    subject { Stub.entity_attribute_names }
+    it { is_expected.to eq Set.new %w{firstname lastname} }
+  end
+
   describe "#attributes" do
     it do
       expect(subject.send(:attributes)).to \


### PR DESCRIPTION
### Context

Certain fields in the CRM seem to slow down queries, plus it balloons up the data we needlessly retrieve.

### Changes proposed in this pull request

1. Explicitly request the columns we require

### Guidance to review

1. Sanity checking
