### PR TITLE
Disable the email field on the Candidate journey

### DIFF
--- a/app/controllers/candidates/registrations/personal_informations_controller.rb
+++ b/app/controllers/candidates/registrations/personal_informations_controller.rb
@@ -6,11 +6,9 @@ module Candidates
       end
 
       def create
-        @personal_information = PersonalInformation.new personal_information_params
-        if candidate_signed_in?
-          @personal_information.email = current_contact.email
-          @personal_information.read_only_email = candidate_signed_in?
-        end
+        @personal_information = PersonalInformation.new attributes_from_session_or_gitis
+        @personal_information.read_only_email = candidate_signed_in?
+        @personal_information.attributes = personal_information_params
 
         render(:new) && return unless @personal_information.valid?
 

--- a/app/controllers/candidates/registrations/personal_informations_controller.rb
+++ b/app/controllers/candidates/registrations/personal_informations_controller.rb
@@ -7,7 +7,11 @@ module Candidates
 
       def create
         @personal_information = PersonalInformation.new personal_information_params
-        @personal_information.read_only_email = candidate_signed_in?
+        if candidate_signed_in?
+          @personal_information.email = current_contact.email
+          @personal_information.read_only_email = candidate_signed_in?
+        end
+
         render(:new) && return unless @personal_information.valid?
 
         persist @personal_information

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -33,7 +33,9 @@
 
           <%= f.text_field :first_name, autocomplete: 'given-name' %>
           <%= f.text_field :last_name, autocomplete: 'family-name' %>
-          <%= f.email_field :email, autocomplete: 'on', readonly: personal_information.read_only_email %>
+          <%= f.email_field :email, autocomplete: 'on',
+                readonly: personal_information.read_only_email,
+                disabled: personal_information.read_only_email %>
           <%= f.date_field :date_of_birth, heading: true %>
 
           <%= f.submit 'Continue' %>

--- a/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
@@ -135,8 +135,19 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
         end
 
         it 'updates the session with the new details' do
-          expect(registration_session.personal_information).to \
-            eq_model personal_information
+          expect(registration_session.personal_information.first_name).to \
+            eq personal_information.first_name
+
+          expect(registration_session.personal_information.last_name).to \
+            eq personal_information.last_name
+
+          expect(registration_session.personal_information.date_of_birth).to \
+            eq personal_information.date_of_birth
+        end
+
+        it "leaves the email address matching the GiTiS contact" do
+          expect(registration_session.personal_information.email).to \
+            eq contact_attributes['emailaddress2']
         end
 
         it "does not send a verification email" do

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -56,7 +56,7 @@ feature 'Candidate Registrations', type: :feature do
       end
 
       scenario "completing the Journey" do
-        complete_personal_information_step 'Enter your details'
+        complete_personal_information_step expected_heading: 'Enter your details'
         complete_contact_information_step
         complete_subject_preference_step
         complete_placement_preference_step
@@ -134,7 +134,7 @@ feature 'Candidate Registrations', type: :feature do
 
       scenario "completing the Journey" do
         sign_in_via_dashboard(token.token)
-        complete_personal_information_step
+        complete_personal_information_step fill_in_email: false
         complete_contact_information_step
         complete_subject_preference_step
         complete_placement_preference_step
@@ -159,7 +159,7 @@ feature 'Candidate Registrations', type: :feature do
 
       scenario "completing the Journey" do
         sign_in_via_dashboard(token.token)
-        complete_personal_information_step
+        complete_personal_information_step(fill_in_email: false)
         complete_contact_information_step
         sign_in_via_dashboard(newtoken.token)
         swap_back_to_subject_preference_step
@@ -171,7 +171,7 @@ feature 'Candidate Registrations', type: :feature do
     end
   end
 
-  def complete_personal_information_step(expected_heading = nil)
+  def complete_personal_information_step(expected_heading: nil, fill_in_email: true)
     # Begin wizard journey
     visit "/candidates/schools/#{school_urn}/registrations/personal_information/new"
     expect(page).to have_text expected_heading || 'Check if we already have your details'
@@ -185,7 +185,7 @@ feature 'Candidate Registrations', type: :feature do
     # Submit personal information form successfully
     fill_in 'First name', with: 'testy'
     fill_in 'Last name', with: 'mctest'
-    fill_in 'Email address', with: email_address
+    fill_in 'Email address', with: email_address if fill_in_email
     fill_in 'Day', with: '01'
     fill_in 'Month', with: '01'
     fill_in 'Year', with: '2000'

--- a/spec/views/candidates/registrations/personal_informations/_form.html.erb_spec.rb
+++ b/spec/views/candidates/registrations/personal_informations/_form.html.erb_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe "candidates/registrations/personal_informations/_form.html.erb", type: :view do
+  let(:email_selector) do
+    "input#candidates_registrations_personal_information_email"
+  end
+
+  before do
+    allow(view).to \
+      receive(:candidates_school_registrations_personal_information_path).
+      and_return('/stubbed')
+  end
+
+  context 'when email address is editable' do
+    before do
+      render 'candidates/registrations/personal_informations/form',
+        personal_information: Candidates::Registrations::PersonalInformation.new
+    end
+
+    it "will allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{email_selector}[readonly]", count: 0)
+      expect(rendered).to have_css("#{email_selector}[disabled]", count: 0)
+    end
+  end
+
+  context 'when email address is read only' do
+    let(:personal_information) do
+      Candidates::Registrations::PersonalInformation.new(
+        first_name: 'Foo',
+        last_name: 'Bar',
+        email: 'foo@bar.com',
+        read_only_email: true,
+        date_of_birth: Date.parse('1980-01-01')
+      )
+    end
+
+    before do
+      render 'candidates/registrations/personal_informations/form',
+        personal_information: personal_information
+    end
+
+    it "will allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{email_selector}[readonly]", count: 1)
+      expect(rendered).to have_css("#{email_selector}[disabled]", count: 1)
+    end
+  end
+end


### PR DESCRIPTION
### Context

The Candidate is not allowed to amend their email address when they are signed in via that email

### Changes proposed in this pull request

1. Disable the field in the page, so the user is aware they can't change it

### Guidance to review

Run in development with

```
PHASE=3
FAKE_CRM=true
```

Complete the Candidate Journey, signing in along the way. Checking the email field is editable and not disabled.
Continue to the the 'Check your answers' screen, choose to change the Name
Verify the field is disabled and read only.
