### PR TITLE
Event log SE-1343

### DIFF
--- a/app/controllers/schools/toggle_enabled_controller.rb
+++ b/app/controllers/schools/toggle_enabled_controller.rb
@@ -5,7 +5,7 @@ module Schools
     def edit; end
 
     def update
-      if current_school.update_attributes(school_availability_params)
+      if update_school_enabled_status(school_enabled_params[:enabled])
         redirect_to schools_dashboard_path
       else
         render :edit
@@ -18,8 +18,16 @@ module Schools
       current_school
     end
 
-    def school_availability_params
+    def school_enabled_params
       params.require(:bookings_school).permit(:enabled)
+    end
+
+    def update_school_enabled_status(status)
+      if ActiveModel::Type::Boolean.new.cast(status)
+        current_school.enable!
+      else
+        current_school.disable!
+      end
     end
   end
 end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -167,7 +167,7 @@ class Bookings::School < ApplicationRecord
     Bookings::School.transaction do
       update(enabled: false)
 
-      Event.create(event_type: :school_disabled, bookings_school: self)
+      Event.create!(event_type: 'school_disabled', bookings_school: self)
     end
   end
 
@@ -176,7 +176,7 @@ class Bookings::School < ApplicationRecord
 
     Bookings::School.transaction do
       update(enabled: true)
-      Event.create!(event_type: :school_enabled, bookings_school: self)
+      Event.create!(event_type: 'school_enabled', bookings_school: self)
     end
   end
 

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -176,6 +176,7 @@ class Bookings::School < ApplicationRecord
 
     Bookings::School.transaction do
       update!(enabled: true)
+
       Event.create!(event_type: 'school_enabled', bookings_school: self)
     end
   end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -79,6 +79,10 @@ class Bookings::School < ApplicationRecord
     foreign_key: :bookings_school_id,
     dependent: :destroy
 
+  has_many :events,
+    foreign_key: :bookings_school_id,
+    dependent: :destroy
+
   scope :enabled, -> { where(enabled: true) }
 
   scope :that_provide, ->(subject_ids) do
@@ -155,6 +159,25 @@ class Bookings::School < ApplicationRecord
 
   def admin_contact_phone
     profile&.admin_contact_phone
+  end
+
+  def disable!
+    return true if disabled?
+
+    Bookings::School.transaction do
+      update(enabled: false)
+
+      Event.create(event_type: :school_disabled, bookings_school: self)
+    end
+  end
+
+  def enable!
+    return true if enabled?
+
+    Bookings::School.transaction do
+      update(enabled: true)
+      Event.create!(event_type: :school_enabled, bookings_school: self)
+    end
   end
 
 private

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -165,7 +165,7 @@ class Bookings::School < ApplicationRecord
     return true if disabled?
 
     Bookings::School.transaction do
-      update(enabled: false)
+      update!(enabled: false)
 
       Event.create!(event_type: 'school_disabled', bookings_school: self)
     end
@@ -175,7 +175,7 @@ class Bookings::School < ApplicationRecord
     return true if enabled?
 
     Bookings::School.transaction do
-      update(enabled: true)
+      update!(enabled: true)
       Event.create!(event_type: 'school_enabled', bookings_school: self)
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,26 @@
 class Event < ApplicationRecord
+  EVENT_TYPES = %w(
+    school_disabled
+    school_enabled
+  ).freeze
+
+  belongs_to :recordable,
+    polymorphic: true,
+    optional: true
+
+  belongs_to :bookings_school,
+    class_name: 'Bookings::School',
+    foreign_key: :bookings_school_id,
+    optional: true
+
+  validates :event_type, inclusion: EVENT_TYPES
+  validate :ensure_school_or_gitis_uuid_present
+
+private
+
+  def ensure_school_or_gitis_uuid_present
+    if bookings_school.blank? && gitis_uuid.blank?
+      errors.add(:base, 'Either a school or gitis_uuid must be present')
+    end
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,14 +13,19 @@ class Event < ApplicationRecord
     foreign_key: :bookings_school_id,
     optional: true
 
+  belongs_to :bookings_candidate,
+    class_name: 'Bookings::Candidate',
+    foreign_key: :bookings_candidate_id,
+    optional: true
+
   validates :event_type, inclusion: EVENT_TYPES
-  validate :ensure_school_or_gitis_uuid_present
+  validate :ensure_school_or_candidate_present
 
 private
 
-  def ensure_school_or_gitis_uuid_present
-    if bookings_school.blank? && gitis_uuid.blank?
-      errors.add(:base, 'Either a school or gitis_uuid must be present')
+  def ensure_school_or_candidate_present
+    if bookings_school_id.blank? && bookings_candidate_id.blank?
+      errors.add(:base, 'Either a school or bookings_candidate must be present')
     end
   end
 end

--- a/db/migrate/20190716094514_create_events.rb
+++ b/db/migrate/20190716094514_create_events.rb
@@ -1,0 +1,19 @@
+class CreateEvents < ActiveRecord::Migration[5.2]
+  def change
+    create_table :events do |t|
+      t.integer :bookings_school_id, null: true
+      t.uuid :gitis_uuid, null: true
+      t.string :event_type, null: false
+
+      t.integer :recordable_id, null: true
+      t.string :recordable_type, null: true
+
+      t.timestamps
+    end
+
+    add_foreign_key :events, :bookings_schools
+
+    add_index :events, :bookings_school_id
+    add_index :events, :gitis_uuid
+  end
+end

--- a/db/migrate/20190717131205_change_event_gitis_uuid_to_bookings_candidate_id.rb
+++ b/db/migrate/20190717131205_change_event_gitis_uuid_to_bookings_candidate_id.rb
@@ -1,0 +1,9 @@
+class ChangeEventGitisUuidToBookingsCandidateId < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :events, :gitis_uuid, :uuid
+
+    add_column :events, :bookings_candidate_id, :integer, null: true
+
+    add_foreign_key :events, :bookings_candidates
+  end
+end

--- a/db/migrate/20190717135225_add_index_to_events_candidate_id.rb
+++ b/db/migrate/20190717135225_add_index_to_events_candidate_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToEventsCandidateId < ActiveRecord::Migration[5.2]
+  def change
+    add_index :events, :bookings_candidate_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_09_133215) do
+ActiveRecord::Schema.define(version: 2019_07_16_094514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -248,6 +248,18 @@ ActiveRecord::Schema.define(version: 2019_07_09_133215) do
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
+  create_table "events", force: :cascade do |t|
+    t.integer "bookings_school_id"
+    t.uuid "gitis_uuid"
+    t.string "event_type", null: false
+    t.integer "recordable_id"
+    t.string "recordable_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["bookings_school_id"], name: "index_events_on_bookings_school_id"
+    t.index ["gitis_uuid"], name: "index_events_on_gitis_uuid"
+  end
+
   create_table "feedbacks", force: :cascade do |t|
     t.string "type", null: false
     t.integer "reason_for_using_service", null: false
@@ -340,5 +352,6 @@ ActiveRecord::Schema.define(version: 2019_07_09_133215) do
   add_foreign_key "bookings_schools_subjects", "bookings_schools"
   add_foreign_key "bookings_schools_subjects", "bookings_subjects"
   add_foreign_key "candidates_session_tokens", "bookings_candidates", column: "candidate_id"
+  add_foreign_key "events", "bookings_schools"
   add_foreign_key "schools_school_profiles", "bookings_schools"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_094514) do
+ActiveRecord::Schema.define(version: 2019_07_17_135225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -250,14 +250,14 @@ ActiveRecord::Schema.define(version: 2019_07_16_094514) do
 
   create_table "events", force: :cascade do |t|
     t.integer "bookings_school_id"
-    t.uuid "gitis_uuid"
     t.string "event_type", null: false
     t.integer "recordable_id"
     t.string "recordable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "bookings_candidate_id"
+    t.index ["bookings_candidate_id"], name: "index_events_on_bookings_candidate_id"
     t.index ["bookings_school_id"], name: "index_events_on_bookings_school_id"
-    t.index ["gitis_uuid"], name: "index_events_on_gitis_uuid"
   end
 
   create_table "feedbacks", force: :cascade do |t|
@@ -352,6 +352,7 @@ ActiveRecord::Schema.define(version: 2019_07_16_094514) do
   add_foreign_key "bookings_schools_subjects", "bookings_schools"
   add_foreign_key "bookings_schools_subjects", "bookings_subjects"
   add_foreign_key "candidates_session_tokens", "bookings_candidates", column: "candidate_id"
+  add_foreign_key "events", "bookings_candidates"
   add_foreign_key "events", "bookings_schools"
   add_foreign_key "schools_school_profiles", "bookings_schools"
 end

--- a/lib/data/school_manager.rb
+++ b/lib/data/school_manager.rb
@@ -15,14 +15,18 @@ class SchoolManager
 
 private
 
-  def set_enabled(enabled)
+  def set_enabled(new_status)
     Bookings::School.transaction do
       urns.each do |row|
         Bookings::School.find_by(urn: row['urn']).tap do |bs|
           fail "no school found with urn #{row['urn']}" unless bs.present?
 
-          puts "Updating #{bs.name}, enabled: #{enabled}"
-          bs.update_attributes(enabled: enabled)
+          puts "Updating #{bs.name}, enabled: #{new_status}"
+          if new_status
+            bs.enable!
+          else
+            bs.disable!
+          end
         end
       end
     end

--- a/spec/factories/events_factory.rb
+++ b/spec/factories/events_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :event do
+  end
+end

--- a/spec/factories/events_factory.rb
+++ b/spec/factories/events_factory.rb
@@ -1,16 +1,15 @@
 FactoryBot.define do
   factory :event do
-    gitis_uuid { "1b505657-37ea-4163-b50e-5503eed386ab" }
+    association :bookings_candidate, factory: :candidate
     association :bookings_school, factory: :bookings_school
     event_type { 'school_enabled' }
 
     trait :without_bookings_school do
       bookings_school { nil }
-      bookings_school_id { nil }
     end
 
-    trait :without_gitis_uuid do
-      gitis_uuid { nil }
+    trait :without_bookings_candidate do
+      bookings_candidate { nil }
     end
   end
 end

--- a/spec/factories/events_factory.rb
+++ b/spec/factories/events_factory.rb
@@ -1,4 +1,16 @@
 FactoryBot.define do
   factory :event do
+    gitis_uuid { "1b505657-37ea-4163-b50e-5503eed386ab" }
+    association :bookings_school, factory: :bookings_school
+    event_type { 'school_enabled' }
+
+    trait :without_bookings_school do
+      bookings_school { nil }
+      bookings_school_id { nil }
+    end
+
+    trait :without_gitis_uuid do
+      gitis_uuid { nil }
+    end
   end
 end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -172,6 +172,13 @@ describe Bookings::School, type: :model do
           .class_name('Bookings::PlacementRequest')
           .dependent(:destroy)
     end
+
+    specify do
+      is_expected.to \
+        have_many(:events)
+          .with_foreign_key(:bookings_school_id)
+          .dependent(:destroy)
+    end
   end
 
   describe 'Paramterisation' do

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -439,5 +439,71 @@ describe Bookings::School, type: :model do
         it { is_expected.to be_private_beta }
       end
     end
+
+    describe '#enable!' do
+      before do
+        allow(Event).to receive(:create!).and_return(true)
+      end
+
+      context 'when the school is enabled' do
+        subject { create(:bookings_school) }
+        before { subject.enable! }
+
+        specify 'the school should remain enabled' do
+          expect(subject).to be_enabled
+        end
+
+        specify 'should not create a school_disabled event' do
+          expect(Event).not_to have_received(:create!)
+        end
+      end
+
+      context 'when the school is disabled' do
+        subject { create(:bookings_school, :disabled) }
+        before { subject.enable! }
+
+        specify 'should enable the school' do
+          expect(subject).to be_enabled
+        end
+
+        specify 'should create a school_enabled event' do
+          expect(Event).to have_received(:create!)
+            .with(event_type: 'school_enabled', bookings_school: subject)
+        end
+      end
+    end
+
+    describe '#disable!' do
+      before do
+        allow(Event).to receive(:create!).and_return(true)
+      end
+
+      context 'when the school is disabled' do
+        subject { create(:bookings_school, :disabled) }
+        before { subject.disable! }
+
+        specify 'the school should remain disabled' do
+          expect(subject).to be_disabled
+        end
+
+        specify 'should not create a school_enabled event' do
+          expect(Event).not_to have_received(:create!)
+        end
+      end
+
+      context 'when the school is enabled' do
+        subject { create(:bookings_school) }
+        before { subject.disable! }
+
+        specify 'should disable the school' do
+          expect(subject).to be_disabled
+        end
+
+        specify 'should create a school_disabled event' do
+          expect(Event).to have_received(:create!)
+            .with(event_type: 'school_disabled', bookings_school: subject)
+        end
+      end
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -19,24 +19,24 @@ describe Event, type: :model do
       expect(subject).to validate_inclusion_of(:event_type).in_array(Event::EVENT_TYPES)
     end
 
-    context 'presence of school or gitis uuid' do
+    context 'presence of school or candidate' do
       context 'when both are missing' do
-        subject { build(:event, :without_gitis_uuid, :without_bookings_school) }
+        subject { build(:event, :without_bookings_candidate, :without_bookings_school) }
         specify { expect(subject).not_to be_valid }
       end
 
       context 'when the school is missing' do
-        subject { build(:event, :without_bookings_school) }
+        subject { create(:event, :without_bookings_school) }
         specify { expect(subject).to be_valid }
       end
 
-      context 'when the gitis uuid is missing' do
-        subject { build(:event, :without_gitis_uuid) }
+      context 'when the candidate is missing' do
+        subject { create(:event, :without_bookings_candidate) }
         specify { expect(subject).to be_valid }
       end
 
       context 'when both are present' do
-        subject { build(:event) }
+        subject { create(:event) }
         specify { expect(subject).to be_valid }
       end
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,6 +8,10 @@ describe Event, type: :model do
         .with_foreign_key(:bookings_school_id)
         .optional
     end
+
+    specify do
+      expect(subject).to belong_to(:recordable).optional
+    end
   end
 
   describe 'Validation' do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,40 @@
 require 'rails_helper'
 
-RSpec.describe Event, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Event, type: :model do
+  describe 'Relationships' do
+    specify do
+      expect(subject).to belong_to(:bookings_school)
+        .class_name('Bookings::School')
+        .with_foreign_key(:bookings_school_id)
+        .optional
+    end
+  end
+
+  describe 'Validation' do
+    specify do
+      expect(subject).to validate_inclusion_of(:event_type).in_array(Event::EVENT_TYPES)
+    end
+
+    context 'presence of school or gitis uuid' do
+      context 'when both are missing' do
+        subject { build(:event, :without_gitis_uuid, :without_bookings_school) }
+        specify { expect(subject).not_to be_valid }
+      end
+
+      context 'when the school is missing' do
+        subject { build(:event, :without_bookings_school) }
+        specify { expect(subject).to be_valid }
+      end
+
+      context 'when the gitis uuid is missing' do
+        subject { build(:event, :without_gitis_uuid) }
+        specify { expect(subject).to be_valid }
+      end
+
+      context 'when both are present' do
+        subject { build(:event) }
+        specify { expect(subject).to be_valid }
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

It's currently impossible to tell the frequency at which schools are enabling and disabling themselves.

### Changes proposed in this pull request

Add a generic `Event` class that's linked to

* `Bookings::School`
* `Bookings::Candidate`
* An optional polymorphic third object. This would make sense if we record that a candidate has made a request on a `Bookings::PlacementDate` - we could then link a single event to the school, candidate and date.

The first two logged events are `school_disabled` and `school_enabled`. Events are logged when the `Bookings::School#enable!` and `Bookings::Schools#disable!` methods are used. The current school enabling and disabling functionality is exposed in two places, in the `ToggleEnabledController` and in the `SchoolManager` object, which is used by the enabling and disabling rake tasks.

There is no change to the UI. The data will be used for analytics only. 

### Guidance to review

Make sure the changes look sensible and will cover most eventualities.



