### PR TITLE
Feature/push pre built docker images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,7 +69,6 @@ jobs:
 
   - task: Docker@2
     displayName: 'push to docker hub'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
       repository: $(DOCKER_HUB_REPO)
@@ -103,8 +102,7 @@ jobs:
   steps:
 
   - script: |
-      docker pull $(DOCKER_HUB_REPO):latest || true
-      docker build -f Dockerfile --cache-from=$(DOCKER_HUB_REPO):latest -t school-experience:latest .
+      docker tag $(DOCKER_HUB_REPO):$(imageTag) school-experience:latest
       docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml up -d 
       sleep 15
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,6 +102,7 @@ jobs:
   steps:
 
   - script: |
+      docker pull $(DOCKER_HUB_REPO):$(imageTag)
       docker tag $(DOCKER_HUB_REPO):$(imageTag) school-experience:latest
       docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml up -d 
       sleep 15


### PR DESCRIPTION
### Context

The functional test in CI are currently run in parallel but the agent rebuilds the docker image as it hasn't been pushed to Docker Hub.

This slows downs builds and means that functional tests are not using exactly the same image as will be used in the CD pipeline.

### Changes proposed in this pull request

Push to Docker Hub regardless of whether it is on `master` or a feature branch. Then pull in the parallel job.

### Guidance to review

Is tested as part of the feature branch build.
