### PR TITLE
Refactor candidate wizard state handling

### DIFF
--- a/app/controllers/candidates/registrations/background_checks_controller.rb
+++ b/app/controllers/candidates/registrations/background_checks_controller.rb
@@ -9,7 +9,7 @@ module Candidates
         @background_check = BackgroundCheck.new background_check_params
         if @background_check.valid?
           persist @background_check
-          redirect_to candidates_school_registrations_application_preview_path
+          redirect_to next_step_path
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/contact_informations_controller.rb
+++ b/app/controllers/candidates/registrations/contact_informations_controller.rb
@@ -10,7 +10,7 @@ module Candidates
 
         if @contact_information.valid?
           persist @contact_information
-          redirect_to new_candidates_school_registrations_education_path
+          redirect_to next_step_path
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/educations_controller.rb
+++ b/app/controllers/candidates/registrations/educations_controller.rb
@@ -10,7 +10,7 @@ module Candidates
 
         if @education.valid?
           persist @education
-          redirect_to new_candidates_school_registrations_teaching_preference_path
+          redirect_to next_step_path
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/placement_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/placement_preferences_controller.rb
@@ -14,7 +14,7 @@ module Candidates
 
         if @placement_preference.valid?
           persist @placement_preference
-          redirect_to new_candidates_school_registrations_background_check_path
+          redirect_to next_step_path
         else
           render :new
         end

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -1,6 +1,8 @@
 module Candidates
   module Registrations
     class PlacementRequestsController < RegistrationsController
+      skip_before_action :ensure_step_permitted!
+
       def show
         @school_name = Bookings::School.find_by!(urn: params[:school_id]).name
       end

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -43,6 +43,9 @@ module Candidates
           uuid: registration_session.uuid
       rescue RegistrationStore::SessionNotFound
         render :session_expired
+      rescue RegistrationSession::StepNotFound
+        @current_registration = registration_session
+        redirect_to next_step_path
       end
 
     private

--- a/app/controllers/candidates/registrations/teaching_preferences_controller.rb
+++ b/app/controllers/candidates/registrations/teaching_preferences_controller.rb
@@ -11,7 +11,7 @@ module Candidates
 
         if @teaching_preference.valid?
           persist @teaching_preference
-          redirect_to new_candidates_school_registrations_placement_preference_path
+          redirect_to next_step_path
         else
           render :new
         end

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -3,7 +3,6 @@ module Candidates
     include GitisAuthentication
     include Registrations::Wizard
 
-    # TODO can remove this
     rescue_from Registrations::RegistrationSession::StepNotFound do |error|
       Rails.logger.warn "Step not found: #{error.inspect}"
       redirect_to next_step_path

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -1,10 +1,12 @@
 module Candidates
   class RegistrationsController < ApplicationController
     include GitisAuthentication
+    include Registrations::Wizard
 
+    # TODO can remove this
     rescue_from Registrations::RegistrationSession::StepNotFound do |error|
       Rails.logger.warn "Step not found: #{error.inspect}"
-      redirect_to next_step_path(current_registration)
+      redirect_to next_step_path
     end
 
   private
@@ -23,11 +25,6 @@ module Candidates
 
     def current_urn
       params[:school_id]
-    end
-
-    def next_step_path(registration_session)
-      step = registration_session.incomplete_steps.first
-      send "new_candidates_school_registrations_#{step}_path"
     end
 
     def gitis_mapper(registration_session = current_registration,

--- a/app/controllers/concerns/candidates/registrations/wizard.rb
+++ b/app/controllers/concerns/candidates/registrations/wizard.rb
@@ -1,0 +1,61 @@
+module Candidates
+  module Registrations
+    module Wizard
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :ensure_step_permitted!
+      end
+
+    private
+
+      def ensure_step_permitted!
+        redirect_to next_step_path unless current_path_permitted?
+      end
+
+      def current_path
+        controller_path.split('/').last.singularize.to_sym
+      end
+
+      def current_path_permitted?
+        return true if registration_state.completed?
+
+        if current_path_is_a_wizard_step?
+          wizard_step_permitted?
+        else
+          signing_in?
+        end
+      end
+
+      def current_path_is_a_wizard_step?
+        registration_state.steps.include? current_path
+      end
+
+      def wizard_step_permitted?
+        registration_state.step_completed?(current_path) || \
+          registration_state.next_step == current_path
+      end
+
+      def signing_in?
+        current_path == :sign_in && \
+          registration_state.step_completed?(:personal_information)
+      end
+
+      def registration_root
+        "/candidates/schools/#{current_registration.urn}/registrations"
+      end
+
+      def next_step_path
+        if registration_state.next_step == :COMPLETED
+          [registration_root, 'application_preview'].join('/')
+        else
+          [registration_root, registration_state.next_step, 'new'].join('/')
+        end
+      end
+
+      def registration_state
+        Registrations::RegistrationState.new current_registration
+      end
+    end
+  end
+end

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -170,32 +170,10 @@ module Candidates
         other.to_json == self.to_json
       end
 
-      def incomplete_steps
-        STEPS.reject do |step|
-          step_completed? step
-        end
-      end
-
     private
 
-      STEPS = %i(
-        personal_information
-        contact_information
-        education
-        teaching_preference
-        placement_preference
-        background_check
-      ).freeze
-
-      def step_completed?(step)
-        model = send step
-        model.valid?
-      rescue StepNotFound
-        false
-      end
-
       def all_steps_completed?
-        STEPS.all? { |step| step_completed? step }
+        RegistrationState.new(self).completed?
       end
     end
   end

--- a/app/services/candidates/registrations/registration_state.rb
+++ b/app/services/candidates/registrations/registration_state.rb
@@ -1,0 +1,42 @@
+module Candidates
+  module Registrations
+    class RegistrationState
+      STEPS = %i(
+        personal_information
+        contact_information
+        education
+        teaching_preference
+        placement_preference
+        background_check
+      ).freeze
+
+      def initialize(registration_session)
+        @registration_session = registration_session
+      end
+
+      def steps
+        STEPS
+      end
+
+      def next_step
+        steps.detect(&method(:step_not_completed?)) || :COMPLETED
+      end
+
+      def completed?
+        next_step == :COMPLETED
+      end
+
+      def step_completed?(step)
+        @registration_session.public_send(step).valid?
+      rescue RegistrationSession::StepNotFound
+        false
+      end
+
+    private
+
+      def step_not_completed?(step)
+        !step_completed? step
+      end
+    end
+  end
+end

--- a/features/candidates/registrations/background_check.feature
+++ b/features/candidates/registrations/background_check.feature
@@ -3,6 +3,15 @@ Feature: Background checks
     As a potential candidate
     I want to inform the school of my DBS check status
 
+    Background:
+       Given my school of choice exists
+       And the school offers 'Physics, Mathematics'
+       And I have completed the personal information form
+       And I have completed the contact information form
+       And I have completed the education form
+       And I have completed the teaching preference form
+       And I have completed the placement preference form
+
     Scenario: Page contents
         Given I am on the 'background checks' page for my school of choice
         Then I should see a paragraph informing me that some schools require a DBS check
@@ -17,6 +26,5 @@ Feature: Background checks
     Scenario: Filling in and submitting the form
         Given I am on the 'background checks' page for my school of choice
         And I choose 'Yes' from the 'Do you have a DBS certificate?' radio buttons
-        # We need to have filled in the whole wizard to progress, revisit
-        #When I submit the form
-        #Then I should be on the 'Check your answers' page
+        When I submit the form
+        Then I should be on the 'Check your answers' page for my school of choice

--- a/features/candidates/registrations/contact_information.feature
+++ b/features/candidates/registrations/contact_information.feature
@@ -3,6 +3,10 @@ Feature: Contact Information
   As a potential candidate
   I want to be able to provide my contact details
 
+    Background:
+        Given my school of choice exists
+        Given I have completed the personal information form
+
     Scenario: Page contents
         Given I am on the 'Enter your contact details' page for my school of choice
         Then the page's main header should be 'Enter your contact details'

--- a/features/candidates/registrations/education.feature
+++ b/features/candidates/registrations/education.feature
@@ -3,6 +3,12 @@ Feature: Entering candidate education details
     As a potential candidate
     I want to enter some details about my degree and preferred subjects
 
+    Background:
+       Given my school of choice exists
+       And the school offers 'Physics, Mathematics'
+       And I have completed the personal information form
+       And I have completed the contact information form
+
     Scenario: Filling in and submitting the form with errors
         Given I am on the 'education' page for my school of choice
         When I submit the form
@@ -32,9 +38,7 @@ Feature: Entering candidate education details
         Then I should see some subject choices
 
     Scenario: Editing choices
-        Given my school of choice exists
-        And the school offers 'Physics, Mathematics'
-        And I have completed the wizard
+        Given I have completed the wizard
         And I have completed the Education step
         And I am on the 'edit education' page for my school of choice
         And I change my degree selection

--- a/features/candidates/registrations/request_school_experience_placement/page_contents.feature
+++ b/features/candidates/registrations/request_school_experience_placement/page_contents.feature
@@ -3,6 +3,14 @@ Feature: Request a school experience placement
     As a potential candidate
     I want to submit my details to the school
 
+    Background:
+       Given my school of choice exists
+       And the school offers 'Physics, Mathematics'
+       And I have completed the personal information form
+       And I have completed the contact information form
+       And I have completed the education form
+       And I have completed the teaching preference form
+
     Scenario: Page title and description
         Given I am on the 'Request school experience placement' page for my school of choice
         Then the page's main header should be 'Request school experience'

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_flexible_availability.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_flexible_availability.feature
@@ -4,7 +4,13 @@ Feature: Request a school experience placement
     I want to submit a description of my availability to the school
 
     Background:
-        Given the school I'm applying to is flexible on dates
+        Given my school of choice exists
+        And the school offers 'Physics, Mathematics'
+        And I have completed the personal information form
+        And I have completed the contact information form
+        And I have completed the education form
+        And I have completed the teaching preference form
+        And the school I'm applying to is flexible on dates
 
     Scenario: Form contents
         Given I am on the 'Request school experience placement' page for my school of choice

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_specified_placement_dates.feature
@@ -4,7 +4,13 @@ Feature: Request a school experience placement
     I want to pick a date from the list provided by the school
 
     Background:
-        Given the school I'm applying to is not flexible on dates
+        Given my school of choice exists
+        And the school offers 'Physics, Mathematics'
+        And I have completed the personal information form
+        And I have completed the contact information form
+        And I have completed the education form
+        And I have completed the teaching preference form
+        And the school I'm applying to is not flexible on dates
 
     Scenario: Form contents
         Given I am on the 'Request school experience placement' page for my school of choice

--- a/features/candidates/registrations/teaching_preference.feature
+++ b/features/candidates/registrations/teaching_preference.feature
@@ -6,21 +6,27 @@ Feature: Entering teaching preference details
     Background:
         Given my school of choice exists
         And the school offers 'Mathematics, Physics'
-        And I am on the 'teaching preference' page for my school of choice
 
     Scenario: Filling in and submitting the form with errors
+        Given I have completed the personal information form
+        And I have completed the contact information form
+        And I have completed the education form
+        And I am on the 'teaching preference' page for my school of choice
         When I submit the form
         Then I should see the validation error 'Select a teaching stage'
         And I should see the validation error 'Select a subject'
 
     Scenario: Filling in and subject the form
-        Given I make my teaching preference selection
+        Given I have completed the personal information form
+        And I have completed the contact information form
+        And I have completed the education form
+        And I am on the 'teaching preference' page for my school of choice
+        And I make my teaching preference selection
         When I submit the form
         Then I should be on the 'request school experience placement' page for my school of choice
 
     Scenario: Editing choices
         Given I have completed the wizard
-        And I have completed the Teaching preference step
         And I am on the 'edit teaching preference' page for my school of choice
         And I change my teaching subject
         When I submit the form

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -31,7 +31,8 @@ end
 
 Given("my school has availability information set") do
   @availability_info = "Tuesday afternoons only"
-  @school = FactoryBot.create(:bookings_school, availability_info: @availability_info)
+  @school ||= FactoryBot.create(:bookings_school)
+  @school.update! availability_info: @availability_info
 end
 
 Then("I should see a warning containing the availability information") do
@@ -42,7 +43,8 @@ Then("I should see a warning containing the availability information") do
 end
 
 Given("my school has availability no information set") do
-  @school = FactoryBot.create(:bookings_school, availability_info: nil)
+  @school ||= FactoryBot.create(:bookings_school)
+  @school.update! availability_info: nil
 end
 
 Then("I should see no warning containing the availability information") do
@@ -54,7 +56,8 @@ Given("the school I'm applying to is flexible on dates") do
 end
 
 Given("the school I'm applying to is not flexible on dates") do
-  @school = FactoryBot.create(:bookings_school, :with_fixed_availability_preference)
+  @school ||= FactoryBot.create(:bookings_school)
+  @school.update! availability_preference_fixed: true
 end
 
 Given("the school has {int} placements available in the upcoming weeks") do |int|

--- a/features/step_definitions/candidates/registrations/teaching_preference_steps.rb
+++ b/features/step_definitions/candidates/registrations/teaching_preference_steps.rb
@@ -5,11 +5,9 @@ Given("I make my teaching preference selection") do
 end
 
 Given("I have completed the Teaching preference step") do
-  steps %(
-    I have completed the Teaching preference step
-    I make my teaching preference selection
-    I submit the form
-  )
+  step "I am on the 'teaching preference' page for my school of choice"
+  step 'I make my teaching preference selection'
+  step 'I submit the form'
 end
 
 Given("I change my teaching subject") do

--- a/spec/controllers/candidates/registrations/application_previews_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/application_previews_controller_spec.rb
@@ -11,12 +11,12 @@ describe Candidates::Registrations::ApplicationPreviewsController, type: :reques
 
     context 'candidate skipped ahead' do
       let :registration_session do
-        Candidates::Registrations::RegistrationSession.new({})
+        FactoryBot.build :registration_session, urn: school.urn, with: []
       end
 
       it 'redirects to the first missing step' do
         expect(response).to redirect_to \
-          '/candidates/schools/urn/registrations/personal_information/new'
+          "/candidates/schools/#{school.urn}/registrations/personal_information/new"
       end
     end
 

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -3,8 +3,18 @@ require 'rails_helper'
 describe Candidates::Registrations::BackgroundChecksController, type: :request do
   include_context 'Stubbed current_registration'
 
+  before do
+    FactoryBot.create :bookings_school, urn: 11048
+  end
+
   let :registration_session do
-    Candidates::Registrations::RegistrationSession.new({})
+    FactoryBot.build :registration_session, with: %i(
+      personal_information
+      contact_information
+      education
+      teaching_preference
+      placement_preference
+    )
   end
 
   context 'without existing background_check in session' do

--- a/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
@@ -4,8 +4,16 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
   include_context 'Stubbed candidates school'
   include_context 'Stubbed current_registration'
 
-  let! :registration_session do
-    FactoryBot.build :registration_session
+  let :registration_session do
+    FactoryBot.build :registration_session, urn: school.urn,
+      with: %i(
+        personal_information
+        contact_information
+        education
+        teaching_preference
+        placement_preference
+        background_check
+      )
   end
 
   let :registration_store do
@@ -46,7 +54,7 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
 
       context 'skipped step' do
         let :registration_session do
-          Candidates::Registrations::RegistrationSession.new({})
+          FactoryBot.build :registration_session, with: []
         end
 
         before do

--- a/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
@@ -4,8 +4,9 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
   include_context 'Stubbed current_registration'
 
   let :registration_session do
-    Candidates::Registrations::RegistrationSession.new({})
+    FactoryBot.build :registration_session, with: %i(personal_information)
   end
+
 
   context 'without existing contact information in the session' do
     context '#new' do

--- a/spec/controllers/candidates/registrations/educations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/educations_controller_spec.rb
@@ -4,8 +4,12 @@ describe Candidates::Registrations::EducationsController, type: :request do
   include_context 'Stubbed current_registration'
 
   let :registration_session do
-    Candidates::Registrations::RegistrationSession.new({})
+    FactoryBot.build :registration_session, with: %i(
+      personal_information
+      contact_information
+    )
   end
+
 
   context '#new' do
     context 'without existing education in session' do

--- a/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_preferences_controller_spec.rb
@@ -5,7 +5,12 @@ describe Candidates::Registrations::PlacementPreferencesController, type: :reque
   include_context 'Stubbed current_registration'
 
   let :registration_session do
-    Candidates::Registrations::RegistrationSession.new({})
+    FactoryBot.build :registration_session, with: %i(
+      personal_information
+      contact_information
+      education
+      teaching_preference
+    )
   end
 
   context 'without existing placement_preference in session' do

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -139,6 +139,25 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
         context 'school has not changed availability type' do
           it_behaves_like 'a successful create'
         end
+
+        context 'with an invalid session' do
+          let :incomplete_registration_session do
+            FactoryBot.build :registration_session,
+              urn: '333333', uuid: 'aaa', with: [:personal_information]
+          end
+
+          before do
+            Candidates::Registrations::RegistrationStore.instance.store! \
+              incomplete_registration_session
+
+            get "/candidates/confirm/#{incomplete_registration_session.uuid}"
+          end
+
+          it 'redirects to the first missing step' do
+            expect(response).to redirect_to \
+              "/candidates/schools/#{incomplete_registration_session.urn}/registrations/contact_information/new"
+          end
+        end
       end
     end
   end

--- a/spec/controllers/candidates/registrations/teaching_preferences_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/teaching_preferences_controller_spec.rb
@@ -5,7 +5,11 @@ describe Candidates::Registrations::TeachingPreferencesController, type: :reques
   include_context 'Stubbed current_registration'
 
   let :registration_session do
-    Candidates::Registrations::RegistrationSession.new 'urn' => school_urn
+    FactoryBot.build :registration_session, with: %i(
+      personal_information
+      contact_information
+      education
+    )
   end
 
   context '#new' do

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -6,6 +6,16 @@ FactoryBot.define do
       placement_date { create(:bookings_placement_date) }
       uuid { 'some-uuid' }
 
+      with do
+        %i(
+          personal_information
+          contact_information
+          background_check
+          placement_preference
+          subject_preference
+        )
+      end
+
       candidates_registrations_personal_information do
         {
           "first_name"   => 'Testy',
@@ -79,13 +89,9 @@ FactoryBot.define do
 
     initialize_with do
       new \
-        "uuid"                                          => uuid,
-        "urn"                                           => urn,
-        "candidates_registrations_personal_information" => candidates_registrations_personal_information,
-        "candidates_registrations_contact_information"  => candidates_registrations_contact_information,
-        "candidates_registrations_background_check"     => candidates_registrations_background_check,
-        "candidates_registrations_placement_preference" => candidates_registrations_placement_preference,
-        "candidates_registrations_subject_preference"   => candidates_registrations_subject_preference
+        with
+          .map { |step| "candidates_registrations_#{step}" }
+          .reduce("uuid" => uuid, "urn" => urn) { |options, step| options.merge step => send(step) }
     end
 
     trait :with_placement_date do

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -168,10 +168,6 @@ feature 'Candidate Registrations', type: :feature do
         complete_contact_information_step
         sign_in_via_dashboard(newtoken.token)
         swap_back_to_education_step
-        complete_education_step
-        complete_teaching_preference_step
-        complete_placement_preference_step
-        complete_background_step
         get_bounced_to_personal_information_step
       end
     end

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -281,21 +281,4 @@ describe Candidates::Registrations::RegistrationSession do
       expect(registration_session).to be_completed
     end
   end
-
-  context '#incomplete_steps' do
-    let :registration_session do
-      described_class.new({})
-    end
-
-    it 'returns the correct models' do
-      expect(registration_session.incomplete_steps).to eq %i(
-        personal_information
-        contact_information
-        education
-        teaching_preference
-        placement_preference
-        background_check
-      )
-    end
-  end
 end

--- a/spec/services/candidates/registrations/registration_state_spec.rb
+++ b/spec/services/candidates/registrations/registration_state_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::RegistrationState do
+  before do
+    FactoryBot.create :bookings_school, urn: 11048
+  end
+
+  subject { described_class.new registration_session }
+
+  context 'without personal information' do
+    let :registration_session do
+      Candidates::Registrations::RegistrationSession.new({})
+    end
+
+    it { expect(subject.next_step).to eq :personal_information }
+    it { is_expected.not_to be_completed }
+  end
+
+  context 'with personal information' do
+    let :registration_session do
+      FactoryBot.build :registration_session, with: [:personal_information]
+    end
+
+    it { expect(subject.next_step).to eq :contact_information }
+    it { is_expected.not_to be_completed }
+  end
+
+  context 'with contact_information' do
+    let :registration_session do
+      FactoryBot.build :registration_session,
+        with: %i(personal_information contact_information)
+    end
+
+    it { expect(subject.next_step).to eq :education }
+    it { is_expected.not_to be_completed }
+  end
+
+  context 'with education' do
+    let :registration_session do
+      FactoryBot.build :registration_session,
+        with: %i(personal_information contact_information education)
+    end
+
+    it { expect(subject.next_step).to eq :teaching_preference }
+    it { is_expected.not_to be_completed }
+  end
+
+  context 'with teaching_preference' do
+    let :registration_session do
+      FactoryBot.build :registration_session, with: %i(
+        personal_information
+        contact_information
+        education
+        teaching_preference
+      )
+    end
+
+    it { expect(subject.next_step).to eq :placement_preference }
+    it { is_expected.not_to be_completed }
+  end
+
+  context 'with placement_preference' do
+    let :registration_session do
+      FactoryBot.build :registration_session, with: %i(
+        personal_information
+        contact_information
+        education
+        teaching_preference
+        placement_preference
+      )
+    end
+
+    it { expect(subject.next_step).to eq :background_check }
+    it { is_expected.not_to be_completed }
+  end
+
+  context 'with background_check' do
+    let :registration_session do
+      FactoryBot.build :registration_session, with: %i(
+        personal_information
+        contact_information
+        education
+        teaching_preference
+        placement_preference
+        background_check
+      )
+    end
+
+    it { expect(subject.next_step).to eq :COMPLETED }
+    it { is_expected.to be_completed }
+  end
+end


### PR DESCRIPTION
Previously the knowledge about the ordering of steps in the wizard was
split between the registration session and the controller redirects.
This commit introduces a RegistrationState which determines the
next_step and a Wizard concern to handle navigation through the wizard.

NOTE: The order the candidate completes the wizard in is now important

Additionally this commit tidys up the registration session factory.

### Context
After splitting up the subject preference screens I noticed I the logic for determining the next step was split between the registration session and the individual create actions

### Changes proposed in this pull request
Move the logic for determining the next step to a single class.

### Guidance to review
Make sure the change to `spec/features/candidates/registrations_spec.rb` looks ok, this had to be changed as the wizard now requires steps to be done in order.