### PR TITLE
poll 'docker-compose ps' output for strings 'db-tasks' and 'exit 0'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -105,7 +105,8 @@ jobs:
       docker pull $(DOCKER_HUB_REPO):$(imageTag)
       docker tag $(DOCKER_HUB_REPO):$(imageTag) school-experience:latest
       docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml up -d 
-      sleep 15
+      WAIT_COUNT=0
+      until docker-compose ps | grep -m 1 "db-tasks" | grep -m 1 "Exit 0" || [ $WAIT_COUNT -eq 12 ]; do echo "WAIT COUNT $(( WAIT_COUNT++ ))" && sleep 5 ; done
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
       docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
     displayName: Run Cucumber Tests


### PR DESCRIPTION
at intervals of 5 secs for a maximum of 60 secs.

### Context
Previously it simply slept for 15 secs and assumed that the database will have bee seeded for db-tasks container by that time. There was some evidence that this wasn't enough time (the truncation of the tables by the cucumber tests failed as they didn't exist).

### Changes proposed in this pull request
Rather than sleep it now check the status of the db-tasks container and wait until it has successfully exited. This container generally restarts as it initially exits with a non zero error code as the database has fully started, the next instance generally is able to connect and run successfully.

### Guidance to review
To confirm locally
```
      docker-compose -f docker-compose.yml -f docker-compose-chrome.yml up -d
      WAIT_COUNT=0
      until docker-compose ps | grep -m 1 "db-tasks" | grep -m 1 "Exit 0" || [ $WAIT_COUNT -eq 12 ]; do echo "WAIT COUNT $(( WAIT_COUNT++ ))" && sleep 5 ; done
      echo SELENIUM_HUB_HOSTNAME=selenium-chrome CUC_DRIVER=$chrome 
      docker-compose -f docker-compose.yml -f docker-compose-chrome.yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-chrome -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=chrome school-experience cucumber 
```