### PR TITLE
make only functional tests agents that are actually needed (chrome an…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,6 @@ jobs:
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
       docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
     displayName: Run Cucumber Tests
-    condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), and(ne(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['browser'],'chrome')))
 
 - job: PublishArtifacts
   pool:

--- a/script/generate_matrix.sh
+++ b/script/generate_matrix.sh
@@ -4,9 +4,18 @@ split -n r/5 features.txt
 
 ls -l
 
+echo "Branch is ${BUILD_SOURCEBRANCHNAME}"
+
+browsers='chrome'
+if [ $BUILD_SOURCEBRANCHNAME -eq 'master' ] ; then
+  browsers='chrome firefox'
+fi
+
+echo "Run tests on ${browsers}"
+
 index=1
 matrix="{"
-for browser in chrome firefox
+for browser in $browsers
 do
   for filename in x*; do
     data=$(


### PR DESCRIPTION
…d firefox on master otherwise just chrome)

### Context

Currently we spin up an agent for firefox functional test only for the step within to be ignored via a condition.

### Changes proposed in this pull request

Generate the matrix variable to take into account the branch that we are on.

### Guidance to review

Only once merged will the running on firefox and chrome be verified.

