### PR TITLE
Raise the state missmatch error in addition to log

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -1,13 +1,13 @@
 module Schools
-  class StateMissmatchError < StandardError; end
+  class StateMismatchError < StandardError; end
   class AuthFailedError < StandardError; end
   class NoIDTokenError < StandardError; end
 
   class SessionsController < ApplicationController
     include DFEAuthentication
 
-    rescue_from AuthFailedError,     with: :authentication_failure
-    rescue_from StateMissmatchError, with: :authentication_failure
+    rescue_from AuthFailedError,    with: :authentication_failure
+    rescue_from StateMismatchError, with: :authentication_failure
 
     def show
       # nothing yet, the view just contains a 'logout' button
@@ -75,7 +75,7 @@ module Schools
 
         Rails.logger.error(message)
 
-        raise StateMissmatchError, message
+        raise StateMismatchError, message
       end
     end
 

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -68,14 +68,14 @@ module Schools
 
     def check_state(session_state, params_state)
       if params_state != session_state
-        Rails.logger.error(
-          "params state (%<params_state>s) doesn't match session state %<session_state>s" % {
-            params_state: params_state,
-            session_state: session_state
-          }
-        )
+        message = "params state (%<params_state>s) doesn't match session state %<session_state>s" % {
+          params_state: params_state,
+          session_state: session_state
+        }
 
-        raise StateMissmatchError
+        Rails.logger.error(message)
+
+        raise StateMissmatchError, message
       end
     end
 

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -89,12 +89,12 @@ describe Schools::SessionsController, type: :request do
       end
 
       context 'errors' do
-        context 'StateMissmatchError' do
+        context 'StateMismatchError' do
           let(:bad_state) { 'aaaaaaaa-bbbb-1111-2222-333333333333' }
           let(:callback) { "/auth/callback?code=#{code}&state=#{bad_state}&session_state=#{session_state}" }
           after { get callback }
 
-          specify 'should raise StateMissmatchError' do
+          specify 'should raise StateMismatchError' do
             expect(Rails.logger).to receive(:error).with(/doesn't match session state/)
           end
 


### PR DESCRIPTION
### Context

The state mismatch error was being raised but the informative message was only going to the logs and not to Sentry

### Changes proposed in this pull request

Increase visibility of what's going on by pushing the error message to Sentry as well as the logs

Also spelling of 'Mismatch'

### Guidance to review

Ensure it looks sensible. Testing difficult because the `rescue_from StateMismatchError` in the `Schools::SessionsController`.