### PR TITLE
Adds skip button to description step

### DIFF
--- a/app/controllers/schools/on_boarding/descriptions_controller.rb
+++ b/app/controllers/schools/on_boarding/descriptions_controller.rb
@@ -6,7 +6,7 @@ module Schools
       end
 
       def create
-        @description = Description.new description_params
+        @description = Description.new new_description_params
 
         if @description.valid?
           current_school_profile.update! description: @description
@@ -21,6 +21,8 @@ module Schools
       end
 
       def update
+        return redirect_to next_step_path(current_school_profile) if skipped?
+
         @description = Description.new description_params
 
         if @description.valid?
@@ -33,8 +35,18 @@ module Schools
 
     private
 
+      def skipped?
+        params[:commit] == 'Skip'
+      end
+
       def description_params
         params.require(:schools_on_boarding_description).permit :details
+      end
+
+      def new_description_params
+        return { details: '' } if skipped?
+
+        description_params
       end
     end
   end

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -57,6 +57,7 @@
       <% end %>
 
       <%= f.submit 'Continue' %>
+      <%= f.submit 'Skip', class: 'govuk-button govuk-button--secondary' %>
     <% end %>
   </div>
 </div>

--- a/spec/controllers/schools/on_boarding/descriptions_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/descriptions_controller_spec.rb
@@ -80,6 +80,21 @@ describe Schools::OnBoarding::DescriptionsController, type: :request do
           new_schools_on_boarding_candidate_experience_detail_path
       end
     end
+
+    context 'skipped' do
+      let :params do
+        { commit: 'Skip' }
+      end
+
+      it 'creates a new description without details' do
+        expect(school_profile.reload.description.details).to be_empty
+      end
+
+      it 'redirects to the next step' do
+        expect(response).to redirect_to \
+          new_schools_on_boarding_candidate_experience_detail_path
+      end
+    end
   end
 
   context '#edit' do
@@ -139,6 +154,27 @@ describe Schools::OnBoarding::DescriptionsController, type: :request do
       end
 
       it 'redirects to the school_profile' do
+        expect(response).to redirect_to schools_on_boarding_profile_path
+      end
+    end
+
+    context 'skipped' do
+      let :description do
+        FactoryBot.build :description, details: 'Updated'
+      end
+
+      let :params do
+        {
+          schools_on_boarding_description: description.attributes,
+          commit: 'Skip'
+        }
+      end
+
+      it "doesn't update the description" do
+        expect(school_profile.reload.description.details).not_to eq 'Updated'
+      end
+
+      it 'redirects the the school_profile' do
         expect(response).to redirect_to schools_on_boarding_profile_path
       end
     end


### PR DESCRIPTION
### Context
Needed to add a skip button to the description step of the school on boarding wizard so it's clear that this step isn't required. 

### Changes proposed in this pull request

### Guidance to review
I've added this as a submit button, I think this is probably better than a link as we don't need to hard code the navigation. Do you think we should blank any details they've entered if they submit the form using the skip button?