### PR TITLE
Fix back links

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,9 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
-  <%= link_to 'Back', (request.referer || candidates_root_path),
-              class: 'govuk-back-link',
-              data: {controller: 'back-link'} %>
+  <%= link_to 'Back', (request.referer || candidates_root_path), class: 'govuk-back-link' %>
 
     <h1 class="govuk-heading-l">Privacy policy for get school experience</h1>
     <section>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
-  <%= link_to 'Back', :back,
+  <%= link_to 'Back', (request.referer || candidates_root_path),
               class: 'govuk-back-link',
               data: {controller: 'back-link'} %>
 


### PR DESCRIPTION
If we're using :back as the url and the user has clicked the 'back to
top' link at the bottom of the page they can get stuck in a loop.
Instead attempt to send the user back to where they came from or failing
that send them to the candidate start page.

### Context

### Changes proposed in this pull request

### Guidance to review

