### PR TITLE
Re-add no dates/availability warnings to dashboard

### DIFF
--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -1,6 +1,14 @@
 <section class="manage-dates">
   <h2 class="govuk-heading-m">Manage dates</h3>
 
+  <%- if show_no_placement_dates_warning?(@current_school) -%>
+    <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
+  <%- end -%>
+
+  <%- if show_no_availability_info_warning?(@current_school) -%>
+    <%= render partial: 'schools/dashboards/no_availability_info_warning' %>
+  <%- end -%>
+
   <%- if @current_school.availability_preference_fixed? -%>
     <div id="update-school-profile" class="subsection">
       <header class="dashboard-medium-priority">

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -85,6 +85,20 @@ Feature: The School Dashboard
         When I am on the 'schools dashboard' page
         Then I should see a 'Turn requests on / off' link to the 'toggle requests' page
 
+    Scenario: Displaying a warning when fixed with no dates
+        Given my school has fully-onboarded
+        And it has 'fixed' availability
+        And my school has no placement dates
+        When I am on the 'schools dashboard' page
+        Then there should be a 'You have no placement dates' warning
+
+    Scenario: Displaying a warning when flexible with no description
+        Given my school has fully-onboarded
+        And it has 'flexible' availability
+        And my school has availability no information set
+        When I am on the 'schools dashboard' page
+        Then there should be a 'You have no availability information' warning
+
     @wip
     Scenario: Candidate attendances counter
         Given there are 4 new candidate attendances


### PR DESCRIPTION
These weren't carried over from the dashlette/dashboard merge (#731)

Because they were from the dashlette side they weren't covered by Cucumber, so scenarios have been added to ensure their presence
