### PR TITLE
Update design system to version 1.13

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
+  config.assets.css_compressor = nil
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
@@ -136,4 +136,6 @@ Rails.application.configure do
   config.x.fake_crm = ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s)
 
   config.x.features = []
+
+  config.sass[:style] = :compressed if config.sass
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3007,9 +3007,9 @@ globule@^1.0.0:
     minimatch "~3.0.2"
 
 govuk-frontend@^2.5:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.7.0.tgz#6a12baf514426653220dd3cdef55b1e1d97f52a6"
-  integrity sha512-IZvho72ExUAOmMOZHbE7s//HdtpSoO1aLn3fcXTnuIUi20UTsz6j+5i1Ztyqr4KUEb8OB/jNMYt4kuYyJnEMRQ==
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.13.0.tgz#0273f7c92070abd6450c73a006ebb3ddc793463a"
+  integrity sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.0"


### PR DESCRIPTION
### Context

We are currently locked to v2.7 of the GOV.UK Frontend - newer versions are failing to compile within the asset pipeline.

After some investigation, this appears to be caused by Sprockets double compiling the SCSS input - once to preprocess it all, and a second run to compress it. 

The GOV.UK Frontend includes code which is 'quoted' to pass through the SCSS processor, 
1. the first run passes through and remove's the quoting, 
2. the second run now tries to run the CSS function because its no longer quoted

The second run is a legacy of supporting a non-sass `application.css` using sprockets to include the other files. This is not an requirement in our instance.

### Changes proposed in this pull request

1. Disable the second SCSS pass
2. Enable compression on the initial SCSS pass

### Guidance to review

1. Does it work ok, does it look correct
