### PR TITLE
Add keepalives and keepalives_interval db settings

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -81,6 +81,21 @@ test: &test
 #   production:
 #     url: <%= ENV['DATABASE_URL'] %>
 #
+# Keepalives info (https://www.postgresql.org/docs/10/libpq-connect.html#LIBPQ-KEEPALIVES)
+#
+#   keepalives:          Controls whether client-side TCP keepalives are used
+#
+#   keepalives_idle:     Controls the number of seconds of inactivity after which
+#                        TCP should send a keepalive message to the server.
+#
+#   keepalives_interval: Controls the number of seconds after which a TCP keepalive
+#                        message that is not acknowledged by the server should be
+#                        retransmitted.
+#
+#   keepalives_count:    Controls the number of TCP keepalives that can be lost before
+#                        the client's connection to the server is considered dead
+#
+#
 production: &production
   <<: *default
   host: <%= ENV['DB_HOST'] %>
@@ -88,7 +103,9 @@ production: &production
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   keepalives: 1
-  keepalives_interval: 60
+  keepalives_idle: 60
+  keepalives_interval: 20
+  keepalives_count: 3
 
 servertest:
   <<: *production

--- a/config/database.yml
+++ b/config/database.yml
@@ -87,6 +87,8 @@ production: &production
   database: <%= ENV['DB_DATABASE'] %>
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
+  keepalives: 1
+  keepalives_interval: 60
 
 servertest:
   <<: *production


### PR DESCRIPTION
The keepalives directive[0] controls whether or not client-side TCP
keepalives are used. The default is `1` (on). The keepalives_interval
directive[1] controls the number of seconds after which a keepalive
message should be sent.

After making these changes it's not really clear that anything has
changed, nothing special about the connection is visible in
`pg_stat_activity`, making thee changes tricky to test.

However, the changes can be seen by interrogating ActiveRecord's
connection info:

```ruby
ActiveRecord::Base.connection.raw_connection.conninfo
```

```
 {:keyword=>"keepalives", :val=>"1", :label=>"TCP-Keepalives", ...}
 {:keyword=>"keepalives_interval", :val=>"60", :label=>"TCP-Keepalives-Interval", ...}
```

Without the new settings, the keepalives and keepalives_interval
settings are present but blank - defaulting to the OS's settings

[0] https://www.postgresql.org/docs/10/libpq-connect.html#LIBPQ-KEEPALIVES
[1] https://www.postgresql.org/docs/10/libpq-connect.html#LIBPQ-KEEPALIVES-INTERVAL
