### PR TITLE
Fix incorrect class, content now aligns properly

### DIFF
--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -1,6 +1,7 @@
 <%- self.page_title = "Confirm booking" %>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full-width">
+  <div class="govuk-grid-column-full">
     <h1>Confirm booking</h1>
 
     <h3>

--- a/app/views/schools/placement_requests/index.html.erb
+++ b/app/views/schools/placement_requests/index.html.erb
@@ -1,7 +1,7 @@
 <% self.page_title = "All placement requests" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full-width">
+  <div class="govuk-grid-column-full">
     <%= link_to 'Back', schools_dashboard_path, class: 'govuk-back-link' %>
 
     <h1>Manage requests</h1>


### PR DESCRIPTION
### Context

Content didn't line up, an superfluous class suffix `-width` was used

### Changes proposed in this pull request

Remove the incorrect suffix
