### PR TITLE
Candidate autocompletion SE-1273

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: 5deefeef33c72545585842ca6f5338d3c7c6352c
+  revision: 369e58074d8c67f277963a324ad9ae8086d34e94
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -16,15 +16,15 @@
           <%= f.telephone_field :phone, autocomplete: 'on' %>
 
           <h2 class="govuk-heading-m">Address</h2>
-          <%= f.text_field :building, autocomplete: 'on' %>
+          <%= f.text_field :building, autocomplete: 'home address-line1' %>
           <% if f.object.errors[:street].any? %>
-            <%= f.text_field :street, autocomplete: 'on' %>
+            <%= f.text_field :street, autocomplete: 'home address-line2' %>
           <% else %>
-            <%= f.text_field :street, autocomplete: 'on', label_options: { class: 'govuk-visually-hidden' } %>
+            <%= f.text_field :street, autocomplete: 'home address-line2', label_options: { class: 'govuk-visually-hidden' } %>
           <% end %>
-          <%= f.text_field :town_or_city, autocomplete: 'on', class: 'govuk-!-width-two-thirds' %>
-          <%= f.text_field :county, autocomplete: 'on', class: 'govuk-!-width-two-thirds' %>
-          <%= f.text_field :postcode, autocomplete: 'on', class: 'govuk-input govuk-input--width-10' %>
+          <%= f.text_field :town_or_city, autocomplete: 'home address-level2', class: 'govuk-!-width-two-thirds' %>
+          <%= f.text_field :county, autocomplete: 'home address-level1', class: 'govuk-!-width-two-thirds' %>
+          <%= f.text_field :postcode, autocomplete: 'home postal-code', class: 'govuk-input govuk-input--width-10' %>
 
           <%= f.submit 'Continue' %>
         <% end %>

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -36,7 +36,7 @@
           <%= f.email_field :email, autocomplete: 'on',
                 readonly: personal_information.read_only_email,
                 disabled: personal_information.read_only_email %>
-          <%= f.date_field :date_of_birth, heading: true, date_of_birth: true %>
+          <%= f.date_field :date_of_birth, { heading: true }, date_of_birth: true %>
 
           <%= f.submit 'Continue' %>
         <% end %>

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -36,7 +36,7 @@
           <%= f.email_field :email, autocomplete: 'on',
                 readonly: personal_information.read_only_email,
                 disabled: personal_information.read_only_email %>
-          <%= f.date_field :date_of_birth, heading: true %>
+          <%= f.date_field :date_of_birth, heading: true, date_of_birth: true %>
 
           <%= f.submit 'Continue' %>
         <% end %>

--- a/app/views/candidates/sessions/new.html.erb
+++ b/app/views/candidates/sessions/new.html.erb
@@ -16,7 +16,7 @@
       <%= f.email_field :email, autocomplete: 'on', class: 'govuk-input govuk-input--width-30' %>
       <%= f.text_field :firstname, autocomplete: 'given-name', class: 'govuk-input govuk-input--width-20' %>
       <%= f.text_field :lastname, autocomplete: 'family-name', class: 'govuk-input govuk-input--width-20' %>
-      <%= f.date_field :date_of_birth, heading: true %>
+      <%= f.date_field :date_of_birth, { heading: true }, {} %>
 
       <%= f.submit 'Sign in' %>
     <% end %>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -20,7 +20,7 @@
 </p>
 
 <%= form_for @placement_date, url: schools_placement_dates_path, method: :post do |form| %>
-  <%= form.date_field :date, heading: true %>
+  <%= form.date_field :date, { heading: true }, {} %>
   <%= form.number_field :duration, width: 3, required: true, label_options: { class: 'govuk-heading-m', overwrite_defaults!: true } %>
   <%= form.submit 'Continue' %>
 <%- end -%>

--- a/features/candidates/registrations/contact_information.feature
+++ b/features/candidates/registrations/contact_information.feature
@@ -15,12 +15,12 @@ Feature: Contact Information
     Scenario: Form contents
         Given I am on the 'Enter your contact details' page for my school of choice
         Then I should see a form with the following fields:
-            | Label               | Type  |
-            | UK telephone number | tel   |
-            | Building and street | text  |
-            | Town or city        | text  |
-            | County              | text  |
-            | Postcode            | text  |
+            | Label               | Type | Autocompletion      |
+            | UK telephone number | tel  | on                  |
+            | Building and street | text | home address-line1  |
+            | Town or city        | text | home address-level2 |
+            | County              | text | home address-level1 |
+            | Postcode            | text | home postal-code    |
 
     Scenario: Submitting my data
       Given I am on the 'Enter your contact details' page for my school of choice

--- a/features/candidates/registrations/personal_information.feature
+++ b/features/candidates/registrations/personal_information.feature
@@ -42,3 +42,7 @@ Feature: Personal Information
 
         When I submit the form
         Then I should be on the 'verify your email' page for my school of choice
+
+    Scenario: Autocomplete attributes
+      Given I am on the 'Enter your personal details' page for my school of choice
+      Then the 'Date of birth' date field should have day, month and year birth date auto-completion enabled

--- a/features/step_definitions/candidates/registrations/personal_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/personal_information_steps.rb
@@ -9,10 +9,8 @@ Then("the {string} date field should have day, month and year birth date auto-co
   date_field_set = page.find('.govuk-fieldset__heading', text: date_label)
 
   within(date_field_set.ancestor('.govuk-form-group')) do
-    %w(Day Month Year).each do |part|
-      label = page.find('label', text: part)
-      input = page.find("input##{label[:for]}")
-      expect(input[:autocomplete]).to eql("bday bday-#{part.downcase}")
+    %w(day month year).each do |part|
+      expect(page).to have_css("input[autocomplete='bday bday-#{part}']")
     end
   end
 end

--- a/features/step_definitions/candidates/registrations/personal_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/personal_information_steps.rb
@@ -4,3 +4,15 @@ Then("I should see a paragraph informing me that my details will be used to iden
       "Provide the following information so we can check if we already have your details."
   end
 end
+
+Then("the {string} date field should have day, month and year birth date auto-completion enabled") do |date_label|
+  date_field_set = page.find('.govuk-fieldset__heading', text: date_label)
+
+  within(date_field_set.ancestor('.govuk-form-group')) do
+    %w(Day Month Year).each do |part|
+      label = page.find('label', text: part)
+      input = page.find("input##{label[:for]}")
+      expect(input[:autocomplete]).to eql("bday bday-#{part.downcase}")
+    end
+  end
+end

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -182,6 +182,6 @@ def ensure_input_exists(form_group, label_text, field_type, autocomplete: nil)
   expect(form_group).to have_field(label_text, type: field_type)
 
   if autocomplete
-    expect(form_group.find('input')[:autocomplete]).to eql(autocomplete)
+    expect(form_group).to have_css("input[autocomplete='#{autocomplete}']")
   end
 end

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -2,6 +2,7 @@ Then("I should see a form with the following fields:") do |table|
   table.hashes.each do |row|
     label_text = row['Label']
     options = row['Options']&.split(',')&.map(&:strip)
+    autocompletion = row['Autocompletion']
 
     within(get_form_group(page, label_text)) do
       case row['Type']
@@ -10,8 +11,8 @@ Then("I should see a form with the following fields:") do |table|
       when /select/ then ensure_select_options_exist(page, options)
       when /checkbox/ then ensure_check_boxes_exist(page, options)
       when /textarea/ then ensure_textarea_exists(page)
-      else # regular inputs
-        expect(page).to have_field(label_text, type: row['Type'])
+      else
+        ensure_input_exists(page, label_text, row['Type'], autocomplete: autocompletion)
       end
     end
   end
@@ -175,4 +176,12 @@ end
 
 def ensure_select_options_exist(form_group, options)
   options.each { |option| expect(form_group).to have_css('select option', text: option) }
+end
+
+def ensure_input_exists(form_group, label_text, field_type, autocomplete: nil)
+  expect(form_group).to have_field(label_text, type: field_type)
+
+  if autocomplete
+    expect(form_group.find('input')[:autocomplete]).to eql(autocomplete)
+  end
 end


### PR DESCRIPTION
### Context

Enhance autocompletion for various steps of the candidate journey, namely their personal details and their date of birth fields

### Changes proposed in this pull request

By being [more-specific than `on`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) we can help the browser provide autocompletion values

### Guidance to review

Ensure everything works and looks ok
