### PR TITLE
Don't allow xss in teacher training urls

### DIFF
--- a/app/forms/schools/on_boarding/experience_outline.rb
+++ b/app/forms/schools/on_boarding/experience_outline.rb
@@ -9,6 +9,7 @@ module Schools
       validates :provides_teacher_training, inclusion: [true, false]
       validates :teacher_training_details, presence: true, if: :provides_teacher_training
       validates :teacher_training_url, format: URI::regexp(%w(http https)), if: -> { teacher_training_url.present? }
+      validates :teacher_training_url, format: /\Ahttps?:\/\/.*/, if: -> { teacher_training_url.present? }
 
       def self.compose(
         candidate_experience,

--- a/spec/forms/schools/on_boarding/experience_outline_spec.rb
+++ b/spec/forms/schools/on_boarding/experience_outline_spec.rb
@@ -14,6 +14,19 @@ describe Schools::OnBoarding::ExperienceOutline, type: :model do
     context 'when provides_teacher_training' do
       subject { described_class.new provides_teacher_training: true }
       it { is_expected.to validate_presence_of :teacher_training_details }
+
+      context 'when teacher_training_url is present' do
+        INVALID_URLS = ['javascript:alert("oh no!")//http://example.com'].freeze
+        VALID_URLS = ['https://www.example.com', 'http://example.com'].freeze
+
+        INVALID_URLS.each do |url|
+          it { is_expected.not_to allow_value(url).for :teacher_training_url }
+        end
+
+        VALID_URLS.each do |url|
+          it { is_expected.to allow_value(url).for :teacher_training_url }
+        end
+      end
     end
 
     context 'when not provides_teacher_training' do


### PR DESCRIPTION
URI::regexp matches when there is text before the scheme, this allows
xss attacks.

Add an additional validation that the url must start with http:// or
https://

### Context
fixing a bug from the security audit

### Changes proposed in this pull request
Adds a validation that the url starts with http:// or https://

### Guidance to review

