### PR TITLE
Fix failing spec caused by update to form builder

### DIFF
--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -17,7 +17,7 @@
     </p>
 
     <%= form_for @booking, url: schools_booking_date_path(@booking), method: 'patch' do |f| %>
-      <%= f.date_field :date, heading: true %>
+      <%= f.date_field :date, { heading: true }, {} %>
         <div id="school-booking-show" class="booking">
           <section id="booking-details">
             <dl class="govuk-summary-list">


### PR DESCRIPTION
PR #768 introduced some changes to the form builder that weren't
reflected in the changes made in #756. This fix makes the necessary
amendment to the problematic form
