### PR TITLE
Don't compress CSS assets in test environments

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
 #  config.action_mailer.delivery_method = :test
 
+  # avoid second pass through SASS since thats incompatible with GovUK Frontend
+  config.assets.css_compressor = nil
+
   # set the cache to use RAM
   config.cache_store = :null_store
 


### PR DESCRIPTION
### Context

The second pass through SASS to compress the CSS trips up the escaping in the
GOV.UK Frontend since v2.8

### Changes proposed in this pull request

This isn't necessary for the tests so disabling it.

### Guidance to review

Does it solve running tests without precompiled assets