### PR TITLE
Feature/summer holidays warnings se 1484

### DIFF
--- a/app/notify/notify_email/candidate_request_confirmation.3860fb06-9af2-49c8-ac0b-007b9f360033.md
+++ b/app/notify/notify_email/candidate_request_confirmation.3860fb06-9af2-49c8-ac0b-007b9f360033.md
@@ -2,7 +2,7 @@ Dear ((candidate_name))
 
 You've requested school experience at ((school_name)).
 
-^ The school will be in touch with you. For example, during term time this could typically mean within 2 weeks.
+^ The school will be in touch with you. Be aware, due to the summer holidays, they may not get in touch until at least late August or early September.
 
 # Your request details
 

--- a/app/views/candidates/home/splash.html.erb
+++ b/app/views/candidates/home/splash.html.erb
@@ -13,9 +13,9 @@
         discuss your request.
       </p>
 
-  		<p>
-        Be aware, during term time it could typically take up to 2 weeks for them
-        to get in touch.
+      <p>
+        Be aware, due to the summer holidays, they may not get in touch until
+        at least late August or early September.
       </p>
 
   		<p>

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -14,14 +14,19 @@
     </p>
     <p class="govuk-!-font-weight-bold">
       The school will email or call you to discuss your request and experience
-      date. For example, during term time this could typically take up to 2 weeks.
+      date.
+    </p>
+
+    <p class="govuk-!-font-weight-bold">
+      Be aware, due to the summer holidays, they may not get in touch until at
+      least late August or early September.
     </p>
     <p>
       We'll email you a copy of your request details to confirm you've requested
       school experience.
     </p>
     <p>
-      This service is still in development. If you would like to make another 
+      This service is still in development. If you would like to make another
       request, you will have to submit your details again.
     </p>
   </div>


### PR DESCRIPTION
### Context

Schools are off for summer and might be slower in responding to candidate requests

### Changes proposed in this pull request

Make some text changes to warn candidates delays might be delayed due to summer holidays

### Guidance to review

Ensure the text makes sense