### PR TITLE
Add 'en-gb' culture to default Bing params

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -21,6 +21,7 @@
 #)
 
 require Rails.root.join('lib', 'geocoder_autoexpire_cache')
+require File.join('geocoder', 'lookups', 'bing')
 
 defaults = {
   units: :miles,
@@ -44,8 +45,4 @@ module BingOverrideURLParams
   end
 end
 
-module Geocoder::Lookup
-  class Bing < Geocoder::Lookup::Base
-    prepend BingOverrideURLParams
-  end
-end
+Geocoder::Lookup::Bing.prepend(BingOverrideURLParams)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -37,3 +37,15 @@ if ENV['BING_MAPS_KEY'].present?
 else
   Geocoder.configure(defaults)
 end
+
+module BingOverrideURLParams
+  def query_url_params(query)
+    { c: 'en-gb' }.merge(super)
+  end
+end
+
+module Geocoder::Lookup
+  class Bing < Geocoder::Lookup::Base
+    prepend BingOverrideURLParams
+  end
+end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -40,7 +40,7 @@ end
 
 module BingOverrideURLParams
   def query_url_params(query)
-    { c: 'en-gb' }.merge(super)
+    super.merge(c: 'en-gb')
   end
 end
 


### PR DESCRIPTION
Having had a slight problem with results for the query 'Leeds' where
Bing was returning "Leeds, Kent" rather than "Leeds, Yorkshire", we were
advised by our Bing Maps support agent that:

> ... if you are querying in England it would really help if you set the
  culture to "en-gb" that will be adding "c=en-gb" to your REST Query.

We were previously using the default, which is "en-us", which was a
contributing factor to the odd search results.

Bing Maps have fixed the data issue so in that instance (for Leeds) the
correct result is returned. To reduce the risk of this problem affecting
other searches we'll also follow their advice and set the culture
