### PR TITLE
Se 1437/school search dac fixes

### DIFF
--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -41,7 +41,9 @@
         <%= link_to 'Get directions', external_map_url(
               latitude: @school.coordinates.latitude,
               longitude: @school.coordinates.longitude,
-              name: @school.name) %>
+              name: @school.name),
+              'aria-label': "Get directions for #{@school.name}"
+            %>
       </p>
     </div>
 
@@ -85,7 +87,8 @@
     <div class="school-start-request-button__tablet_plus">
       <%= link_to "Start request",
                   new_candidates_school_registrations_personal_information_path(@school),
-                  class:"govuk-button" %>
+                  class:"govuk-button",
+                  'aria-label': "Start request for school experience at #{@school.name}" %>
     </div>
     <%- end -%>
 
@@ -133,7 +136,8 @@
     <div class="school-start-request-button__mobile">
       <%= link_to "Start request",
                   new_candidates_school_registrations_personal_information_path(@school),
-                  class:"govuk-button" %>
+                  class:"govuk-button",
+                  'aria-label': "Start request for school experience at #{@school.name}" %>
     </div>
   <%- end -%>
 

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -35,7 +35,9 @@
         <%= link_to 'Get directions', external_map_url(
               latitude: @school.coordinates.latitude,
               longitude: @school.coordinates.longitude,
-              name: @school.name) %>
+              name: @school.name),
+              'aria-label': "Get directions for #{@school.name}"
+            %>
       </p>
     </div>
 
@@ -88,7 +90,8 @@
     <div class="school-start-request-button__tablet_plus">
       <%= link_to "Start request",
                   new_candidates_school_registrations_personal_information_path(@presenter.school),
-                  class:"govuk-button" %>
+                  class:"govuk-button",
+                  'aria-label': "Start request for school experience at #{@presenter.school.name}" %>
     </div>
 
     <p>
@@ -202,7 +205,8 @@
     <div class="school-start-request-button__mobile">
       <%= link_to "Start request",
                   new_candidates_school_registrations_personal_information_path(@presenter.school),
-                  class:"govuk-button" %>
+                  class:"govuk-button",
+                  'aria-label': "Start request for school experience at #{@presenter.school.name}" %>
     </div>
   </div>
 </div>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -111,7 +111,7 @@
             <%= summary_row 'Experience subjects', format_school_subjects(school) %>
           </dl>
 
-          <%= link_to 'View school details', candidates_school_path(school), class: 'govuk-button' %>
+          <%= link_to 'View school details', candidates_school_path(school), class: 'govuk-button', 'aria-label': "View school details for #{school.name}" %>
         </article>
       </li>
       <% end %>


### PR DESCRIPTION
### Context
View school details and some of the links on candidates/schools/show were lacking context for screen readers

### Changes proposed in this pull request
Added aria-labels to provide better context for links when using a screen reader

### Guidance to review
Links should now have a better context when read by a screen reader

<img width="1054" alt="school-index" src="https://user-images.githubusercontent.com/9936028/62793216-ef264900-bac8-11e9-9448-7b533c16244d.png">
<img width="1054" alt="school-show" src="https://user-images.githubusercontent.com/9936028/62793218-f0f00c80-bac8-11e9-81f1-85e2102ae553.png">

