### PR TITLE
Removed migration code for PersonalInformation attributes

### DIFF
--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -9,7 +9,6 @@ module Candidates
 
       PENDING_EMAIL_CONFIRMATION_STATUS = 'pending_email_confirmation'.freeze
       COMPLETED_STATUS = 'completed'.freeze
-      MIGRATE_ATTRS = %w{first_name last_name email}.freeze
 
       def initialize(session)
         @registration_session = session
@@ -77,32 +76,11 @@ module Candidates
       end
 
       def personal_information
-        # Allow populating from pre Phase 3 data in the session
-        param_key = PersonalInformation.model_name.param_key
-
-        if !@registration_session[param_key].nil?
-          return PersonalInformation.new @registration_session.fetch(param_key)
-        end
-
-        contact = @registration_session.fetch(ContactInformation.model_name.param_key, {})
-        migrate = contact.slice(*MIGRATE_ATTRS)
-
-        raise StepNotFound, param_key if migrate.empty?
-
-        PersonalInformation.new(migrate).tap do |migrated|
-          save migrated
-        end
-      rescue KeyError
-        raise StepNotFound, param_key
+        fetch PersonalInformation
       end
 
       def personal_information_attributes
-        attrs = @registration_session.fetch(PersonalInformation.model_name.param_key, {})
-        return attrs if attrs.any?
-
-        # Allow populating with pre Phase 3 data in the session
-        migrate = @registration_session.fetch(ContactInformation.model_name.param_key, {})
-        migrate.slice(*MIGRATE_ATTRS)
+        fetch_attributes PersonalInformation
       end
 
       def placement_preference


### PR DESCRIPTION
### Context

Originally when Personal Information was split from Contact Information some
temporary migration code was added, to handle reading the fields from Contact
Information if necessary.

### Changes proposed in this pull request

This is no longer needed and has been removed.



