### PR TITLE
SE-1553 Moved CRM config into environment config files

### DIFF
--- a/app/services/bookings/gitis/api.rb
+++ b/app/services/bookings/gitis/api.rb
@@ -3,11 +3,10 @@ module Bookings::Gitis
     ENDPOINT = '/api/data/v9.1'.freeze
 
     attr_reader :endpoint_url, :access_token
-    delegate :config, to: Rails.application.config.x.gitis
 
     def initialize(token, service_url: nil, endpoint: nil)
       @access_token = token
-      @service_url = service_url || config.service_url
+      @service_url = service_url || Rails.application.config.x.gitis.service_url
       @endpoint = endpoint || ENDPOINT
       @endpoint_url = "#{@service_url}#{@endpoint}"
     end

--- a/app/services/bookings/gitis/api.rb
+++ b/app/services/bookings/gitis/api.rb
@@ -3,10 +3,11 @@ module Bookings::Gitis
     ENDPOINT = '/api/data/v9.1'.freeze
 
     attr_reader :endpoint_url, :access_token
+    delegate :config, to: Rails.application.config.x.gitis
 
     def initialize(token, service_url: nil, endpoint: nil)
       @access_token = token
-      @service_url = service_url || ENV.fetch("CRM_SERVICE_URL")
+      @service_url = service_url || config.service_url
       @endpoint = endpoint || ENDPOINT
       @endpoint_url = "#{@service_url}#{@endpoint}"
     end

--- a/app/services/bookings/gitis/auth.rb
+++ b/app/services/bookings/gitis/auth.rb
@@ -1,7 +1,7 @@
 module Bookings
   module Gitis
     class Auth
-      prepend FakeAuth if Rails.application.config.x.fake_crm
+      prepend FakeAuth if Rails.application.config.x.gitis.fake_crm
 
       CACHE_KEY = 'gitis-auth-token'.freeze
       AUTH_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/token".freeze

--- a/app/services/bookings/gitis/auth.rb
+++ b/app/services/bookings/gitis/auth.rb
@@ -8,12 +8,13 @@ module Bookings
       attr_reader :service_url, :expires_at, :expires_in
 
       delegate :cache, to: Rails
+      delegate :config, to: Rails.application.config.x.gitis
 
       def initialize(client_id: nil, client_secret: nil, tenant_id: nil, service_url: nil)
-        @client_id = client_id || ENV.fetch('CRM_CLIENT_ID')
-        @client_secret = client_secret || ENV.fetch('CRM_CLIENT_SECRET')
-        @tenant_id = tenant_id || ENV.fetch('CRM_AUTH_TENANT_ID')
-        @service_url = service_url || ENV.fetch('CRM_SERVICE_URL')
+        @client_id = client_id || config.auth_client_id
+        @client_secret = client_secret || config.auth_secret
+        @tenant_id = tenant_id || config.auth_tenant_id
+        @service_url = service_url || config.service_url
       end
 
       def token(force_reload = false)

--- a/app/services/bookings/gitis/auth.rb
+++ b/app/services/bookings/gitis/auth.rb
@@ -8,13 +8,16 @@ module Bookings
       attr_reader :service_url, :expires_at, :expires_in
 
       delegate :cache, to: Rails
-      delegate :config, to: Rails.application.config.x.gitis
 
       def initialize(client_id: nil, client_secret: nil, tenant_id: nil, service_url: nil)
         @client_id = client_id || config.auth_client_id
         @client_secret = client_secret || config.auth_secret
         @tenant_id = tenant_id || config.auth_tenant_id
         @service_url = service_url || config.service_url
+      end
+
+      def config
+        Rails.application.config.x.gitis
       end
 
       def token(force_reload = false)

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -3,9 +3,6 @@ module Bookings
     class Contact
       include Entity
 
-      # Call pot in Gitis to insert the record into
-      CHANNEL_CREATION = ENV['CRM_CHANNEL_CREATION'].presence || 0
-
       # Status of record within Gitis
       STATE_CODE = 0
 
@@ -51,7 +48,7 @@ module Bookings
         self.address1_postalcode      = @crm_data['address1_postalcode']
         self.birthdate                = @crm_data['birthdate']
         self.statecode                = @crm_data['statecode'] || STATE_CODE
-        self.dfe_channelcreation      = @crm_data['dfe_channelcreation'] || CHANNEL_CREATION
+        self.dfe_channelcreation      = @crm_data['dfe_channelcreation'] || Rails.application.config.channel_creation
 
         super # handles resetting dirty attributes
 

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -32,6 +32,10 @@ module Bookings
 
       validates :email, presence: true, format: /\A.+@.+\..+\z/
 
+      def self.channel_creation
+        Rails.application.config.x.gitis.channel_creation
+      end
+
       def initialize(crm_contact_data = {})
         @crm_data                     = crm_contact_data.stringify_keys
         self.contactid                = @crm_data['contactid']
@@ -48,7 +52,7 @@ module Bookings
         self.address1_postalcode      = @crm_data['address1_postalcode']
         self.birthdate                = @crm_data['birthdate']
         self.statecode                = @crm_data['statecode'] || STATE_CODE
-        self.dfe_channelcreation      = @crm_data['dfe_channelcreation'] || Rails.application.config.channel_creation
+        self.dfe_channelcreation      = @crm_data['dfe_channelcreation'] || self.class.channel_creation
 
         super # handles resetting dirty attributes
 
@@ -65,7 +69,7 @@ module Bookings
       end
 
       def created_by_us?
-        dfe_channelcreation.to_s == CHANNEL_CREATION.to_s
+        dfe_channelcreation.to_s == Rails.application.config.x.gitis.channel_creation.to_s
       end
 
       def address

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -3,6 +3,7 @@ module Bookings
     class CRM
       prepend FakeCrm if Rails.application.config.x.gitis.fake_crm
       delegate :logger, to: Rails
+      delegate :config, to: Rails.application.config.x.gitis
 
       def initialize(token, service_url: nil, endpoint: nil)
         @token = token

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -3,7 +3,6 @@ module Bookings
     class CRM
       prepend FakeCrm if Rails.application.config.x.gitis.fake_crm
       delegate :logger, to: Rails
-      delegate :config, to: Rails.application.config.x.gitis
 
       def initialize(token, service_url: nil, endpoint: nil)
         @token = token

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -1,7 +1,7 @@
 module Bookings
   module Gitis
     class CRM
-      prepend FakeCrm if Rails.application.config.x.fake_crm
+      prepend FakeCrm if Rails.application.config.x.gitis.fake_crm
       delegate :logger, to: Rails
 
       def initialize(token, service_url: nil, endpoint: nil)

--- a/app/services/bookings/gitis/fake_auth.rb
+++ b/app/services/bookings/gitis/fake_auth.rb
@@ -1,7 +1,7 @@
 module Bookings::Gitis
   module FakeAuth
     def initialize(client_id: nil, client_secret: nil, tenant_id: nil, service_url: nil)
-      Rails.application.config.x.fake_crm || super
+      Rails.application.config.x.gitis.fake_crm || super
     end
 
     def token
@@ -11,7 +11,7 @@ module Bookings::Gitis
   private
 
     def stubbed?
-      Rails.application.config.x.fake_crm
+      Rails.application.config.x.gitis.fake_crm
     end
   end
 end

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -95,7 +95,7 @@ module Bookings::Gitis
     end
 
     def stubbed?
-      Rails.application.config.x.fake_crm
+      Rails.application.config.x.gitis.fake_crm
     end
 
     # only Contacts are mocked for now

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -61,10 +61,12 @@ module Bookings::Gitis
     end
 
     def fake_contact_id
-      if %w{true yes 1}.include? config.fake_crm_uuid.to_s
+      fake_uuid = Rails.config.x.gitis.fake_crm_uuid
+
+      if %w{true yes 1}.include? fake_uuid
         KNOWN_UUID
       else
-        config.fake_crm_uuid.presence || SecureRandom.uuid
+        fake_uuid.presence || SecureRandom.uuid
       end
     end
 

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -61,14 +61,10 @@ module Bookings::Gitis
     end
 
     def fake_contact_id
-      if Rails.env.test? || Rails.env.servertest?
-        SecureRandom.uuid # Mock it if predictable behaviour required
-      elsif %w{true yes 1}.include? ENV['FAKE_CRM_UUID'].to_s
+      if %w{true yes 1}.include? config.fake_crm_uuid.to_s
         KNOWN_UUID
-      elsif ENV['FAKE_CRM_UUID'].present?
-        ENV['FAKE_CRM_UUID']
       else
-        SecureRandom.uuid
+        config.fake_crm_uuid.presence || SecureRandom.uuid
       end
     end
 

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -61,7 +61,7 @@ module Bookings::Gitis
     end
 
     def fake_contact_id
-      fake_uuid = Rails.config.x.gitis.fake_crm_uuid
+      fake_uuid = Rails.application.config.x.gitis.fake_crm_uuid
 
       if %w{true yes 1}.include? fake_uuid
         KNOWN_UUID

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -92,6 +92,7 @@ Rails.application.configure do
   end
 
   config.x.gitis.fake_crm = ['true', '1', 'yes'].include?(String(ENV.fetch('FAKE_CRM') { true }))
+  config.x.gitis.fake_crm_uuid = ENV.fetch('FAKE_CRM_UUID', nil)
   config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
   config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET', 'notset')
   config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID', 'notset')

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -91,12 +91,10 @@ Rails.application.configure do
     Rails.application.config.x.notify_client = ENV['NOTIFY_CLIENT'].constantize
   end
 
-  config.x.gitis = {
-    fake_crm: ['true', '1', 'yes'].include?(String(ENV.fetch('FAKE_CRM') { true })),
-    auth_client_id: ENV.fetch('CRM_CLIENT_ID', 'notset'),
-    auth_secret: ENV.fetch('CRM_CLIENT_SECRET', 'notset'),
-    auth_tenant_id: ENV.fetch('CRM_AUTH_TENANT_ID', 'notset'),
-    service_url: ENV.fetch('CRM_SERVICE_URL', 'notset'),
-    channel_creation: ENV.fetch('CRM_CHANNEL_CREATION', '0')
-  }
+  config.x.gitis.fake_crm = ['true', '1', 'yes'].include?(String(ENV.fetch('FAKE_CRM') { true }))
+  config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
+  config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET', 'notset')
+  config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID', 'notset')
+  config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
+  config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION', '0')
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -87,9 +87,16 @@ Rails.application.configure do
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
   config.x.oidc_services_list_url = 'https://pp-services.signin.education.gov.uk/my-services'
 
-  config.x.fake_crm = ['true', '1', 'yes'].include?(String(ENV.fetch('FAKE_CRM') { true }))
-
   if ENV['NOTIFY_CLIENT'] && ENV['NOTIFY_CLIENT'] != ''
     Rails.application.config.x.notify_client = ENV['NOTIFY_CLIENT'].constantize
   end
+
+  config.x.gitis = {
+    fake_crm: ['true', '1', 'yes'].include?(String(ENV.fetch('FAKE_CRM') { true })),
+    auth_client_id: ENV.fetch('CRM_CLIENT_ID', 'notset'),
+    auth_client_secret: ENV.fetch('CRM_CLIENT_SECRET', 'notset'),
+    auth_tenant_id: ENV.fetch('CRM_AUTH_TENANT_ID', 'notset'),
+    service_url: ENV.fetch('CRM_SERVICE_URL', 'notset'),
+    channel_creation: ENV.fetch('CRM_CHANNEL_CREATION', '0')
+  }
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -94,7 +94,7 @@ Rails.application.configure do
   config.x.gitis = {
     fake_crm: ['true', '1', 'yes'].include?(String(ENV.fetch('FAKE_CRM') { true })),
     auth_client_id: ENV.fetch('CRM_CLIENT_ID', 'notset'),
-    auth_client_secret: ENV.fetch('CRM_CLIENT_SECRET', 'notset'),
+    auth_secret: ENV.fetch('CRM_CLIENT_SECRET', 'notset'),
     auth_tenant_id: ENV.fetch('CRM_AUTH_TENANT_ID', 'notset'),
     service_url: ENV.fetch('CRM_SERVICE_URL', 'notset'),
     channel_creation: ENV.fetch('CRM_CHANNEL_CREATION', '0')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,14 +133,12 @@ Rails.application.configure do
     'https://services.signin.education.gov.uk/my-services'
   end
 
-  config.x.gitis = {
-    fake_crm: ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s),
-    auth_client_id: ENV.fetch('CRM_CLIENT_ID'),
-    auth_secret: ENV.fetch('CRM_CLIENT_SECRET'),
-    auth_tenant_id: ENV.fetch('CRM_AUTH_TENANT_ID'),
-    service_url: ENV.fetch('CRM_SERVICE_URL'),
-    channel_creation: ENV.fetch('CRM_CHANNEL_CREATION')
-  }
+  config.x.gitis.fake_crm = ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s)
+  config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
+  config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET')
+  config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID')
+  config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
+  config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
 
   config.x.features = []
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -134,11 +134,13 @@ Rails.application.configure do
   end
 
   config.x.gitis.fake_crm = ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s)
-  config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
-  config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET')
-  config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID')
-  config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
-  config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
+  if ENV['CRM_CLIENT_ID'].present?
+    config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
+    config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET')
+    config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID')
+    config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
+    config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
+  end
 
   config.x.features = []
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -136,7 +136,7 @@ Rails.application.configure do
   config.x.gitis = {
     fake_crm: ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s),
     auth_client_id: ENV.fetch('CRM_CLIENT_ID'),
-    auth_client_secret: ENV.fetch('CRM_CLIENT_SECRET'),
+    auth_secret: ENV.fetch('CRM_CLIENT_SECRET'),
     auth_tenant_id: ENV.fetch('CRM_AUTH_TENANT_ID'),
     service_url: ENV.fetch('CRM_SERVICE_URL'),
     channel_creation: ENV.fetch('CRM_CHANNEL_CREATION')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -133,7 +133,14 @@ Rails.application.configure do
     'https://services.signin.education.gov.uk/my-services'
   end
 
-  config.x.fake_crm = ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s)
+  config.x.gitis = {
+    fake_crm: ['true', '1', 'yes'].include?(ENV['FAKE_CRM'].to_s),
+    auth_client_id: ENV.fetch('CRM_CLIENT_ID'),
+    auth_client_secret: ENV.fetch('CRM_CLIENT_SECRET'),
+    auth_tenant_id: ENV.fetch('CRM_AUTH_TENANT_ID'),
+    service_url: ENV.fetch('CRM_SERVICE_URL'),
+    channel_creation: ENV.fetch('CRM_CHANNEL_CREATION')
+  }
 
   config.x.features = []
 

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -21,4 +21,5 @@ Rails.application.configure do
   config.x.oidc_services_list_url = 'https://some-oidc.provider.com/my-services'
 
   config.x.gitis.fake_crm = true
+  config.x.gitis.channel_creation = '0'
 end

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -20,5 +20,5 @@ Rails.application.configure do
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
   config.x.oidc_services_list_url = 'https://some-oidc.provider.com/my-services'
 
-  config.x.fake_crm = true
+  config.x.gitis.fake_crm = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   config.x.oidc_host = 'some-oidc-host.education.gov.uk'
   config.x.oidc_services_list_url = 'https://some-oidc.provider.com/my-services'
 
-  config.x.fake_crm = true
+  config.x.gitis.fake_crm = true
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,6 +76,7 @@ Rails.application.configure do
   config.x.oidc_services_list_url = 'https://some-oidc.provider.com/my-services'
 
   config.x.gitis.fake_crm = true
+  config.x.gitis.channel_creation = '0'
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,7 +8,7 @@ require 'cucumber/rails'
 require 'selenium/webdriver'
 require 'capybara-screenshot/cucumber'
 
-Rails.application.config.x.fake_crm = true
+Rails.application.config.x.gitis.fake_crm = true
 
 # Capybara defaults to CSS3 selectors rather than XPath.
 # If you'd prefer to use XPath, just uncomment this line and adjust any

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -69,7 +69,7 @@ describe Bookings::Gitis::Contact, type: :model do
     context 'with our record' do
       subject do
         build :gitis_contact, \
-          dfe_channelcreation: described_class::CHANNEL_CREATION
+          dfe_channelcreation: described_class::channel_creation
       end
 
       it { is_expected.to be_created_by_us }
@@ -78,7 +78,7 @@ describe Bookings::Gitis::Contact, type: :model do
     context 'with existing gitis record' do
       subject do
         build :gitis_contact, \
-          dfe_channelcreation: described_class::CHANNEL_CREATION.to_s + '1'
+          dfe_channelcreation: described_class::channel_creation.to_s + '1'
       end
 
       it { is_expected.not_to be_created_by_us }
@@ -173,7 +173,7 @@ describe Bookings::Gitis::Contact, type: :model do
       subject { contact.attributes_for_update }
 
       context 'with records we created' do
-        let(:channel) { described_class::CHANNEL_CREATION }
+        let(:channel) { described_class::channel_creation }
 
         context 'when unmodified' do
           it { is_expected.not_to include('contactid') }
@@ -206,7 +206,7 @@ describe Bookings::Gitis::Contact, type: :model do
       end
 
       context "with other gitis records" do
-        let(:channel) { described_class::CHANNEL_CREATION.to_s + '1' }
+        let(:channel) { described_class::channel_creation.to_s + '1' }
 
         context 'when unmodified' do
           it { is_expected.not_to include('contactid') }

--- a/spec/support/bypass_fake_gitis.rb
+++ b/spec/support/bypass_fake_gitis.rb
@@ -1,3 +1,3 @@
 shared_context "bypass fake Gitis" do
-  before { allow(Rails.application.config.x).to receive(:fake_crm).and_return(false) }
+  before { allow(Rails.application.config.x.gitis).to receive(:fake_crm).and_return(false) }
 end


### PR DESCRIPTION
### Context

Currently we are accessing environment variables directly then occassionally applying logic specific to different environments

### Changes proposed in this pull request

Instead access the config from `Rails.application.config.x.gitis`, and load the environment variables into there.

### Guidance to review
1. Does it look sane
2. Does Gitis access still work, if you've got the gitis config settings
