### PR TITLE
Update the way of setting Chrome to be headless

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -85,14 +85,13 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :chrome_headless do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) }
-  )
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.headless!
 
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    options: options
   )
 end
 


### PR DESCRIPTION
This appears to have changed in a Selenium update, the 'capabilities'
approach is no longer mentioned. It has been replaced by creating an
options object and calling the `#headless!` method on it.

The other option that was originally set, disable-gpu, doesn't appear to
have a corresponding method. I suggest we allow this to remain as
default and revisit if it causes problems

https://www.rubydoc.info/gems/selenium-webdriver/Selenium/WebDriver/Chrome/Options#headless!-instance_method
