### PR TITLE
Replace SVG with div with border radius

### DIFF
--- a/app/assets/stylesheets/school-dashboard.scss
+++ b/app/assets/stylesheets/school-dashboard.scss
@@ -43,20 +43,16 @@ article#dashboard {
       padding: 1rem 0rem;
     }
 
-    svg {
-      vertical-align: middle;
-      margin-left: 4px;
-      circle {
-        &.red {
-          fill: #A32526;
-        }
-      }
-      text {
-        text-anchor: middle;
-        font-family: sans-serif;
-        font-weight: bold;
-        fill: white;
-      }
+    div.numbered-circle {
+      background-color: #A32526;
+      border-radius: 50%;
+      color: white;
+      display: inline-block;
+      height: 1.8rem;
+      margin-left: 0.5rem;
+      min-width: 1.8rem;
+      padding: 0.3rem;
+      text-align: center;
     }
 
     &.requests-and-bookings {

--- a/app/assets/stylesheets/school-dashboard.scss
+++ b/app/assets/stylesheets/school-dashboard.scss
@@ -43,19 +43,35 @@ article#dashboard {
       padding: 1rem 0rem;
     }
 
-    div.numbered-circle {
-      background-color: #A32526;
-      border-radius: 50%;
-      color: white;
+    div.alert-counter {
       display: inline-block;
-      height: 1.8rem;
       margin-left: 0.5rem;
-      min-width: 1.8rem;
-      padding: 0.3rem;
-      text-align: center;
-    }
 
-    &.requests-and-bookings {
+      div.numbered-circle-container {
+        display: flex;
+        justify-content: center;
+
+        div.numbered-circle {
+          background-color: #A32526;
+          border-radius: 50%;
+          width: 1.2rem;
+          height: 1.2rem;
+          padding: 0.2rem;
+          display: flex;
+          justify-content: center;
+
+          div.number {
+            display: flex;
+            justify-content: center;
+            color: white;
+            text-align: center;
+            padding: 0rem;
+            margin: 0rem;
+            font-size: 1rem;
+            line-height: 1.3;
+          }
+        }
+      }
     }
 
     #requests {

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -7,11 +7,11 @@ module Schools::DashboardsHelper
     end
   end
 
-  def numbered_circle(number, id: nil, show_if_zero: false)
+  def numbered_circle(number, aria_label:, id: nil, show_if_zero: false)
     # Does string comparison in case its not a number
     return if number.to_s == '0' && !show_if_zero
 
-    content_tag('div', id: id, class: 'numbered-circle') do
+    content_tag('div', id: id, class: 'numbered-circle', aria: { label: "#{number} #{aria_label}" }) do
       tag.span(number, class: 'number')
     end
   end

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -7,17 +7,12 @@ module Schools::DashboardsHelper
     end
   end
 
-  def numbered_circle(number, id: nil, colour: 'red', width: 26, height: 30, font_size: "16px", circle_size: 13, show_if_zero: false)
+  def numbered_circle(number, id: nil, show_if_zero: false)
     # Does string comparison in case its not a number
     return if number.to_s == '0' && !show_if_zero
 
-    content_tag(:svg, id: id, width: width, height: height) do
-      safe_join([
-        tag(:circle, class: colour, cx: circle_size, cy: circle_size, r: circle_size),
-        content_tag(:text, x: "50%", y: "50%", dy: "0.2em", "font-size" => font_size) do
-          number.to_s
-        end
-      ])
+    content_tag('div', id: id, class: 'numbered-circle') do
+      tag.span(number, class: 'number')
     end
   end
 

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -11,8 +11,12 @@ module Schools::DashboardsHelper
     # Does string comparison in case its not a number
     return if number.to_s == '0' && !show_if_zero
 
-    content_tag('div', id: id, class: 'numbered-circle', aria: { label: "#{number} #{aria_label}" }) do
-      tag.span(number, class: 'number')
+    content_tag('div', class: 'alert-counter') do
+      content_tag('div', class: 'numbered-circle-container') do
+        content_tag('div', id: id, class: 'numbered-circle', aria: { label: "#{number} #{aria_label}" }) do
+          tag.div(number, class: 'number')
+        end
+      end
     end
   end
 

--- a/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
@@ -6,7 +6,7 @@
   <div id="requests" class="subsection">
     <header class="dashboard-high-priority">
       <%= link_to "Manage requests", schools_placement_requests_path %>
-      <%= numbered_circle(@new_requests, id: 'new-requests-counter') %>
+      <%= numbered_circle(@new_requests, id: 'new-requests-counter', aria_label: 'new placement requests') %>
     </header>
     <p class="govuk-hint">Candidates have requested school experience</p>
   </div>
@@ -14,7 +14,7 @@
   <div id="bookings" class="subsection">
     <header class="dashboard-high-priority">
       <%= link_to "Manage bookings", schools_bookings_path  %>
-      <%= numbered_circle(@new_bookings, id: 'new-bookings-counter') %>
+      <%= numbered_circle(@new_bookings, id: 'new-bookings-counter', aria_label: 'new upcoming bookings') %>
     </header>
     <p class="govuk-hint">A candidate has asked to change a booking</p>
   </div>
@@ -22,7 +22,7 @@
   <div id="confirm-attendance" class="subsection">
     <header class="dashboard-high-priority">
       <%= link_to "Confirm attendance", schools_confirm_attendance_path  %>
-      <%= numbered_circle(@new_bookings, id: 'new-bookings-counter') %>
+      <%= numbered_circle(@new_bookings, id: 'new-bookings-counter', aria_label: 'attendances to confirm') %>
     </header>
     <p class="govuk-hint">Confirm if candidates have attended their school experience</p>
   </div>

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -42,7 +42,7 @@ Given("there are {int} new candidate attendances") do |qty|
 end
 
 Then("the {string} should be {int}") do |string, int|
-  expect(page).to have_css("svg#%<id>s" % { id: string.tr(' ', '-') }, text: int.to_s)
+  expect(page).to have_css("div#%<id>s" % { id: string.tr(' ', '-') }, text: int.to_s)
 end
 
 Given("my school has not yet fully-onboarded") do

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -17,89 +17,14 @@ describe Schools::DashboardsHelper, type: 'helper' do
         let(:id) { 'what-a-nice-circle' }
         let(:circle) { numbered_circle(text, id: id) }
         specify 'should be set to the overridden value' do
-          expect(subject.at_css('svg')['id']).to eql(id)
-        end
-      end
-    end
-
-    context 'shape and colour' do
-      specify 'should default to a red circle' do
-        expect(subject).to have_css('svg > circle.red')
-      end
-
-      specify 'should have the correct dimensions' do
-        subject.at_css('svg').tap do |svg|
-          expect(svg['height']).to eql("30")
-          expect(svg['width']).to eql("26")
-        end
-      end
-
-      context 'overriding colour' do
-        custom_colour = 'blue'
-        let(:circle) { numbered_circle(15, colour: 'blue') }
-        let(:custom_colour) { custom_colour }
-
-        specify "should be a #{custom_colour} circle" do
-          expect(subject).to have_css("svg > circle.#{custom_colour}")
-        end
-      end
-
-      context 'overriding container size' do
-        let(:circle) { numbered_circle(15, width: 40, height: 40) }
-        specify 'should have the correct dimensions' do
-          subject.at_css('svg').tap do |svg|
-            expect(svg['height']).to eql("40")
-            expect(svg['width']).to eql("40")
-          end
-        end
-      end
-
-      context 'overriding circle size' do
-        custom_size = '19'
-        let(:custom_size) { custom_size }
-        let(:circle) { numbered_circle(20, circle_size: custom_size) }
-
-        specify "should be a #{custom_size}-sized circle" do
-          %w{cx cy r}.each do |dimension|
-            expect(subject.at_css('svg > circle')[dimension]).to eql(custom_size)
-          end
-        end
-      end
-
-      context 'with 0 as number' do
-        let(:circle) { numbered_circle(0) }
-        subject { circle }
-
-        it "will return nil" do
-          is_expected.to be_nil
-        end
-
-        context 'and show_if_zero set' do
-          let(:circle) { numbered_circle(0, show_if_zero: true) }
-
-          it "will return with zero" do
-            is_expected.not_to be_nil
-          end
+          expect(subject.at_css('div.numbered-circle')['id']).to eql(id)
         end
       end
     end
 
     context 'text' do
       specify 'should contain the supplied text' do
-        expect(subject).to have_css("svg > text", text: text)
-      end
-
-      specify 'font size defaults to 16px' do
-        expect(subject.at_css('svg > text')['font-size']).to eql('16px')
-      end
-
-      context 'overriding font-size' do
-        let(:fs) { '22px' }
-        let(:circle) { numbered_circle(text, font_size: fs) }
-
-        specify "should be sized at the custom size" do
-          expect(subject.at_css('svg > text')['font-size']).to eql(fs)
-        end
+        expect(subject).to have_css("div.numbered-circle", text: text)
       end
     end
   end

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 describe Schools::DashboardsHelper, type: 'helper' do
   describe '#numbered_circle' do
     let(:text) { '15' }
-    let(:circle) { numbered_circle(text) }
+    let(:aria_label) { 'upcoming bookings' }
+    let(:circle) { numbered_circle(text, aria_label: aria_label) }
     subject { Nokogiri.parse(circle) }
 
     context 'id' do
@@ -15,17 +16,21 @@ describe Schools::DashboardsHelper, type: 'helper' do
 
       context 'when set' do
         let(:id) { 'what-a-nice-circle' }
-        let(:circle) { numbered_circle(text, id: id) }
+        let(:circle) { numbered_circle(text, id: id, aria_label: aria_label) }
         specify 'should be set to the overridden value' do
           expect(subject.at_css('div.numbered-circle')['id']).to eql(id)
         end
       end
     end
 
-    context 'text' do
-      specify 'should contain the supplied text' do
-        expect(subject).to have_css("div.numbered-circle", text: text)
-      end
+    specify 'should contain the supplied text' do
+      expect(subject).to have_css("div.numbered-circle", text: text)
+    end
+
+    specify 'should have the correct aria label' do
+      expect(subject.at_css('div.numbered-circle')['aria-label']).to eql(
+        "#{text} #{aria_label}"
+      )
     end
   end
 


### PR DESCRIPTION
### Context

The SVG notification counters weren't particularly accessible

### Changes proposed in this pull request

Replace the SVGs with `div` tags with rounded corners, and add `aria-label` attributes with appropriate values.

![Screenshot 2019-08-12 at 16 02 03](https://user-images.githubusercontent.com/128088/62875263-a36ade00-bd1a-11e9-8d92-3ace995dfa0d.png)

One difference is that now, when numbers overflow the circle, rather than the circle increasing in size (like with the SVG), the `div` tag stretches. This will _probably_ never happen but it's worth mentioning

![Screenshot 2019-08-12 at 16 01 42](https://user-images.githubusercontent.com/128088/62875320-bed5e900-bd1a-11e9-832b-1f4a4e9e7f7e.png)

### Guidance to review

Ensure everything makes sense, is accessible and looks ok.

