### PR TITLE
SE-1502 Reduce session timeout

### DIFF
--- a/app/models/candidates/session_token.rb
+++ b/app/models/candidates/session_token.rb
@@ -1,5 +1,5 @@
 class Candidates::SessionToken < ApplicationRecord
-  AUTO_EXPIRE = 1.day.freeze
+  AUTO_EXPIRE = 1.hour.freeze
 
   belongs_to :candidate, class_name: 'Bookings::Candidate'
   has_secure_token

--- a/app/notify/notify_email/candidate_signin_link.5b451894-3640-47df-a119-6461ecb890d9.md
+++ b/app/notify/notify_email/candidate_signin_link.5b451894-3640-47df-a119-6461ecb890d9.md
@@ -4,4 +4,4 @@ Click the link below to sign in to your school experience dashboard
 
 ((confirmation_link))
 
-This link will expire within 24 hours.
+This link will expire within 1 hour.

--- a/app/notify/notify_email/candidate_verify_email_link.0e4b2eaa-ae1f-472a-9293-c2a24f3f8187.md
+++ b/app/notify/notify_email/candidate_verify_email_link.0e4b2eaa-ae1f-472a-9293-c2a24f3f8187.md
@@ -4,4 +4,4 @@ Click the link below to verify your email address
 
 ((verification_link))
 
-This link will expire within 24 hours.
+This link will expire within 1 hour.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,7 +67,10 @@ Rails.application.configure do
   config.cache_store = :redis_cache_store, {
     url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL']
   }
-  config.session_store :cache_store, key: 'schoolex-session'
+
+  config.session_store :cache_store,
+    key: 'schoolex-session',
+    expire_after: 1.hour # Sets explicit TTL for Session Redis keys
 
   config.after_initialize do
     Bullet.enable = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,7 +111,7 @@ Rails.application.configure do
 
   config.session_store :cache_store,
     key: 'schoolex-session',
-    expire_after: 24.hours # Sets explicit TTL for Session Redis keys
+    expire_after: 1.hour # Sets explicit TTL for Session Redis keys
 
   config.active_job.queue_adapter = :delayed_job
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,7 +51,9 @@ Rails.application.configure do
 
   # Use Redis for Session and cache
   config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
-  config.session_store :cache_store, key: 'schoolex-test-session'
+  config.session_store :cache_store,
+    key: 'schoolex-test-session',
+    expire_after: 1.hour # Sets explicit TTL for Session Redis keys
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
### Context

Current sessions require 24 hours of inactivity to timeout. This has been determined to be too long as part of our pen test.

### Changes proposed in this pull request

1. Reduce session timeout to be 1 hour
2. Reduce session sign in tokens to a lifetime of 1 hour - this avoids users expecting to sign in and continue with their session when in fact it has expired.

