### PR TITLE
SE-1515 Remove csp wildcard

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -13,7 +13,7 @@ class Candidates::SchoolsController < ApplicationController
       'https://*.virtualearth.net',
       "https://www.googletagmanager.com",
       "https://www.google-analytics.com",
-      "https://*.vo.msecnd.net"
+      "https://az416426.vo.msecnd.net" # needed for AppInsights
   end
 
   def index

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -32,5 +32,5 @@
    policy.script_src :self, "'unsafe-inline'",
      "https://www.googletagmanager.com",
      "https://www.google-analytics.com",
-     "https://*.vo.msecnd.net"
+     "https://az416426.vo.msecnd.net" # needed for App Insights
  end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -29,6 +29,7 @@
 
    policy.connect_src :self, "https://*.visualstudio.com"
    policy.img_src :self, "https://www.google-analytics.com"
+   policy.object_src :none
    policy.script_src :self, "'unsafe-inline'",
      "https://www.googletagmanager.com",
      "https://www.google-analytics.com",


### PR DESCRIPTION
### Context

Pen test pointed out out the wildcard we'd added on the microsoft domain was actually their CDN, so could potential host other hostile scripts

### Changes proposed in this pull request

1. Locked the App Insights JS to a specific subdomain in the CDN
2. Removed the ability to load <object>s

### Guidance to review

