### PR TITLE
Add aria labels to repeated links

### DIFF
--- a/app/views/schools/confirmed_bookings/_booking_table.html.erb
+++ b/app/views/schools/confirmed_bookings/_booking_table.html.erb
@@ -20,7 +20,8 @@
           <%= booking.date.to_formatted_s(:govuk) %>
         </td>
         <td class="govuk-table__cell">
-          <%= link_to "View", schools_booking_path(booking) %>
+          <%= link_to "View", schools_booking_path(booking),
+            'aria-label': "View booking for #{booking.candidate_name}, #{booking.date.to_formatted_s(:govuk)}" %>
         </td>
       </tr>
     <%- end -%>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -41,7 +41,7 @@
             <td class="govuk-table__cell">
               <%= link_to(edit_schools_placement_date_path(placement_date)) do %>
                 Change
-                <span class="govuk-visually-hidden"> placement date</span>
+                <span class="govuk-visually-hidden"> placement date <%= placement_date.date.to_formatted_s(:govuk) %></span>
               <%- end -%>
             </td>
           </tr>

--- a/app/views/schools/placement_requests/_placement_request.html.erb
+++ b/app/views/schools/placement_requests/_placement_request.html.erb
@@ -12,6 +12,7 @@
     <%= placement_request.dates_requested %>
   </td>
   <td class="govuk-table__cell">
-    <%= link_to "View", schools_placement_request_path(placement_request) %>
+    <%= link_to "View", schools_placement_request_path(placement_request),
+      'aria-label': "View placement request for #{placement_request.gitis_contact.full_name} #{placement_request.dates_requested}" %>
   </td>
 </tr>


### PR DESCRIPTION
Repeated links with the same text make navigating with screen readers
difficult. Add aria labels to repeated links to give more context for
screen readers.

### Context

### Changes proposed in this pull request

### Guidance to review

