### PR TITLE
SE-1525 Add gitis registration session

### DIFF
--- a/app/controllers/candidates/registrations/contact_informations_controller.rb
+++ b/app/controllers/candidates/registrations/contact_informations_controller.rb
@@ -2,7 +2,7 @@ module Candidates
   module Registrations
     class ContactInformationsController < RegistrationsController
       def new
-        @contact_information = ContactInformation.new attributes_from_session_or_gitis
+        @contact_information = ContactInformation.new attributes_from_session
       end
 
       def create
@@ -50,13 +50,6 @@ module Candidates
 
       def attributes_from_session
         current_registration.contact_information_attributes.except 'created_at'
-      end
-
-      def attributes_from_session_or_gitis
-        attrs = attributes_from_session
-        return attrs if attrs.any?
-
-        current_contact ? gitis_mapper.contact_to_contact_information : {}
       end
     end
   end

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -15,11 +15,7 @@ module Candidates
     end
 
     def current_registration
-      @current_registration ||= if candidate_signed_in?
-                                  school_session.gitis_registration(current_contact)
-                                else
-                                  school_session.current_registration
-                                end
+      @current_registration ||= school_session.current_registration(current_contact)
     end
 
     def school_session

--- a/app/controllers/candidates/registrations_controller.rb
+++ b/app/controllers/candidates/registrations_controller.rb
@@ -15,7 +15,11 @@ module Candidates
     end
 
     def current_registration
-      @current_registration ||= school_session.current_registration
+      @current_registration ||= if candidate_signed_in?
+                                  school_session.gitis_registration(current_contact)
+                                else
+                                  school_session.current_registration
+                                end
     end
 
     def school_session

--- a/app/services/candidates/registrations/gitis_registration_session.rb
+++ b/app/services/candidates/registrations/gitis_registration_session.rb
@@ -1,0 +1,20 @@
+module Candidates
+  module Registrations
+    class GitisRegistrationSession < RegistrationSession
+      attr_reader :gitis_contact
+
+      def initialize(session, gitis_contact)
+        @gitis_contact = gitis_contact
+        super(session)
+      end
+
+      def contact_information_attributes
+        fetch_attributes ContactInformation, mapper.contact_to_contact_information
+      end
+
+      def mapper
+        @mapper ||= Bookings::RegistrationContactMapper.new(self, gitis_contact)
+      end
+    end
+  end
+end

--- a/app/services/candidates/registrations/gitis_registration_session.rb
+++ b/app/services/candidates/registrations/gitis_registration_session.rb
@@ -8,6 +8,15 @@ module Candidates
         super(session)
       end
 
+      def personal_information_attributes
+        fetch_attributes(PersonalInformation, mapper.contact_to_personal_information).
+          merge('read_only_email' => true, 'email' => gitis_contact.email)
+      end
+
+      def personal_information
+        PersonalInformation.new personal_information_attributes
+      end
+
       def contact_information_attributes
         fetch_attributes ContactInformation, mapper.contact_to_contact_information
       end

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -131,8 +131,8 @@ module Candidates
         raise StepNotFound, e.key
       end
 
-      def fetch_attributes(klass)
-        @registration_session.fetch(klass.model_name.param_key, {})
+      def fetch_attributes(klass, defaults = {})
+        @registration_session.fetch(klass.model_name.param_key, defaults)
       end
 
       def to_h

--- a/app/services/candidates/registrations/school_session.rb
+++ b/app/services/candidates/registrations/school_session.rb
@@ -19,6 +19,10 @@ module Candidates
       def current_registration
         @current_registration ||= RegistrationSession.new @school_session
       end
+
+      def gitis_registration(current_contact)
+        @gitis_registration ||= GitisRegistrationSession.new @school_session, current_contact
+      end
     end
   end
 end

--- a/app/services/candidates/registrations/school_session.rb
+++ b/app/services/candidates/registrations/school_session.rb
@@ -16,12 +16,12 @@ module Candidates
         @school_session.merge! 'urn' => urn
       end
 
-      def current_registration
-        @current_registration ||= RegistrationSession.new @school_session
-      end
-
-      def gitis_registration(current_contact)
-        @gitis_registration ||= GitisRegistrationSession.new @school_session, current_contact
+      def current_registration(current_contact = nil)
+        @current_registration ||= if current_contact
+                                    GitisRegistrationSession.new @school_session, current_contact
+                                  else
+                                    RegistrationSession.new @school_session
+                                  end
       end
     end
   end

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -7,17 +7,17 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
     FactoryBot.create :bookings_school, urn: 11048
   end
 
-  let :registration_session do
-    FactoryBot.build :registration_session, with: %i(
-      personal_information
-      contact_information
-      education
-      teaching_preference
-      placement_preference
-    )
-  end
-
   context 'without existing background_check in session' do
+    let :registration_session do
+      FactoryBot.build :registration_session, with: %i(
+        personal_information
+        contact_information
+        education
+        teaching_preference
+        placement_preference
+      )
+    end
+
     context '#new' do
       before do
         get '/candidates/schools/11048/registrations/background_check/new'
@@ -75,6 +75,16 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
   end
 
   context 'with existing background check in session' do
+    let :registration_session do
+      FactoryBot.build :gitis_registration_session, with: %i(
+        personal_information
+        contact_information
+        education
+        teaching_preference
+        placement_preference
+      )
+    end
+
     let :existing_background_check do
       FactoryBot.build :background_check
     end

--- a/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
@@ -3,12 +3,13 @@ require 'rails_helper'
 describe Candidates::Registrations::ContactInformationsController, type: :request do
   include_context 'Stubbed current_registration'
 
-  let :registration_session do
-    FactoryBot.build :registration_session, with: %i(personal_information)
-  end
-
+  let(:gitis_contact) { build(:gitis_contact, :persisted) }
 
   context 'without existing contact information in the session' do
+    let :registration_session do
+      FactoryBot.build :registration_session, with: %i(personal_information)
+    end
+
     context '#new' do
       before do
         get '/candidates/schools/11048/registrations/contact_information/new'
@@ -67,10 +68,10 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
   end
 
   context 'with existing contact information in gitis' do
-    let(:gitis_contact) { build(:gitis_contact, :persisted) }
-    before do
-      allow_any_instance_of(ActionDispatch::Request::Session).to \
-        receive(:[]).with(:gitis_contact).and_return(gitis_contact.attributes)
+    let :registration_session do
+      FactoryBot.build :gitis_registration_session,
+        gitis_contact: gitis_contact,
+        with: %i(personal_information)
     end
 
     context '#new' do
@@ -80,7 +81,7 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
 
       it 'populates the form with the values from gitis' do
         expect(assigns(:contact_information)).to have_attributes \
-          phone: gitis_contact.telephone1,
+          phone: gitis_contact.phone,
           postcode: gitis_contact.postcode
       end
 
@@ -91,6 +92,12 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
   end
 
   context 'with existing contact information in session' do
+    let :registration_session do
+      FactoryBot.build :gitis_registration_session,
+        gitis_contact: gitis_contact,
+        with: %i(personal_information)
+    end
+
     let :existing_contact_information do
       FactoryBot.build :contact_information
     end

--- a/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
@@ -163,10 +163,10 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
   end
 
   context 'with existing personal information in gitis' do
-    let(:gitis_contact) { build(:gitis_contact, :persisted) }
-    before do
-      allow_any_instance_of(ActionDispatch::Request::Session).to \
-        receive(:[]).with(:gitis_contact).and_return(gitis_contact.attributes)
+    include_context 'candidate signin'
+
+    let :registration_session do
+      Candidates::Registrations::GitisRegistrationSession.new({ 'urn' => '10020' }, gitis_contact)
     end
 
     context '#new' do

--- a/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :gitis_registration_session, parent: :registration_session,
+    class: Candidates::Registrations::GitisRegistrationSession do
+
+    gitis_contact { build(:gitis_contact, :persisted) }
+
+    initialize_with do
+      new \
+        with
+          .map { |step| "candidates_registrations_#{step}" }
+          .reduce("uuid" => uuid, "urn" => urn) { |options, step| options.merge step => send(step) },
+        gitis_contact
+    end
+  end
+end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -173,7 +173,7 @@ feature 'Candidate Registrations', type: :feature do
         complete_contact_information_step
         sign_in_via_dashboard(newtoken.token)
         swap_back_to_education_step
-        get_bounced_to_personal_information_step
+        get_bounced_to_contact_information_step
       end
     end
   end
@@ -350,9 +350,9 @@ feature 'Candidate Registrations', type: :feature do
     visit "/candidates/schools/#{school_urn}/registrations/education/new"
   end
 
-  def get_bounced_to_personal_information_step
+  def get_bounced_to_contact_information_step
     visit "/candidates/schools/#{school_urn}/registrations/application_preview"
     expect(page.current_path).to eq \
-      "/candidates/schools/#{school_urn}/registrations/personal_information/new"
+      "/candidates/schools/#{school_urn}/registrations/contact_information/new"
   end
 end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -85,8 +85,10 @@ feature 'Candidate Registrations', type: :feature do
     end
 
     context 'for unknown Candidate but Contact is in Gitis' do
+      include_context 'fake gitis with known uuid'
+
       let(:token) { create(:candidate_session_token) }
-      let(:email_address) { 'test@example.com' }
+      let(:email_address) { fake_gitis.send(:fake_contact_data)['emailaddress2'] }
 
       scenario "completing the Journey" do
         complete_personal_information_step
@@ -102,8 +104,11 @@ feature 'Candidate Registrations', type: :feature do
     end
 
     context 'for known Candidate not signed in' do
-      let(:token) { create(:candidate_session_token) }
-      let(:email_address) { 'test@example.com' }
+      include_context 'fake gitis with known uuid'
+
+      let(:email_address) { fake_gitis.send(:fake_contact_data)['emailaddress2'] }
+      let!(:candidate) { create(:candidate, :confirmed, gitis_uuid: fake_gitis_uuid) }
+      let(:token) { create(:candidate_session_token, candidate: candidate) }
 
       before do
         allow_any_instance_of(Candidates::Registrations::PersonalInformation).to \

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::GitisRegistrationSession do
+  it "needs to be tested"
+end

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -1,5 +1,106 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::GitisRegistrationSession do
-  it "needs to be tested"
+  let(:contact) { build(:gitis_contact, :persisted) }
+
+  describe '#contact_information_attributes' do
+    let(:data) { { 'phone' => '01111 222333' } }
+
+    let(:key) do
+      Candidates::Registrations::ContactInformation.model_name.param_key
+    end
+
+    context 'with overridden contact data' do
+      subject do
+        described_class.new({ key => data }, contact).
+          contact_information_attributes
+      end
+
+      it { is_expected.to include(data) }
+    end
+
+    context 'with only gitis data' do
+      subject do
+        described_class.new({}, contact).contact_information_attributes
+      end
+
+      it { is_expected.to include('phone' => contact.phone) }
+    end
+  end
+
+  describe '#contact_information' do
+    let(:data) { { 'phone' => '01111 222333' } }
+
+    let(:key) do
+      Candidates::Registrations::ContactInformation.model_name.param_key
+    end
+
+    context 'with overridden contact data' do
+      subject do
+        described_class.new({ key => data }, contact).contact_information
+      end
+
+      it { is_expected.to have_attributes(phone: data['phone']) }
+    end
+
+    context 'with only gitis data' do
+      it "will raise a missing step error" do
+        expect { described_class.new({}, contact).contact_information }.to \
+          raise_exception Candidates::Registrations::RegistrationSession::StepNotFound
+      end
+    end
+  end
+
+  describe "#personal_information_attributes" do
+    let(:data) { { 'first_name' => 'Person', 'email' => 'person@personl.com' } }
+
+    let(:key) do
+      Candidates::Registrations::PersonalInformation.model_name.param_key
+    end
+
+    context 'with overridden personal data' do
+      subject do
+        described_class.new({ key => data }, contact).
+          personal_information_attributes
+      end
+
+      it { is_expected.to include('first_name' => data['first_name']) }
+      it { is_expected.to include('email' => contact.email) }
+    end
+
+    context 'with only gitis data' do
+      subject do
+        described_class.new({}, contact).personal_information_attributes
+      end
+
+      it { is_expected.to include('first_name' => contact.firstname) }
+      it { is_expected.to include('email' => contact.email) }
+    end
+  end
+
+  describe '#personal_information' do
+    let(:data) { { 'first_name' => 'Person', 'email' => 'person@personl.com' } }
+
+    let(:key) do
+      Candidates::Registrations::PersonalInformation.model_name.param_key
+    end
+
+    context 'with overridden personal data' do
+      subject do
+        described_class.new({ key => data }, contact).personal_information
+      end
+
+      it { is_expected.to have_attributes(first_name: data['first_name']) }
+      it { is_expected.to have_attributes(email: contact.email) }
+    end
+
+    context 'with only gitis data' do
+      subject do
+        described_class.new({}, contact).personal_information
+      end
+
+      it { is_expected.to have_attributes(first_name: contact.firstname) }
+      it { is_expected.to have_attributes(email: contact.email) }
+    end
+  end
 end

--- a/spec/services/candidates/registrations/school_session_spec.rb
+++ b/spec/services/candidates/registrations/school_session_spec.rb
@@ -60,15 +60,17 @@ describe Candidates::Registrations::SchoolSession do
   context '#current_registration' do
     context '1 school' do
       subject do
-        described_class.new school_urn_1, session
+        described_class.new(school_urn_1, session).current_registration
       end
 
       before do
-        subject.current_registration.save personal_information_1
+        subject.save personal_information_1
       end
 
+      it { is_expected.to be_kind_of Candidates::Registrations::RegistrationSession }
+
       it 'returns the current_registration' do
-        expect(subject.current_registration.personal_information).to eq \
+        expect(subject.personal_information).to eq \
           personal_information_1
       end
 
@@ -102,7 +104,7 @@ describe Candidates::Registrations::SchoolSession do
           personal_information_2
       end
 
-      it 'stores the registratiosn for each school seperatley' do
+      it 'stores the registrations for each school seperatley' do
         expect(session).to eq \
           "schools/#{school_urn_1}/registrations" => {
             'urn' => school_urn_1,
@@ -112,6 +114,32 @@ describe Candidates::Registrations::SchoolSession do
             'urn' => school_urn_2,
             personal_information_2.model_name.param_key => personal_information_2.attributes
           }
+      end
+    end
+
+    context 'with a gitis_contact' do
+      let(:gitis_contact) { build(:gitis_contact, :persisted) }
+
+      subject do
+        described_class.new(school_urn_1, session).current_registration(gitis_contact)
+      end
+
+      before do
+        subject.save personal_information_1
+      end
+
+      it { is_expected.to be_kind_of Candidates::Registrations::GitisRegistrationSession }
+
+      it 'returns the current_registration' do
+        expect(subject.personal_information.email).to eq gitis_contact.email
+      end
+
+      it 'stores the registration in the session' do
+        expect(session["schools/#{school_urn_1}/registrations"]).to \
+          include('urn' => school_urn_1)
+
+        expect(session["schools/#{school_urn_1}/registrations"]).to \
+          include(personal_information_1.model_name.param_key)
       end
     end
   end


### PR DESCRIPTION
### Context

Currently the GiTiS contact data is merged in as part of the controller. This leads to some complexity around trying to sync between GiTiS and Registration Session - in some scenarios (Address, Phone number) the Registration data takes priority. In others (Email address) the GiTiS data takes priority.

Currently this logic logic is spread piecemeal across the registration controllers.

### Changes proposed in this pull request

This PR adds a `GitisRegistrationSession`, which will either return data from GiTiS or the Registration Steps as appropriate, and can be unit tested.

### Guidance to review
1. Do the various behaviours in the Candidate journey still work
2. Do the tests still pass
