### PR TITLE
Remove admin_contact_full_name from school profile

### DIFF
--- a/db/migrate/20190814151928_remove_admin_contact_full_name_from_schools_school_profiles.rb
+++ b/db/migrate/20190814151928_remove_admin_contact_full_name_from_schools_school_profiles.rb
@@ -1,0 +1,5 @@
+class RemoveAdminContactFullNameFromSchoolsSchoolProfiles < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :schools_school_profiles, :admin_contact_full_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_24_092556) do
+ActiveRecord::Schema.define(version: 2019_08_14_151928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -329,7 +329,6 @@ ActiveRecord::Schema.define(version: 2019_07_24_092556) do
     t.boolean "experience_outline_provides_teacher_training"
     t.text "experience_outline_teacher_training_details"
     t.string "experience_outline_teacher_training_url"
-    t.string "admin_contact_full_name"
     t.string "admin_contact_email"
     t.string "admin_contact_phone"
     t.integer "bookings_school_id", null: false

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -162,10 +162,6 @@ describe Schools::SchoolProfile, type: :model do
     end
 
     it do
-      is_expected.to have_db_column(:admin_contact_full_name).of_type :string
-    end
-
-    it do
       is_expected.to have_db_column(:admin_contact_email).of_type :string
     end
 


### PR DESCRIPTION
Don't merge this until after schools have come back in early September, don't want to end up losing data if it turns out we do need the admin contact name

### Context

### Changes proposed in this pull request

### Guidance to review

