### PR TITLE
SE-1525 Mark personal info read only

### DIFF
--- a/app/controllers/candidates/registrations/personal_informations_controller.rb
+++ b/app/controllers/candidates/registrations/personal_informations_controller.rb
@@ -34,7 +34,6 @@ module Candidates
       def update
         @personal_information = current_registration.personal_information
         @personal_information.assign_attributes personal_information_params
-        @personal_information.read_only_email = candidate_signed_in?
 
         if @personal_information.valid?
           persist @personal_information
@@ -49,12 +48,12 @@ module Candidates
 
       def personal_information_params
         if candidate_signed_in?
-          params.require(:candidates_registrations_personal_information).permit \
+          params.fetch(:candidates_registrations_personal_information, {}).permit \
             :first_name,
             :last_name,
             :date_of_birth
         else
-          params.require(:candidates_registrations_personal_information).permit \
+          params.fetch(:candidates_registrations_personal_information, {}).permit \
             :first_name,
             :last_name,
             :email,

--- a/app/controllers/candidates/registrations/sign_ins_controller.rb
+++ b/app/controllers/candidates/registrations/sign_ins_controller.rb
@@ -20,7 +20,7 @@ module Candidates
         candidate = Candidates::Session.signin!(params[:token])
 
         if candidate
-          personal_information.read_only_email = true
+          personal_information.read_only = true
           persist personal_information
 
           self.current_candidate = candidate

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -8,6 +8,7 @@ module Bookings
 
       UPDATE_BLACKLIST = %w{
         dfe_channelcreation statecode mobilephone address1_telephone1
+        firstname lastname birthdate
       }.freeze
 
       UPDATE_BLACKLIST_OTHER_RECORDS = (

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -12,7 +12,7 @@ module Candidates
         :last_name,
         :full_name,
         :email,
-        :read_only_email,
+        :read_only,
         to: :@personal_information
 
       delegate \

--- a/app/services/candidates/registrations/gitis_registration_session.rb
+++ b/app/services/candidates/registrations/gitis_registration_session.rb
@@ -9,8 +9,13 @@ module Candidates
       end
 
       def personal_information_attributes
+        # default with GiTiS attributes if no personal info
+        # override anything set for which there's a gitis equivalent
+        # finally lock it with read only
+
         fetch_attributes(PersonalInformation, mapper.contact_to_personal_information).
-          merge('read_only_email' => true, 'email' => gitis_contact.email)
+          merge(mapper.contact_to_personal_information).
+          merge('read_only' => true)
       end
 
       def personal_information

--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -12,7 +12,7 @@ module Candidates
       attribute :last_name
       attribute :email
       attribute :date_of_birth, :date
-      attribute :read_only_email, :boolean, default: false
+      attribute :read_only, :boolean, default: false
 
       validates :first_name, presence: true
       validates :last_name, presence: true
@@ -31,8 +31,8 @@ module Candidates
         build_candidate_session(gitis_crm).create_signin_token
       end
 
-      def email=(email_address)
-        read_only_email ? email : super
+      def email=(*args)
+        read_only ? email : super
       end
 
       # Rescue argument error thrown by

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -10,19 +10,27 @@
 
       <h2 class="govuk-heading-m">Personal details</h2>
 
-      <%= summary_row \
-        'Full name',
-        @application_preview.full_name,
-        edit_candidates_school_registrations_personal_information_path(
-          anchor: 'candidates_registrations_personal_information_first_name_container'
-        ) %>
+      <%- if @application_preview.read_only -%>
 
-      <%= summary_row \
-        'Date of birth',
-        @application_preview.date_of_birth,
-        edit_candidates_school_registrations_personal_information_path(
-          anchor: 'candidates_registrations_personal_information_date_of_birth_container'
-        ) %>
+        <%= summary_row 'Full name', @application_preview.full_name %>
+        <%= summary_row 'Date of birth', @application_preview.date_of_birth %>
+
+      <%- else -%>
+
+        <%= summary_row \
+          'Full name',
+          @application_preview.full_name,
+          edit_candidates_school_registrations_personal_information_path(
+            anchor: 'candidates_registrations_personal_information_first_name_container'
+          ) %>
+
+        <%= summary_row \
+          'Date of birth',
+          @application_preview.date_of_birth,
+          edit_candidates_school_registrations_personal_information_path(
+            anchor: 'candidates_registrations_personal_information_date_of_birth_container'
+          ) %>
+      <% end %>
 
       <%= summary_row \
         'Address',
@@ -38,7 +46,7 @@
           anchor: 'candidates_registrations_contact_information_phone_container'
         ) %>
 
-      <%- if @application_preview.read_only_email -%>
+      <%- if @application_preview.read_only -%>
         <%= summary_row 'Email address', @application_preview.email_address %>
       <%- else -%>
         <%= summary_row \

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -31,12 +31,21 @@
         <%= form_for personal_information, url: candidates_school_registrations_personal_information_path do |f| %>
           <%= GovukElementsErrorsHelper.error_summary personal_information, 'There is a problem', '' %>
 
-          <%= f.text_field :first_name, autocomplete: 'given-name' %>
-          <%= f.text_field :last_name, autocomplete: 'family-name' %>
+          <%= f.text_field :first_name, autocomplete: 'given-name',
+                readonly: personal_information.read_only,
+                disabled: personal_information.read_only %>
+
+          <%= f.text_field :last_name, autocomplete: 'family-name',
+                readonly: personal_information.read_only,
+                disabled: personal_information.read_only %>
+
           <%= f.email_field :email, autocomplete: 'on',
-                readonly: personal_information.read_only_email,
-                disabled: personal_information.read_only_email %>
-          <%= f.date_field :date_of_birth, heading: true, date_of_birth: true %>
+                readonly: personal_information.read_only,
+                disabled: personal_information.read_only %>
+
+          <%= f.date_field :date_of_birth, heading: true, date_of_birth: true,
+                readonly: personal_information.read_only,
+                disabled: personal_information.read_only %>
 
           <%= f.submit 'Continue' %>
         <% end %>

--- a/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
@@ -123,7 +123,7 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
         end
 
         let :personal_information do
-          FactoryBot.build :personal_information, read_only_email: true
+          FactoryBot.build :personal_information, read_only: true
         end
 
         before do
@@ -132,15 +132,15 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
             params: personal_information_params
         end
 
-        it 'updates the personal information with supplied details' do
+        it 'leaves the personal information with GiTiS details' do
           expect(registration_session.personal_information.first_name).to \
-            eq personal_information.first_name
+            eq gitis_contact.firstname
 
           expect(registration_session.personal_information.last_name).to \
-            eq personal_information.last_name
+            eq gitis_contact.lastname
 
           expect(registration_session.personal_information.date_of_birth).to \
-            eq personal_information.date_of_birth
+            eq gitis_contact.date_of_birth
         end
 
         it "leaves the email address matching the GiTiS contact" do

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
       end
 
       it "will have marked the email address read only" do
-        expect(personal_info).to have_attributes read_only_email: true
+        expect(personal_info).to have_attributes read_only: true
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
       end
 
       it "will not have marked the email address read only" do
-        expect(personal_info).to have_attributes read_only_email: false
+        expect(personal_info).to have_attributes read_only: false
       end
     end
 

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -88,7 +88,10 @@ feature 'Candidate Registrations', type: :feature do
       include_context 'fake gitis with known uuid'
 
       let(:token) { create(:candidate_session_token) }
-      let(:email_address) { fake_gitis.send(:fake_contact_data)['emailaddress2'] }
+      let(:fake_data) { fake_gitis.send(:fake_contact_data) }
+      let(:email_address) { fake_data['emailaddress2'] }
+      let(:name) { fake_data['firstname'] + ' ' + fake_data['lastname'] }
+      let(:date_of_birth) { Date.parse fake_data['birthdate'] }
 
       scenario "completing the Journey" do
         complete_personal_information_step
@@ -98,7 +101,7 @@ feature 'Candidate Registrations', type: :feature do
         complete_teaching_preference_step
         complete_placement_preference_step
         complete_background_step
-        complete_application_preview_step
+        complete_application_preview_step(name: name, date_of_birth: date_of_birth)
         view_request_acknowledgement_step
       end
     end
@@ -106,7 +109,10 @@ feature 'Candidate Registrations', type: :feature do
     context 'for known Candidate not signed in' do
       include_context 'fake gitis with known uuid'
 
-      let(:email_address) { fake_gitis.send(:fake_contact_data)['emailaddress2'] }
+      let(:fake_data) { fake_gitis.send(:fake_contact_data) }
+      let(:email_address) { fake_data['emailaddress2'] }
+      let(:name) { fake_data['firstname'] + ' ' + fake_data['lastname'] }
+      let(:date_of_birth) { Date.parse fake_data['birthdate'] }
       let!(:candidate) { create(:candidate, :confirmed, gitis_uuid: fake_gitis_uuid) }
       let(:token) { create(:candidate_session_token, candidate: candidate) }
 
@@ -123,7 +129,7 @@ feature 'Candidate Registrations', type: :feature do
         complete_teaching_preference_step
         complete_placement_preference_step
         complete_background_step
-        complete_application_preview_step
+        complete_application_preview_step(name: name, date_of_birth: date_of_birth)
         view_request_acknowledgement_step
       end
     end
@@ -132,7 +138,10 @@ feature 'Candidate Registrations', type: :feature do
       include_context 'fake gitis with known uuid'
 
       # Contact gets default email address after reload via token lookup
-      let(:email_address) { fake_gitis.send(:fake_contact_data)['emailaddress2'] }
+      let(:fake_data) { fake_gitis.send(:fake_contact_data) }
+      let(:email_address) { fake_data['emailaddress2'] }
+      let(:name) { fake_data['firstname'] + ' ' + fake_data['lastname'] }
+      let(:date_of_birth) { Date.parse fake_data['birthdate'] }
       let!(:candidate) { create(:candidate, :confirmed, gitis_uuid: fake_gitis_uuid) }
       let(:token) { create(:candidate_session_token, candidate: candidate) }
 
@@ -143,13 +152,13 @@ feature 'Candidate Registrations', type: :feature do
 
       scenario "completing the Journey" do
         sign_in_via_dashboard(token.token)
-        complete_personal_information_step fill_in_email: false
+        complete_personal_information_step fill_in_fields: false
         complete_contact_information_step
         complete_education_step
         complete_teaching_preference_step
         complete_placement_preference_step
         complete_background_step
-        complete_application_preview_step
+        complete_application_preview_step(name: name, date_of_birth: date_of_birth)
         view_request_acknowledgement_step
       end
     end
@@ -169,7 +178,7 @@ feature 'Candidate Registrations', type: :feature do
 
       scenario "completing the Journey" do
         sign_in_via_dashboard(token.token)
-        complete_personal_information_step(fill_in_email: false)
+        complete_personal_information_step(fill_in_fields: false)
         complete_contact_information_step
         sign_in_via_dashboard(newtoken.token)
         swap_back_to_education_step
@@ -178,24 +187,27 @@ feature 'Candidate Registrations', type: :feature do
     end
   end
 
-  def complete_personal_information_step(expected_heading: nil, fill_in_email: true)
+  def complete_personal_information_step(expected_heading: nil, fill_in_fields: true)
     # Begin wizard journey
     visit "/candidates/schools/#{school_urn}/registrations/personal_information/new"
     expect(page).to have_text expected_heading || 'Check if we already have your details'
 
-    # Submit personal information form with errors
-    fill_in 'First name', with: 'testy'
-    fill_in 'Last name', with: ''
-    click_button 'Continue'
-    expect(page).to have_text 'There is a problem'
+    if fill_in_fields
+      # Submit personal information form with errors
+      fill_in 'First name', with: 'testy'
+      fill_in 'Last name', with: ''
+      click_button 'Continue'
+      expect(page).to have_text 'There is a problem'
 
-    # Submit personal information form successfully
-    fill_in 'First name', with: 'testy'
-    fill_in 'Last name', with: 'mctest'
-    fill_in 'Email address', with: email_address if fill_in_email
-    fill_in 'Day', with: '01'
-    fill_in 'Month', with: '01'
-    fill_in 'Year', with: '2000'
+      # Submit personal information form successfully
+      fill_in 'First name', with: 'testy'
+      fill_in 'Last name', with: 'mctest'
+      fill_in 'Email address', with: email_address
+      fill_in 'Day', with: '01'
+      fill_in 'Month', with: '01'
+      fill_in 'Year', with: '2000'
+    end
+
     click_button 'Continue'
   end
 
@@ -285,17 +297,19 @@ feature 'Candidate Registrations', type: :feature do
     click_button 'Continue'
   end
 
-  def complete_application_preview_step
+  def complete_application_preview_step(name: 'testy mctest', email: nil,
+    date_of_birth: Date.parse('2000-01-01'))
+
     expect(page.current_path).to eq \
       "/candidates/schools/#{school_urn}/registrations/application_preview"
 
     # Expect preview to match the data we successfully submited
-    expect(page).to have_text 'Full name testy mctest'
+    expect(page).to have_text "Full name #{name}"
     expect(page).to have_text \
       'Address Test house, Test street, Test Town, Testshire, TE57 1NG'
     expect(page).to have_text 'UK telephone number 01234567890'
-    expect(page).to have_text "Email address #{email_address}"
-    expect(page).to have_text 'Date of birth 01/01/2000'
+    expect(page).to have_text "Email address #{email || email_address}"
+    expect(page).to have_text "Date of birth #{date_of_birth.strftime '%d/%m/%Y'}"
     expect(page).to have_text "School or college #{school.name}"
     expect(page).to have_text 'Experience availability Only free from Epiphany to Whitsunday'
     expect(page).to have_text "Experience outcome I enjoy teaching"

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -181,6 +181,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('dfe_channelcreation') }
           it { is_expected.not_to include('firstname') }
           it { is_expected.not_to include('lastname') }
+          it { is_expected.not_to include('birthdate') }
           it { is_expected.to include('telephone2') }
           it { is_expected.to include('emailaddress2') }
         end
@@ -196,8 +197,9 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('contactid') }
           it { is_expected.not_to include('statecode') }
           it { is_expected.not_to include('dfe_channelcreation') }
-          it { is_expected.to include('firstname') }
-          it { is_expected.to include('lastname') }
+          it { is_expected.not_to include('firstname') }
+          it { is_expected.not_to include('lastname') }
+          it { is_expected.not_to include('birthdate') }
           it { is_expected.to include('emailaddress1') }
           it { is_expected.to include('emailaddress2') }
           it { is_expected.to include('telephone1') }
@@ -214,6 +216,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('dfe_channelcreation') }
           it { is_expected.not_to include('firstname') }
           it { is_expected.not_to include('lastname') }
+          it { is_expected.not_to include('birthdate') }
           it { is_expected.not_to include('emailaddress1') }
           it { is_expected.to include('emailaddress2') }
           it { is_expected.not_to include('telephone1') }
@@ -231,8 +234,9 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('contactid') }
           it { is_expected.not_to include('statecode') }
           it { is_expected.not_to include('dfe_channelcreation') }
-          it { is_expected.to include('firstname') }
-          it { is_expected.to include('lastname') }
+          it { is_expected.not_to include('firstname') }
+          it { is_expected.not_to include('lastname') }
+          it { is_expected.not_to include('birthdate') }
           it { is_expected.not_to include('emailaddress1') }
           it { is_expected.to include('emailaddress2') }
           it { is_expected.not_to include('telephone1') }

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -164,10 +164,10 @@ describe Bookings::Gitis::CRM, type: :model do
       before do
         @contact = build(:gitis_contact, contact_attributes.merge(id: contactid))
         @contact.reset_dirty_attributes
-        @contact.firstname = 'Changed'
-        @contact.lastname = 'Name'
+        @contact.address1_line1 = 'Changed'
+        @contact.address1_line2 = 'Address'
         gitis_stub.stub_update_contact_request(
-          { 'firstname' => 'Changed', 'lastname' => 'Name' },
+          { 'address1_line1' => 'Changed', 'address1_line2' => 'Address' },
           contactid
         )
       end

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -71,10 +71,10 @@ describe Candidates::Registrations::GitisRegistrationSession do
           personal_information_attributes
       end
 
-      it { is_expected.to include('first_name' => data['first_name']) }
-      it { is_expected.to include('last_name' => data['last_name']) }
+      it { is_expected.to include('first_name' => contact.firstname) }
+      it { is_expected.to include('last_name' => contact.lastname) }
       it { is_expected.to include('email' => contact.email) }
-      it { is_expected.to include('date_of_birth' => data['date_of_birth']) }
+      it { is_expected.to include('date_of_birth' => contact.date_of_birth) }
     end
 
     context 'with only gitis data' do
@@ -101,10 +101,10 @@ describe Candidates::Registrations::GitisRegistrationSession do
         described_class.new({ key => data }, contact).personal_information
       end
 
-      it { is_expected.to have_attributes(first_name: data['first_name']) }
-      it { is_expected.to have_attributes(last_name: data['last_name']) }
+      it { is_expected.to have_attributes(first_name: contact.firstname) }
+      it { is_expected.to have_attributes(last_name: contact.lastname) }
       it { is_expected.to have_attributes(email: contact.email) }
-      it { is_expected.to have_attributes(date_of_birth: data['date_of_birth']) }
+      it { is_expected.to have_attributes(date_of_birth: contact.date_of_birth) }
     end
 
     context 'with only gitis data' do

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -52,7 +52,14 @@ describe Candidates::Registrations::GitisRegistrationSession do
   end
 
   describe "#personal_information_attributes" do
-    let(:data) { { 'first_name' => 'Person', 'email' => 'person@personl.com' } }
+    let(:data) do
+      {
+        'first_name' => 'Person',
+        'last_name' => 'A',
+        'email' => 'person@personl.com',
+        'date_of_birth' => Date.parse('1970-01-01')
+      }
+    end
 
     let(:key) do
       Candidates::Registrations::PersonalInformation.model_name.param_key
@@ -65,7 +72,9 @@ describe Candidates::Registrations::GitisRegistrationSession do
       end
 
       it { is_expected.to include('first_name' => data['first_name']) }
+      it { is_expected.to include('last_name' => data['last_name']) }
       it { is_expected.to include('email' => contact.email) }
+      it { is_expected.to include('date_of_birth' => data['date_of_birth']) }
     end
 
     context 'with only gitis data' do
@@ -74,12 +83,14 @@ describe Candidates::Registrations::GitisRegistrationSession do
       end
 
       it { is_expected.to include('first_name' => contact.firstname) }
+      it { is_expected.to include('last_name' => contact.lastname) }
       it { is_expected.to include('email' => contact.email) }
+      it { is_expected.to include('date_of_birth' => contact.date_of_birth) }
     end
   end
 
   describe '#personal_information' do
-    let(:data) { { 'first_name' => 'Person', 'email' => 'person@personl.com' } }
+    let(:data) { { 'first_name' => 'Person', 'email' => 'person@person.com' } }
 
     let(:key) do
       Candidates::Registrations::PersonalInformation.model_name.param_key
@@ -91,7 +102,9 @@ describe Candidates::Registrations::GitisRegistrationSession do
       end
 
       it { is_expected.to have_attributes(first_name: data['first_name']) }
+      it { is_expected.to have_attributes(last_name: data['last_name']) }
       it { is_expected.to have_attributes(email: contact.email) }
+      it { is_expected.to have_attributes(date_of_birth: data['date_of_birth']) }
     end
 
     context 'with only gitis data' do
@@ -100,7 +113,9 @@ describe Candidates::Registrations::GitisRegistrationSession do
       end
 
       it { is_expected.to have_attributes(first_name: contact.firstname) }
+      it { is_expected.to have_attributes(last_name: contact.lastname) }
       it { is_expected.to have_attributes(email: contact.email) }
+      it { is_expected.to have_attributes(date_of_birth: contact.date_of_birth) }
     end
   end
 end

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -8,8 +8,8 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     it { is_expected.to respond_to :first_name }
     it { is_expected.to respond_to :last_name }
     it { is_expected.to respond_to :email }
-    it { is_expected.to respond_to :read_only_email }
-    it { is_expected.to have_attributes read_only_email: false }
+    it { is_expected.to respond_to :read_only }
+    it { is_expected.to have_attributes read_only: false }
   end
 
   context 'validations' do
@@ -174,8 +174,7 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
 
     context 'with unvalidate emails' do
       subject do
-        build(:personal_information, email: 'first@test.com',
-          read_only_email: false)
+        build(:personal_information, email: 'first@test.com', read_only: false)
       end
 
       it { is_expected.to have_attributes email: 'second@test.com' }
@@ -183,8 +182,7 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
 
     context 'with validated emails' do
       subject do
-        build(:personal_information, email: 'first@test.com',
-          read_only_email: true)
+        build(:personal_information, email: 'first@test.com', read_only: true)
       end
 
       it { is_expected.to have_attributes email: 'first@test.com' }

--- a/spec/views/candidates/registrations/personal_informations/_form.html.erb_spec.rb
+++ b/spec/views/candidates/registrations/personal_informations/_form.html.erb_spec.rb
@@ -5,6 +5,18 @@ RSpec.describe "candidates/registrations/personal_informations/_form.html.erb", 
     "input#candidates_registrations_personal_information_email"
   end
 
+  let(:fname_selector) do
+    "input#candidates_registrations_personal_information_first_name"
+  end
+
+  let(:lname_selector) do
+    "input#candidates_registrations_personal_information_last_name"
+  end
+
+  let(:dob_selector) do
+    "input#candidates_registrations_personal_information_date_of_birth_3i"
+  end
+
   before do
     allow(view).to \
       receive(:candidates_school_registrations_personal_information_path).
@@ -22,6 +34,24 @@ RSpec.describe "candidates/registrations/personal_informations/_form.html.erb", 
       expect(rendered).to have_css("#{email_selector}[readonly]", count: 0)
       expect(rendered).to have_css("#{email_selector}[disabled]", count: 0)
     end
+
+    it "will allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{fname_selector}[readonly]", count: 0)
+      expect(rendered).to have_css("#{fname_selector}[disabled]", count: 0)
+    end
+
+    it "will allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{lname_selector}[readonly]", count: 0)
+      expect(rendered).to have_css("#{lname_selector}[disabled]", count: 0)
+    end
+
+    it "will allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{dob_selector}[readonly]", count: 0)
+      expect(rendered).to have_css("#{dob_selector}[disabled]", count: 0)
+    end
   end
 
   context 'when email address is read only' do
@@ -30,7 +60,7 @@ RSpec.describe "candidates/registrations/personal_informations/_form.html.erb", 
         first_name: 'Foo',
         last_name: 'Bar',
         email: 'foo@bar.com',
-        read_only_email: true,
+        read_only: true,
         date_of_birth: Date.parse('1980-01-01')
       )
     end
@@ -40,10 +70,28 @@ RSpec.describe "candidates/registrations/personal_informations/_form.html.erb", 
         personal_information: personal_information
     end
 
-    it "will allow the address to be changed" do
+    it "will not allow the address to be changed" do
       expect(rendered).to have_css(email_selector, count: 1)
       expect(rendered).to have_css("#{email_selector}[readonly]", count: 1)
       expect(rendered).to have_css("#{email_selector}[disabled]", count: 1)
+    end
+
+    it "will not allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{fname_selector}[readonly]", count: 1)
+      expect(rendered).to have_css("#{fname_selector}[disabled]", count: 1)
+    end
+
+    it "will not allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{lname_selector}[readonly]", count: 1)
+      expect(rendered).to have_css("#{lname_selector}[disabled]", count: 1)
+    end
+
+    it "will not allow the address to be changed" do
+      expect(rendered).to have_css(email_selector, count: 1)
+      expect(rendered).to have_css("#{dob_selector}[readonly]", count: 1)
+      expect(rendered).to have_css("#{dob_selector}[disabled]", count: 1)
     end
   end
 end


### PR DESCRIPTION
### Context

This builds off PR802 which is now merged.

Users should be prevented from updating their firstname, lastname, email or date_of_birth in Gitis

### Changes proposed in this pull request

1. This marks those fields as read only in the UI
2. Gives precendence to the Gitis versions in `GitisRegistrationSession`
3. Marks the fields to be excluded from updates in the Gitis Contact Entity

### Guidance to review

