### PR TITLE
SE-1275 Updated attributes mapping

### DIFF
--- a/app/controllers/candidates/registrations/background_checks_controller.rb
+++ b/app/controllers/candidates/registrations/background_checks_controller.rb
@@ -2,7 +2,7 @@ module Candidates
   module Registrations
     class BackgroundChecksController < RegistrationsController
       def new
-        @background_check = BackgroundCheck.new attributes_from_session_or_gitis
+        @background_check = BackgroundCheck.new attributes_from_session
       end
 
       def create
@@ -40,13 +40,6 @@ module Candidates
 
       def attributes_from_session
         current_registration.background_check_attributes.except 'created_at'
-      end
-
-      def attributes_from_session_or_gitis
-        attrs = attributes_from_session
-        return attrs if attrs.any?
-
-        current_contact ? gitis_mapper.contact_to_background_check : {}
       end
     end
   end

--- a/app/controllers/candidates/registrations/background_checks_controller.rb
+++ b/app/controllers/candidates/registrations/background_checks_controller.rb
@@ -2,7 +2,7 @@ module Candidates
   module Registrations
     class BackgroundChecksController < RegistrationsController
       def new
-        @background_check = BackgroundCheck.new attributes_from_session
+        @background_check = BackgroundCheck.new attributes_from_session_or_gitis
       end
 
       def create
@@ -40,6 +40,13 @@ module Candidates
 
       def attributes_from_session
         current_registration.background_check_attributes.except 'created_at'
+      end
+
+      def attributes_from_session_or_gitis
+        attrs = attributes_from_session
+        return attrs if attrs.any?
+
+        current_contact ? gitis_mapper.contact_to_background_check : {}
       end
     end
   end

--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -23,7 +23,7 @@ module Bookings
       gitis_contact.county = contact_information.county
       gitis_contact.postcode = contact_information.postcode
 
-      gitis_contact.dfe_hasdbscertificate = background_check.has_dbs_check
+      gitis_contact.has_dbs_check = background_check.has_dbs_check
 
       gitis_contact
     end
@@ -50,7 +50,7 @@ module Bookings
 
     def contact_to_background_check
       {
-        'has_dbs_check' => gitis_contact.dfe_hasdbscertificate
+        'has_dbs_check' => gitis_contact.has_dbs_check
       }
     end
   end

--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -23,6 +23,8 @@ module Bookings
       gitis_contact.county = contact_information.county
       gitis_contact.postcode = contact_information.postcode
 
+      gitis_contact.dfe_hasdbscertificate = background_check.has_dbs_check
+
       gitis_contact
     end
 
@@ -43,6 +45,12 @@ module Bookings
         'last_name'     => gitis_contact.last_name,
         'email'         => gitis_contact.email,
         'date_of_birth' => gitis_contact.date_of_birth
+      }
+    end
+
+    def contact_to_background_check
+      {
+        'has_dbs_check' => gitis_contact.dfe_hasdbscertificate
       }
     end
   end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -35,6 +35,7 @@ module Bookings
         self.lastname                 = @crm_data['lastname']
         self.emailaddress1            = @crm_data['emailaddress1']
         self.emailaddress2            = @crm_data['emailaddress2']
+        self.telephone1               = @crm_data['telephone1']
         self.telephone2               = @crm_data['telephone2']
         self.address1_line1           = @crm_data['address1_line1']
         self.address1_line2           = @crm_data['address1_line2']
@@ -95,12 +96,15 @@ module Bookings
       end
 
       def phone
-        telephone2
+        telephone2.presence || telephone1.presence || mobilephone
       end
 
       def phone=(phonenumber)
+        if created_by_us? || telephone1.blank?
+          self.telephone1 = phonenumber&.strip
+        end
+
         self.telephone2 = phonenumber&.strip
-        self.telephone1 = self.telephone2 if created_by_us?
       end
 
       def date_of_birth

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -26,19 +26,18 @@ module Bookings
 
       delegate :default_owner, :default_country, to: :class
 
-      def self.default_owner
-        "teams(#{ENV.fetch['CRM_OWNER_ID']})"
-      end
+      class << self
+        def default_owner
+          "teams(#{Rails.application.config.x.gitis.owner_id})"
+        end
 
-      def self.default_country
-        "dfe_countries(#{ENV.fetch['CRM_COUNTRY_ID']})"
-      end
+        def default_country
+          "dfe_countries(#{Rails.application.config.x.gitis.country_id})"
+        end
 
-      def self.channel_creation
-        Rails.application.config.x.gitis.channel_creation
-
-      def self.default_owner_id
-        ENV.fetch['CRM_OWNER_ID']
+        def channel_creation
+          Rails.application.config.x.gitis.channel_creation
+        end
       end
 
       def initialize(crm_contact_data = {})

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -24,6 +24,16 @@ module Bookings
 
       validates :email, presence: true, format: /\A.+@.+\..+\z/
 
+      delegate :default_owner, :default_country, to: :class
+
+      def self.default_owner
+        "teams(#{ENV.fetch['CRM_OWNER_ID']})"
+      end
+
+      def self.default_country
+        "dfe_countries(#{ENV.fetch['CRM_COUNTRY_ID']})"
+      end
+
       def self.channel_creation
         Rails.application.config.x.gitis.channel_creation
 
@@ -142,7 +152,8 @@ module Bookings
 
       def attributes_for_create
         super.merge(
-          'ownerid@odata.bind' => "teams(#{self.class.default_owner_id})"
+          'ownerid@odata.bind' => default_owner,
+          'dfe_Country@odata.bind' => default_country
         )
       end
     end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -13,6 +13,8 @@ module Bookings
       entity_attributes :address1_postalcode
       entity_attributes :telephone1, :telephone2
 
+      entity_attributes :dfe_hasdbscertificate
+
       entity_attributes :mobilephone, :dfe_channelcreation, except: :update
 
       alias_attribute :first_name, :firstname
@@ -44,6 +46,7 @@ module Bookings
         self.address1_postalcode      = @crm_data['address1_postalcode']
         self.birthdate                = @crm_data['birthdate']
         self.dfe_channelcreation      = @crm_data['dfe_channelcreation'] || self.class.channel_creation
+        self.dfe_hasdbscertificate    = @crm_data['dfe_hasdbscertificate']
 
         super # handles resetting dirty attributes
 

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -3,11 +3,8 @@ module Bookings
     class Contact
       include Entity
 
-      # Status of record within Gitis
-      STATE_CODE = 0
-
       UPDATE_BLACKLIST = %w{
-        dfe_channelcreation statecode mobilephone address1_telephone1
+        dfe_channelcreation mobilephone address1_telephone1
         firstname lastname birthdate
       }.freeze
 
@@ -22,7 +19,7 @@ module Bookings
       entity_attributes :address1_city, :address1_stateorprovince
       entity_attributes :address1_postalcode, :birthdate
       entity_attributes :telephone1, :telephone2, :mobilephone
-      entity_attributes :statecode, :dfe_channelcreation
+      entity_attributes :dfe_channelcreation
 
       alias_attribute :first_name, :firstname
       alias_attribute :last_name, :lastname
@@ -52,7 +49,6 @@ module Bookings
         self.address1_stateorprovince = @crm_data['address1_stateorprovince']
         self.address1_postalcode      = @crm_data['address1_postalcode']
         self.birthdate                = @crm_data['birthdate']
-        self.statecode                = @crm_data['statecode'] || STATE_CODE
         self.dfe_channelcreation      = @crm_data['dfe_channelcreation'] || self.class.channel_creation
 
         super # handles resetting dirty attributes

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -3,23 +3,17 @@ module Bookings
     class Contact
       include Entity
 
-      UPDATE_BLACKLIST = %w{
-        dfe_channelcreation mobilephone address1_telephone1
-        firstname lastname birthdate
-      }.freeze
-
-      UPDATE_BLACKLIST_OTHER_RECORDS = (
-        UPDATE_BLACKLIST + %w{telephone1 emailaddress1}
-      ).freeze
-
       entity_id_attribute :contactid
 
-      entity_attributes :firstname, :lastname, :emailaddress1, :emailaddress2
+      entity_attributes :firstname, :lastname, :birthdate, except: :update
+
+      entity_attributes :emailaddress1, :emailaddress2
       entity_attributes :address1_line1, :address1_line2, :address1_line3
       entity_attributes :address1_city, :address1_stateorprovince
-      entity_attributes :address1_postalcode, :birthdate
-      entity_attributes :telephone1, :telephone2, :mobilephone
-      entity_attributes :dfe_channelcreation
+      entity_attributes :address1_postalcode
+      entity_attributes :telephone1, :telephone2
+
+      entity_attributes :mobilephone, :dfe_channelcreation, except: :update
 
       alias_attribute :first_name, :firstname
       alias_attribute :last_name, :lastname
@@ -123,10 +117,6 @@ module Bookings
         firstname.downcase == fname && lastname.downcase == lname ||
           firstname.downcase == fname && birthdate == gitis_format_dob ||
           lastname.downcase == lname && birthdate == gitis_format_dob
-      end
-
-      def attributes_for_update
-        super.except(*UPDATE_BLACKLIST)
       end
     end
   end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -26,6 +26,9 @@ module Bookings
 
       def self.channel_creation
         Rails.application.config.x.gitis.channel_creation
+
+      def self.default_owner_id
+        ENV.fetch['CRM_OWNER_ID']
       end
 
       def initialize(crm_contact_data = {})
@@ -135,6 +138,12 @@ module Bookings
         firstname.downcase == fname && lastname.downcase == lname ||
           firstname.downcase == fname && birthdate == gitis_format_dob ||
           lastname.downcase == lname && birthdate == gitis_format_dob
+      end
+
+      def attributes_for_create
+        super.merge(
+          'ownerid@odata.bind' => "teams(#{self.class.default_owner_id})"
+        )
       end
     end
   end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -12,9 +12,7 @@ module Bookings
       entity_attributes :address1_city, :address1_stateorprovince
       entity_attributes :address1_postalcode
       entity_attributes :telephone1, :telephone2
-
-      entity_attributes :dfe_hasdbscertificate
-
+      entity_attributes :dfe_hasdbscertificate, :dfe_dateofissueofdbscertificate
       entity_attributes :mobilephone, :dfe_channelcreation, except: :update
 
       alias_attribute :first_name, :firstname
@@ -47,6 +45,7 @@ module Bookings
         self.birthdate                = @crm_data['birthdate']
         self.dfe_channelcreation      = @crm_data['dfe_channelcreation'] || self.class.channel_creation
         self.dfe_hasdbscertificate    = @crm_data['dfe_hasdbscertificate']
+        self.dfe_dateofissueofdbscertificate = @crm_data['dfe_dateofissueofdbscertificate']
 
         super # handles resetting dirty attributes
 
@@ -110,6 +109,18 @@ module Bookings
 
       def date_of_birth=(dob)
         self.birthdate = dob.present? ? dob.to_formatted_s(:db) : nil
+      end
+
+      def has_dbs_check
+        dfe_hasdbscertificate
+      end
+
+      def has_dbs_check=(value)
+        if value != dfe_hasdbscertificate
+          self.dfe_dateofissueofdbscertificate = nil
+        end
+
+        self.dfe_hasdbscertificate = value
       end
 
       def signin_attributes_match?(fname, lname, dob)

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -103,10 +103,11 @@ module Bookings::Gitis
         end
       end
 
-      def entity_attribute(attr_name)
+      def entity_attribute(attr_name, internal: false)
         define_method :"#{attr_name}" do
           attributes[attr_name.to_s]
         end
+        private :"#{attr_name}" if internal
 
         define_method :"#{attr_name}=" do |value|
           unless value == send(attr_name.to_sym)
@@ -115,13 +116,14 @@ module Bookings::Gitis
 
           attributes[attr_name.to_s] = value
         end
+        private :"#{attr_name}=" if internal
 
         self.entity_attribute_names << attr_name.to_s
       end
 
-      def entity_attributes(*attr_names)
+      def entity_attributes(*attr_names, internal: false)
         Array.wrap(attr_names).flatten.each do |attr_name|
-          entity_attribute(attr_name)
+          entity_attribute(attr_name, internal: internal)
         end
       end
 

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -3,7 +3,6 @@ module Bookings::Gitis
 
   module Entity
     extend ActiveSupport::Concern
-    include ActiveModel::AttributeAssignment
     include ActiveModel::Validations
     include ActiveModel::Conversion
 

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -5,9 +5,13 @@ module Bookings::Gitis
       firstname lastname emailaddress2 telephone2 birthdate
       address1_line1 address1_city address1_stateorprovince address1_postalcode
       dfe_channelcreation dfe_hasdbscertificate
+      dfe_Country@odata.bind ownerid@odata.bind
     }.freeze
     ALLOWED = (
-      REQUIRED + %w{telephone1 address1_line2 address1_line3 emailaddress1}
+      REQUIRED + %w{
+        telephone1 address1_line2 address1_line3 emailaddress1
+        dfe_dateofissueofdbscertificate
+      }
     ).freeze
 
     def find_by_email(address)

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -91,7 +91,6 @@ module Bookings::Gitis
         'address1_stateorprovince' => 'Manchester',
         'address1_postalcode' => 'MA1 1AM',
         'birthdate' => '1980-01-01',
-        'statecode' => 0,
         'dfe_channelcreation' => 10
       }
     end

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -4,7 +4,7 @@ module Bookings::Gitis
     REQUIRED = %w{
       firstname lastname emailaddress2 telephone2 birthdate
       address1_line1 address1_city address1_stateorprovince address1_postalcode
-      statecode dfe_channelcreation
+      dfe_channelcreation
     }.freeze
     ALLOWED = (
       REQUIRED + %w{telephone1 address1_line2 address1_line3 emailaddress1}

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -4,7 +4,7 @@ module Bookings::Gitis
     REQUIRED = %w{
       firstname lastname emailaddress2 telephone2 birthdate
       address1_line1 address1_city address1_stateorprovince address1_postalcode
-      dfe_channelcreation
+      dfe_channelcreation dfe_hasdbscertificate
     }.freeze
     ALLOWED = (
       REQUIRED + %w{telephone1 address1_line2 address1_line3 emailaddress1}

--- a/app/services/candidates/registrations/gitis_registration_session.rb
+++ b/app/services/candidates/registrations/gitis_registration_session.rb
@@ -26,6 +26,10 @@ module Candidates
         fetch_attributes ContactInformation, mapper.contact_to_contact_information
       end
 
+      def background_check_attributes
+        fetch_attributes BackgroundCheck, mapper.contact_to_background_check
+      end
+
       def mapper
         @mapper ||= Bookings::RegistrationContactMapper.new(self, gitis_contact)
       end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -101,4 +101,6 @@ Rails.application.configure do
   config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID', 'notset')
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
   config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION', '0')
+  config.x.gitis.owner_id = ENV.fetch('CRM_OWNER_ID', SecureRandom.uuid)
+  config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -140,6 +140,8 @@ Rails.application.configure do
     config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID')
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
+    config.x.gitis.owner_id = ENV.fetch('CRM_OWNER_ID')
+    config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
   end
 
   config.x.features = []

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -22,4 +22,6 @@ Rails.application.configure do
 
   config.x.gitis.fake_crm = true
   config.x.gitis.channel_creation = '0'
+  config.x.gitis.owner_id = SecureRandom.uuid
+  config.x.gitis.country_id = SecureRandom.uuid
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -79,6 +79,8 @@ Rails.application.configure do
 
   config.x.gitis.fake_crm = true
   config.x.gitis.channel_creation = '0'
+  config.x.gitis.owner_id = SecureRandom.uuid
+  config.x.gitis.country_id = SecureRandom.uuid
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 end

--- a/lib/apimock/gitis_crm.rb
+++ b/lib/apimock/gitis_crm.rb
@@ -294,7 +294,6 @@ module Apimock
         'address1_city' => "Manchester",
         'address1_stateorprovince' => "",
         'address1_postalcode' => "MA1 1AM",
-        'statecode' => 0,
         'dfe_channelcreation' => 222750021
       }
     end

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -75,10 +75,18 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
   end
 
   context 'with existing background check in gitis' do
-    let(:gitis_contact) { build(:gitis_contact, :persisted) }
-    before do
-      allow_any_instance_of(ActionDispatch::Request::Session).to \
-        receive(:[]).with(:gitis_contact).and_return(gitis_contact.attributes)
+    include_context 'candidate signin'
+
+    let :registration_session do
+      FactoryBot.build :gitis_registration_session,
+        gitis_contact: gitis_contact,
+        with: %i(
+          personal_information
+          contact_information
+          education
+          teaching_preference
+          placement_preference
+        )
     end
 
     context '#new' do

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -74,6 +74,29 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
     end
   end
 
+  context 'with existing background check in gitis' do
+    let(:gitis_contact) { build(:gitis_contact, :persisted) }
+    before do
+      allow_any_instance_of(ActionDispatch::Request::Session).to \
+        receive(:[]).with(:gitis_contact).and_return(gitis_contact.attributes)
+    end
+
+    context '#new' do
+      before do
+        get '/candidates/schools/11048/registrations/background_check/new'
+      end
+
+      it 'populates the form with the values from gitis' do
+        expect(assigns(:background_check)).to have_attributes \
+          has_dbs_check: gitis_contact.dfe_hasdbscertificate
+      end
+
+      it 'renders the new template' do
+        expect(response).to render_template :new
+      end
+    end
+  end
+
   context 'with existing background check in session' do
     let :registration_session do
       FactoryBot.build :gitis_registration_session, with: %i(

--- a/spec/factories/bookings/gitis/contact_factory.rb
+++ b/spec/factories/bookings/gitis/contact_factory.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     address1_postalcode { "MA1 1AM" }
     birthdate { '1980-01-01' }
     dfe_channelcreation { 10 }
+    dfe_hasdbscertificate { true }
 
     trait :persisted do
       contactid { SecureRandom.uuid }

--- a/spec/factories/bookings/gitis/contact_factory.rb
+++ b/spec/factories/bookings/gitis/contact_factory.rb
@@ -10,7 +10,6 @@ FactoryBot.define do
     address1_stateorprovince { "Test County" }
     address1_postalcode { "MA1 1AM" }
     birthdate { '1980-01-01' }
-    statecode { 0 }
     dfe_channelcreation { 10 }
 
     trait :persisted do

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to have_attributes(town_or_city: registration.contact_information.town_or_city) }
     it { is_expected.to have_attributes(county: registration.contact_information.county) }
     it { is_expected.to have_attributes(postcode: registration.contact_information.postcode) }
+    it { is_expected.to have_attributes(dfe_hasdbscertificate: registration.background_check.has_dbs_check) }
     it "should copy more attributes over"
   end
 

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -245,4 +245,25 @@ describe Bookings::Gitis::Contact, type: :model do
       end
     end
   end
+
+  describe '#has_dbs_check' do
+    subject do
+      described_class.new(
+        dfe_hasdbscertificate: true,
+        dfe_dateofissueofdbscertificate: '2019-01-01'
+      )
+    end
+
+    context 'with matching value' do
+      before { subject.has_dbs_check = true }
+      it { is_expected.to have_attributes(dfe_hasdbscertificate: true) }
+      it { is_expected.to have_attributes(dfe_dateofissueofdbscertificate: '2019-01-01') }
+    end
+
+    context 'with non matching value' do
+      before { subject.has_dbs_check = false }
+      it { is_expected.to have_attributes(dfe_hasdbscertificate: false) }
+      it { is_expected.to have_attributes(dfe_dateofissueofdbscertificate: nil) }
+    end
+  end
 end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -266,4 +266,54 @@ describe Bookings::Gitis::Contact, type: :model do
       it { is_expected.to have_attributes(dfe_dateofissueofdbscertificate: nil) }
     end
   end
+
+  describe 'phone=' do
+    subject { described_class.new attrs }
+    before { allow(subject).to receive(:created_by_us?).and_return(ours) }
+    before { subject.phone = '01234567890' }
+
+    context 'on existing GiTiS record' do
+      let(:ours) { false }
+
+      context 'with blank telephone1' do
+        let(:attrs) do
+          { 'telephone1' => '', 'telephone2' => '' }
+        end
+
+        it { is_expected.to have_attributes(telephone1: '01234567890') }
+        it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+
+      context 'with matching telephone1' do
+        let(:attrs) do
+          { 'telephone1' => '01234567890', 'telephone2' => '07123456789' }
+        end
+
+        it { is_expected.to have_attributes(telephone1: '01234567890') }
+        it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+
+      context 'for unmatching telephone1' do
+        let(:attrs) do
+          { 'telephone1' => '07123456789', 'telephone2' => '07123456789' }
+        end
+
+        it { is_expected.to have_attributes(telephone1: '07123456789') }
+        it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+    end
+
+    context 'on record we created' do
+      let(:ours) { true }
+
+      context 'for unmatching telephone1' do
+        let(:attrs) do
+          { 'telephone1' => '07123456789', 'telephone2' => '07123456789' }
+        end
+
+        it { is_expected.to have_attributes(telephone1: '01234567890') }
+        it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+    end
+  end
 end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -160,7 +160,7 @@ describe Bookings::Gitis::Contact, type: :model do
       it { is_expected.to include('emailaddress1') }
       it { is_expected.to include('emailaddress2') }
       it { is_expected.to include('telephone2') }
-      it { is_expected.to include('statecode') }
+      it { is_expected.not_to include('statecode') }
       it { is_expected.to include('dfe_channelcreation') }
     end
 

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -267,7 +267,7 @@ describe Bookings::Gitis::Contact, type: :model do
     end
   end
 
-  describe 'phone=' do
+  describe '#phone=' do
     subject { described_class.new attrs }
     before { allow(subject).to receive(:created_by_us?).and_return(ours) }
     before { subject.phone = '01234567890' }
@@ -313,6 +313,56 @@ describe Bookings::Gitis::Contact, type: :model do
 
         it { is_expected.to have_attributes(telephone1: '01234567890') }
         it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+    end
+  end
+
+  describe '#email=' do
+    subject { described_class.new attrs }
+    before { allow(subject).to receive(:created_by_us?).and_return(ours) }
+    before { subject.email = 'foobar@education.gov.uk' }
+
+    context 'on existing GiTiS record' do
+      let(:ours) { false }
+
+      context 'with blank emailaddress1' do
+        let(:attrs) do
+          { 'emailaddress1' => '', 'emailaddress2' => '' }
+        end
+
+        it { is_expected.to have_attributes(emailaddress1: 'foobar@education.gov.uk') }
+        it { is_expected.to have_attributes(emailaddress2: 'foobar@education.gov.uk') }
+      end
+
+      context 'with matching emailaddress1' do
+        let(:attrs) do
+          { 'emailaddress1' => 'foobar@education.gov.uk', 'emailaddress2' => 'barfoo@education.gov.uk' }
+        end
+
+        it { is_expected.to have_attributes(emailaddress1: 'foobar@education.gov.uk') }
+        it { is_expected.to have_attributes(emailaddress2: 'foobar@education.gov.uk') }
+      end
+
+      context 'for unmatching emailaddress1' do
+        let(:attrs) do
+          { 'emailaddress1' => 'barfoo@education.gov.uk', 'emailaddress2' => 'barfoo@education.gov.uk' }
+        end
+
+        it { is_expected.to have_attributes(emailaddress1: 'barfoo@education.gov.uk') }
+        it { is_expected.to have_attributes(emailaddress2: 'foobar@education.gov.uk') }
+      end
+    end
+
+    context 'on record we created' do
+      let(:ours) { true }
+
+      context 'for unmatching emailaddress1' do
+        let(:attrs) do
+          { 'emailaddress1' => 'barfoo@education.gov.uk', 'emailaddress2' => 'barfoo@education.gov.uk' }
+        end
+
+        it { is_expected.to have_attributes(emailaddress1: 'foobar@education.gov.uk') }
+        it { is_expected.to have_attributes(emailaddress2: 'foobar@education.gov.uk') }
       end
     end
   end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe Bookings::Gitis::Contact, type: :model do
+  before do
+    allow(described_class).to \
+      receive(:default_owner_id).and_return(SecureRandom.uuid)
+  end
+
   describe '.entity_path' do
     subject { described_class.entity_path }
     it { is_expected.to eq('contacts') }
@@ -162,6 +167,7 @@ describe Bookings::Gitis::Contact, type: :model do
       it { is_expected.to include('telephone2') }
       it { is_expected.not_to include('statecode') }
       it { is_expected.to include('dfe_channelcreation') }
+      it { is_expected.to include('ownerid@odata.bind') }
     end
 
     describe "#attributes_for_update" do
@@ -184,6 +190,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('birthdate') }
           it { is_expected.to include('telephone2') }
           it { is_expected.to include('emailaddress2') }
+          it { is_expected.not_to include('ownerid@odata.bind') }
         end
 
         context 'when modified' do
@@ -204,6 +211,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.to include('emailaddress2') }
           it { is_expected.to include('telephone1') }
           it { is_expected.to include('telephone2') }
+          it { is_expected.not_to include('ownerid@odata.bind') }
         end
       end
 
@@ -221,6 +229,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.to include('emailaddress2') }
           it { is_expected.not_to include('telephone1') }
           it { is_expected.to include('telephone2') }
+          it { is_expected.not_to include('ownerid@odata.bind') }
         end
 
         context 'when modified' do
@@ -241,6 +250,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.to include('emailaddress2') }
           it { is_expected.not_to include('telephone1') }
           it { is_expected.to include('telephone2') }
+          it { is_expected.not_to include('ownerid@odata.bind') }
         end
       end
     end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 describe Bookings::Gitis::Contact, type: :model do
   before do
     allow(described_class).to \
-      receive(:default_owner_id).and_return(SecureRandom.uuid)
+      receive(:default_owner).and_return(SecureRandom.uuid)
+
+    allow(described_class).to \
+      receive(:default_country).and_return(SecureRandom.uuid)
   end
 
   describe '.entity_path' do
@@ -168,6 +171,7 @@ describe Bookings::Gitis::Contact, type: :model do
       it { is_expected.not_to include('statecode') }
       it { is_expected.to include('dfe_channelcreation') }
       it { is_expected.to include('ownerid@odata.bind') }
+      it { is_expected.to include('dfe_Country@odata.bind') }
     end
 
     describe "#attributes_for_update" do
@@ -191,6 +195,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.to include('telephone2') }
           it { is_expected.to include('emailaddress2') }
           it { is_expected.not_to include('ownerid@odata.bind') }
+          it { is_expected.not_to include('dfe_Country@odata.bind') }
         end
 
         context 'when modified' do
@@ -212,6 +217,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.to include('telephone1') }
           it { is_expected.to include('telephone2') }
           it { is_expected.not_to include('ownerid@odata.bind') }
+          it { is_expected.not_to include('dfe_Country@odata.bind') }
         end
       end
 
@@ -230,6 +236,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('telephone1') }
           it { is_expected.to include('telephone2') }
           it { is_expected.not_to include('ownerid@odata.bind') }
+          it { is_expected.not_to include('dfe_Country@odata.bind') }
         end
 
         context 'when modified' do
@@ -251,6 +258,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('telephone1') }
           it { is_expected.to include('telephone2') }
           it { is_expected.not_to include('ownerid@odata.bind') }
+          it { is_expected.not_to include('dfe_Country@odata.bind') }
         end
       end
     end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -168,7 +168,6 @@ describe Bookings::Gitis::Contact, type: :model do
       it { is_expected.to include('emailaddress1') }
       it { is_expected.to include('emailaddress2') }
       it { is_expected.to include('telephone2') }
-      it { is_expected.not_to include('statecode') }
       it { is_expected.to include('dfe_channelcreation') }
       it { is_expected.to include('ownerid@odata.bind') }
       it { is_expected.to include('dfe_Country@odata.bind') }
@@ -187,7 +186,6 @@ describe Bookings::Gitis::Contact, type: :model do
 
         context 'when unmodified' do
           it { is_expected.not_to include('contactid') }
-          it { is_expected.not_to include('statecode') }
           it { is_expected.not_to include('dfe_channelcreation') }
           it { is_expected.not_to include('firstname') }
           it { is_expected.not_to include('lastname') }
@@ -207,7 +205,6 @@ describe Bookings::Gitis::Contact, type: :model do
           end
 
           it { is_expected.not_to include('contactid') }
-          it { is_expected.not_to include('statecode') }
           it { is_expected.not_to include('dfe_channelcreation') }
           it { is_expected.not_to include('firstname') }
           it { is_expected.not_to include('lastname') }
@@ -226,7 +223,6 @@ describe Bookings::Gitis::Contact, type: :model do
 
         context 'when unmodified' do
           it { is_expected.not_to include('contactid') }
-          it { is_expected.not_to include('statecode') }
           it { is_expected.not_to include('dfe_channelcreation') }
           it { is_expected.not_to include('firstname') }
           it { is_expected.not_to include('lastname') }
@@ -248,7 +244,6 @@ describe Bookings::Gitis::Contact, type: :model do
           end
 
           it { is_expected.not_to include('contactid') }
-          it { is_expected.not_to include('statecode') }
           it { is_expected.not_to include('dfe_channelcreation') }
           it { is_expected.not_to include('firstname') }
           it { is_expected.not_to include('lastname') }

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -149,7 +149,7 @@ describe Bookings::Gitis::CRM, type: :model do
       let(:contact) { build(:gitis_contact, contact_attributes) }
 
       before do
-        sorted_attrs = contact_attributes.sort.to_h
+        sorted_attrs = contact.attributes_for_create.sort.to_h
         gitis_stub.stub_create_contact_request(sorted_attrs, contactid)
       end
 

--- a/spec/services/bookings/gitis/entity_spec.rb
+++ b/spec/services/bookings/gitis/entity_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Bookings::Gitis::Entity do
     entity_id_attribute :stubid
     entity_attributes :firstname, :lastname
     entity_attributes :hidden, internal: true
+    entity_attributes :notcreate, except: :create
+    entity_attributes :notupdate, except: :update
 
     def initialize(data = {})
       self.stubid = data['stubid']
@@ -31,7 +33,7 @@ RSpec.describe Bookings::Gitis::Entity do
 
   describe ".entity_attribute_names" do
     subject { Stub.entity_attribute_names }
-    it { is_expected.to eq Set.new %w{firstname lastname hidden} }
+    it { is_expected.to eq Set.new %w{firstname lastname hidden notcreate notupdate} }
   end
 
   describe "#attributes" do
@@ -168,5 +170,17 @@ RSpec.describe Bookings::Gitis::Entity do
     it { expect(Stub.entity_attribute_names).to include('hidden') }
     it { expect(Stub.respond_to?('hidden')).to be false }
     it { expect(Stub.respond_to?('hidden=')).to be false }
+  end
+
+  describe "exclude: :create attributes" do
+    subject { Stub.new.tap { |s| s.notcreate = 'test' } }
+    it { expect(subject.attributes_for_create).not_to include('notcreate' => 'test') }
+    it { expect(subject.attributes_for_update).to include('notcreate' => 'test') }
+  end
+
+  describe "exclude: :update attributes" do
+    subject { Stub.new.tap { |s| s.notupdate = 'test' } }
+    it { expect(subject.attributes_for_create).to include('notupdate' => 'test') }
+    it { expect(subject.attributes_for_update).not_to include('notupdate' => 'test') }
   end
 end

--- a/spec/services/bookings/gitis/entity_spec.rb
+++ b/spec/services/bookings/gitis/entity_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Bookings::Gitis::Entity do
 
     entity_id_attribute :stubid
     entity_attributes :firstname, :lastname
+    entity_attributes :hidden, internal: true
 
     def initialize(data = {})
       self.stubid = data['stubid']
@@ -30,7 +31,7 @@ RSpec.describe Bookings::Gitis::Entity do
 
   describe ".entity_attribute_names" do
     subject { Stub.entity_attribute_names }
-    it { is_expected.to eq Set.new %w{firstname lastname} }
+    it { is_expected.to eq Set.new %w{firstname lastname hidden} }
   end
 
   describe "#attributes" do
@@ -161,5 +162,11 @@ RSpec.describe Bookings::Gitis::Entity do
       it { is_expected.to include('firstname' => 'changed') }
       it { is_expected.to include('lastname' => 'changed') }
     end
+  end
+
+  describe "private attributes" do
+    it { expect(Stub.entity_attribute_names).to include('hidden') }
+    it { expect(Stub.respond_to?('hidden')).to be false }
+    it { expect(Stub.respond_to?('hidden=')).to be false }
   end
 end

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -118,4 +118,52 @@ describe Candidates::Registrations::GitisRegistrationSession do
       it { is_expected.to have_attributes(date_of_birth: contact.date_of_birth) }
     end
   end
+
+  describe '#background_check_attributes' do
+    let(:data) { { 'has_dbs_check' => false } }
+
+    let(:key) do
+      Candidates::Registrations::BackgroundCheck.model_name.param_key
+    end
+
+    context 'with overridden background data' do
+      subject do
+        described_class.new({ key => data }, contact).
+          background_check_attributes
+      end
+
+      it { is_expected.to include(data) }
+    end
+
+    context 'with only gitis data' do
+      subject do
+        described_class.new({}, contact).background_check_attributes
+      end
+
+      it { is_expected.to include('has_dbs_check' => contact.has_dbs_check) }
+    end
+  end
+
+  describe '#background_check' do
+    let(:data) { { 'has_dbs_check' => false } }
+
+    let(:key) do
+      Candidates::Registrations::BackgroundCheck.model_name.param_key
+    end
+
+    context 'with overridden background data' do
+      subject do
+        described_class.new({ key => data }, contact).background_check
+      end
+
+      it { is_expected.to have_attributes(has_dbs_check: false) }
+    end
+
+    context 'with only gitis data' do
+      it "will raise a missing step error" do
+        expect { described_class.new({}, contact).background_check }.to \
+          raise_exception Candidates::Registrations::RegistrationSession::StepNotFound
+      end
+    end
+  end
 end

--- a/spec_external/gitis_crm_spec.rb
+++ b/spec_external/gitis_crm_spec.rb
@@ -357,6 +357,7 @@ RSpec.describe "The GITIS CRM Api" do
       'dfe_notesforclassroomexperience' =>
         existing_data['dfe_notesforclassroomexperience'] +
         "#{existing_data['dfe_notesforclassroomexperience']}\nUpdated at #{Time.zone.now}"
+      'dfe_hasdbscertificate' => true
     }
   end
 

--- a/spec_external/gitis_crm_spec.rb
+++ b/spec_external/gitis_crm_spec.rb
@@ -338,7 +338,6 @@ RSpec.describe "The GITIS CRM Api" do
       'address1_city' => "Manchester",
       'address1_stateorprovince' => "",
       'address1_postalcode' => "MA1 1AM",
-      'statecode' => 0,
       'dfe_channelcreation' => ENV.fetch('CRM_CHANNEL_CREATION'),
       'dfe_notesforclassroomexperience' => "Written by School Experience",
       'dfe_hasdbscertificate' => true,


### PR DESCRIPTION
**Note:** This PR is currently based against the SE-1525 branch since it builds off that and this simplifies the diff for review

### Context

We've have a revised plan for the integration with Gitis Contacts. This PR implements most of that plan.

### Changes proposed in this pull request

1. Assign Ownerid
2. Assign the country
3. Revised how telephone number and email address get updated
4. Assign the dbs certificate information
5. Removed references to `statecode`
6. Added support for attributes which are not written at either `create` or `update`

Note: Assignment of ownerid and country is a bit simplistic at the moment but is sufficient until I implement some relationship logic.

### Guidance to review

1. Check that creating a contact in Gitis still works