### PR TITLE
Cookies banner SE-1405

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@ $govuk-grid-widths: (
 @import "font-awesome" ;
 @import "../../../node_modules/govuk-frontend/all" ;
 @import "global-styles" ;
+@import "cookie-banner" ;
 @import "form-extensions" ;
 @import "school-search" ;
 @import "pagination" ;

--- a/app/assets/stylesheets/cookie-banner.scss
+++ b/app/assets/stylesheets/cookie-banner.scss
@@ -1,0 +1,25 @@
+#cookie-banner {
+  background-color: lighten(govuk-colour("blue"), 65%);
+  padding: 0.6rem 0rem 0.4rem;
+
+  #cookie-banner-message {
+    > p {
+      padding: 0rem;
+      margin: 0rem;
+      line-height: 1;
+      color: $govuk-text-colour;
+
+      // forego the underline, it interferes with the header bar immediately
+      // below
+      > a {
+        text-decoration: none;
+
+        // darken when hovering because the light blue background doesn't
+        // provide enough contrast
+        &:hover {
+          color: darken($govuk-link-colour, 15%);
+        }
+      }
+    }
+  }
+}

--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -8,7 +8,7 @@ module CookiesHelper
     cookies[cookie_name] = {
       value: seen_value,
       httponly: true,
-      expires: 1.month.from_now
+      expires: 2.weeks.from_now
     }
   end
 end

--- a/app/helpers/cookies_helper.rb
+++ b/app/helpers/cookies_helper.rb
@@ -1,0 +1,14 @@
+module CookiesHelper
+  def show_cookie_message?
+    cookie_name = 'seen_cookie_message'
+    seen_value = 'yes'
+
+    return false if cookies[cookie_name] == seen_value
+
+    cookies[cookie_name] = {
+      value: seen_value,
+      httponly: true,
+      expires: 1.month.from_now
+    }
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,8 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
+    <%= render partial: 'shared/application/cookie_banner' %>
+
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
     <header class="govuk-header " role="banner" data-module="header">

--- a/app/views/shared/application/_cookie_banner.html.erb
+++ b/app/views/shared/application/_cookie_banner.html.erb
@@ -1,5 +1,5 @@
 <% if show_cookie_message? %>
-  <div id="cookie-banner">
+  <div id="cookie-banner" aria-label="cookie banner" role="region">
     <div id="cookie-banner-message" class="govuk-width-container">
       <p class="govuk-body-s">
       School experience uses cookies to make the site simpler.

--- a/app/views/shared/application/_cookie_banner.html.erb
+++ b/app/views/shared/application/_cookie_banner.html.erb
@@ -1,8 +1,10 @@
-<div id="cookie-banner">
-  <div id="cookie-banner-message" class="govuk-width-container">
-    <p class="govuk-body-s">
-    School experience uses cookies to make the site simpler.
-      <%= link_to("Find out more about cookies", cookies_policy_path) %>
-    </p>
+<% if show_cookie_message? %>
+  <div id="cookie-banner">
+    <div id="cookie-banner-message" class="govuk-width-container">
+      <p class="govuk-body-s">
+      School experience uses cookies to make the site simpler.
+        <%= link_to("Find out more about cookies", cookies_policy_path) %>
+      </p>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/shared/application/_cookie_banner.html.erb
+++ b/app/views/shared/application/_cookie_banner.html.erb
@@ -1,0 +1,8 @@
+<div id="cookie-banner">
+  <div id="cookie-banner-message" class="govuk-width-container">
+    <p class="govuk-body-s">
+    School experience uses cookies to make the site simpler.
+      <%= link_to("Find out more about cookies", cookies_policy_path) %>
+    </p>
+  </div>
+</div>

--- a/features/step_definitions/candidates/landing_page_steps.rb
+++ b/features/step_definitions/candidates/landing_page_steps.rb
@@ -1,5 +1,5 @@
 Then("the leading paragraph should provide me with a summary of the service") do
-  within('div > p:first-of-type') do
+  within('.govuk-main-wrapper div > p:first-of-type') do
     [
       'interested in becoming a teacher',
       'find and request school experience',

--- a/spec/requests/cookie_banner_spec.rb
+++ b/spec/requests/cookie_banner_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe "Displaying the cookie banner", type: :request do
+  let(:cookie_name) { 'seen_cookie_message' }
+  let(:banner_contents) { /School experience uses cookies/ }
+
+  context 'on the first visit (when the seen_cookie_message cookie is absent)' do
+    specify "the cookie should be set to 'yes'" do
+      expect(cookies[cookie_name]).to be_nil
+      get candidates_root_path
+      expect(cookies[cookie_name]).to eql('yes')
+    end
+
+    specify 'the page should display the cookie banner' do
+      get candidates_root_path
+      expect(response.body).to match(banner_contents)
+    end
+  end
+
+  context 'on subsequent visits (when the seen_cookie_message is present)' do
+    before { cookies[cookie_name] = 'yes' }
+
+    specify 'the page should not display the cookie banner' do
+      get candidates_root_path
+      expect(response.body).not_to match(banner_contents)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We currently don't actively warn users that we use cookies

### Changes proposed in this pull request

Add a banner that's displayed when users first visit the School Experience web app. When it's displayed a cookie called `seen_cookie_message` is set and whenever this is present the banner is not displayed. It defaults, as per our existing cookie policy message, to expire after two weeks

![Screenshot 2019-08-16 at 12 26 00](https://user-images.githubusercontent.com/128088/63167362-fe594980-c028-11e9-83ef-528d5c8359a6.png)

### Guidance to review

Ensure things work as expected, everything looks ok and is accessible.

The ratio of the text on the light blue is AAA and the link is AA.