### PR TITLE
Fixed typo which got introduced into the Gitis testsuite

### DIFF
--- a/spec_external/gitis_crm_spec.rb
+++ b/spec_external/gitis_crm_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe "The GITIS CRM Api" do
       'dfe_dateofissueofdbscertificate' => nil,
       'dfe_notesforclassroomexperience' =>
         existing_data['dfe_notesforclassroomexperience'] +
-        "#{existing_data['dfe_notesforclassroomexperience']}\nUpdated at #{Time.zone.now}"
+        "#{existing_data['dfe_notesforclassroomexperience']}\nUpdated at #{Time.zone.now}",
       'dfe_hasdbscertificate' => true
     }
   end


### PR DESCRIPTION
### Context

Gitis test suite is broken because of the syntax error.

### Changes proposed in this pull request

Add a missing comma


