### PR TITLE
Dont require env vars which are not yet used in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -140,8 +140,8 @@ Rails.application.configure do
     config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID')
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
-    config.x.gitis.owner_id = ENV.fetch('CRM_OWNER_ID')
-    config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
+    config.x.gitis.owner_id = 'ignore' # ENV.fetch('CRM_OWNER_ID')
+    config.x.gitis.country_id = 'ignore' # ENV.fetch('CRM_COUNTRY_ID')
   end
 
   config.x.features = []


### PR DESCRIPTION
### Context

We currently depend on some env vars which are not needed is most environments, and not yet configured in others.

### Changes proposed in this pull request

Stub out until they are setup

### Guidance to review

This will get reverted once they are set in the production environments
