### PR TITLE
Send users through choose date type screen SE-1541

### DIFF
--- a/app/controllers/schools/availability_preferences_controller.rb
+++ b/app/controllers/schools/availability_preferences_controller.rb
@@ -5,17 +5,21 @@ class Schools::AvailabilityPreferencesController < Schools::BaseController
 
   def update
     if @current_school.update(placement_date_params)
-      if @current_school.availability_preference_fixed?
-        redirect_to schools_placement_dates_path
-      else
-        redirect_to schools_dashboard_path
-      end
+      redirect_to redirection_path
     else
       render :edit
     end
   end
 
 private
+
+  def redirection_path
+    if @current_school.availability_preference_fixed?
+      schools_placement_dates_path
+    else
+      edit_schools_availability_info_path
+    end
+  end
 
   def placement_date_params
     params.require(:bookings_school).permit(:availability_preference_fixed)

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -7,6 +7,11 @@ module Schools::DashboardsHelper
     end
   end
 
+  def is_fixed_and_has_active_dates?(school)
+    school.availability_preference_fixed? &&
+      school.bookings_placement_dates.available.any?
+  end
+
   def numbered_circle(number, aria_label:, id: nil, show_if_zero: false)
     # Does string comparison in case its not a number
     return if number.to_s == '0' && !show_if_zero

--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -9,7 +9,15 @@
     <%= render partial: 'schools/dashboards/no_availability_info_warning' %>
   <%- end -%>
 
-  <div id="update-school-profile" class="subsection">
+  <%- if is_fixed_and_has_active_dates?(@current_school) -%>
+    <div id="add-remove-and-change-dates" class="subsection">
+      <header class="dashboard-medium-priority">
+        <%= link_to "Add, remove and change dates", schools_placement_dates_path %>
+      </header>
+    </div>
+  <%- end -%>
+
+  <div id="change-how-dates-are-displayed" class="subsection">
     <header class="dashboard-medium-priority">
       <%= link_to "Change dates and how they're displayed", edit_schools_availability_preference_path %>
     </header>

--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -9,20 +9,6 @@
     <%= render partial: 'schools/dashboards/no_availability_info_warning' %>
   <%- end -%>
 
-  <%- if @current_school.availability_preference_fixed? -%>
-    <div id="update-school-profile" class="subsection">
-      <header class="dashboard-medium-priority">
-        <%= link_to "Add, remove and change dates", schools_placement_dates_path %>
-      </header>
-    </div>
-  <%- else -%>
-    <div id="update-school-profile" class="subsection">
-      <header class="dashboard-medium-priority">
-        <%= link_to "Describe when you’ll host school experience candidates", edit_schools_availability_info_path %>
-      </header>
-    </div>
-  <%- end -%>
-
   <div id="update-school-profile" class="subsection">
     <header class="dashboard-medium-priority">
       <%= link_to "Change how dates are displayed", edit_schools_availability_preference_path %>

--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -11,7 +11,7 @@
 
   <div id="update-school-profile" class="subsection">
     <header class="dashboard-medium-priority">
-      <%= link_to "Change how dates are displayed", edit_schools_availability_preference_path %>
+      <%= link_to "Change dates and how they're displayed", edit_schools_availability_preference_path %>
     </header>
   </div>
 </section>

--- a/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
+++ b/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
@@ -2,7 +2,7 @@
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-    You have no placement dates, your school will not appear in candidate
+    You haven't entered any dates, your school will not appear in candidate
     searches
   </strong>
 </div>

--- a/features/schools/availability_preferences/edit.feature
+++ b/features/schools/availability_preferences/edit.feature
@@ -30,5 +30,5 @@ Feature: Editing placement dates
         Given I am on the 'availability preferences' page
         When I choose "Display a description of when you\'ll host school experience candidates" from the "Change how dates are displayed" radio buttons
         And I submit the form
-        Then I should be on the 'schools dashboard' page
+        Then I should be on the 'availability information' page
         And my school's availability preference should be 'fixed'

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -38,6 +38,23 @@ Feature: The School Dashboard
             | Text                                   | Hint | Path                                  |
             | Change dates and how they're displayed | None | /schools/availability_preference/edit |
 
+    Scenario: Adding, removing and changing dates visible when fixed and dates present
+        Given my school has fully-onboarded
+        And my school has 3 placement dates
+        And it has 'fixed' availability
+        When I am on the 'schools dashboard' page
+        Then I should see the following 'medium-priority' links:
+            | Text                                   | Hint | Path                                  |
+            | Change dates and how they're displayed | None | /schools/availability_preference/edit |
+            | Add, remove and change dates           | None | /schools/placement_dates              |
+
+    Scenario: Adding, removing and changing dates not visible when not fixed and dates not present
+        Given my school has fully-onboarded
+        And it has 'fixed' availability
+        When I am on the 'schools dashboard' page
+        Then there should be no 'Add, remove and change dates' link
+
+
     Scenario: Account admin
         Given my school has fully-onboarded
         When I am on the 'schools dashboard' page
@@ -80,7 +97,7 @@ Feature: The School Dashboard
         And it has 'fixed' availability
         And my school has no placement dates
         When I am on the 'schools dashboard' page
-        Then there should be a 'You haven't entered any dates' warning
+        Then there should be a "You haven't entered any dates" warning
 
     Scenario: Displaying a warning when flexible with no description
         Given my school has fully-onboarded

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -35,8 +35,8 @@ Feature: The School Dashboard
         And it has 'fixed' availability
         When I am on the 'schools dashboard' page
         Then I should see the following 'medium-priority' links:
-            | Text                           | Hint | Path                                  |
-            | Change how dates are displayed | None | /schools/availability_preference/edit |
+            | Text                                   | Hint | Path                                  |
+            | Change dates and how they're displayed | None | /schools/availability_preference/edit |
 
     Scenario: Account admin
         Given my school has fully-onboarded
@@ -80,7 +80,7 @@ Feature: The School Dashboard
         And it has 'fixed' availability
         And my school has no placement dates
         When I am on the 'schools dashboard' page
-        Then there should be a 'You have no placement dates' warning
+        Then there should be a 'You haven't entered any dates' warning
 
     Scenario: Displaying a warning when flexible with no description
         Given my school has fully-onboarded

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -30,23 +30,13 @@ Feature: The School Dashboard
             | Manage requests | Candidates have requested school experience | /schools/placement_requests |
             | Manage bookings | A candidate has asked to change a booking   | /schools/bookings           |
 
-    Scenario: Manage dates (fixed dates)
+    Scenario: Manage dates
         Given my school has fully-onboarded
         And it has 'fixed' availability
         When I am on the 'schools dashboard' page
         Then I should see the following 'medium-priority' links:
             | Text                           | Hint | Path                                  |
-            | Add, remove and change dates   | None | /schools/placement_dates              |
             | Change how dates are displayed | None | /schools/availability_preference/edit |
-
-    Scenario: Manage dates (flexible dates)
-        Given my school has fully-onboarded
-        And it has 'flexible' availability
-        When I am on the 'schools dashboard' page
-        Then I should see the following 'medium-priority' links:
-            | Text                                                   | Hint | Path                                  |
-            | Describe when you’ll host school experience candidates | None | /schools/availability_info/edit       |
-            | Change how dates are displayed                         | None | /schools/availability_preference/edit |
 
     Scenario: Account admin
         Given my school has fully-onboarded

--- a/features/schools/placement_dates/index.feature
+++ b/features/schools/placement_dates/index.feature
@@ -36,7 +36,7 @@ Feature: Listing placement dates
     Scenario: Warning displayed when there are no dates
         Given my school has no placement dates
         When I am on the 'placement dates' page
-        Then there should be a 'You have no placement dates, your school will not appear in candidate searches' warning
+        Then there should be a 'You haven't entered any dates, your school will not appear in candidate searches' warning
 
     Scenario: The return to dashboard button
         Given I am on the 'placement dates' page


### PR DESCRIPTION
### Context

The **Manage dates** section of the dashboard still wasn't clear

### Changes proposed in this pull request 📆

Now there is only one link in the **Manage dates** section:

![Screenshot 2019-08-23 at 09 46 44](https://user-images.githubusercontent.com/128088/63583928-d5d6cf80-c593-11e9-8d8c-f7309901c394.png)

Users will first need to pick fixed or flexible, then, depending on their choice they'll be directed to the date manager or availability description page.

### Guidance to review

Ensure the changes make sense and everything works as expected. Wording agreed with @fredbrenton 
