### PR TITLE
Integrate the dashboard confirm attendance counter SE-1590

### DIFF
--- a/app/controllers/schools/dashboards_controller.rb
+++ b/app/controllers/schools/dashboards_controller.rb
@@ -7,7 +7,11 @@ module Schools
 
       @new_requests = current_school.placement_requests.unprocessed.count
       @new_bookings = current_school.bookings.upcoming.count
-      @candidate_attendances = 4
+      @candidate_attendances = current_school
+        .bookings
+        .previous
+        .attendance_unlogged
+        .count
     end
   end
 end

--- a/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
@@ -22,7 +22,7 @@
   <div id="confirm-attendance" class="subsection">
     <header class="dashboard-high-priority">
       <%= link_to "Confirm attendance", schools_confirm_attendance_path  %>
-      <%= numbered_circle(@new_bookings, id: 'new-bookings-counter', aria_label: 'attendances to confirm') %>
+      <%= numbered_circle(@candidate_attendances, id: 'confirm-attendance-counter', aria_label: 'attendances to confirm') %>
     </header>
     <p class="govuk-hint">Confirm if candidates have attended their school experience</p>
   </div>

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -75,6 +75,12 @@ Feature: The School Dashboard
         When I am on the 'schools dashboard' page
         Then the 'new bookings counter' should be 3
 
+    Scenario: Confirm attendance counter
+        Given my school has fully-onboarded
+        And there are 2 bookings in the past with no attendance logged
+        When I am on the 'schools dashboard' page
+        Then the 'confirm attendance counter' should be 2
+
     Scenario: Hide the enable/disable link if schools not onboarded
         Given my school has not yet fully-onboarded
         When I am on the 'schools dashboard' page
@@ -98,9 +104,3 @@ Feature: The School Dashboard
         And my school has availability no information set
         When I am on the 'schools dashboard' page
         Then there should be a 'You have no availability information' warning
-
-    @wip
-    Scenario: Candidate attendances counter
-        Given there are 4 new candidate attendances
-        When I am on the 'schools dashboard' page
-        Then the 'candidate attendances counter' should be 4

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -35,10 +35,13 @@ Given("there are {int} new bookings") do |qty|
   FactoryBot.create_list :bookings_booking, qty, :upcoming, bookings_school: @school
 end
 
-
-Given("there are {int} new candidate attendances") do |qty|
-  qty
-  #  do nothing, currently hard-coded in controller
+Given("there are {int} bookings in the past with no attendance logged") do |qty|
+  @bookings = FactoryBot.create_list :bookings_booking, qty, bookings_school: @school
+  @bookings.each do |b|
+    b.date = 1.week.ago
+    b.attended = nil
+    b.save(validate: false)
+  end
 end
 
 Then("the {string} should be {int}") do |string, int|


### PR DESCRIPTION
### Context

The confirm attendance counter was added before the confirm attendance feature, the two weren't integrated.

### Changes proposed in this pull request

Plumb the counter in so it shows an accurate number of attendances to confirm

![Screenshot 2019-08-23 at 11 32 53](https://user-images.githubusercontent.com/128088/63586727-f73aba00-c599-11e9-9627-6eeaacbba443.png)


### Guidance to review

Ensure the count looks right. It's all bookings that have no attendance marked that are in the past.
