### PR TITLE
Update wording on request school experience screen

### DIFF
--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -20,31 +20,24 @@
             :availability,
             rows: 5,
             maxwords: { count: 150 },
-            placeholder: t('.availability_placeholder'),
             'aria-describedby': 'candidates_registrations_placement_preference_availability_label',
             label_options: { overwrite_defaults!: true, class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_availability_label' } do %>
 
-            <p>
-              We need a few details so we can forward your experience requirements to the school.
-            </p>
-
-            <p>
-              Tell us about your availability. For example, if you're:
-            </p>
+            <p>For example, if you're:</p>
 
             <ul class="govuk-list govuk-list--bullet">
               <li>
                 available for any specific experience dates offered by schools
               </li>
               <li>
-                only available or unavailable for experience on particular days, dates or for certain periods of time
+                only available or unavailable on particular days, dates or for certain periods of time
               </li>
             </ul>
+
             <p>
-              The school will use this information to offer you the best dates it has available and may contact you to arrange the exact date of your experience.
-            </p>
-            <p>
-              Depending on availability and time of year, schools may not always be able to offer you the exact dates you’re looking for.
+              Depending on availability and time of year, the school may not
+              offer the exact date you’re looking for. They may contact you
+              directly to discuss the most suitable dates.
             </p>
 
             <%- if @school.availability_info.present? -%>
@@ -71,7 +64,8 @@
           'aria-describedby': 'candidates_registrations_placement_preference_objectives_label',
           label_options: { overwrite_defaults!: true, class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_objectives_label' } do %>
           <p>
-            Provide a short explanation. For example:
+            Provide a short explanation to help the school offer you the kind of
+            experience you’re looking for. For example:
           </p>
           <ul class="govuk-list govuk-list--bullet">
             <li>
@@ -87,9 +81,6 @@
               I want to see how teachers teach my subject
             </li>
           </ul>
-          <p>
-            This will help the school see if it can offer you the kind of experience you’re looking for.
-          </p>
         <% end %>
 
       <%= f.submit 'Continue' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -393,15 +393,6 @@ en:
         degree_subject: Select the nearest or equivalent subject.
       candidates_registrations_placement_preference:
         bookings_placement_date_id: School experience is only available on the following days
-        availability:
-          - Tell us about your availability. For example, when you'll be
-            available for placements or any particular days or periods when you
-            won't.
-          - The school will contact you to arrange the exact date of your
-            placement and will use this information to offer you the best dates
-            it has available.
-          - Depending on availability and time of year, schools may not always
-            be able to offer you the exact dates you’re looking for.
       candidates_session:
         date_of_birth: This will only be used to identify you and won’t be shared with any schools. For example, 12 11 2007
       schools_on_boarding_candidate_experience_detail:
@@ -449,7 +440,7 @@ en:
           true: "Yes"
           false: "No"
       candidates_registrations_placement_preference:
-        availability: Is there anything schools need to know about your availability for school experience?
+        availability: Tell us about your availability
         objectives: What do you want to get out of your school experience?
       candidates_registrations_privacy_policy:
         acceptance_html: 'By checking this box and sending this request you’re confirming, to the best of your knowledge, the details you’re providing are correct and you accept our <a href="/privacy_policy" class="govuk-link">privacy policy</a>'
@@ -582,9 +573,3 @@ en:
     pagination:
       next: Next
       previous: Previous
-
-  candidates:
-    registrations:
-      placement_preferences:
-        form:
-          availability_placeholder: Such as, from 4 to 8 May, from the start of next term, any time during May, June or July or I can only do Thursdays and Fridays

--- a/features/candidates/registrations/request_school_experience_placement/page_contents.feature
+++ b/features/candidates/registrations/request_school_experience_placement/page_contents.feature
@@ -39,10 +39,10 @@ Feature: Request a school experience placement
     @javascript
     Scenario: Word counting in placement objectives in availability
         Given I am on the 'Request school experience placement' page for my school of choice
-        Then the 'Is there anything schools need to know about your availability for school experience?' word count should say 'You have 150 words remaining'
+        Then the 'Tell us about your availability' word count should say 'You have 150 words remaining'
 
     @javascript
     Scenario: Updating the word count in availability
         Given I am on the 'Request school experience placement' page for my school of choice
-        When I enter 'The quick brown fox' into the 'Is there anything schools need to know about your availability for school experience?' text area
-        Then the 'Is there anything schools need to know about your availability for school experience?' word count should say 'You have 146 words remaining'
+        When I enter 'The quick brown fox' into the 'Tell us about your availability' text area
+        Then the 'Tell us about your availability' word count should say 'You have 146 words remaining'

--- a/features/candidates/registrations/request_school_experience_placement/schools_with_flexible_availability.feature
+++ b/features/candidates/registrations/request_school_experience_placement/schools_with_flexible_availability.feature
@@ -15,9 +15,9 @@ Feature: Request a school experience placement
     Scenario: Form contents
         Given I am on the 'Request school experience placement' page for my school of choice
         Then I should see a form with the following fields:
-            | Label                                                                                 | Type     |
-            | Is there anything schools need to know about your availability for school experience? | textarea |
-            | What do you want to get out of your school experience?                                | textarea |
+            | Label                                                  | Type     |
+            | Tell us about your availability                        | textarea |
+            | What do you want to get out of your school experience? | textarea |
 
     Scenario: Submitting my data
         Given I am on the 'Request school experience placement' page for my school of choice

--- a/features/step_definitions/candidates/registrations/application_preview_steps.rb
+++ b/features/step_definitions/candidates/registrations/application_preview_steps.rb
@@ -56,7 +56,7 @@ Given("I have filled in my placement preferences successfully") do
   if @fixed_dates
     choose @wanted_bookings_placement_date
   else
-    fill_in 'Is there anything schools need to know about your availability for school experience?', with: 'Only free from Epiphany to Whitsunday'
+    fill_in 'Tell us about your availability', with: 'Only free from Epiphany to Whitsunday'
   end
   fill_in 'What do you want to get out of your school experience?', with: 'I enjoy teaching'
   click_button 'Continue'

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -25,7 +25,7 @@ Then("a text area labelled {string} should have appeared") do |string|
 end
 
 Given("I have filled in the form with accurate data") do
-  fill_in "Is there anything schools need to know about your availability for school experience?", with: "Anytime!"
+  fill_in "Tell us about your availability", with: "Anytime!"
   fill_in "What do you want to get out of your school experience?", with: "I love teaching"
 end
 

--- a/features/step_definitions/candidates/registrations/wizard_steps.rb
+++ b/features/step_definitions/candidates/registrations/wizard_steps.rb
@@ -6,7 +6,7 @@ end
 
 Given("I have completed the placement preference form") do
   visit path_for 'request school experience placement', school: @school
-  fill_in 'Is there anything schools need to know about your availability for school experience?', with: 'From Epiphany to Whitsunday'
+  fill_in 'Tell us about your availability', with: 'From Epiphany to Whitsunday'
   fill_in 'What do you want to get out of your school experience?', with: 'I enjoy teaching'
   click_button 'Continue'
 end
@@ -65,7 +65,7 @@ end
 Then("the placement preference form should populated with the details I've entered so far") do
   visit path_for 'request school experience placement', school: @school
   expect(find_field(
-    'Is there anything schools need to know about your availability for school experience?'
+    'Tell us about your availability'
   ).value).to eq 'From Epiphany to Whitsunday'
   expect(find_field('What do you want to get out of your school experience?').value).to eq 'I enjoy teaching'
 end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -279,7 +279,7 @@ feature 'Candidate Registrations', type: :feature do
     expect(page).to have_text 'There is a problem'
 
     # Submit registrations/placement_preference form successfully
-    fill_in 'Is there anything schools need to know about your availability for school experience?', with: 'Only free from Epiphany to Whitsunday'
+    fill_in 'Tell us about your availability', with: 'Only free from Epiphany to Whitsunday'
     fill_in 'What do you want to get out of your school experience?', with: 'I enjoy teaching'
     click_button 'Continue'
   end


### PR DESCRIPTION
This screen had some repeated text and was generally too long. The text
has been replaced with more succinct copy and now matches the prototype

![Screenshot 2019-08-23 at 15 09 34](https://user-images.githubusercontent.com/128088/63599253-1dbc1d80-c5b9-11e9-9758-3ee827c15b36.png)