### PR TITLE
SE-1624 Assign address1_telephone1 when creating Contacts

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -11,7 +11,7 @@ module Bookings
       entity_attributes :address1_line1, :address1_line2, :address1_line3
       entity_attributes :address1_city, :address1_stateorprovince
       entity_attributes :address1_postalcode
-      entity_attributes :telephone1, :telephone2
+      entity_attributes :telephone1, :address1_telephone1, :telephone2
       entity_attributes :dfe_hasdbscertificate, :dfe_dateofissueofdbscertificate
       entity_attributes :dfe_notesforclassroomexperience
       entity_attributes :mobilephone, :dfe_channelcreation, except: :update
@@ -49,6 +49,7 @@ module Bookings
         self.address1_city                    = @crm_data['address1_city']
         self.address1_stateorprovince         = @crm_data['address1_stateorprovince']
         self.address1_postalcode              = @crm_data['address1_postalcode']
+        self.address1_telephone1              = @crm_data['address1_telephone1']
         self.birthdate                        = @crm_data['birthdate']
         self.dfe_channelcreation              = @crm_data['dfe_channelcreation'] || self.class.channel_creation
         self.dfe_hasdbscertificate            = @crm_data['dfe_hasdbscertificate']
@@ -113,6 +114,10 @@ module Bookings
       def phone=(phonenumber)
         if created_by_us? || telephone1.blank?
           self.telephone1 = phonenumber&.strip
+        end
+
+        if created_by_us? || address1_telephone1.blank?
+          self.address1_telephone1 = phonenumber&.strip
         end
 
         self.telephone2 = phonenumber&.strip

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -9,8 +9,8 @@ module Bookings::Gitis
     }.freeze
     ALLOWED = (
       REQUIRED + %w{
-        telephone1 address1_line2 address1_line3 emailaddress1
-        dfe_dateofissueofdbscertificate
+        telephone1 address1_telephone1 address1_line2 address1_line3
+        emailaddress1 dfe_dateofissueofdbscertificate
         dfe_PreferredTeachingSubject01@odata.bind
         dfe_PreferredTeachingSubject02@odata.bind
       }
@@ -92,6 +92,7 @@ module Bookings::Gitis
         'address1_city' => 'Manchester',
         'address1_stateorprovince' => 'Manchester',
         'address1_postalcode' => 'MA1 1AM',
+        'address1_telephone1' => '01234 567890',
         'birthdate' => '1980-01-01',
         'dfe_channelcreation' => 10
       }

--- a/lib/apimock/gitis_crm.rb
+++ b/lib/apimock/gitis_crm.rb
@@ -294,6 +294,7 @@ module Apimock
         'address1_city' => "Manchester",
         'address1_stateorprovince' => "",
         'address1_postalcode' => "MA1 1AM",
+        'address1_telephone1' => "01234567890",
         'dfe_channelcreation' => 222750021
       }
     end

--- a/spec/factories/bookings/gitis/contact_factory.rb
+++ b/spec/factories/bookings/gitis/contact_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:lastname) { |n| "User#{n}" }
     sequence(:emailaddress1) { |n| "testuser#{n}@testdomain.com" }
     telephone1 { "01234 567890" }
+    address1_telephone1 { "01234 567890" }
     address1_line1 { "My Building" }
     address1_line2 { "Test Street" }
     address1_city { "Test Town" }

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -205,6 +205,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.to include('emailaddress2') }
           it { is_expected.to include('telephone1') }
           it { is_expected.to include('telephone2') }
+          it { is_expected.to include('address1_telephone1') }
           it { is_expected.not_to include('ownerid@odata.bind') }
           it { is_expected.not_to include('dfe_Country@odata.bind') }
         end
@@ -222,6 +223,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('emailaddress1') }
           it { is_expected.to include('emailaddress2') }
           it { is_expected.not_to include('telephone1') }
+          it { is_expected.not_to include('address1_telephone1') }
           it { is_expected.to include('telephone2') }
           it { is_expected.not_to include('ownerid@odata.bind') }
           it { is_expected.not_to include('dfe_Country@odata.bind') }
@@ -243,6 +245,7 @@ describe Bookings::Gitis::Contact, type: :model do
           it { is_expected.not_to include('emailaddress1') }
           it { is_expected.to include('emailaddress2') }
           it { is_expected.not_to include('telephone1') }
+          it { is_expected.not_to include('address1_telephone1') }
           it { is_expected.to include('telephone2') }
           it { is_expected.not_to include('ownerid@odata.bind') }
           it { is_expected.not_to include('dfe_Country@odata.bind') }
@@ -277,10 +280,10 @@ describe Bookings::Gitis::Contact, type: :model do
     before { allow(subject).to receive(:created_by_us?).and_return(ours) }
     before { subject.phone = '01234567890' }
 
-    context 'on existing GiTiS record' do
+    context 'on existing GiTiS record for telephone1' do
       let(:ours) { false }
 
-      context 'with blank telephone1' do
+      context 'with blank' do
         let(:attrs) do
           { 'telephone1' => '', 'telephone2' => '' }
         end
@@ -289,7 +292,7 @@ describe Bookings::Gitis::Contact, type: :model do
         it { is_expected.to have_attributes(telephone2: '01234567890') }
       end
 
-      context 'with matching telephone1' do
+      context 'with matching' do
         let(:attrs) do
           { 'telephone1' => '01234567890', 'telephone2' => '07123456789' }
         end
@@ -298,7 +301,7 @@ describe Bookings::Gitis::Contact, type: :model do
         it { is_expected.to have_attributes(telephone2: '01234567890') }
       end
 
-      context 'for unmatching telephone1' do
+      context 'for unmatching' do
         let(:attrs) do
           { 'telephone1' => '07123456789', 'telephone2' => '07123456789' }
         end
@@ -308,15 +311,51 @@ describe Bookings::Gitis::Contact, type: :model do
       end
     end
 
+    context 'on existing GiTiS record for address1_telephone1' do
+      let(:ours) { false }
+
+      context 'with blank' do
+        let(:attrs) do
+          { 'address1_telephone1' => '', 'telephone2' => '' }
+        end
+
+        it { is_expected.to have_attributes(address1_telephone1: '01234567890') }
+        it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+
+      context 'with matching' do
+        let(:attrs) do
+          { 'address1_telephone1' => '01234567890', 'telephone2' => '07123456789' }
+        end
+
+        it { is_expected.to have_attributes(address1_telephone1: '01234567890') }
+        it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+
+      context 'for unmatching' do
+        let(:attrs) do
+          { 'address1_telephone1' => '07123456789', 'telephone2' => '07123456789' }
+        end
+
+        it { is_expected.to have_attributes(address1_telephone1: '07123456789') }
+        it { is_expected.to have_attributes(telephone2: '01234567890') }
+      end
+    end
+
     context 'on record we created' do
       let(:ours) { true }
 
       context 'for unmatching telephone1' do
         let(:attrs) do
-          { 'telephone1' => '07123456789', 'telephone2' => '07123456789' }
+          {
+            'telephone1' => '07123456789',
+            'address1_telephone1' => '07123456789',
+            'telephone2' => '07123456789'
+          }
         end
 
         it { is_expected.to have_attributes(telephone1: '01234567890') }
+        it { is_expected.to have_attributes(address1_telephone1: '01234567890') }
         it { is_expected.to have_attributes(telephone2: '01234567890') }
       end
     end


### PR DESCRIPTION
### Context

We've been asked by the CRM team to assign Address1 Telephone1 when creating new GiTiS contacts

### Changes proposed in this pull request

1. Assign address1_telephone1 when creating new Contacts in GiTiS

### Guidance to review

1. Sanity check code
