### PR TITLE
Always set the updated at when publishing a profile

### DIFF
--- a/app/models/bookings/profile_publisher.rb
+++ b/app/models/bookings/profile_publisher.rb
@@ -15,6 +15,7 @@ module Bookings
         school.subject_ids = @school_profile.subject_ids
         school.phase_ids = converted_phase_ids
         school.save!
+        profile.updated_at = DateTime.now
         profile.tap(&:save!)
       end
     end


### PR DESCRIPTION
### Context

The confirmations controller uses the timestamp to check the latest profile
has been published, if a change occurs on the SchoolProfile, which is not
reflected on the Bookings::Profile then the user ends up in a loop.

### Changes proposed in this pull request

For now we solve this by always setting the updated at timestamp

### Guidance to review

1. Code review
2. Do the testsuites still pass
