### PR TITLE
Corrected typos in the original privacy policy content

### DIFF
--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -74,7 +74,7 @@ Service</h1>
         </li>
 
         <li>
-          If you are using the Get School experience service, your data will be
+          If you are using the Get School Experience service, your data will be
           used to process your request for school experience with the school(s)
           in question. We will also use it to send out notifications, reminders
           and feedback questionnaires. We track your progress through this
@@ -179,7 +179,7 @@ Service</h1>
       <p>
         If you are using the Get School Experience service, we will share some
         of your personal data to the staff who manage school experience at the
-        school where you've requested school experience at. This allows them to
+        school where you've requested school experience. This allows them to
         process your application and get back to you about your school
         experience.
       </p>


### PR DESCRIPTION
### Context

There were a couple of small typos in our privacy policy

### Changes proposed in this pull request

1. Removal of an errant 'at' at the end of a sentence.
2. Corrected a capitalisation of Get School Experience

### Guidance to review

1. Code review

