### PR TITLE
Add accepted to the upcoming scope

### DIFF
--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -50,7 +50,7 @@ module Bookings
     UPCOMING_TIMEFRAME = 2.weeks
 
     scope :unprocessed, -> { joins(:bookings_placement_request).merge(PlacementRequest.not_cancelled) }
-    scope :upcoming, -> { unprocessed.where(arel_table[:date].between(Time.now..UPCOMING_TIMEFRAME.from_now)) }
+    scope :upcoming, -> { unprocessed.accepted.where(arel_table[:date].between(Time.now..UPCOMING_TIMEFRAME.from_now)) }
     scope :accepted, -> { where.not(accepted_at: nil) }
     scope :previous, -> { where(arel_table[:date].lteq(Date.today)) }
     scope :attendance_unlogged, -> { where(attended: nil) }

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -32,7 +32,7 @@ Given("there are {int} new requests") do |qty|
 end
 
 Given("there are {int} new bookings") do |qty|
-  FactoryBot.create_list :bookings_booking, qty, :upcoming, bookings_school: @school
+  FactoryBot.create_list :bookings_booking, qty, :upcoming, :accepted, bookings_school: @school
 end
 
 Given("there are {int} bookings in the past with no attendance logged") do |qty|

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -99,8 +99,8 @@ describe Bookings::Booking do
   describe 'Scopes' do
     describe '.upcoming' do
       # upcoming is currently set to any date within the next 2 weeks
-      let!(:included) { [0, 1, 13, 14].map { |offset| create(:bookings_booking, date: offset.days.from_now) } }
-      let!(:excluded) { [-4, -1, 15, 50].map { |offset| build(:bookings_booking, date: offset.days.from_now).save(validate: false) } }
+      let!(:included) { [0, 1, 13, 14].map { |offset| create(:bookings_booking, :accepted, date: offset.days.from_now) } }
+      let!(:excluded) { [-4, -1, 15, 50].map { |offset| build(:bookings_booking, :accepted, date: offset.days.from_now).save(validate: false) } }
 
       specify 'should include bookings that fall within the range' do
         expect(described_class.upcoming).to match_array(included)


### PR DESCRIPTION
We don't want to show incomplete bookings in the upcoming counter on the
dashboard

### Context
Phantom bookings were being showing in the upcoming bookings counter.

### Changes proposed in this pull request
Exercise phantom bookings by limiting the upcoming scope to only available bookings

### Guidance to review
Create a booking within the upcoming window (2 weeks) but don't complete the last step. Expect it not to show in the manage bookings counter on school dashboard

