### PR TITLE
SE-1640 Support switching devices as part of registration process

### DIFF
--- a/app/controllers/candidates/registrations/sign_ins_controller.rb
+++ b/app/controllers/candidates/registrations/sign_ins_controller.rb
@@ -23,13 +23,22 @@ module Candidates
         if candidate
           self.current_candidate = candidate
 
+          # Ensure PersonalInformation is updated in session
+          # necessary for if switching device as part of email verification
+          personal_information = PersonalInformation.new attributes_from_session
+          persist personal_information
+
           redirect_to new_candidates_school_registrations_contact_information_path
-        else
+        elsif attributes_from_session.any?
           @resend_link = candidates_school_registrations_sign_in_path
         end
       end
 
     private
+
+      def attributes_from_session
+        current_registration.personal_information_attributes
+      end
 
       def verification_email(token)
         NotifyEmail::CandidateVerifyEmailLink.new(

--- a/app/controllers/candidates/registrations/sign_ins_controller.rb
+++ b/app/controllers/candidates/registrations/sign_ins_controller.rb
@@ -1,6 +1,8 @@
 module Candidates
   module Registrations
     class SignInsController < RegistrationsController
+      skip_before_action :ensure_step_permitted!, only: :update
+
       def show
         @email_address = current_registration.personal_information.email
         @resend_link = candidates_school_registrations_sign_in_path
@@ -16,14 +18,11 @@ module Candidates
       end
 
       def update
-        personal_information = current_registration.personal_information
         candidate = Candidates::Session.signin!(params[:token])
 
         if candidate
-          personal_information.read_only = true
-          persist personal_information
-
           self.current_candidate = candidate
+
           redirect_to new_candidates_school_registrations_contact_information_path
         else
           @resend_link = candidates_school_registrations_sign_in_path

--- a/app/views/candidates/registrations/sign_ins/update.html.erb
+++ b/app/views/candidates/registrations/sign_ins/update.html.erb
@@ -10,12 +10,20 @@
       Your Email verification link has expired
     </p>
 
+    <% if @resend_link %>
     <p>
       Click below to be emailed a new link
     </p>
 
     <p>
       <%= button_to 'Send a new link', @resend_link, class: 'govuk-button govuk-button--secondary' %>
+    </p>
+    <% end %>
+
+    <p>
+      <%= link_to 'Restart your application',
+       new_candidates_school_registrations_personal_information_path,
+       class: 'govuk-link' %>
     </p>
   </div>
 </div>

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Candidates::Registrations::SignInsController, type: :request do
   include ActiveJob::TestHelper
   let(:school_id) { 11048 }
-  include_context 'Stubbed current_registration'
   include_context 'fake gitis with known uuid'
 
   let :registration_session do
@@ -20,6 +19,8 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
   end
 
   describe 'GET #show' do
+    include_context 'Stubbed current_registration'
+
     before { get candidates_school_registrations_sign_in_path(school_id) }
 
     it "should return HTTP success" do
@@ -32,6 +33,8 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
     let(:personal_info) { registration_session.personal_information }
 
     context 'with valid token' do
+      include_context 'Stubbed current_registration'
+
       before do
         get candidates_registration_verify_path(school_id, token)
       end
@@ -44,13 +47,11 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
       it "will have confirmed candidate" do
         expect(token.candidate.reload).to be_confirmed
       end
-
-      it "will have marked the email address read only" do
-        expect(personal_info).to have_attributes read_only: true
-      end
     end
 
     context 'with invalid token' do
+      include_context 'Stubbed current_registration'
+
       before do
         expect(Candidates::Session).to receive(:signin!).and_return(nil)
         get candidates_registration_verify_path(school_id, token)
@@ -59,13 +60,10 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
       it "will show error screen" do
         expect(response).to have_http_status(:success)
       end
-
-      it "will not have marked the email address read only" do
-        expect(personal_info).to have_attributes read_only: false
-      end
     end
 
     context 'when already signed in' do
+      include_context 'Stubbed current_registration'
       include_context 'candidate signin'
 
       before do
@@ -80,9 +78,26 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
           redirect_to new_candidates_school_registrations_contact_information_path(school_id)
       end
     end
+
+    context 'when having swapped device' do
+      before do
+        get candidates_registration_verify_path(school_id, token)
+      end
+
+      it "will redirect_to ContactInformation step" do
+        expect(response).to \
+          redirect_to new_candidates_school_registrations_contact_information_path(school_id)
+      end
+
+      it "will have confirmed candidate" do
+        expect(token.candidate.reload).to be_confirmed
+      end
+    end
   end
 
   describe 'POST #create' do
+    include_context 'Stubbed current_registration'
+
     before do
       NotifyFakeClient.reset_deliveries!
       allow(queue_adapter).to receive(:perform_enqueued_jobs).and_return(true)

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -106,6 +106,7 @@ describe Candidates::Registrations::GitisRegistrationSession do
         it { is_expected.to include('last_name' => contact.lastname) }
         it { is_expected.to include('email' => contact.email) }
         it { is_expected.to include('date_of_birth' => contact.date_of_birth) }
+        it { is_expected.to include('read_only' => true) }
       end
 
       context 'with only gitis data' do
@@ -117,6 +118,7 @@ describe Candidates::Registrations::GitisRegistrationSession do
         it { is_expected.to include('last_name' => contact.lastname) }
         it { is_expected.to include('email' => contact.email) }
         it { is_expected.to include('date_of_birth' => contact.date_of_birth) }
+        it { is_expected.to include('read_only' => true) }
       end
     end
 

--- a/spec/views/candidates/registrations/sign_ins/update.html.erb_spec.rb
+++ b/spec/views/candidates/registrations/sign_ins/update.html.erb_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe "candidates/registrations/sign_ins/update.html.erb", type: :view do
   before do
+    allow(view).to \
+      receive(:new_candidates_school_registrations_personal_information_path).
+      and_return('/stubbed')
+
     assign(:resend_link, '/my/resend/link')
     render
   end
@@ -10,5 +14,7 @@ RSpec.describe "candidates/registrations/sign_ins/update.html.erb", type: :view 
     expect(rendered).to have_css('h1', text: /Verify/i)
     expect(rendered).to \
       have_css("form[action=\"/my/resend/link\"] input[value=\"Send a new link\"]")
+    expect(rendered).to \
+      have_css("a[href=\"/stubbed\"]")
   end
 end


### PR DESCRIPTION
### Context

A Candidate may start the Registration process on one device (eg their laptop),
they will then expect to continue the process on the device they received their
sign in link on, potentially their phone.

We actually hold enough information to facilitate this - everything from the
first step, Personal Information, is overridden by the GiTiS Contact
information, and the school URN is included in the URN.

### Changes proposed in this pull request

1. This PR removes some unnecessary processing of the PersonalInformation now we
instead override it with GitisRegistrationSession

2. Removes off the step check for just the token sign in since thats not
necessary in this context and it then allows the sign in to occur.

### Guidance to review

1. Code review
2. Testing process
    1. Complete a full registration in a private browser session to ensure your in Gitis
    2. Close all private browser sessions
    3. Make another application with same personal details - you should get a verification link in your email
    4. Close all private browser sessions
    5. Open the link in a new private browser session
    6. You should be able to complete the full Registration