### PR TITLE
Se 1453/schools/onboarding/return to dashboard link

### DIFF
--- a/app/views/schools/on_boarding/confirmations/show.html.erb
+++ b/app/views/schools/on_boarding/confirmations/show.html.erb
@@ -11,24 +11,21 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        You've successfully set up your school experience profile
+        You've set up your profile
       </h1>
     </div>
 
-    <h2 class="govuk-heading-m">
-      What happens next
-    </h2>
     <p>
-      You’ve provided all the relevant details to start receiving requests from candidates.
+      You can now receive candidate requests and be sent their full name,
+      contact and other details to help you offer them school experience.
     </p>
 
-    <h3 class="govkuk-heading-s">
-      Try and respond to requests within 10 working days during term time.
-    </h3>
     <p>
-      In these requests, you’ll receive their full name, contact details and
-      other useful information to help you decide whether to offer them experience.
+      <strong>
+        Try and respond to requests within 10 working days during term time.
+      </strong>
     </p>
+
     <p>
       You'll also be told if they’ve got a Disclosure and Barring Service (DBS)
       certificate. However, these details will not be verified by DfE.

--- a/app/views/schools/on_boarding/confirmations/show.html.erb
+++ b/app/views/schools/on_boarding/confirmations/show.html.erb
@@ -34,17 +34,12 @@
       certificate. However, these details will not be verified by DfE.
     </p>
 
-    <h2 class="govuk-heading-m">
-      View and update your school experience details
-    </h2>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>
-        <% if Rails.application.config.x.phase >= 4 %>
-          <%= link_to 'Your requests and bookings', schools_dashboard_path %>
-        <% else %>
-          <%= link_to 'Manage school experience', schools_dashboard_path %>
-        <% end %>
-      </li>
-    </ul>
+    <p>
+      <% if Rails.application.config.x.phase >= 4 %>
+        <%= link_to 'Your requests and bookings', schools_dashboard_path, class: 'govuk-button' %>
+      <% else %>
+        <%= link_to 'Manage school experience', schools_dashboard_path, class: 'govuk-button' %>
+      <% end %>
+    </p>
   </div>
 </div>


### PR DESCRIPTION
### Context
User's were missing the link to return to their dashboard.

### Changes proposed in this pull request
Reduce the content so the return to dashboard link is above the page fold.
Style the link as a button so it's more noticeable.

### Guidance to review
