### PR TITLE
Add DfE contact us page for schools SE-1415

### DIFF
--- a/app/controllers/schools/contact_us_controller.rb
+++ b/app/controllers/schools/contact_us_controller.rb
@@ -1,0 +1,9 @@
+module Schools
+  class ContactUsController < BaseController
+    skip_before_action :ensure_onboarded
+
+    def show
+      @school = current_school
+    end
+  end
+end

--- a/app/views/schools/contact_us/show.html.erb
+++ b/app/views/schools/contact_us/show.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = "Contact us" %>
 
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Contact us</h1>

--- a/app/views/schools/contact_us/show.html.erb
+++ b/app/views/schools/contact_us/show.html.erb
@@ -1,0 +1,17 @@
+<% self.page_title = "Contact us" %>
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Contact us</h1>
+
+    <p>
+      If you need help and support or have a question about the service email us
+      with your URN at <%= mail_to 'organise.school-experience@education.gov.uk' %>.
+    </p>
+
+    <p class="govuk-!-margin-top-6">
+      <%= link_to 'Return to requests and bookings', schools_dashboard_path, class: 'govuk-button' %>
+    </p>
+  <div>
+</div>

--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -40,7 +40,7 @@
 
         <div id="contact-us" class="subsection">
           <header class="dashboard-low-priority">
-            <%= mail_to 'organise.school-experience@education.gov.uk', 'Contact us' %>
+            <%= link_to 'Contact us', schools_contact_us_path %>
           </header>
           <span class="govuk-hint">
             Get in touch if you need help using the service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
     end
     resource :switch, only: %i(new), controller: 'switch'
     resource :dashboard, only: :show
+    resource :contact_us, only: :show, controller: 'contact_us'
     resource :toggle_enabled, only: %i(edit update), as: 'enabled', controller: 'toggle_enabled'
 
     if Rails.application.config.x.phase >= 4

--- a/features/schools/contact_us.feature
+++ b/features/schools/contact_us.feature
@@ -1,0 +1,12 @@
+Feature: The School Dashboard
+    To provide me with assistance if I need it
+    As a school administrator
+    I want to be able to contact the suitable person at the DfE
+
+    Background:
+        Given I am logged in as a DfE user
+
+    Scenario: Links
+        Given I am on the 'contact us' page
+        Then I should see a email link to 'organise.school-experience@education.gov.uk'
+        And I should see a 'Return to requests and bookings' link to the 'schools dashboard'

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -60,8 +60,8 @@ Feature: The School Dashboard
         Given my school has fully-onboarded
         When I am on the 'schools dashboard' page
         Then I should see the following 'low-priority' links:
-            | Text       | Hint                                            | Path                                               |
-            | Contact us | Get in touch if you need help using the service | mailto:organise.school-experience@education.gov.uk |
+            | Text       | Hint                                            | Path                |
+            | Contact us | Get in touch if you need help using the service | /schools/contact_us |
 
     Scenario: Candidate requests counter
         Given my school has fully-onboarded

--- a/features/support/path_helper.rb
+++ b/features/support/path_helper.rb
@@ -32,6 +32,7 @@ def path_for(descriptor, school: nil, placement_date_id: nil, booking_id: nil,
 
     #school paths
     "schools" => [:schools_path],
+    "contact us" => [:schools_contact_us_path],
     "schools dashboard" => [:schools_dashboard_path],
     "bookings" => [:schools_bookings_path],
     "upcoming bookings" => [:schools_upcoming_bookings_path],


### PR DESCRIPTION
### Context

In case schools need to contact the DfE regarding School Experience there should be a single place with relevant contact details

### Changes proposed in this pull request

Add a 'Contact us' page for schools. Currently it only has an email address, phone number to follow once set up

### Guidance to review

Make sure it looks ok and works correctly

