### PR TITLE
[WIP] SE-1469 Added a caching layer to the crm

### DIFF
--- a/app/services/bookings/gitis/caching_crm.rb
+++ b/app/services/bookings/gitis/caching_crm.rb
@@ -1,0 +1,85 @@
+module Bookings::Gitis
+  module CachingCrm
+    EXPIRATION = 1.hour.freeze
+
+    def find(uuids, entity_type: Contact, refresh: false, **options)
+      return super unless cache_enabled?
+
+      multiple_ids = uuids.is_a?(Array)
+
+      uuids = normalise_ids(uuids)
+      validate_ids(uuids)
+
+      remove_from_cache(entity_type, uuids) if refresh
+
+      if multiple_ids
+        cached_find_many(entity_type, uuids)
+      else
+        cached_find_one(entity_type, uuids[0])
+      end
+    end
+
+    def write(entity)
+      super.tap do |entity_id|
+        if cache_enabled?
+          Rails.cache.delete cache_key(entity.class, entity_id)
+        end
+      end
+    end
+
+  private
+
+    def cached_find_one(type, uuid)
+      Rails.cache.fetch(cache_key(type, uuid), expires_in: EXPIRATION) do
+        crmlog "READING Contact #{uuid.inspect}"
+        find_one(type, uuid, '$top' => 1)
+      end
+    end
+
+    def find_in_cache(type, uuids)
+      keys = cache_keys(type, uuids)
+      Rails.cache.read_multi(*keys).values.index_by(&:id)
+    end
+
+    def cached_find_many(type, uuids)
+      hits = find_in_cache(type, uuids)
+      misses = uuids - hits.keys
+
+      unless misses.empty?
+        crmlog "READING #{type.name.split('::').last.pluralize} #{misses.inspect}"
+
+        entities = find_many(type, misses, '$top' => misses.length).index_by(&:id)
+
+        entities.each do |id, entity|
+          Rails.cache.write(cache_key(type, id), entity, expires_in: EXPIRATION)
+        end
+      end
+
+      uuids.map { |id| hits[id] || entities[id] }.compact
+    end
+
+    def cache_enabled?
+      Rails.application.config.x.gitis.caching
+    end
+
+    def cache_keys(type, uuids)
+      uuids.map do |uuid|
+        cache_key type, uuid
+      end
+    end
+
+    def remove_from_cache(type, uuids)
+      cache_keys(type, uuids).each do |key|
+        Rails.cache.delete key
+      end
+    end
+
+    def cache_key(type, uuid)
+      "#{type.model_name.cache_key}/#{uuid}/#{version}"
+    end
+
+    def version
+      "v1"
+    end
+  end
+end

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -94,7 +94,7 @@ module Bookings
       end
 
       def log_school_experience(contact_id, logline)
-        contact = find(contact_id)
+        contact = find(contact_id, refresh: true)
         return false unless contact
 
         contact.add_school_experience(logline)

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -103,14 +103,14 @@ module Bookings::Gitis
     end
 
     # only Contacts are mocked for now
-    def find_one(_entity_type, uuid, params)
+    def find_one(_entity_type, uuid, params = {})
       return super unless stubbed?
 
       Contact.new(fake_contact_data.merge('contactid' => uuid))
     end
 
     # only Contacts are mocked for now
-    def find_many(entity_type, uuids, params)
+    def find_many(entity_type, uuids, params = {})
       return super unless stubbed?
 
       uuids.map do |uuid|

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -103,6 +103,7 @@ Rails.application.configure do
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
   config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION', '0')
   config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
+  config.x.gitis.caching = ['1', 'true', 'yes'].include?(ENV['CRM_CACHING'].to_s)
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -141,6 +141,7 @@ Rails.application.configure do
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
     config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
+    config.x.gitis.caching = ['1', 'true', 'yes'].include?(ENV['CRM_CACHING'].to_s)
   end
 
   config.x.features = []

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -24,5 +24,7 @@ Rails.application.configure do
   config.x.gitis.fake_crm = true
   config.x.gitis.channel_creation = '0'
   config.x.gitis.country_id = SecureRandom.uuid
+  config.x.gitis.caching = false
+
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -81,6 +81,7 @@ Rails.application.configure do
   config.x.gitis.fake_crm = true
   config.x.gitis.channel_creation = '0'
   config.x.gitis.country_id = SecureRandom.uuid
+  config.x.gitis.caching = false
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)

--- a/spec/factories/bookings/gitis/contact_factory.rb
+++ b/spec/factories/bookings/gitis/contact_factory.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
     address1_stateorprovince { "Test County" }
     address1_postalcode { "MA1 1AM" }
     birthdate { '1980-01-01' }
-    dfe_channelcreation { 10 }
     dfe_hasdbscertificate { true }
     _dfe_preferredteachingsubject01_value { '04fc5f49-887b-4ac6-82ea-4278e9f3a9c1' }
     _dfe_preferredteachingsubject02_value { '686ba354-2a91-430b-affa-68b4e1fdffc0' }

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -270,7 +270,7 @@ describe Bookings::Gitis::CRM, type: :model do
     let(:logline) { "01/10/2019 TEST                   01/11/2019 #{school.urn} #{school.name}" }
 
     before do
-      allow(gitis).to receive(:find).with(contact.id).and_return(contact)
+      allow(gitis).to receive(:find).with(contact.id, refresh: true).and_return(contact)
       allow(gitis).to receive(:update_entity).and_return(true)
 
       gitis.log_school_experience(contact.id, logline)


### PR DESCRIPTION
### Context

When we are making repeated queries to the Gitis API it would be beneficial to cache the response, particularly for when school administrators are going back and forth between pages.

### Changes proposed in this pull request

1. Added a caching layer to the CRM

### Guidance to review

1. Code review
2. Can be tested by setting up to run against the CRM - actual API calls are logged, so you can see the first request hitting the API and subsequent refreshes don't.

### Side note

1. IMO this is a layering violation. I have a PR planned which splits the different layers of the Gitis abstraction up much more cleanly and this would be reimplemented more cleanly as part of that but this code provides reliable logic that can be used in that refactor.

