### PR TITLE
overwrite compose file rather than append

### DIFF
--- a/script/compose-school-experience.sh
+++ b/script/compose-school-experience.sh
@@ -6,7 +6,7 @@
 ###################################################
 
 
-cat <<EOF >> compose-school-experience.yml
+cat <<EOF > compose-school-experience.yml
 version: '3.3'
 
 services:


### PR DESCRIPTION
### Context

The `deploy.sh` script deletes the created `compose-school-experience.yml` after the deployment so the appending behaviour is not immediately apparent. Only is seen when you kill the deploy script during the `az group deployment` .

### Changes proposed in this pull request

overwrite rather than append.

### Guidance to review

Is used in the CD pipeline so requires merging etc. to test.
