### PR TITLE
Use CRLF (DOS) line endings when writing notes in Gitis

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -153,10 +153,10 @@ module Bookings
 
       def add_school_experience(log_line)
         unless dfe_notesforclassroomexperience.present?
-          self.dfe_notesforclassroomexperience = EventLogger::NOTES_HEADER + "\n\n"
+          self.dfe_notesforclassroomexperience = EventLogger::NOTES_HEADER + "\r\n\r\n"
         end
 
-        self.dfe_notesforclassroomexperience = "#{dfe_notesforclassroomexperience}#{log_line}\n"
+        self.dfe_notesforclassroomexperience = "#{dfe_notesforclassroomexperience}#{log_line}\r\n"
       end
     end
   end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -421,12 +421,12 @@ describe Bookings::Gitis::Contact, type: :model do
 
       it "will create a classroomexperience entry" do
         is_expected.to have_attributes \
-          dfe_notesforclassroomexperience: "#{headerline}\n\n#{logline}\n"
+          dfe_notesforclassroomexperience: "#{headerline}\r\n\r\n#{logline}\r\n"
       end
 
       it "will write the changes to the crm" do
         expect(contact.attributes_for_create).to include \
-          'dfe_notesforclassroomexperience' => "#{headerline}\n\n#{logline}\n"
+          'dfe_notesforclassroomexperience' => "#{headerline}\r\n\r\n#{logline}\r\n"
       end
     end
 
@@ -436,7 +436,7 @@ describe Bookings::Gitis::Contact, type: :model do
       end
 
       before do
-        contact.dfe_notesforclassroomexperience = "#{headerline}\n\n#{logline}\n"
+        contact.dfe_notesforclassroomexperience = "#{headerline}\r\n\r\n#{logline}\r\n"
         contact.reset_dirty_attributes
         contact.add_school_experience secondline
       end
@@ -446,13 +446,13 @@ describe Bookings::Gitis::Contact, type: :model do
       it "will append to the classroomexperience entry" do
         is_expected.to have_attributes \
           dfe_notesforclassroomexperience:
-            "#{headerline}\n\n#{logline}\n#{secondline}\n"
+            "#{headerline}\r\n\r\n#{logline}\r\n#{secondline}\r\n"
       end
 
       it "will write the changes to the crm" do
         expect(subject.attributes_for_update).to include \
           'dfe_notesforclassroomexperience' =>
-            "#{headerline}\n\n#{logline}\n#{secondline}\n"
+            "#{headerline}\r\n\r\n#{logline}\r\n#{secondline}\r\n"
       end
     end
   end

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -279,7 +279,7 @@ describe Bookings::Gitis::CRM, type: :model do
     it "will create a new entry with a single row" do
       expect(gitis).to have_received(:update_entity).with(
         contact.entity_id,
-        'dfe_notesforclassroomexperience' => "#{headerline}\n\n#{logline}\n"
+        'dfe_notesforclassroomexperience' => "#{headerline}\r\n\r\n#{logline}\r\n"
       )
     end
   end


### PR DESCRIPTION
### Context

Currently we write newlines into the GiTiS notes field using LF line separators, in order to show correctly in dynamics these probably need to be CRLF.

### Changes proposed in this pull request

1. Change line endings to CRLF

### Guidance to review

1. Code review should be enough
