### PR TITLE
Update the date preferences screen

### DIFF
--- a/app/helpers/schools/availability_preference_helper.rb
+++ b/app/helpers/schools/availability_preference_helper.rb
@@ -1,0 +1,8 @@
+module Schools::AvailabilityPreferenceHelper
+  # always show future dates so the user won't be
+  # confused by being shown past dates
+  def example_future_dates
+    future_date = 1.month.from_now.monday.to_date
+    [future_date, future_date + 1.day]
+  end
+end

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -1,37 +1,78 @@
-<%- self.page_title = "Change how dates are displayed" %>
+<%- self.page_title = "Choose how dates are displayed" %>
 
 <%
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,
-    'Change how dates are displayed' => nil
+    'Choose how dates are displayed' => nil
   }
 %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @current_school, url: schools_availability_preference_path, method: 'patch' do |f| %>
+    <%= form_for @current_school, url: schools_availability_preference_path, method: 'patch', builder: ActionView::Helpers::FormBuilder do |f| %>
+
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
-      <%= f.hidden_field :fixed, value: nil %>
+      <div class="govuk-form-group <%= "govuk-form-group--error" if f.object.errors.any? %>">
+		<fieldset class="govuk-fieldset" aria-describedby="choose-how-dates-are-displayed-hint">
+		  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+			<h1 class="govuk-fieldset__heading">
+              Choose how dates are displayed
+			</h1>
 
-      <%= f.radio_button_fieldset :availability_preference_fixed do |fieldset| %>
-        <p>
-          Select how you’d like to show your school experience dates to candidates:
-        </p>
-        <%= fieldset.radio_input(true, 'aria-describedby' => 'availability-preference-fixed-true-hint') %>
-        <span id="availability-preference-fixed-true-hint" class="govuk-hint govuk-hint__indented">
-          If you do not enter any specific dates then you will not receive
-          school experience requests from candidates
-        </span>
+            <span id="choose-how-dates-are-displayed-hint" class="govuk-hint">
+              Select how you'd like to present school experience dates to candidates.
+            </span>
+		  </legend>
 
-        <%= fieldset.radio_input(false, 'aria-describedby' => 'availability-preference-fixed-false-hint') %>
-        <span id="availability-preference-fixed-false-hint" class="govuk-hint govuk-hint__indented">
-          For example, on certain days of the week or around exams, holidays
-          and term times
-        </span>
-      <% end %>
+          <%- if f.object.errors[:availability_preference_fixed].present? %>
+            <span class="govuk-error-message" id="bookings-school-availability-preference-fixed-error">
+              <span class="govuk-visually-hidden">
+                Error:
+              </span>
+              <%= f.object.errors[:availability_preference_fixed].first %>
+            </span>
+          <% end %>
 
-      <%= f.submit 'Continue' %>
+          <div class="govuk-radios">
+            <div class="govuk-radios__item">
+              <%= f.radio_button :availability_preference_fixed, true, class: "govuk-radios__input", aria: { describedby: 'bookings-school-availability-preference-fixed-true-hint' } %>
+              <%= f.label :availability_preference_fixed, 'Show specific dates', value: true, class: 'govuk-label govuk-radios__label govuk-!-font-weight-bold' %>
+              <div id="bookings-school-availability-preference-fixed-true-hint" class="govuk-hint govuk-radios__hint">
+                You must enter specific school experience dates to start receiving requests from candidates
+
+                <div class="govuk-inset-text">
+                  <h3>Upcoming experience dates</h3>
+
+                  <ul class="govuk-list">
+                    <%- example_future_dates.each do |fd| %>
+                      <li><%= fd.to_formatted_s(:govuk) %> (1 day)</li>
+                    <% end %>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <div class="govuk-radios__item">
+              <%= f.radio_button :availability_preference_fixed, false, class: "govuk-radios__input", aria: { describedby: 'bookings-school-availability-preference-fixed-false-hint' } %>
+              <%= f.label :availability_preference_fixed, 'Show a description of when you can host candidates', value: false, class: 'govuk-label govuk-radios__label govuk-!-font-weight-bold' %>
+
+              <div id="bookings-school-availability-preference-fixed-false-hint" class="govuk-hint govuk-radios__hint">
+                For example, on set days of the week or at certain times of the year such as around exams, holidays and busy term times
+
+                <div class="govuk-inset-text">
+                  <h3>Experience availability</h3>
+
+                  <p>We offer career experience placements throughout the school year.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+		</fieldset>
+	  </div>
+	  <div class="govuk-form-group">
+        <%= f.submit 'Continue', class: 'govuk-button' %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -14,16 +14,16 @@
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
       <div class="govuk-form-group <%= "govuk-form-group--error" if f.object.errors.any? %>">
-		<fieldset class="govuk-fieldset" aria-describedby="choose-how-dates-are-displayed-hint">
-		  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-			<h1 class="govuk-fieldset__heading">
+        <fieldset class="govuk-fieldset" aria-describedby="choose-how-dates-are-displayed-hint">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+            <h1 class="govuk-fieldset__heading">
               Choose how dates are displayed
-			</h1>
+            </h1>
 
             <span id="choose-how-dates-are-displayed-hint" class="govuk-hint">
               Select how you'd like to present school experience dates to candidates.
             </span>
-		  </legend>
+          </legend>
 
           <%- if f.object.errors[:availability_preference_fixed].present? %>
             <span class="govuk-error-message" id="bookings-school-availability-preference-fixed-error">
@@ -68,9 +68,9 @@
               </div>
             </div>
           </div>
-		</fieldset>
-	  </div>
-	  <div class="govuk-form-group">
+        </fieldset>
+      </div>
+      <div class="govuk-form-group">
         <%= f.submit 'Continue', class: 'govuk-button' %>
       </div>
     <% end %>

--- a/features/schools/availability_preferences/edit.feature
+++ b/features/schools/availability_preferences/edit.feature
@@ -10,25 +10,25 @@ Feature: Editing placement dates
 
     Scenario: Page title
         Given I am on the 'availability preferences' page
-        Then the page title should be 'Change how dates are displayed'
+        Then the page title should be 'Choose how dates are displayed'
 
     Scenario: Breadcrumbs
         Given I am on the 'availability preferences' page
         Then I should see the following breadcrumbs:
             | Text                           | Link               |
             | Some school                    | /schools/dashboard |
-            | Change how dates are displayed | None               |
+            | Choose how dates are displayed | None               |
 
     Scenario: Page contents
         Given I am on the 'availability preferences' page
-        Then I should see radio buttons for 'Change how dates are displayed' with the following options:
-            | Display specific dates                                                 |
-            | Display a description of when you'll host school experience candidates |
+        Then I should see radio buttons for 'Choose how dates are displayed' with the following options:
+            | Show specific dates                                |
+            | Show a description of when you can host candidates |
         And the submit button should contain text 'Continue'
 
     Scenario: Submitting the form
         Given I am on the 'availability preferences' page
-        When I choose "Display a description of when you\'ll host school experience candidates" from the "Change how dates are displayed" radio buttons
+        When I choose "Show a description of when you can host candidates" from the "Choose how dates are displayed" radio buttons
         And I submit the form
         Then I should be on the 'schools dashboard' page
         And my school's availability preference should be 'fixed'


### PR DESCRIPTION
### Context

There's a new design for the availability preference screen that now has some extra text
beneath the radio buttons with example data

### Changes proposed in this pull request

The new design includes features that aren't supported by the form
builder, namely hints on radio buttons and additional (example)
information that's related to the radio button.

As a result, the default Rails form builder is used and the inputs are
manually surrounded by the appropriate HTML.

### Guidance to review

Ensure it looks ok. This is a good candidate for replacement with the new form builder when it's deemed to be the right time 👍🏽