### PR TITLE
Fix for whitespace in email addresses held in gitis

### DIFF
--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -46,7 +46,7 @@ module Bookings
       {
         'first_name'    => gitis_contact.first_name,
         'last_name'     => gitis_contact.last_name,
-        'email'         => gitis_contact.email,
+        'email'         => gitis_contact.email&.strip,
         'date_of_birth' => gitis_contact.date_of_birth
       }
     end

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -52,6 +52,18 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to include('last_name' => contact.last_name) }
     it { is_expected.to include('email' => contact.email) }
     it { is_expected.to include('date_of_birth' => contact.date_of_birth) }
+
+    context 'with whitespace in email address' do
+      let(:contact) do
+        build(:gitis_contact, :persisted,
+          emailaddress1: ' someone@education.gov.uk ',
+          emailaddress2: nil)
+      end
+
+      it "will strip the whitespace" do
+        is_expected.to include('email' => 'someone@education.gov.uk')
+      end
+    end
   end
 
   describe "#contact_to_contact_information" do


### PR DESCRIPTION
### Context

If there is whitespace in an email address, gitis still matches it returns data to us but we then treat that data as invalid, preventing the user from signing in.

### Changes proposed in this pull request

1. Strip the whitespace from the returned email address in the mapper.

### Guidance to review

1. Code review

