### PR TITLE
Handle blank fields supplied from Gitis which we require values for

### DIFF
--- a/app/services/candidates/registrations/gitis_registration_session.rb
+++ b/app/services/candidates/registrations/gitis_registration_session.rb
@@ -14,7 +14,7 @@ module Candidates
         # finally lock it with read only
 
         fetch_attributes(PersonalInformation, mapper.contact_to_personal_information).
-          merge(mapper.contact_to_personal_information).
+          merge(completed_contact_fields_for_personal_information).
           merge('read_only' => true)
       end
 
@@ -36,6 +36,16 @@ module Candidates
 
       def mapper
         @mapper ||= Bookings::RegistrationContactMapper.new(self, gitis_contact)
+      end
+
+    private
+
+      def completed_contact_fields_for_personal_information
+        # Ignore blank fields in Gitis and fall back to our data for validation purposes
+
+        mapper.contact_to_personal_information.reject do |_key, value|
+          value.blank?
+        end
       end
     end
   end

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -107,6 +107,21 @@ describe Candidates::Registrations::GitisRegistrationSession do
         it { is_expected.to include('email' => contact.email) }
         it { is_expected.to include('date_of_birth' => contact.date_of_birth) }
         it { is_expected.to include('read_only' => true) }
+
+        context 'with some blank fields in gitis data' do
+          let(:contact) do
+            build :gitis_contact, :persisted,
+              date_of_birth: nil,
+              firstname: "",
+              lastname: ""
+          end
+
+          it { is_expected.to include('first_name' => data['first_name']) }
+          it { is_expected.to include('last_name' => data['last_name']) }
+          it { is_expected.to include('email' => contact.email) }
+          it { is_expected.to include('date_of_birth' => data['date_of_birth']) }
+          it { is_expected.to include('read_only' => true) }
+        end
       end
 
       context 'with only gitis data' do
@@ -132,6 +147,21 @@ describe Candidates::Registrations::GitisRegistrationSession do
         it { is_expected.to have_attributes(last_name: contact.lastname) }
         it { is_expected.to have_attributes(email: contact.email) }
         it { is_expected.to have_attributes(date_of_birth: contact.date_of_birth) }
+
+        context 'with some blank fields in gitis data' do
+          let(:contact) do
+            build :gitis_contact, :persisted,
+              date_of_birth: nil,
+              firstname: "",
+              lastname: ""
+          end
+
+          it { is_expected.to be_valid }
+          it { is_expected.to have_attributes(first_name: data['first_name']) }
+          it { is_expected.to have_attributes(last_name: data['last_name']) }
+          it { is_expected.to have_attributes(email: contact.email) }
+          it { is_expected.to have_attributes(date_of_birth: data['date_of_birth']) }
+        end
       end
 
       context 'with only gitis data' do


### PR DESCRIPTION
### Context

Currently we break if the date of birth in a matched Gitis Contact is blank because this then fails our own validation.

### Changes proposed in this pull request

1. Fall through to the users supplied value in the absence of the absence of a value in Gitis

### Guidance to review

1. Code review
