### PR TITLE
Add safeguards around current_user_full_name method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,7 +61,7 @@ module ApplicationHelper
   def current_user_info_and_logout_link
     logout_link = link_to("Logout", logout_schools_session_path)
 
-    greeting = if @current_user.is_a?(OpenIDConnect::ResponseObject::UserInfo)
+    greeting = if valid_user?(@current_user)
                  "Welcome #{current_user_full_name}"
                end
 
@@ -71,6 +71,8 @@ module ApplicationHelper
   end
 
   def current_user_full_name
+    return 'Unknown' unless valid_user?(@current_user)
+
     [@current_user.given_name, @current_user.family_name].join(' ')
   end
 
@@ -88,5 +90,11 @@ module ApplicationHelper
     else
       new_candidates_feedback_path
     end
+  end
+
+private
+
+  def valid_user?(user)
+    user.is_a?(OpenIDConnect::ResponseObject::UserInfo)
   end
 end

--- a/app/views/schools/errors/not_registered/show.html.erb
+++ b/app/views/schools/errors/not_registered/show.html.erb
@@ -19,9 +19,11 @@
       </a>
     </p>
 
-    <p>
-      You are currently logged in as <strong><%= current_user_full_name %></strong>.
-    </p>
+    <% if @current_user.present? %>
+      <p>
+        You are currently logged in as <strong><%= current_user_full_name %></strong>.
+      </p>
+    <% end %>
 
     <section>
       <p>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,9 @@
 require 'rails_helper'
 
 describe ApplicationHelper, type: :helper do
+  let(:given_name) { 'Martin' }
+  let(:family_name) { 'Prince' }
+
   context 'Breadcrumbs' do
     let(:args) do
       {
@@ -53,8 +56,6 @@ describe ApplicationHelper, type: :helper do
 
   context '#current_user_info_and_logout_link' do
     subject { helper.current_user_info_and_logout_link }
-    let(:given_name) { 'Martin' }
-    let(:family_name) { 'Prince' }
     context 'when a user is logged in' do
       before do
         assign(
@@ -72,6 +73,32 @@ describe ApplicationHelper, type: :helper do
 
       specify "should contain a logout link" do
         expect(subject).to have_link('Logout', href: '/schools/session/logout')
+      end
+    end
+  end
+
+  describe '#current_user_full_name' do
+    subject { helper.current_user_full_name }
+
+    context 'when current_user present' do
+      before do
+        assign(
+          :current_user,
+          OpenIDConnect::ResponseObject::UserInfo.new(
+            given_name: given_name,
+            family_name: family_name
+          )
+        )
+      end
+
+      specify 'should return the combined given and family names' do
+        expect(subject).to eql("#{given_name} #{family_name}")
+      end
+    end
+
+    context 'when current_user absent' do
+      specify "should return 'Unknown'" do
+        expect(subject).to eql("Unknown")
       end
     end
   end


### PR DESCRIPTION
The `current_user_full_name` is ordinarily only used after we've checked
that the user is present (in the Phase Banner partial).

The one other place it's used is on the not registered error page. That call has been
wrapped to prevent the paragraph from being shown if the user is absent
and the method will now return 'Unknown' if the current user isn't a
valid `UserInfo` object
