### PR TITLE
Revert summer holiday warnings SE-1548

### DIFF
--- a/app/notify/notify_email/candidate_request_confirmation.3860fb06-9af2-49c8-ac0b-007b9f360033.md
+++ b/app/notify/notify_email/candidate_request_confirmation.3860fb06-9af2-49c8-ac0b-007b9f360033.md
@@ -2,7 +2,7 @@ Dear ((candidate_name))
 
 You've requested school experience at ((school_name)).
 
-^ The school will be in touch with you. Be aware, due to the summer holidays, they may not get in touch until at least late August or early September.
+^ The school will be in touch with you. During term time this could typically take up to 2 weeks.
 
 # Your request details
 

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -14,7 +14,7 @@
     </p>
     <p class="govuk-!-font-weight-bold">
       The school will email or call you to discuss your request and experience
-      date.
+      date. During term time this could typically take up to 2 weeks.
     </p>
 
     <p class="govuk-!-font-weight-bold">


### PR DESCRIPTION
Revert summer holiday delay warnings. The email change has already been made on Notify and is reflected by the change to the candidate request notification template.