### PR TITLE
SE-1582 Accept privacy policy

### DIFF
--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -12,6 +12,8 @@ module Candidates
 
         unless registration_session.completed?
           if gitis_integration?
+            already_signed_in = candidate_signed_in?
+
             self.current_candidate = Bookings::Candidate.create_or_update_from_registration_session! \
               gitis_crm,
               registration_session,
@@ -21,6 +23,12 @@ module Candidates
               registration_session,
               cookies[:analytics_tracking_uuid],
               context: :returning_from_confirmation_email
+
+            unless already_signed_in || Bookings::Gitis::PrivacyPolicy.default.nil?
+              AcceptPrivacyPolicyJob.perform_later \
+                current_candidate.gitis_uuid,
+                Bookings::Gitis::PrivacyPolicy.default
+            end
 
             Bookings::Gitis::EventLogger.write_later \
               current_candidate.gitis_uuid, :request, placement_request

--- a/app/jobs/bookings/log_to_gitis_job.rb
+++ b/app/jobs/bookings/log_to_gitis_job.rb
@@ -1,20 +1,10 @@
 module Bookings
-  class LogToGitisJob < ApplicationJob
+  class LogToGitisJob < GitisJob
     retry_on StandardError, wait: A_DECENT_AMOUNT_LONGER, attempts: 8
 
     def perform(contact_id, logline)
       gitis.log_school_experience \
         contact_id, logline
-    end
-
-  private
-
-    def gitis_token
-      Bookings::Gitis::Auth.new.token
-    end
-
-    def gitis
-      Bookings::Gitis::CRM.new gitis_token
     end
   end
 end

--- a/app/jobs/candidates/registrations/accept_privacy_policy_job.rb
+++ b/app/jobs/candidates/registrations/accept_privacy_policy_job.rb
@@ -1,11 +1,9 @@
 class Candidates::Registrations::AcceptPrivacyPolicyJob < GitisJob
   retry_on StandardError, wait: A_DECENT_AMOUNT_LONGER, attempts: 8
 
-  def perform(contact_id, privacy_policy_id)
-    contact = gitis.find(contact_id)
-
-    gitis.write \
-      Bookings::Gitis::CandidatePrivacyPolicy.build_for_contact \
-        contact.id, privacy_policy_id
+  def perform(contact_id, policy_id)
+    Bookings::Gitis::AcceptPrivacyPolicy.
+      new(gitis, contact_id, policy_id).
+      accept!
   end
 end

--- a/app/jobs/candidates/registrations/accept_privacy_policy_job.rb
+++ b/app/jobs/candidates/registrations/accept_privacy_policy_job.rb
@@ -1,0 +1,11 @@
+class Candidates::Registrations::AcceptPrivacyPolicyJob < GitisJob
+  retry_on StandardError, wait: A_DECENT_AMOUNT_LONGER, attempts: 8
+
+  def perform(contact_id, privacy_policy_id)
+    contact = gitis.find(contact_id)
+
+    gitis.write \
+      Bookings::Gitis::CandidatePrivacyPolicy.build_for_contact \
+        contact.id, privacy_policy_id
+  end
+end

--- a/app/jobs/gitis_job.rb
+++ b/app/jobs/gitis_job.rb
@@ -1,0 +1,11 @@
+class GitisJob < ApplicationJob
+private
+
+  def gitis_token
+    Bookings::Gitis::Auth.new.token
+  end
+
+  def gitis
+    Bookings::Gitis::CRM.new gitis_token
+  end
+end

--- a/app/services/bookings/gitis/accept_privacy_policy.rb
+++ b/app/services/bookings/gitis/accept_privacy_policy.rb
@@ -1,0 +1,33 @@
+module Bookings
+  module Gitis
+    class AcceptPrivacyPolicy
+      attr_reader :contact_id, :policy_id
+
+      def initialize(crm, contact_id, policy_id)
+        @crm = crm
+        @contact_id = contact_id
+        @policy_id = policy_id
+      end
+
+      def accept!
+        @crm.write build
+      end
+
+      def contact
+        @contact ||= @crm.find(contact_id)
+      end
+
+    private
+
+      def build
+        CandidatePrivacyPolicy.new \
+          'dfe_name' => "Online consent as part of school experience registration",
+          'dfe_consentreceivedby' => PrivacyPolicy.consent,
+          'dfe_meanofconsent' => PrivacyPolicy.consent,
+          'dfe_timeofconsent' => Time.now.utc.iso8601,
+          '_dfe_candidate_value' => contact.id,
+          '_dfe_privacypolicynumber_value' => @policy_id
+      end
+    end
+  end
+end

--- a/app/services/bookings/gitis/candidate_privacy_policy.rb
+++ b/app/services/bookings/gitis/candidate_privacy_policy.rb
@@ -1,0 +1,31 @@
+module Bookings::Gitis
+  class CandidatePrivacyPolicy
+    include Entity
+
+    self.entity_path = 'dfe_candidateprivacypolicies'
+
+    entity_id_attribute :dfe_candidateprivacypolicyid
+    entity_attribute :dfe_name
+    entity_attribute :dfe_consentreceivedby
+    entity_attribute :dfe_meanofconsent
+    entity_attribute :dfe_timeofconsent
+
+    entity_association :dfe_Candidate, Contact
+    entity_association :dfe_PrivacyPolicyNumber, PrivacyPolicy
+
+    def initialize(crm_data = {})
+      crm_data = crm_data.stringify_keys
+
+      self.dfe_candidateprivacypolicyid = crm_data['dfe_candidateprivacypolicyid']
+      self.dfe_name                     = crm_data['dfe_name']
+      self.dfe_consentreceivedby        = crm_data['dfe_consentreceivedby']
+      self.dfe_meanofconsent            = crm_data['dfe_meanofconsent']
+      self.dfe_timeofconsent            = crm_data['dfe_timeofconsent']
+
+      self.dfe_Candidate                = crm_data['_dfe_candidate_value']
+      self.dfe_PrivacyPolicyNumber      = crm_data['_dfe_privacypolicynumber_value']
+
+      super
+    end
+  end
+end

--- a/app/services/bookings/gitis/candidate_privacy_policy.rb
+++ b/app/services/bookings/gitis/candidate_privacy_policy.rb
@@ -13,14 +13,14 @@ module Bookings::Gitis
     entity_association :dfe_Candidate, Contact
     entity_association :dfe_PrivacyPolicyNumber, PrivacyPolicy
 
-    def self.build_for_contact(contact)
+    def self.build_for_contact(contact_id, policy_id)
       new \
         'dfe_name' => "Online consent as part of school experience registration",
         'dfe_consentreceivedby' => PrivacyPolicy.consent,
         'dfe_meanofconsent' => PrivacyPolicy.consent,
         'dfe_timeofconsent' => Time.now.utc.iso8601,
-        '_dfe_candidate_value' => contact.id,
-        '_dfe_privacypolicynumber_value' => PrivacyPolicy.default
+        '_dfe_candidate_value' => contact_id,
+        '_dfe_privacypolicynumber_value' => policy_id
     end
 
     def initialize(crm_data = {})

--- a/app/services/bookings/gitis/candidate_privacy_policy.rb
+++ b/app/services/bookings/gitis/candidate_privacy_policy.rb
@@ -13,6 +13,16 @@ module Bookings::Gitis
     entity_association :dfe_Candidate, Contact
     entity_association :dfe_PrivacyPolicyNumber, PrivacyPolicy
 
+    def self.build_for_contact(contact)
+      new \
+        'dfe_name' => "Online consent as part of school experience registration",
+        'dfe_consentreceivedby' => PrivacyPolicy.consent,
+        'dfe_meanofconsent' => PrivacyPolicy.consent,
+        'dfe_timeofconsent' => Time.now.utc.iso8601,
+        '_dfe_candidate_value' => contact.id,
+        '_dfe_privacypolicynumber_value' => PrivacyPolicy.default
+    end
+
     def initialize(crm_data = {})
       crm_data = crm_data.stringify_keys
 

--- a/app/services/bookings/gitis/candidate_privacy_policy.rb
+++ b/app/services/bookings/gitis/candidate_privacy_policy.rb
@@ -13,16 +13,6 @@ module Bookings::Gitis
     entity_association :dfe_Candidate, Contact
     entity_association :dfe_PrivacyPolicyNumber, PrivacyPolicy
 
-    def self.build_for_contact(contact_id, policy_id)
-      new \
-        'dfe_name' => "Online consent as part of school experience registration",
-        'dfe_consentreceivedby' => PrivacyPolicy.consent,
-        'dfe_meanofconsent' => PrivacyPolicy.consent,
-        'dfe_timeofconsent' => Time.now.utc.iso8601,
-        '_dfe_candidate_value' => contact_id,
-        '_dfe_privacypolicynumber_value' => policy_id
-    end
-
     def initialize(crm_data = {})
       crm_data = crm_data.stringify_keys
 

--- a/app/services/bookings/gitis/privacy_policy.rb
+++ b/app/services/bookings/gitis/privacy_policy.rb
@@ -9,6 +9,16 @@ module Bookings::Gitis
     entity_attribute :dfe_name
     entity_attribute :dfe_active
 
+    class << self
+      def default
+        Rails.application.config.x.gitis.privacy_policy_id
+      end
+
+      def consent
+        Rails.application.config.x.gitis.privacy_consent_id
+      end
+    end
+
     def initialize(crm_data = {})
       crm_data = crm_data.stringify_keys
 

--- a/app/services/bookings/gitis/privacy_policy.rb
+++ b/app/services/bookings/gitis/privacy_policy.rb
@@ -1,0 +1,23 @@
+module Bookings::Gitis
+  class PrivacyPolicy
+    include Entity
+
+    self.entity_path = 'dfe_privacypolicies'
+
+    entity_id_attribute :dfe_privacypolicyid
+    entity_attribute :dfe_policyid
+    entity_attribute :dfe_name
+    entity_attribute :dfe_active
+
+    def initialize(crm_data = {})
+      crm_data = crm_data.stringify_keys
+
+      self.dfe_privacypolicyid  = crm_data['dfe_privacypolicyid']
+      self.dfe_policyid         = crm_data['dfe_policyid']
+      self.dfe_name             = crm_data['dfe_name']
+      self.dfe_active           = crm_data['dfe_active']
+
+      super
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -103,7 +103,7 @@ Rails.application.configure do
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
   config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION', '0')
   config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
-  config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACYPOLICY_ID'].presence
+  config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence
   if config.x.gitis.privacy_policy_id
     config.x.gitis.privacy_consent_id = ENV.fetch('CRM_PRIVACY_CONSENT_ID')
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -103,6 +103,10 @@ Rails.application.configure do
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
   config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION', '0')
   config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
+  config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACYPOLICY_ID'].presence
+  if config.x.gitis.privacy_policy_id
+    config.x.gitis.privacy_consent_id = ENV.fetch('CRM_PRIVACY_CONSENT_ID')
+  end
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -141,6 +141,10 @@ Rails.application.configure do
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
     config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
+    config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACYPOLICY_ID'].presence
+    if config.x.gitis.privacy_policy_id
+      config.x.gitis.privacy_consent_id = ENV.fetch('CRM_PRIVACY_CONSENT_ID')
+    end
   end
 
   config.x.features = []

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -141,7 +141,7 @@ Rails.application.configure do
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
     config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
-    config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACYPOLICY_ID'].presence
+    config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence
     if config.x.gitis.privacy_policy_id
       config.x.gitis.privacy_consent_id = ENV.fetch('CRM_PRIVACY_CONSENT_ID')
     end

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -24,5 +24,8 @@ Rails.application.configure do
   config.x.gitis.fake_crm = true
   config.x.gitis.channel_creation = '0'
   config.x.gitis.country_id = SecureRandom.uuid
+  config.x.gitis.privacy_policy_id = SecureRandom.uuid
+  config.x.gitis.privacy_consent_id = '10'
+
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -81,6 +81,8 @@ Rails.application.configure do
   config.x.gitis.fake_crm = true
   config.x.gitis.channel_creation = '0'
   config.x.gitis.country_id = SecureRandom.uuid
+  config.x.gitis.privacy_policy_id = SecureRandom.uuid
+  config.x.gitis.privacy_consent_id = '10'
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -76,7 +76,11 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
 
         shared_examples 'a successful create' do
           before do
-            allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return(true)
+            allow(Bookings::LogToGitisJob).to \
+              receive(:perform_later).and_return(true)
+
+            allow(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
+              receive(:perform_later).and_return(true)
 
             expect(fake_gitis).to receive(:create_entity) do |entity_id, _data|
               "#{entity_id}(#{fake_gitis_uuid})"
@@ -119,6 +123,13 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
                 uuid,
                 candidates_cancel_url(Bookings::PlacementRequest.last.token),
                 schools_placement_request_url(Bookings::PlacementRequest.last)
+          end
+
+          it 'enqueues an accept privacy policy job' do
+            expect(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
+              have_received(:perform_later).with \
+                fake_gitis_uuid,
+                Bookings::Gitis::PrivacyPolicy.default
           end
 
           it 'enqueues a log to gitis job' do

--- a/spec/jobs/candidates/registrations/accept_privacy_policy_job_spec.rb
+++ b/spec/jobs/candidates/registrations/accept_privacy_policy_job_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::AcceptPrivacyPolicyJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+  include_context 'fake gitis with known uuid'
+
+  before do
+    allow_any_instance_of(described_class).to \
+      receive(:gitis).and_return(fake_gitis)
+  end
+
+  context '#perform' do
+    before do
+      allow(described_class.queue_adapter).to \
+        receive(:perform_enqueued_jobs).and_return(true)
+    end
+
+    context 'on error' do
+      before do
+        allow(described_class.queue_adapter).to receive(:enqueue_at).and_return(true)
+        allow(fake_gitis).to receive(:write) { raise "network error" }
+
+        freeze_time
+
+        described_class.perform_later \
+          fake_gitis_uuid, Bookings::Gitis::PrivacyPolicy.default
+      end
+
+      it 'retrys the job' do
+        expect(described_class.queue_adapter).to \
+          have_received(:enqueue_at).with \
+            an_instance_of(described_class),
+            described_class::RETRYS.first.from_now.to_i
+      end
+    end
+
+    context 'on success' do
+      before do
+        allow(fake_gitis).to receive(:create_entity).and_return(SecureRandom.uuid)
+
+        freeze_time
+
+        described_class.perform_later \
+          fake_gitis_uuid, Bookings::Gitis::PrivacyPolicy.default
+      end
+
+      it "creates a CandidatePrivacyPolicy entity" do
+        expect(fake_gitis).to have_received(:create_entity).with \
+          'dfe_candidateprivacypolicies', hash_including(
+            'dfe_meanofconsent' => Bookings::Gitis::PrivacyPolicy.consent,
+            'dfe_timeofconsent' => Time.now.utc.iso8601,
+            'dfe_Candidate@odata.bind' => "contacts(#{fake_gitis_uuid})",
+            'dfe_PrivacyPolicyNumber@odata.bind' =>
+              "dfe_privacypolicies(#{Bookings::Gitis::PrivacyPolicy.default})"
+          )
+      end
+    end
+  end
+end

--- a/spec/services/bookings/gitis/accept_privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/accept_privacy_policy_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe Bookings::Gitis::AcceptPrivacyPolicy do
+  include ActiveSupport::Testing::TimeHelpers
+  include_context 'fake gitis'
+  let(:contact) { build(:gitis_contact, :persisted) }
+  let(:policy_id) { SecureRandom.uuid }
+  let(:candidate_pp_id) { SecureRandom.uuid }
+  let(:consent_id) { Bookings::Gitis::PrivacyPolicy.consent }
+  let(:cpp_entity_path) { Bookings::Gitis::CandidatePrivacyPolicy.entity_path }
+  let(:pp_entity_path) { Bookings::Gitis::PrivacyPolicy.entity_path }
+
+  describe '.new' do
+    subject { described_class.new(fake_gitis, contact.id, policy_id) }
+    it { is_expected.to be_kind_of Bookings::Gitis::AcceptPrivacyPolicy }
+    it { is_expected.to have_attributes(contact_id: contact.id) }
+    it { is_expected.to have_attributes(policy_id: policy_id) }
+  end
+
+  describe '#build' do
+    before { freeze_time }
+
+    subject do
+      described_class.new(fake_gitis, contact.id, policy_id).send(:build)
+    end
+
+    it { is_expected.to have_attributes(dfe_candidateprivacypolicyid: nil) }
+    it { is_expected.to have_attributes(dfe_name: /school experience/) }
+    it { is_expected.to have_attributes(dfe_consentreceivedby: consent_id) }
+    it { is_expected.to have_attributes(dfe_meanofconsent: consent_id) }
+    it { is_expected.to have_attributes(dfe_timeofconsent: Time.now.utc.iso8601) }
+    it { is_expected.to have_attributes(_dfe_candidate_value: contact.id) }
+    it { is_expected.to have_attributes(_dfe_privacypolicynumber_value: policy_id) }
+  end
+
+  describe '#accept!' do
+    before do
+      allow(fake_gitis).to \
+        receive(:create_entity).
+        and_return("#{cpp_entity_path}(#{candidate_pp_id})")
+
+      freeze_time
+    end
+
+    subject! { described_class.new(fake_gitis, contact.id, policy_id).accept! }
+
+    it "will write to gitis" do
+      expect(fake_gitis).to have_received(:create_entity).with \
+        cpp_entity_path,
+        'dfe_name' => /school experience/,
+        'dfe_consentreceivedby' => consent_id,
+        'dfe_meanofconsent' => consent_id,
+        'dfe_timeofconsent' => Time.now.utc.iso8601,
+        'dfe_Candidate@odata.bind' => contact.entity_id,
+        'dfe_PrivacyPolicyNumber@odata.bind' => "#{pp_entity_path}(#{policy_id})"
+    end
+  end
+end

--- a/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Bookings::Gitis::CandidatePrivacyPolicy, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
   let(:uuid) { SecureRandom.uuid }
 
   describe '.entity_path' do
@@ -49,5 +51,23 @@ RSpec.describe Bookings::Gitis::CandidatePrivacyPolicy, type: :model do
     it { is_expected.to have_attributes(_dfe_candidate_value: candidate_uuid) }
     it { is_expected.to have_attributes(_dfe_privacypolicynumber_value: privacypolicy_uuid) }
     it { is_expected.to have_attributes(changed_attributes: {}) }
+  end
+
+  describe '.build_for_contact' do
+    let(:contact) { build(:gitis_contact) }
+    before { freeze_time }
+    subject { described_class.build_for_contact(contact) }
+
+    it { is_expected.to have_attributes(dfe_candidateprivacypolicyid: nil) }
+    it { is_expected.to have_attributes(dfe_name: /school experience/) }
+    it { is_expected.to have_attributes(dfe_consentreceivedby: Bookings::Gitis::PrivacyPolicy.consent) }
+    it { is_expected.to have_attributes(dfe_meanofconsent: Bookings::Gitis::PrivacyPolicy.consent) }
+    it { is_expected.to have_attributes(dfe_timeofconsent: Time.now.utc.iso8601) }
+    it { is_expected.to have_attributes(_dfe_candidate_value: contact.id) }
+    it do
+      is_expected.to have_attributes(
+        _dfe_privacypolicynumber_value: Bookings::Gitis::PrivacyPolicy.default
+      )
+    end
   end
 end

--- a/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
@@ -55,8 +55,9 @@ RSpec.describe Bookings::Gitis::CandidatePrivacyPolicy, type: :model do
 
   describe '.build_for_contact' do
     let(:contact) { build(:gitis_contact) }
+    let(:privacypolicy_uuid) { SecureRandom.uuid }
     before { freeze_time }
-    subject { described_class.build_for_contact(contact) }
+    subject { described_class.build_for_contact(contact.id, privacypolicy_uuid) }
 
     it { is_expected.to have_attributes(dfe_candidateprivacypolicyid: nil) }
     it { is_expected.to have_attributes(dfe_name: /school experience/) }
@@ -66,7 +67,7 @@ RSpec.describe Bookings::Gitis::CandidatePrivacyPolicy, type: :model do
     it { is_expected.to have_attributes(_dfe_candidate_value: contact.id) }
     it do
       is_expected.to have_attributes(
-        _dfe_privacypolicynumber_value: Bookings::Gitis::PrivacyPolicy.default
+        _dfe_privacypolicynumber_value: privacypolicy_uuid
       )
     end
   end

--- a/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::Gitis::CandidatePrivacyPolicy, type: :model do
+  let(:uuid) { SecureRandom.uuid }
+
+  describe '.entity_path' do
+    subject { described_class.entity_path }
+    it { is_expected.to eq('dfe_candidateprivacypolicies') }
+  end
+
+  describe '.primary_key' do
+    subject { described_class.primary_key }
+    it { is_expected.to eq('dfe_candidateprivacypolicyid') }
+  end
+
+  describe 'attributes' do
+    it { is_expected.to respond_to :dfe_candidateprivacypolicyid }
+    it { is_expected.to respond_to :dfe_name }
+    it { is_expected.to respond_to :dfe_consentreceivedby }
+    it { is_expected.to respond_to :dfe_meanofconsent }
+    it { is_expected.to respond_to :dfe_timeofconsent }
+    it { is_expected.to respond_to :'dfe_Candidate@odata.bind' }
+    it { is_expected.to respond_to :_dfe_candidate_value }
+    it { is_expected.to respond_to :'dfe_PrivacyPolicyNumber@odata.bind' }
+    it { is_expected.to respond_to :_dfe_privacypolicynumber_value }
+  end
+
+  describe '.new' do
+    let(:candidate_uuid) { SecureRandom.uuid }
+    let(:privacypolicy_uuid) { SecureRandom.uuid }
+
+    subject do
+      described_class.new(
+        'dfe_candidateprivacypolicyid' => uuid,
+        'dfe_name' => "school experience",
+        'dfe_consentreceivedby' => '100',
+        'dfe_meanofconsent' => '100',
+        'dfe_timeofconsent' => Time.now.utc.iso8601,
+        '_dfe_candidate_value' => candidate_uuid,
+        '_dfe_privacypolicynumber_value' => privacypolicy_uuid
+      )
+    end
+
+    it { is_expected.to have_attributes(dfe_candidateprivacypolicyid: uuid) }
+    it { is_expected.to have_attributes(dfe_name: 'school experience') }
+    it { is_expected.to have_attributes(dfe_consentreceivedby: '100') }
+    it { is_expected.to have_attributes(dfe_meanofconsent: '100') }
+    it { is_expected.to have_attributes(dfe_timeofconsent: Time.now.utc.iso8601) }
+    it { is_expected.to have_attributes(_dfe_candidate_value: candidate_uuid) }
+    it { is_expected.to have_attributes(_dfe_privacypolicynumber_value: privacypolicy_uuid) }
+    it { is_expected.to have_attributes(changed_attributes: {}) }
+  end
+end

--- a/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/candidate_privacy_policy_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Bookings::Gitis::CandidatePrivacyPolicy, type: :model do
-  include ActiveSupport::Testing::TimeHelpers
-
   let(:uuid) { SecureRandom.uuid }
 
   describe '.entity_path' do
@@ -51,24 +49,5 @@ RSpec.describe Bookings::Gitis::CandidatePrivacyPolicy, type: :model do
     it { is_expected.to have_attributes(_dfe_candidate_value: candidate_uuid) }
     it { is_expected.to have_attributes(_dfe_privacypolicynumber_value: privacypolicy_uuid) }
     it { is_expected.to have_attributes(changed_attributes: {}) }
-  end
-
-  describe '.build_for_contact' do
-    let(:contact) { build(:gitis_contact) }
-    let(:privacypolicy_uuid) { SecureRandom.uuid }
-    before { freeze_time }
-    subject { described_class.build_for_contact(contact.id, privacypolicy_uuid) }
-
-    it { is_expected.to have_attributes(dfe_candidateprivacypolicyid: nil) }
-    it { is_expected.to have_attributes(dfe_name: /school experience/) }
-    it { is_expected.to have_attributes(dfe_consentreceivedby: Bookings::Gitis::PrivacyPolicy.consent) }
-    it { is_expected.to have_attributes(dfe_meanofconsent: Bookings::Gitis::PrivacyPolicy.consent) }
-    it { is_expected.to have_attributes(dfe_timeofconsent: Time.now.utc.iso8601) }
-    it { is_expected.to have_attributes(_dfe_candidate_value: contact.id) }
-    it do
-      is_expected.to have_attributes(
-        _dfe_privacypolicynumber_value: privacypolicy_uuid
-      )
-    end
   end
 end

--- a/spec/services/bookings/gitis/privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/privacy_policy_spec.rb
@@ -36,4 +36,26 @@ RSpec.describe Bookings::Gitis::PrivacyPolicy, type: :model do
     it { is_expected.to have_attributes(dfe_active: true) }
     it { is_expected.to have_attributes(changed_attributes: {}) }
   end
+
+  describe '.default' do
+    let(:pp_uuid) { SecureRandom.uuid }
+
+    before do
+      allow(Rails.application.config.x.gitis).to \
+        receive(:privacy_policy_id).and_return(pp_uuid)
+    end
+
+    it { expect(described_class.default).to eql(pp_uuid) }
+  end
+
+  describe '.consent' do
+    let(:consent) { '10' }
+
+    before do
+      allow(Rails.application.config.x.gitis).to \
+        receive(:privacy_consent_id).and_return(consent)
+    end
+
+    it { expect(described_class.consent).to eql(consent) }
+  end
 end

--- a/spec/services/bookings/gitis/privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/privacy_policy_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Bookings::Gitis::PrivacyPolicy, type: :model do
+  let(:uuid) { SecureRandom.uuid }
+
+  describe '.entity_path' do
+    subject { described_class.entity_path }
+    it { is_expected.to eq('dfe_privacypolicies') }
+  end
+
+  describe '.primary_key' do
+    subject { described_class.primary_key }
+    it { is_expected.to eq('dfe_privacypolicyid') }
+  end
+
+  describe 'attributes' do
+    it { is_expected.to respond_to :dfe_name }
+    it { is_expected.to respond_to :dfe_privacypolicyid }
+    it { is_expected.to respond_to :dfe_policyid }
+    it { is_expected.to respond_to :dfe_active }
+  end
+
+  describe '.new' do
+    subject do
+      described_class.new(
+        'dfe_privacypolicyid' => uuid,
+        'dfe_policyid' => 1,
+        'dfe_active' => true,
+        'dfe_name' => 'Test Policy'
+      )
+    end
+
+    it { is_expected.to have_attributes(dfe_privacypolicyid: uuid) }
+    it { is_expected.to have_attributes(dfe_policyid: 1) }
+    it { is_expected.to have_attributes(dfe_name: 'Test Policy') }
+    it { is_expected.to have_attributes(dfe_active: true) }
+    it { is_expected.to have_attributes(changed_attributes: {}) }
+  end
+end

--- a/spec_external/gitis_crm_spec.rb
+++ b/spec_external/gitis_crm_spec.rb
@@ -387,7 +387,6 @@ RSpec.describe "The GITIS CRM Api" do
   def update_contact_data(existing_data)
     {
       'lastname' => 'New Last Name',
-      'dfe_hasdbscertificate' => false,
       'dfe_dateofissueofdbscertificate' => nil,
       'dfe_notesforclassroomexperience' =>
         existing_data['dfe_notesforclassroomexperience'] +


### PR DESCRIPTION
### Context

When a Candidate completes the application process, they accept the current privacy.

### Changes proposed in this pull request

1. Record acceptance of this within Gitis by creating an appropriate dfe_CandidatePrivacyPolicy entity for any new Contacts we create

### Guidance to review

1. Code review

### Notes

This currently only applies to new Contacts - there will be a follow on PR for existing contacts.
