### PR TITLE
Switch to simplified notification email for schools

### DIFF
--- a/app/jobs/candidates/registrations/placement_request_job.rb
+++ b/app/jobs/candidates/registrations/placement_request_job.rb
@@ -8,10 +8,10 @@ module Candidates
         application_preview  = ApplicationPreview.new registration_session
 
         if Rails.application.config.x.phase >= 4
-          NotifyEmail::SchoolRequestConfirmationWithPlacementRequestUrl.from_application_preview(
-            registration_session.school.notification_emails,
-            application_preview,
-            placement_request_url
+          NotifyEmail::SchoolRequestConfirmationLinkOnly.new(
+            to: registration_session.school.notification_emails,
+            school_name: registration_session.school_name,
+            placement_request_url: placement_request_url
           ).despatch_later!
 
           NotifyEmail::CandidateRequestConfirmationWithConfirmationLink.from_application_preview(

--- a/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
+++ b/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
@@ -1,0 +1,15 @@
+Hello,
+
+A candidate has requested school experience at ((school_name)).
+
+^ You should try and make a decision on their request within 10 working days (term time).
+
+# View the request 
+ 
+To view and manage the request use the following link:
+
+View the request – ((placement_request_url))
+
+Help and support
+ 
+If you’ve got any feedback, questions or would like to take part in user testing contact us at organise.schoolexperience@education.gov.uk.

--- a/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
+++ b/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
@@ -10,6 +10,6 @@ To view and manage the request use the following link:
 
 View the request – ((placement_request_url))
 
-Help and support
+# Help and support
  
 If you’ve got any feedback, questions or would like to take part in user testing contact us at organise.schoolexperience@education.gov.uk.

--- a/app/notify/notify_email/school_request_confirmation_link_only.rb
+++ b/app/notify/notify_email/school_request_confirmation_link_only.rb
@@ -1,0 +1,22 @@
+class NotifyEmail::SchoolRequestConfirmationLinkOnly < Notify
+  attr_accessor :school_name, :placement_request_url
+
+  def initialize(to:, school_name:, placement_request_url:)
+    self.school_name = school_name
+    self.placement_request_url = placement_request_url
+    super(to: to)
+  end
+
+private
+
+  def template_id
+    '2a5a54b8-17cb-4da8-94ce-1647d6bf1da3'
+  end
+
+  def personalisation
+    {
+      school_name: school_name,
+      placement_request_url: placement_request_url
+    }
+  end
+end

--- a/spec/jobs/candidates/registrations/placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/placement_request_job_spec.rb
@@ -24,8 +24,8 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
     double NotifyEmail::CandidateRequestConfirmation, despatch_later!: true
   end
 
-  let :school_request_confirmation_notification_with_placement_request_url do
-    double NotifyEmail::SchoolRequestConfirmationWithPlacementRequestUrl, despatch_later!: true
+  let :school_request_confirmation_notification_link_only do
+    double NotifyEmail::SchoolRequestConfirmationLinkOnly, despatch_later!: true
   end
 
   let :candidate_request_confirmation_notification_with_confirmation_link do
@@ -52,8 +52,8 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
     allow(NotifyEmail::CandidateRequestConfirmation).to \
       receive(:from_application_preview) { candidate_request_confirmation_notification }
 
-    allow(NotifyEmail::SchoolRequestConfirmationWithPlacementRequestUrl).to \
-      receive(:from_application_preview) { school_request_confirmation_notification_with_placement_request_url }
+    allow(NotifyEmail::SchoolRequestConfirmationLinkOnly).to \
+      receive(:new) { school_request_confirmation_notification_link_only }
 
     allow(NotifyEmail::CandidateRequestConfirmationWithConfirmationLink).to \
       receive(:from_application_preview) { candidate_request_confirmation_notification_with_confirmation_link }
@@ -104,13 +104,13 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
         end
 
         it 'notifies the school' do
-          expect(NotifyEmail::SchoolRequestConfirmationWithPlacementRequestUrl).to \
-            have_received(:from_application_preview).with \
-              school.notification_emails,
-              application_preview,
-              placement_request_url
+          expect(NotifyEmail::SchoolRequestConfirmationLinkOnly).to \
+            have_received(:new).with \
+              to: school.notification_emails,
+              school_name: school.name,
+              placement_request_url: placement_request_url
 
-          expect(school_request_confirmation_notification_with_placement_request_url).to \
+          expect(school_request_confirmation_notification_link_only).to \
             have_received :despatch_later!
         end
 

--- a/spec/notify/notify_email/school_request_confirmation_link_only_spec.rb
+++ b/spec/notify/notify_email/school_request_confirmation_link_only_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+describe NotifyEmail::SchoolRequestConfirmationLinkOnly do
+  it_should_behave_like "email template", "2a5a54b8-17cb-4da8-94ce-1647d6bf1da3",
+    school_name: "First School",
+    placement_request_url: "https://schoolexperience.education.gov.uk/test/request"
+end


### PR DESCRIPTION
### Context

We want School Administratrors to use our Dashboard to view Placement Requests and interact with the service.

### Changes proposed in this pull request

1. Removed information from the Email so they are required to engage with the service.

### Guidance to review

1. Code review
2. Test url in email works
