### PR TITLE
Populate entity attributes on initialize

### DIFF
--- a/app/services/bookings/gitis/candidate_privacy_policy.rb
+++ b/app/services/bookings/gitis/candidate_privacy_policy.rb
@@ -12,20 +12,5 @@ module Bookings::Gitis
 
     entity_association :dfe_Candidate, Contact
     entity_association :dfe_PrivacyPolicyNumber, PrivacyPolicy
-
-    def initialize(crm_data = {})
-      crm_data = crm_data.stringify_keys
-
-      self.dfe_candidateprivacypolicyid = crm_data['dfe_candidateprivacypolicyid']
-      self.dfe_name                     = crm_data['dfe_name']
-      self.dfe_consentreceivedby        = crm_data['dfe_consentreceivedby']
-      self.dfe_meanofconsent            = crm_data['dfe_meanofconsent']
-      self.dfe_timeofconsent            = crm_data['dfe_timeofconsent']
-
-      self.dfe_Candidate                = crm_data['_dfe_candidate_value']
-      self.dfe_PrivacyPolicyNumber      = crm_data['_dfe_privacypolicynumber_value']
-
-      super
-    end
   end
 end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -34,42 +34,12 @@ module Bookings
       end
 
       def initialize(crm_contact_data = {})
-        @crm_data                             = crm_contact_data.stringify_keys
-        self.contactid                        = @crm_data['contactid']
-        self.firstname                        = @crm_data['firstname']
-        self.lastname                         = @crm_data['lastname']
-        self.emailaddress1                    = @crm_data['emailaddress1']
-        self.emailaddress2                    = @crm_data['emailaddress2']
-        self.telephone1                       = @crm_data['telephone1']
-        self.telephone2                       = @crm_data['telephone2']
-        self.address1_line1                   = @crm_data['address1_line1']
-        self.address1_line2                   = @crm_data['address1_line2']
-        self.address1_line3                   = @crm_data['address1_line3']
-        self.address1_city                    = @crm_data['address1_city']
-        self.address1_stateorprovince         = @crm_data['address1_stateorprovince']
-        self.address1_postalcode              = @crm_data['address1_postalcode']
-        self.address1_telephone1              = @crm_data['address1_telephone1']
-        self.birthdate                        = @crm_data['birthdate']
-        self.dfe_channelcreation              = @crm_data['dfe_channelcreation'] || self.class.channel_creation
-        self.dfe_hasdbscertificate            = @crm_data['dfe_hasdbscertificate']
-        self.dfe_dateofissueofdbscertificate  = @crm_data['dfe_dateofissueofdbscertificate']
-        self.dfe_notesforclassroomexperience  = @crm_data['dfe_notesforclassroomexperience']
-        self.dfe_Country                      = @crm_data['_dfe_countryid_value'] || Country.default
-        self.dfe_PreferredTeachingSubject01   = @crm_data['_dfe_preferredteachingsubject01_value']
-        self.dfe_PreferredTeachingSubject02   = @crm_data['_dfe_preferredteachingsubject02_value']
+        @crm_data = crm_contact_data.stringify_keys
 
-        super # handles resetting dirty attributes
+        super # handles populating
 
-        if @crm_data['emailaddress2'].blank? && @crm_data['emailaddress1'].present?
-          self.emailaddress2 = @crm_data['emailaddress1']
-        end
-
-        if @crm_data['telephone2'].blank?
-          self.telephone2 = @crm_data['mobilephone'].presence || \
-            @crm_data['address1_telephone1'].presence || \
-            @crm_data['telephone1'].presence || \
-            self.telephone2
-        end
+        set_email_address_2_if_blank
+        set_telephone_2_if_blank @crm_data
       end
 
       def created_by_us?
@@ -157,6 +127,30 @@ module Bookings
         end
 
         self.dfe_notesforclassroomexperience = "#{dfe_notesforclassroomexperience}#{log_line}\r\n"
+      end
+
+    private
+
+      def populate(attrs)
+        super
+
+        self.dfe_channelcreation  = self.class.channel_creation unless dfe_channelcreation.present?
+        self.dfe_Country          = Country.default unless _dfe_country_value.present?
+      end
+
+      def set_email_address_2_if_blank
+        return if emailaddress2.present? || emailaddress1.blank?
+
+        self.emailaddress2 = emailaddress1
+      end
+
+      def set_telephone_2_if_blank(data = {})
+        return if telephone2.present?
+
+        self.telephone2 = data['mobilephone'].presence || \
+          data['address1_telephone1'].presence || \
+          data['telephone1'].presence || \
+          telephone2
       end
     end
   end

--- a/app/services/bookings/gitis/country.rb
+++ b/app/services/bookings/gitis/country.rb
@@ -10,14 +10,5 @@ module Bookings::Gitis
     def self.default
       Rails.application.config.x.gitis.country_id
     end
-
-    def initialize(crm_data = {})
-      crm_data = crm_data.stringify_keys
-
-      self.dfe_countryid = crm_data['dfe_countryid']
-      self.dfe_name = crm_data['dfe_name']
-
-      super
-    end
   end
 end

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -30,7 +30,9 @@ module Bookings::Gitis
       self.update_blacklist = []
     end
 
-    def initialize(*_args)
+    def initialize(attrs = {})
+      populate attrs
+
       reset_dirty_attributes if persisted?
     end
 
@@ -98,6 +100,19 @@ module Bookings::Gitis
     end
 
     class InvalidEntityIdError < RuntimeError; end
+
+  private
+
+    def populate(attrs)
+      attrs.stringify_keys.each do |attr_name, value|
+        if self.class.primary_key == attr_name ||
+            (respond_to?(:"#{attr_name}=") &&
+            self.class.select_attribute_names.include?(attr_name))
+
+          send(:"#{attr_name}=", value)
+        end
+      end
+    end
 
     module ClassMethods
       def attributes_to_select

--- a/app/services/bookings/gitis/privacy_policy.rb
+++ b/app/services/bookings/gitis/privacy_policy.rb
@@ -18,16 +18,5 @@ module Bookings::Gitis
         Rails.application.config.x.gitis.privacy_consent_id
       end
     end
-
-    def initialize(crm_data = {})
-      crm_data = crm_data.stringify_keys
-
-      self.dfe_privacypolicyid  = crm_data['dfe_privacypolicyid']
-      self.dfe_policyid         = crm_data['dfe_policyid']
-      self.dfe_name             = crm_data['dfe_name']
-      self.dfe_active           = crm_data['dfe_active']
-
-      super
-    end
   end
 end

--- a/app/services/bookings/gitis/teaching_subject.rb
+++ b/app/services/bookings/gitis/teaching_subject.rb
@@ -6,14 +6,5 @@ module Bookings::Gitis
 
     entity_id_attribute :dfe_teachingsubjectlistid
     entity_attribute :dfe_name
-
-    def initialize(crm_data = {})
-      crm_data = crm_data.stringify_keys
-
-      self.dfe_teachingsubjectlistid = crm_data['dfe_teachingsubjectlistid']
-      self.dfe_name = crm_data['dfe_name']
-
-      super
-    end
   end
 end

--- a/spec/services/bookings/gitis/entity_spec.rb
+++ b/spec/services/bookings/gitis/entity_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Bookings::Gitis::Entity do
   describe "#attributes" do
     it do
       expect(subject.send(:attributes)).to \
-        eq('firstname' => 'test', 'lastname' => 'user', 'testentityid' => nil)
+        eq('firstname' => 'test', 'lastname' => 'user')
     end
   end
 

--- a/spec/support/test_entity.rb
+++ b/spec/support/test_entity.rb
@@ -7,13 +7,5 @@ shared_context 'test entity' do
     entity_attributes :hidden, internal: true
     entity_attributes :notcreate, except: :create
     entity_attributes :notupdate, except: :update
-
-    def initialize(data = {})
-      self.testentityid = data['testentityid']
-      self.firstname = data['firstname']
-      self.lastname = data['lastname']
-
-      super
-    end
   end
 end


### PR DESCRIPTION
### Context

Currently we require manual assignment of entity attributes on initialize - this is a product of prior assumptions on how we'd handle mapping attributes and is no longer necessary.

### Changes proposed in this pull request

1. Automatically assign recognised entity attributes as part of the default initialize method.
2. Added an inheritable method to define custom assignments.

### Guidance to review

1. Code review