### PR TITLE
Don't show the action list when it's not required SE-1593

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,8 +46,8 @@ module ApplicationHelper
     request.path.start_with?('/schools')
   end
 
-  def summary_row(key, value, change_path = nil, id: nil)
-    action = change_path ? link_to('Change', change_path, 'aria-label': "Change #{key}") : ""
+  def summary_row(key, value, change_path = nil, id: nil, show_action: true)
+    action = show_action && (change_path ? link_to('Change', change_path, 'aria-label': "Change #{key}") : "")
 
     render \
       partial: "shared/list_row",

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -113,9 +113,9 @@
           </h2>
 
           <dl class="govuk-summary-list">
-            <%= summary_row 'Address', format_school_address(school) %>
-            <%= summary_row 'Education phases', format_school_phases(school) %>
-            <%= summary_row 'Experience subjects', format_school_subjects(school) %>
+            <%= summary_row 'Address', format_school_address(school), nil, show_action: false %>
+            <%= summary_row 'Education phases', format_school_phases(school), nil, show_action: false %>
+            <%= summary_row 'Experience subjects', format_school_subjects(school), nil, show_action: false %>
           </dl>
 
           <%= link_to 'View school details', candidates_school_path(school), class: 'govuk-button', 'aria-label': "View school details for #{school.name}" %>


### PR DESCRIPTION
The summary_row method was always rendering the action element even when
it's not required. Now the summary_row helper takes an additional
show_action argument that overrides its display, in the search results
it is set to false

![Screenshot 2019-09-09 at 16 19 24](https://user-images.githubusercontent.com/128088/64543723-a1963980-d31d-11e9-95fb-4823d8093c86.png)

