### PR TITLE
Remove unnecessary text from candidate start page SE-1676

### DIFF
--- a/app/views/candidates/home/index.html.erb
+++ b/app/views/candidates/home/index.html.erb
@@ -29,8 +29,6 @@
       <h2 class="govuk-heading-m">Before you start</h2>
 
       <p>
-        To request school experience, you’ll need to provide:
-
         By using this service, you'll be registered with the Department for
         Education's <%= link_to 'Get Into Teaching Information Service', 'https://getintoteaching.education.gov.uk/' %>
         to receive tailored advice about becoming a teacher.


### PR DESCRIPTION
Remove an unnecessary bit of text from the candidate home page
