### PR TITLE
Se 1564/dac fixes/focus order

### DIFF
--- a/app/assets/stylesheets/school-search.scss
+++ b/app/assets/stylesheets/school-search.scss
@@ -112,4 +112,8 @@
   }
 }
 
-
+#skip-to-results{
+  &:focus {
+    margin-bottom: 10px !important;
+  }
+}

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -15,6 +15,7 @@
       </button>
 
       <div data-target="collapsible.panel">
+        <%= link_to 'Skip to search results', '#search-results', class: 'govuk-skip-link', id: 'skip-to-results' %>
         <%= form_for @search, as: '',
               method: :get,
               data: {controller: 'instant-filter'},


### PR DESCRIPTION
### Context
Users who navigate with the keyboard have to tab through a large number of filters before getting to the search results.

### Changes proposed in this pull request
Adds a hidden skip to results link that's only focusable via the keyboard.

### Guidance to review
On the search results page start tabbing, expect to see a "skip to results" link appear. Hitting enter on this link should jump you straight to the results and allow you to tab through them.