### PR TITLE
SE-1664 Dont revalidate gitis data

### DIFF
--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -69,7 +69,7 @@ module Candidates
       end
 
       def date_of_birth
-        @personal_information.date_of_birth.strftime '%d/%m/%Y'
+        @personal_information.date_of_birth&.strftime '%d/%m/%Y'
       end
 
       def has_bookings_date?

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -93,6 +93,26 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
         expect(token.candidate.reload).to be_confirmed
       end
     end
+
+    context 'with valid token but invalid Gitis data' do
+      include_context 'candidate signin'
+      let(:gitis_contact_attrs) do
+        attributes_for(:gitis_contact, :persisted, birthdate: nil)
+      end
+
+      before do
+        get candidates_registration_verify_path(school_id, token)
+      end
+
+      it "will redirect_to ContactInformation step" do
+        expect(response).to \
+          redirect_to new_candidates_school_registrations_contact_information_path(school_id)
+      end
+
+      it "will have confirmed candidate" do
+        expect(token.candidate.reload).to be_confirmed
+      end
+    end
   end
 
   describe 'POST #create' do

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -93,6 +93,18 @@ describe Candidates::Registrations::ApplicationPreview do
     it 'returns the correct value' do
       expect(subject.date_of_birth).to eq '01/01/2000'
     end
+
+    context 'with a nil date_of_birth' do
+      let :personal_information do
+        build :personal_information,
+          first_name: 'Testy',
+          last_name: 'McTest',
+          email: 'test@example.com',
+          date_of_birth: nil
+      end
+
+      it { expect(subject.date_of_birth).to be_nil }
+    end
   end
 
   context '#school' do

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -16,6 +16,15 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     it { is_expected.to validate_presence_of :first_name }
     it { is_expected.to validate_presence_of :last_name }
     it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_presence_of :date_of_birth }
+
+    context 'when read only' do
+      subject { described_class.new read_only: true }
+      it { is_expected.not_to validate_presence_of :first_name }
+      it { is_expected.not_to validate_presence_of :last_name }
+      it { is_expected.to validate_presence_of :email }
+      it { is_expected.not_to validate_presence_of :date_of_birth }
+    end
 
     context 'email is present' do
       VALID_EMAILS = ['test@example.com', 'testymctest@gmail.com'].freeze
@@ -169,23 +178,22 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     end
   end
 
-  describe '.email=' do
-    before { subject.email = 'second@test.com' }
+  describe 'with read_only set to true' do
+    let(:pinfo) { described_class.new(read_only: true) }
 
-    context 'with unvalidate emails' do
-      subject do
-        build(:personal_information, email: 'first@test.com', read_only: false)
-      end
-
-      it { is_expected.to have_attributes email: 'second@test.com' }
+    before do
+      pinfo.assign_attributes \
+        first_name: 'test',
+        last_name: 'test',
+        email: 'test@test.com',
+        date_of_birth: Date.parse('1980-01-01')
     end
 
-    context 'with validated emails' do
-      subject do
-        build(:personal_information, email: 'first@test.com', read_only: true)
-      end
+    subject { pinfo }
 
-      it { is_expected.to have_attributes email: 'first@test.com' }
-    end
+    it { is_expected.to have_attributes first_name: nil }
+    it { is_expected.to have_attributes last_name: nil }
+    it { is_expected.to have_attributes email: nil }
+    it { is_expected.to have_attributes date_of_birth: nil }
   end
 end


### PR DESCRIPTION
### Context

Currently we validate the personal information fields we get back from Gitis, but this data may not comply with our validation rules. 

We should also not be letting the user change these it in Gitis. 

This leaves the user unable to progress with their registration.

### Changes proposed in this pull request

1. Don't validate these fields if we will not allow the user to change them.

### Guidance to review

1. Code review
2. Testing
- Change Fake CRM to return a nil date_of_birth
- Start a registration using a private browser
- Simulate device switch by closing down all private browser sessions
- Start a new private browser session, use the verification URL
- You should be able to successfully complete the registration