### PR TITLE
Changed FakeCRM to return a valid postcode

### DIFF
--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -93,7 +93,7 @@ module Bookings::Gitis
         'address1_line3' => 'Third Line',
         'address1_city' => 'Manchester',
         'address1_stateorprovince' => 'Manchester',
-        'address1_postalcode' => 'MA1 1AM',
+        'address1_postalcode' => 'TE57 1NG',
         'address1_telephone1' => '01234 567890',
         'birthdate' => '1980-01-01',
         'dfe_channelcreation' => 10

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -27,7 +27,7 @@ Feature: Viewing a booking
         When I am viewing my chosen booking
         Then I should see a 'Personal details' section with the following values:
             | Heading             | Value                                                                |
-            | Address             | First Line, Second Line, Third Line, Manchester, Manchester, MA1 1AM |
+            | Address             | First Line, Second Line, Third Line, Manchester, Manchester, TE57 1NG |
             | UK telephone number | 07123 456789                                                         |
             | Email address       | second@thisaddress.com                                               |
 

--- a/features/schools/placement_requests/show.feature
+++ b/features/schools/placement_requests/show.feature
@@ -18,7 +18,7 @@ Feature: Viewing a placement request
         When I am on the placement request page
         Then I should see a 'Personal details' section with the following values:
             | Heading             | Value                                                                |
-            | Address             | First Line, Second Line, Third Line, Manchester, Manchester, MA1 1AM |
+            | Address             | First Line, Second Line, Third Line, Manchester, Manchester, TE57 1NG |
             | UK telephone number | 07123 456789                                                         |
             | Email address       | second@thisaddress.com                                               |
 

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -225,7 +225,7 @@ feature 'Candidate Registrations', type: :feature do
       "/candidates/schools/#{school_urn}/registrations/contact_information/new"
 
     # Submit contact information form with errors
-    fill_in 'Building', with: 'Test house'
+    fill_in 'Building', with: ''
     click_button 'Continue'
     expect(page).to have_text 'There is a problem'
 


### PR DESCRIPTION
### Context

Fake CRM currently returns an invalid postcode. This results in the registration specs for a known candidate passing 'accidentally'

Its also annoying when doing manual testing with fake crm.

### Changes proposed in this pull request

1. Changed FakeCRM to return a valid postcode

### Guidance to review

1. Code review
