### PR TITLE
Removes instant-filter from search filters

### DIFF
--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -17,7 +17,6 @@
       <div data-target="collapsible.panel">
         <%= form_for @search, as: '',
               method: :get,
-              data: {controller: 'instant-filter'},
               html: {class: "collapsible__content"} do |f| %>
 
           <%= f.hidden_field :query %>

--- a/features/candidates/schools/search/results/filtering.feature
+++ b/features/candidates/schools/search/results/filtering.feature
@@ -30,5 +30,6 @@ Feature: Filtering school search results
             | Burnley School    | Primary   | Burnley    |
         And I have provided a point in 'Bury' as my location
         And there are both 'Primary' and 'Secondary' schools in the results
-        When I check the 'Secondary' filter box
+        And I check the 'Secondary' filter box
+        When I click the 'Update schools list' button
         Then only 'Secondary' schools should remain in the results


### PR DESCRIPTION
### Context
DAC feed back indicated the page reload when the filter is applied was
disorienting to blind users.

### Changes proposed in this pull request
Remove the filter and instead provide a submit button.

### Guidance to review
Filters on the school search results page shouldn't auto reload when clicked, there should now be a search button at the bottom of the page.
