### PR TITLE
Handle session expiry errors more gracefully SE-1681

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -41,10 +41,7 @@ module Schools
     def create
       return redirect_to schools_dashboard_path if user_signed_in?
 
-      # using fetch rather than :[] so it'll blow up
-      # here if it's retrieiving the state from the session that's
-      # the problem rather than the comparison
-      check_state(session.fetch(:state), params[:state])
+      check_state(session[:state], params[:state])
 
       client                    = get_oidc_client
       client.authorization_code = params[:code]

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -41,6 +41,7 @@ module Schools
     def create
       return redirect_to schools_dashboard_path if user_signed_in?
 
+      check_for_errors(params[:error])
       check_state(session[:state], params[:state])
 
       client                    = get_oidc_client
@@ -73,6 +74,14 @@ module Schools
         Rails.logger.error(message)
 
         raise StateMismatchError, message
+      end
+    end
+
+    def check_for_errors(params_error)
+      if params_error
+        Rails.logger.error("DfE Sign-in error response #{params_error}, #{params}")
+
+        raise AuthFailedError, params_error
       end
     end
 

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -89,6 +89,22 @@ describe Schools::SessionsController, type: :request do
       end
 
       context 'errors' do
+        context 'Errors returned by DfE Sign-in' do
+          let(:error) { 'baderror' }
+          let(:callback) { "/auth/callback?error=#{error}" }
+
+          after { get callback }
+
+          specify 'should raise an AuthFailed error' do
+            expect(response.status).to eql 302
+            expect(response.redirect_url).to end_with('schools/errors/auth_failed')
+          end
+
+          specify 'should write a message to the log' do
+            expect(Rails.logger).to receive(:error).with(/DfE Sign-in error response/)
+          end
+        end
+
         context 'StateMismatchError' do
           {
             'aaaaaaaa-bbbb-1111-2222-333333333333' => 'not-matching',
@@ -105,6 +121,7 @@ describe Schools::SessionsController, type: :request do
 
               specify 'should redirect to an error page' do
                 expect(response.status).to eql 302
+                expect(response.redirect_url).to end_with('schools/errors/auth_failed')
               end
             end
           end
@@ -120,6 +137,7 @@ describe Schools::SessionsController, type: :request do
 
           specify 'should redirect to an error page' do
             expect(response.status).to eql 302
+            expect(response.redirect_url).to end_with('schools/errors/auth_failed')
           end
         end
       end

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -90,16 +90,23 @@ describe Schools::SessionsController, type: :request do
 
       context 'errors' do
         context 'StateMismatchError' do
-          let(:bad_state) { 'aaaaaaaa-bbbb-1111-2222-333333333333' }
-          let(:callback) { "/auth/callback?code=#{code}&state=#{bad_state}&session_state=#{session_state}" }
-          after { get callback }
+          {
+            'aaaaaaaa-bbbb-1111-2222-333333333333' => 'not-matching',
+            '' => 'empty',
+            nil => 'missing'
+          }.each do |bad_state, description|
+            context description do
+              let(:callback) { "/auth/callback?code=#{code}&state=#{bad_state}&session_state=#{session_state}" }
+              after { get callback }
 
-          specify 'should raise StateMismatchError' do
-            expect(Rails.logger).to receive(:error).with(/doesn't match session state/)
-          end
+              specify 'should raise StateMismatchError' do
+                expect(Rails.logger).to receive(:error).with(/doesn't match session state/)
+              end
 
-          specify 'should redirect to an error page' do
-            expect(response.status).to eql 302
+              specify 'should redirect to an error page' do
+                expect(response.status).to eql 302
+              end
+            end
           end
         end
 


### PR DESCRIPTION
### Context

State mismatch errors where the state is missing (none returned from DfE Sign-in) weren't
being reported because they were failing earlier, because of the use of `#fetch`. This was done
intentionally to highlight the problem but has been reverted to give users a better experience by
showing them a more-relevant error message

### Changes proposed in this pull request

Revert the change in accessing params by fetch instead of square bracket notation.

Also, this PR includes a change that checks for errors returned by DfE Sign-in. These have been
observed in production but fail with a KeyError which just shows a generic error page, these
are now swept up by AuthFailedError (and logged)

### Guidance to review

Ensure everything looks sensible and works. The error handling can be tested by logging out of the app then navigating to `/auth/callback?error=sessionexpired`; you should be redirected to `/schools/errors/auth_failed`.
