### PR TITLE
SE-1596 Prefer gitis contacts we already know

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -115,16 +115,6 @@ module Bookings
         self.dfe_hasdbscertificate = value
       end
 
-      def signin_attributes_match?(fname, lname, dob)
-        gitis_format_dob = dob.to_formatted_s(:db)
-        fname = fname.downcase
-        lname = lname.downcase
-
-        firstname.downcase == fname && lastname.downcase == lname ||
-          firstname.downcase == fname && birthdate == gitis_format_dob ||
-          lastname.downcase == lname && birthdate == gitis_format_dob
-      end
-
       def add_school_experience(log_line)
         if dfe_notesforclassroomexperience.blank?
           self.dfe_notesforclassroomexperience = EventLogger::NOTES_HEADER + "\r\n\r\n"

--- a/app/services/bookings/gitis/contact_fuzzy_matcher.rb
+++ b/app/services/bookings/gitis/contact_fuzzy_matcher.rb
@@ -1,0 +1,28 @@
+module Bookings
+  module Gitis
+    class ContactFuzzyMatcher
+      def initialize(firstname, lastname, birthdate)
+        @firstname = firstname.downcase
+        @lastname = lastname.downcase
+        @birthdate = birthdate.to_formatted_s(:db)
+      end
+
+      def find(contacts)
+        contacts.find(&method(:matches?))
+      end
+
+    private
+
+      def matches?(contact)
+        compare(:firstname, contact) && compare(:lastname, contact) ||
+          compare(:firstname, contact) && compare(:birthdate, contact) ||
+          compare(:lastname, contact) && compare(:birthdate, contact)
+      end
+
+      def compare(attribute, contact)
+        cvalue = contact.public_send(attribute).to_s.downcase
+        cvalue == instance_variable_get("@#{attribute}")
+      end
+    end
+  end
+end

--- a/app/services/bookings/gitis/contact_fuzzy_matcher.rb
+++ b/app/services/bookings/gitis/contact_fuzzy_matcher.rb
@@ -8,7 +8,9 @@ module Bookings
       end
 
       def find(contacts)
-        contacts.find(&method(:matches?))
+        known, unknown = prioritise(contacts)
+
+        known.find(&method(:matches?)) || unknown.find(&method(:matches?))
       end
 
     private
@@ -22,6 +24,16 @@ module Bookings
       def compare(attribute, contact)
         cvalue = contact.public_send(attribute).to_s.downcase
         cvalue == instance_variable_get("@#{attribute}")
+      end
+
+      def prioritise(contacts)
+        contact_ids = contacts.map(&:contactid).compact
+
+        candidates = Bookings::Candidate.
+          where(gitis_uuid: contact_ids).
+          pluck(:gitis_uuid)
+
+        contacts.partition { |c| candidates.include? c.contactid }
       end
     end
   end

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -29,7 +29,7 @@ module Bookings
       # Will return nil of it cannot match a Contact on final implementation
       def find_contact_for_signin(email:, firstname:, lastname:, date_of_birth:)
         filter = filter_pairs(emailaddress2: email, emailaddress1: email)
-        contacts = fetch(Contact, filter: filter, limit: 20, order: 'createdon desc')
+        contacts = fetch(Contact, filter: filter, limit: 30, order: 'createdon desc')
 
         matcher = ContactFuzzyMatcher.new(firstname, lastname, date_of_birth)
         matcher.find(contacts).tap do |match|

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -29,10 +29,12 @@ module Bookings
       # Will return nil of it cannot match a Contact on final implementation
       def find_contact_for_signin(email:, firstname:, lastname:, date_of_birth:)
         filter = filter_pairs(emailaddress2: email, emailaddress1: email)
+        contacts = fetch(Contact, filter: filter, limit: 20, order: 'createdon desc')
 
-        store.fetch(Contact, filter: filter, limit: 20, order: 'createdon desc')
-          .find { |c| c.signin_attributes_match? firstname, lastname, date_of_birth }
-          .tap { |c| crmlog "Read contact #{c.contactid}" if c }
+        matcher = ContactFuzzyMatcher.new(firstname, lastname, date_of_birth)
+        matcher.find(contacts).tap do |match|
+          crmlog "Read contact #{match.contactid}" if match
+        end
       end
 
       def log_school_experience(contact_id, logline)

--- a/lib/apimock/gitis_crm.rb
+++ b/lib/apimock/gitis_crm.rb
@@ -79,7 +79,7 @@ module Apimock
           .merge(contactdata.stringify_keys)
       end
 
-      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=20&$filter=emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'&$select=#{contact_attributes}&$orderby=createdon desc").
+      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=30&$filter=emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'&$select=#{contact_attributes}&$orderby=createdon desc").
         with(headers: get_headers).
         to_return(
           status: 200,

--- a/spec/services/bookings/gitis/contact_fuzzy_matcher_spec.rb
+++ b/spec/services/bookings/gitis/contact_fuzzy_matcher_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe Bookings::Gitis::ContactFuzzyMatcher, type: :model do
+  describe "#find" do
+    let(:contact) { build(:gitis_contact) }
+    let(:date_of_birth) { Date.parse(contact.birthdate) }
+    subject { described_class.new(*match_attrs).find([contact]) }
+
+    context 'with matching name' do
+      let(:match_attrs) do
+        [contact.firstname, contact.lastname, Date.parse('2000-01-01')]
+      end
+
+      it { is_expected.to eql(contact) }
+    end
+
+    context 'with all matching' do
+      let(:match_attrs) { [contact.firstname, contact.lastname, date_of_birth] }
+      it { is_expected.to eql(contact) }
+    end
+
+    context 'with matching dob' do
+      let(:match_attrs) { ['', '', date_of_birth] }
+      it { is_expected.to be_nil }
+    end
+
+    context 'with partial name match and matching dob' do
+      let(:match_attrs) { ['', contact.lastname, date_of_birth] }
+      it { is_expected.to eql(contact) }
+    end
+  end
+end

--- a/spec/services/bookings/gitis/contact_fuzzy_matcher_spec.rb
+++ b/spec/services/bookings/gitis/contact_fuzzy_matcher_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe Bookings::Gitis::ContactFuzzyMatcher, type: :model do
   describe "#find" do
-    let(:contact) { build(:gitis_contact) }
+    let(:contact) { build(:gitis_contact, :persisted) }
     let(:date_of_birth) { Date.parse(contact.birthdate) }
-    subject { described_class.new(*match_attrs).find([contact]) }
+    let(:contacts) { [contact] }
+    subject { described_class.new(*match_attrs).find(contacts) }
 
     context 'with matching name' do
       let(:match_attrs) do
@@ -27,6 +28,19 @@ describe Bookings::Gitis::ContactFuzzyMatcher, type: :model do
     context 'with partial name match and matching dob' do
       let(:match_attrs) { ['', contact.lastname, date_of_birth] }
       it { is_expected.to eql(contact) }
+    end
+
+    context 'with matches we know about' do
+      let(:second_uuid) { SecureRandom.uuid }
+      let(:second) do
+        build :gitis_contact, :persisted,
+          contact.attributes.merge(contactid: second_uuid)
+      end
+      let(:contacts) { [contact, second] }
+      before { create(:candidate, gitis_uuid: second_uuid) }
+      let(:match_attrs) { [contact.firstname, contact.lastname, date_of_birth] }
+
+      it { is_expected.to eql(second) }
     end
   end
 end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -128,38 +128,6 @@ describe Bookings::Gitis::Contact, type: :model do
     end
   end
 
-  describe "#signin_attributes_match?" do
-    let(:contact) { build(:gitis_contact) }
-    let(:date_of_birth) { Date.parse(contact.birthdate) }
-    subject { contact.signin_attributes_match?(*signin_attrs) }
-
-    context 'with matching name' do
-      let(:signin_attrs) do
-        [contact.firstname, contact.lastname, Date.parse('2000-01-01')]
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'with all matching' do
-      let(:signin_attrs) do
-        [contact.firstname, contact.lastname, date_of_birth]
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context 'with matching dob' do
-      let(:signin_attrs) { ['', '', date_of_birth] }
-      it { is_expected.to be false }
-    end
-
-    context 'with partial name match and matching dob' do
-      let(:signin_attrs) { ['', contact.lastname, date_of_birth] }
-      it { is_expected.to be true }
-    end
-  end
-
   describe 'writing' do
     describe "#attributes_for_create" do
       let(:contact) do

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -116,6 +116,20 @@ describe Bookings::Gitis::CRM, type: :model do
         is_expected.to have_attributes(id: firstuuid)
       end
     end
+
+    context 'with multiple matches and one has been used by us before' do
+      before do
+        create(:candidate, gitis_uuid: seconduuid)
+
+        gitis_stub.stub_contact_signin_request(email,
+          firstuuid => signin_attrs.merge('emailaddress1' => 'foo@bar.com', 'emailaddress2' => email),
+          seconduuid => signin_attrs)
+      end
+
+      it "will return the first contact record" do
+        is_expected.to have_attributes(id: seconduuid)
+      end
+    end
   end
 
   describe '#write' do


### PR DESCRIPTION
### Context

Currently we treat all contacts in Gitis equally. We would prefer a match for a candidate who we already know about though.

### Changes proposed in this pull request

1. Refactored some of the logic
2. Look up matched contacts against the Candidates we have, and prioritise those contacts we have Candidate records for.

### Guidance to review
1. Code review
