### PR TITLE
Avoid incompatible layers of HTTP Auth definitions

### DIFF
--- a/config/initializers/password_protection.rb
+++ b/config/initializers/password_protection.rb
@@ -1,4 +1,4 @@
-if ENV['SECURE_USERNAME'].present? && ENV['SECURE_PASSWORD'].present?
+if ENV['SECURE_USERNAME'].present? && ENV['SECURE_PASSWORD'].present? && !Rails.env.test?
   ApplicationController.before_action :http_basic_authenticate
-  PagesController.skip_before_action :http_basic_authenticate, only: :healthcheck
+  HealthchecksController.skip_before_action :http_basic_authenticate, except: :show
 end


### PR DESCRIPTION
### Context

Currently we set multiple http auth checks on the `/deployment.txt` endpoint when a global auth pair is defined. This can never pass

### Changes proposed in this pull request

1. Skip the global auth for the `/deployment.txt` end point

### Guidance to review

1. Code review