### PR TITLE
Keep formatting on pasted text

### DIFF
--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -35,7 +35,7 @@
         @profile.primary_key_stages_offered? ? edit_schools_on_boarding_key_stage_list_path : edit_schools_on_boarding_phases_list_path %>
       <%= summary_row 'Subjects', @profile.subjects, \
         @profile.subjects_offered? ? edit_schools_on_boarding_subjects_path : edit_schools_on_boarding_phases_list_path %>
-      <%= summary_row 'Description', @profile.descriptions, edit_schools_on_boarding_description_path %>
+      <%= summary_row 'Description', simple_format(@profile.descriptions), edit_schools_on_boarding_description_path %>
       <%= summary_row 'School experience details', @profile.school_experience_details, edit_schools_on_boarding_experience_outline_path %>
       <%= summary_row 'Teacher training links', @profile.teacher_training_links, edit_schools_on_boarding_experience_outline_path %>
     </dl>

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -212,7 +212,7 @@ end
 
 Then "the page should have the following summary list information:" do |table|
   table.raw.to_h.each do |key, value|
-    expect(page).to have_text %r{#{key} #{value}}
+    expect(page).to have_text %r{#{key} #{value}}, normalize_ws: true
   end
 end
 


### PR DESCRIPTION
Schools were worried they were losing formatting when pasting content
from their websites in to the school description.  Wrap description on
check answers in simple_format so it keeps formatting. The
candidates/schools#show view already wraps descriptions in
simple_format.

### Context

### Changes proposed in this pull request

### Guidance to review

