### PR TITLE
Force column info reload before appyling update SE-1454

### DIFF
--- a/db/migrate/20190911085544_add_secondary_subject_flag_to_subjects.rb
+++ b/db/migrate/20190911085544_add_secondary_subject_flag_to_subjects.rb
@@ -2,6 +2,8 @@ class AddSecondarySubjectFlagToSubjects < ActiveRecord::Migration[5.2]
   def up
     add_column :bookings_subjects, :secondary_subject, :boolean, null: false, default: true
 
+    Bookings::Subject.reset_column_information
+
     Bookings::Subject.find_by(name: 'Primary').update(secondary_subject: false)
   end
 


### PR DESCRIPTION
### Context

In the dev environment this migration failed because the schema hadn't
been reloaded between the column being added and the following line
attepting to write to it.

### Changes proposed in this pull request

Calling #reset_column_information between those two events should
fix it

### Guidance to review

Ensure it looks sensible. Appropriate Rails docs [here](https://api.rubyonrails.org/classes/ActiveRecord/ModelSchema/ClassMethods.html#method-i-reset_column_information).