### PR TITLE
Don't show inset if subject_specific_dates enabled.

### DIFF
--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -36,6 +36,8 @@
   <%= form.submit 'Continue' %>
 <%- end -%>
 
+<% unless Feature.instance.active? :subject_specific_dates %>
 <p class="govuk-inset-text">
   You'll be able to add subject-specific dates soon.
 </p>
+<% end %>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -26,6 +26,8 @@
   <%= form.submit 'Continue' %>
 <%- end -%>
 
+<% unless Feature.instance.active? :subject_specific_dates %>
 <p class="govuk-inset-text">
   You'll be able to add subject-specific dates soon.
 </p>
+<% end %>


### PR DESCRIPTION
### Context
Fix from QA

### Changes proposed in this pull request
Hide "You'll be able to add subject-specific dates soon." if subject specific dates are enabled

### Guidance to review

