### PR TITLE
Make update not raise exception if row not found

### DIFF
--- a/db/migrate/20190911085544_add_secondary_subject_flag_to_subjects.rb
+++ b/db/migrate/20190911085544_add_secondary_subject_flag_to_subjects.rb
@@ -4,7 +4,7 @@ class AddSecondarySubjectFlagToSubjects < ActiveRecord::Migration[5.2]
 
     Bookings::Subject.reset_column_information
 
-    Bookings::Subject.find_by(name: 'Primary').update(secondary_subject: false)
+    Bookings::Subject.where(name: 'Primary').update_all(secondary_subject: false)
   end
 
   def down


### PR DESCRIPTION
### Context

This migration was causing problems in environments where the record
isn't found

Following on from #929

### Changes proposed in this pull request

Make the migration not raise when the subject `Primary` isn't found

### Guidance to review

Ensure it looks sensible
