### PR TITLE
use --no-deps in CI functional tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,7 @@ jobs:
       WAIT_COUNT=0
       until docker-compose ps | grep -m 1 "db-tasks" | grep -m 1 "Exit 0" || [ $WAIT_COUNT -eq 12 ]; do echo "WAIT COUNT $(( WAIT_COUNT++ ))" && sleep 5 ; done
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
-      docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) school-experience cucumber $(features)
+      docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) --no-deps school-experience cucumber $(features)
     displayName: Run Cucumber Tests
 
 - job: PublishArtifacts


### PR DESCRIPTION
### Context

There have been intermittent database truncation errors in the CI functional tests.

### Changes proposed in this pull request

Use `--no-deps` with  `docker-compose run` so that there is no attempt to start dependent services (even though it should only start dependent services if they are not already started without the flag). This simplifies the logs and will help work out what is going on with the truncation errors.

### Guidance to review

This is only a minor change and the test is whether the CI functional tests succeed.

