### PR TITLE
Remove PII from candidate request confirmation.

### DIFF
--- a/app/jobs/candidates/registrations/placement_request_job.rb
+++ b/app/jobs/candidates/registrations/placement_request_job.rb
@@ -13,7 +13,7 @@ module Candidates
           placement_request_url: placement_request_url
         ).despatch_later!
 
-        NotifyEmail::CandidateRequestConfirmationWithConfirmationLink.from_application_preview(
+        NotifyEmail::CandidateRequestConfirmationNoPii.from_application_preview(
           registration_session.email,
           application_preview,
           cancellation_url

--- a/app/notify/notify_email/candidate_request_confirmation_no_pii.8ee470a1-0b94-48ee-9fe7-98b7beb8921c.md
+++ b/app/notify/notify_email/candidate_request_confirmation_no_pii.8ee470a1-0b94-48ee-9fe7-98b7beb8921c.md
@@ -2,20 +2,11 @@ Dear ((candidate_name))
 
 You've requested school experience at ((school_name)).
 
-^ The school will be in touch with you. For example, during term time this could typically mean within 2 weeks.
+^ You will be contacted about your request. Schools aim to get in touch within 10 working days during term time.
 
 # Your request details
 
 Here's a copy of your request details which have been forwarded to the school.
-
-Personal details
-
-* Full name: ((candidate_name))
-* Address: ((candidate_address))
-* UK telephone number: ((candidate_phone_number))
-* Email address: ((candidate_email_address))
-
-Request details
 
 * School or college: ((school_name))
 * Availability/preferred dates: ((placement_availability))

--- a/app/notify/notify_email/candidate_request_confirmation_no_pii.8ee470a1-0b94-48ee-9fe7-98b7beb8921c.md
+++ b/app/notify/notify_email/candidate_request_confirmation_no_pii.8ee470a1-0b94-48ee-9fe7-98b7beb8921c.md
@@ -1,4 +1,4 @@
-Dear ((candidate_name))
+Hello
 
 You've requested school experience at ((school_name)).
 

--- a/app/notify/notify_email/candidate_request_confirmation_no_pii.rb
+++ b/app/notify/notify_email/candidate_request_confirmation_no_pii.rb
@@ -3,7 +3,6 @@ class NotifyEmail::CandidateRequestConfirmationNoPii < Notify
     :candidate_dbs_check_document,
     :candidate_degree_stage,
     :candidate_degree_subject,
-    :candidate_name,
     :candidate_teaching_stage,
     :candidate_teaching_subject_first_choice,
     :candidate_teaching_subject_second_choice,
@@ -17,7 +16,6 @@ class NotifyEmail::CandidateRequestConfirmationNoPii < Notify
     candidate_dbs_check_document:,
     candidate_degree_stage:,
     candidate_degree_subject:,
-    candidate_name:,
     candidate_teaching_stage:,
     candidate_teaching_subject_first_choice:,
     candidate_teaching_subject_second_choice:,
@@ -30,7 +28,6 @@ class NotifyEmail::CandidateRequestConfirmationNoPii < Notify
     self.candidate_dbs_check_document             =        candidate_dbs_check_document
     self.candidate_degree_stage                   =        candidate_degree_stage
     self.candidate_degree_subject                 =        candidate_degree_subject
-    self.candidate_name                           =        candidate_name
     self.candidate_teaching_stage                 =        candidate_teaching_stage
     self.candidate_teaching_subject_first_choice  =        candidate_teaching_subject_first_choice
     self.candidate_teaching_subject_second_choice =        candidate_teaching_subject_second_choice
@@ -48,7 +45,6 @@ class NotifyEmail::CandidateRequestConfirmationNoPii < Notify
       candidate_dbs_check_document: application_preview.dbs_check_document,
       candidate_degree_stage: application_preview.degree_stage,
       candidate_degree_subject: application_preview.degree_subject,
-      candidate_name: application_preview.full_name,
       candidate_teaching_stage: application_preview.teaching_stage,
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
@@ -69,7 +65,6 @@ private
       candidate_dbs_check_document: candidate_dbs_check_document,
       candidate_degree_stage: candidate_degree_stage,
       candidate_degree_subject: candidate_degree_subject,
-      candidate_name: candidate_name,
       candidate_teaching_stage: candidate_teaching_stage,
       candidate_teaching_subject_first_choice: candidate_teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: candidate_teaching_subject_second_choice,

--- a/app/notify/notify_email/candidate_request_confirmation_no_pii.rb
+++ b/app/notify/notify_email/candidate_request_confirmation_no_pii.rb
@@ -1,11 +1,9 @@
-class NotifyEmail::CandidateRequestConfirmationWithConfirmationLink < Notify
-  attr_accessor :candidate_address,
+class NotifyEmail::CandidateRequestConfirmationNoPii < Notify
+  attr_accessor \
     :candidate_dbs_check_document,
     :candidate_degree_stage,
     :candidate_degree_subject,
-    :candidate_email_address,
     :candidate_name,
-    :candidate_phone_number,
     :candidate_teaching_stage,
     :candidate_teaching_subject_first_choice,
     :candidate_teaching_subject_second_choice,
@@ -16,13 +14,10 @@ class NotifyEmail::CandidateRequestConfirmationWithConfirmationLink < Notify
 
   def initialize(
     to:,
-    candidate_address:,
     candidate_dbs_check_document:,
     candidate_degree_stage:,
     candidate_degree_subject:,
-    candidate_email_address:,
     candidate_name:,
-    candidate_phone_number:,
     candidate_teaching_stage:,
     candidate_teaching_subject_first_choice:,
     candidate_teaching_subject_second_choice:,
@@ -32,13 +27,10 @@ class NotifyEmail::CandidateRequestConfirmationWithConfirmationLink < Notify
     cancellation_url:
   )
 
-    self.candidate_address                        =        candidate_address
     self.candidate_dbs_check_document             =        candidate_dbs_check_document
     self.candidate_degree_stage                   =        candidate_degree_stage
     self.candidate_degree_subject                 =        candidate_degree_subject
-    self.candidate_email_address                  =        candidate_email_address
     self.candidate_name                           =        candidate_name
-    self.candidate_phone_number                   =        candidate_phone_number
     self.candidate_teaching_stage                 =        candidate_teaching_stage
     self.candidate_teaching_subject_first_choice  =        candidate_teaching_subject_first_choice
     self.candidate_teaching_subject_second_choice =        candidate_teaching_subject_second_choice
@@ -53,13 +45,10 @@ class NotifyEmail::CandidateRequestConfirmationWithConfirmationLink < Notify
   def self.from_application_preview(to, application_preview, cancellation_url)
     new \
       to: to,
-      candidate_address: application_preview.full_address,
       candidate_dbs_check_document: application_preview.dbs_check_document,
       candidate_degree_stage: application_preview.degree_stage,
       candidate_degree_subject: application_preview.degree_subject,
-      candidate_email_address: application_preview.email_address,
       candidate_name: application_preview.full_name,
-      candidate_phone_number: application_preview.telephone_number,
       candidate_teaching_stage: application_preview.teaching_stage,
       candidate_teaching_subject_first_choice: application_preview.teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: application_preview.teaching_subject_second_choice,
@@ -72,18 +61,15 @@ class NotifyEmail::CandidateRequestConfirmationWithConfirmationLink < Notify
 private
 
   def template_id
-    '102bb4df-82ca-4f6b-80e9-fa19af712ad6'
+    '8ee470a1-0b94-48ee-9fe7-98b7beb8921c'
   end
 
   def personalisation
     {
-      candidate_address: candidate_address,
       candidate_dbs_check_document: candidate_dbs_check_document,
       candidate_degree_stage: candidate_degree_stage,
       candidate_degree_subject: candidate_degree_subject,
-      candidate_email_address: candidate_email_address,
       candidate_name: candidate_name,
-      candidate_phone_number: candidate_phone_number,
       candidate_teaching_stage: candidate_teaching_stage,
       candidate_teaching_subject_first_choice: candidate_teaching_subject_first_choice,
       candidate_teaching_subject_second_choice: candidate_teaching_subject_second_choice,

--- a/spec/jobs/candidates/registrations/placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/placement_request_job_spec.rb
@@ -21,7 +21,7 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
   end
 
   let :candidate_request_confirmation_notification_with_confirmation_link do
-    double NotifyEmail::CandidateRequestConfirmationWithConfirmationLink,
+    double NotifyEmail::CandidateRequestConfirmationNoPii,
       despatch_later!: true
   end
 
@@ -41,7 +41,7 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
     allow(NotifyEmail::SchoolRequestConfirmationLinkOnly).to \
       receive(:new) { school_request_confirmation_notification_link_only }
 
-    allow(NotifyEmail::CandidateRequestConfirmationWithConfirmationLink).to \
+    allow(NotifyEmail::CandidateRequestConfirmationNoPii).to \
       receive(:from_application_preview) { candidate_request_confirmation_notification_with_confirmation_link }
 
     registration_store.store! registration_session
@@ -67,7 +67,7 @@ describe Candidates::Registrations::PlacementRequestJob, type: :job do
       end
 
       it 'notifies the candidate' do
-        expect(NotifyEmail::CandidateRequestConfirmationWithConfirmationLink).to \
+        expect(NotifyEmail::CandidateRequestConfirmationNoPii).to \
           have_received(:from_application_preview).with \
             registration_session.email,
             application_preview,

--- a/spec/notify/notify_email/candidate_request_confirmation_no_pii_spec.rb
+++ b/spec/notify/notify_email/candidate_request_confirmation_no_pii_spec.rb
@@ -6,7 +6,6 @@ describe NotifyEmail::CandidateRequestConfirmationNoPii do
     candidate_dbs_check_document: "Yes",
     candidate_degree_stage: "Postgraduate",
     candidate_degree_subject: "Sociology",
-    candidate_name: "Tony Hancock",
     candidate_teaching_stage: "I want to become a teacher",
     candidate_teaching_subject_first_choice: "Sociology",
     candidate_teaching_subject_second_choice: "Philosophy",
@@ -45,10 +44,6 @@ describe NotifyEmail::CandidateRequestConfirmationNoPii do
 
       specify 'candidate_degree_stage is correctly-assigned' do
         expect(subject.candidate_degree_stage).to eql(ap.degree_stage)
-      end
-
-      specify 'candidate_name is correctly-assigned' do
-        expect(subject.candidate_name).to eql(ap.full_name)
       end
 
       specify 'candidate_teaching_stage is correctly-assigned' do

--- a/spec/notify/notify_email/candidate_request_confirmation_no_pii_spec.rb
+++ b/spec/notify/notify_email/candidate_request_confirmation_no_pii_spec.rb
@@ -1,15 +1,12 @@
 require 'rails_helper'
 
-describe NotifyEmail::CandidateRequestConfirmationWithConfirmationLink do
-  it_should_behave_like "email template", "102bb4df-82ca-4f6b-80e9-fa19af712ad6",
+describe NotifyEmail::CandidateRequestConfirmationNoPii do
+  it_should_behave_like "email template", "8ee470a1-0b94-48ee-9fe7-98b7beb8921c",
     school_name: "Springfield Elementary School",
-    candidate_address: "23 Railway Cuttings, East Cheam, CR3 0HD",
     candidate_dbs_check_document: "Yes",
     candidate_degree_stage: "Postgraduate",
     candidate_degree_subject: "Sociology",
-    candidate_email_address: "tony.hancock@bbc.co.uk",
     candidate_name: "Tony Hancock",
-    candidate_phone_number: "01234 456 678",
     candidate_teaching_stage: "I want to become a teacher",
     candidate_teaching_subject_first_choice: "Sociology",
     candidate_teaching_subject_second_choice: "Philosophy",
@@ -42,10 +39,6 @@ describe NotifyEmail::CandidateRequestConfirmationWithConfirmationLink do
         expect(subject.cancellation_url).to eql(cancellation_url)
       end
 
-      specify 'candidate_address is correctly-assigned' do
-        expect(subject.candidate_address).to eql(ap.full_address)
-      end
-
       specify 'candidate_dbs_check_document is correctly-assigned' do
         expect(subject.candidate_dbs_check_document).to eql(ap.dbs_check_document)
       end
@@ -54,16 +47,8 @@ describe NotifyEmail::CandidateRequestConfirmationWithConfirmationLink do
         expect(subject.candidate_degree_stage).to eql(ap.degree_stage)
       end
 
-      specify 'candidate_email_address is correctly-assigned' do
-        expect(subject.candidate_email_address).to eql(ap.email_address)
-      end
-
       specify 'candidate_name is correctly-assigned' do
         expect(subject.candidate_name).to eql(ap.full_name)
-      end
-
-      specify 'candidate_phone_number is correctly-assigned' do
-        expect(subject.candidate_phone_number).to eql(ap.telephone_number)
       end
 
       specify 'candidate_teaching_stage is correctly-assigned' do


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Removes PII section from candidate request confirmation email.

### Guidance to review
Should look sensible.