### PR TITLE
Add aria-label to sample description

### DIFF
--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -20,7 +20,7 @@
       <%= f.text_area :details, rows: 10 do %>
 
         <details id="description-example" class="govuk-details" role="group" data-module="govuk-details">
-          <summary class="govuk-details__summary" role="button">
+          <summary class="govuk-details__summary" role="button" aria-label="View an example school description that could be entered to complete this step">
             <span class="govuk-details__summary-text">View description example</span>
           </summary>
           <div class="govuk-details__text">


### PR DESCRIPTION
When browsing out of context with a screen reader it's not clear what
"View description example" refers to.

### Context

### Changes proposed in this pull request

### Guidance to review

