### PR TITLE
Removed candidate name from page title

### DIFF
--- a/app/views/schools/confirmed_bookings/show.html.erb
+++ b/app/views/schools/confirmed_bookings/show.html.erb
@@ -8,8 +8,6 @@
   }
 %>
 
-<% self.page_title = "Booking for #{@booking.candidate_name}" %>
-
 <h1>Booking by <%= @booking.candidate_name %></h1>
 
 <div id="school-booking-show" class="booking">


### PR DESCRIPTION
### Context

Currently the page titles are included in logging to AppInsights and potentially Google Analytics. The page title when viewing a confirmed booking includes the candidates name. This looks to be the result of a merge conflict since the page title is set twice.

### Changes proposed in this pull request

1. Remove the candidate name from the page title

