### PR TITLE
just check for Buile Hill rather than a full name

### DIFF
--- a/jmeter/schoolexperience.jmx
+++ b/jmeter/schoolexperience.jmx
@@ -258,7 +258,7 @@
           <hashTree/>
           <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
             <collectionProp name="Asserion.test_strings">
-              <stringProp name="-306087655">Buile Hill Visual Arts College</stringProp>
+              <stringProp name="-306087655">Buile Hill</stringProp>
             </collectionProp>
             <stringProp name="Assertion.custom_message"></stringProp>
             <stringProp name="Assertion.test_field">Assertion.response_data</stringProp>


### PR DESCRIPTION
### Context

Load tests are failing again.

### Changes proposed in this pull request

Made the check for Buile Hill to be less sensitive to the full name i.e. just the text Buile Hill

### Guidance to review

Will only be verified in CD (Staging)

