### PR TITLE
Fix email-preview colour

### DIFF
--- a/app/assets/stylesheets/cookie-banner.scss
+++ b/app/assets/stylesheets/cookie-banner.scss
@@ -1,5 +1,5 @@
 #cookie-banner {
-  background-color: lighten(govuk-colour("blue"), 65%);
+  background-color: lighten(govuk-colour("blue"), 55%);
   padding: 0.6rem 0rem 0.4rem;
 
   #cookie-banner-message {

--- a/app/assets/stylesheets/school-placement-requests.scss
+++ b/app/assets/stylesheets/school-placement-requests.scss
@@ -39,5 +39,5 @@
 
 .email-preview {
   padding: 1.5rem;
-  background-color: lighten(govuk-colour("light-blue"), 50%);
+  background-color: lighten(govuk-colour("light-blue"), 35%);
 }


### PR DESCRIPTION
The update to govuk frontend has lightened govuk light-blue, when we
lighten it 50% it becomes white. Lightening it 35% fixes the issue.

### Context

### Changes proposed in this pull request

### Guidance to review

