### PR TITLE
SE-1240 Create Placement Requests asynchronously

### DIFF
--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -20,15 +20,6 @@ module Candidates
             registration_session,
             cookies[:analytics_tracking_uuid]
 
-          unless Bookings::Gitis::PrivacyPolicy.default.nil?
-            AcceptPrivacyPolicyJob.perform_later \
-              current_candidate.gitis_uuid,
-              Bookings::Gitis::PrivacyPolicy.default
-          end
-
-          Bookings::Gitis::EventLogger.write_later \
-            current_candidate.gitis_uuid, :request, placement_request
-
           registration_session.flag_as_completed!
 
           RegistrationStore.instance.store! registration_session

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -16,19 +16,14 @@ module Candidates
             registration_session,
             current_contact
 
-          placement_request = current_candidate.placement_requests.create_from_registration_session! \
-            registration_session,
-            cookies[:analytics_tracking_uuid]
-
           registration_session.flag_as_completed!
-
           RegistrationStore.instance.store! registration_session
 
           CreatePlacementRequestJob.perform_later \
-            placement_request.id,
             registration_session.uuid,
             current_contact&.id,
-            request.host
+            request.host,
+            cookies[:analytics_tracking_uuid]
         end
 
         redirect_to candidates_school_registrations_placement_request_path \

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -33,10 +33,11 @@ module Candidates
 
           RegistrationStore.instance.store! registration_session
 
-          PlacementRequestJob.perform_later \
+          CreatePlacementRequestJob.perform_later \
+            placement_request.id,
             registration_session.uuid,
-            cancellation_url(placement_request),
-            placement_url(placement_request)
+            current_contact&.id,
+            request.host
         end
 
         redirect_to candidates_school_registrations_placement_request_path \

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -11,11 +11,6 @@ module Candidates
         registration_session = RegistrationStore.instance.retrieve! params[:uuid]
 
         unless registration_session.completed?
-          self.current_candidate = Bookings::Candidate.create_or_update_from_registration_session! \
-            gitis_crm,
-            registration_session,
-            current_contact
-
           registration_session.flag_as_completed!
           RegistrationStore.instance.store! registration_session
 
@@ -31,7 +26,7 @@ module Candidates
           uuid: registration_session.uuid
       rescue RegistrationStore::SessionNotFound
         render :session_expired
-      rescue RegistrationSession::StepNotFound
+      rescue RegistrationSession::StepNotFound, RegistrationSession::NotCompletedError
         @current_registration = registration_session
         redirect_to next_step_path
       end

--- a/app/jobs/candidates/registrations/create_placement_request_job.rb
+++ b/app/jobs/candidates/registrations/create_placement_request_job.rb
@@ -1,9 +1,9 @@
 module Candidates
   module Registrations
-    class CreatePlacementRequestJob < ApplicationJob
+    class CreatePlacementRequestJob < GitisJob
       def perform(registration_uuid, contact_id, host, analytics_uuid)
         Candidates::Registrations::CreatePlacementRequest.
-          new(registration_uuid, contact_id, host, analytics_uuid).
+          new(gitis, registration_uuid, contact_id, host, analytics_uuid).
           create!
       end
     end

--- a/app/jobs/candidates/registrations/create_placement_request_job.rb
+++ b/app/jobs/candidates/registrations/create_placement_request_job.rb
@@ -1,0 +1,11 @@
+module Candidates
+  module Registrations
+    class CreatePlacementRequestJob < ApplicationJob
+      def perform(placement_id, registration_uuid, contact_id, host)
+        Candidates::Registrations::CreatePlacementRequest.
+          new(placement_id, registration_uuid, contact_id, host).
+          create!
+      end
+    end
+  end
+end

--- a/app/jobs/candidates/registrations/create_placement_request_job.rb
+++ b/app/jobs/candidates/registrations/create_placement_request_job.rb
@@ -1,6 +1,8 @@
 module Candidates
   module Registrations
     class CreatePlacementRequestJob < GitisJob
+      retry_on StandardError, wait: A_DECENT_AMOUNT_LONGER, attempts: 8
+
       def perform(registration_uuid, contact_id, host, analytics_uuid)
         Candidates::Registrations::CreatePlacementRequest.
           new(gitis, registration_uuid, contact_id, host, analytics_uuid).

--- a/app/jobs/candidates/registrations/create_placement_request_job.rb
+++ b/app/jobs/candidates/registrations/create_placement_request_job.rb
@@ -1,9 +1,9 @@
 module Candidates
   module Registrations
     class CreatePlacementRequestJob < ApplicationJob
-      def perform(placement_id, registration_uuid, contact_id, host)
+      def perform(registration_uuid, contact_id, host, analytics_uuid)
         Candidates::Registrations::CreatePlacementRequest.
-          new(placement_id, registration_uuid, contact_id, host).
+          new(registration_uuid, contact_id, host, analytics_uuid).
           create!
       end
     end

--- a/app/services/candidates/registrations/create_placement_request.rb
+++ b/app/services/candidates/registrations/create_placement_request.rb
@@ -11,19 +11,12 @@ module Candidates
       end
 
       def create!
-        NotifyEmail::SchoolRequestConfirmationLinkOnly.new(
-          to: registration_session.school.notification_emails,
-          school_name: registration_session.school_name,
-          placement_request_url: placement_request_url
-        ).despatch_later!
+        send_school_confirmation_email
+        send_candidate_confirmation_email
+        remove_registration_from_store
 
-        NotifyEmail::CandidateRequestConfirmationWithConfirmationLink.from_application_preview(
-          registration_session.email,
-          application_preview,
-          cancellation_url
-        ).despatch_later!
-
-        RegistrationStore.instance.delete! registration_uuid
+        accept_privacy_policy
+        log_request_to_gitis_contact
       end
 
     private
@@ -37,7 +30,7 @@ module Candidates
       end
 
       def placement_request
-        Bookings::PlacementRequest.find placement_request_id
+        @placement_request ||= Bookings::PlacementRequest.find placement_request_id
       end
 
       def routes
@@ -50,6 +43,39 @@ module Candidates
 
       def placement_request_url
         routes.schools_placement_request_url placement_request, host: @host
+      end
+
+      def send_school_confirmation_email
+        NotifyEmail::SchoolRequestConfirmationLinkOnly.new(
+          to: registration_session.school.notification_emails,
+          school_name: registration_session.school_name,
+          placement_request_url: placement_request_url
+        ).despatch_later!
+      end
+
+      def send_candidate_confirmation_email
+        NotifyEmail::CandidateRequestConfirmationNoPii.from_application_preview(
+          registration_session.email,
+          application_preview,
+          cancellation_url
+        ).despatch_later!
+      end
+
+      def remove_registration_from_store
+        RegistrationStore.instance.delete! registration_uuid
+      end
+
+      def accept_privacy_policy
+        return if Bookings::Gitis::PrivacyPolicy.default.nil?
+
+        AcceptPrivacyPolicyJob.perform_later \
+          gitis_contact_id,
+          Bookings::Gitis::PrivacyPolicy.default
+      end
+
+      def log_request_to_gitis_contact
+        Bookings::Gitis::EventLogger.write_later \
+          gitis_contact_id, :request, placement_request
       end
     end
   end

--- a/app/services/candidates/registrations/create_placement_request.rb
+++ b/app/services/candidates/registrations/create_placement_request.rb
@@ -97,6 +97,8 @@ module Candidates
       def create_or_update_gitis_contact
         @candidate = Bookings::Candidate.create_or_update_from_registration_session! \
           @crm, registration_session, @gitis_contact
+
+        @gitis_contact_id = @candidate.gitis_uuid
       end
     end
   end

--- a/app/services/candidates/registrations/create_placement_request.rb
+++ b/app/services/candidates/registrations/create_placement_request.rb
@@ -1,0 +1,56 @@
+module Candidates
+  module Registrations
+    class CreatePlacementRequest
+      attr_reader :placement_request_id, :registration_uuid, :gitis_contact_id
+
+      def initialize(placement_request_id, registration_uuid, gitis_contact_id, host)
+        @placement_request_id = placement_request_id
+        @registration_uuid = registration_uuid
+        @contact_id = gitis_contact_id
+        @host = host
+      end
+
+      def create!
+        NotifyEmail::SchoolRequestConfirmationLinkOnly.new(
+          to: registration_session.school.notification_emails,
+          school_name: registration_session.school_name,
+          placement_request_url: placement_request_url
+        ).despatch_later!
+
+        NotifyEmail::CandidateRequestConfirmationWithConfirmationLink.from_application_preview(
+          registration_session.email,
+          application_preview,
+          cancellation_url
+        ).despatch_later!
+
+        RegistrationStore.instance.delete! registration_uuid
+      end
+
+    private
+
+      def registration_session
+        @registration_session ||= RegistrationStore.instance.retrieve! registration_uuid
+      end
+
+      def application_preview
+        @application_preview ||= ApplicationPreview.new registration_session
+      end
+
+      def placement_request
+        Bookings::PlacementRequest.find placement_request_id
+      end
+
+      def routes
+        Rails.application.routes.url_helpers
+      end
+
+      def cancellation_url
+        routes.candidates_cancel_url placement_request.token, host: @host
+      end
+
+      def placement_request_url
+        routes.schools_placement_request_url placement_request, host: @host
+      end
+    end
+  end
+end

--- a/app/services/candidates/registrations/create_placement_request.rb
+++ b/app/services/candidates/registrations/create_placement_request.rb
@@ -7,13 +7,14 @@ module Candidates
       def initialize(crm, registration_uuid, gitis_contact_id, host, analytics_uuid = nil)
         @crm = crm
         @registration_uuid = registration_uuid
-        fetch_registration_session
         @gitis_contact_id = gitis_contact_id
         @host = host
         @analytics_uuid = analytics_uuid
       end
 
       def create!
+        fetch_registration_session
+
         fetch_gitis_contact
         create_or_update_gitis_contact
 

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -34,6 +34,8 @@ module Candidates
       end
 
       def flag_as_completed!
+        raise NotCompletedError unless all_steps_completed?
+
         @data['status'] = COMPLETED_STATUS
       end
 

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -15,7 +15,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
     Candidates::Registrations::RegistrationStore.instance.store! \
       registration_session
 
-    allow(Candidates::Registrations::PlacementRequestJob).to \
+    allow(Candidates::Registrations::CreatePlacementRequestJob).to \
       receive(:perform_later) { true }
   end
 
@@ -34,8 +34,8 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
           eq @placement_request_count
       end
 
-      it "doesn't queue a PlacementRequestJob" do
-        expect(Candidates::Registrations::PlacementRequestJob).not_to \
+      it "doesn't queue a CreatePlacementRequestJob" do
+        expect(Candidates::Registrations::CreatePlacementRequestJob).not_to \
           have_received :perform_later
       end
 
@@ -57,8 +57,8 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
             eq @placement_request_count
         end
 
-        it "doesn't requeue a PlacementRequestJob" do
-          expect(Candidates::Registrations::PlacementRequestJob).to \
+        it "doesn't requeue a CreatePlacementRequestJob" do
+          expect(Candidates::Registrations::CreatePlacementRequestJob).to \
             have_received(:perform_later).exactly(:once)
         end
 
@@ -114,11 +114,12 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
           end
 
           it 'enqueues the placement request job' do
-            expect(Candidates::Registrations::PlacementRequestJob).to \
+            expect(Candidates::Registrations::CreatePlacementRequestJob).to \
               have_received(:perform_later).with \
+                Bookings::PlacementRequest.last.id,
                 uuid,
-                candidates_cancel_url(Bookings::PlacementRequest.last.token),
-                schools_placement_request_url(Bookings::PlacementRequest.last)
+                fake_gitis_uuid,
+                'www.example.com'
           end
 
           it 'enqueues an accept privacy policy job' do

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -72,15 +72,9 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       end
 
       context 'registration job not already enqueued' do
+        include_context 'fake gitis with known uuid'
+
         shared_examples 'a successful create' do
-          before do
-            expect(fake_gitis).to receive(:create_entity) do |entity_id, _data|
-              "#{entity_id}(#{fake_gitis_uuid})"
-            end
-          end
-
-          include_context 'fake gitis with known uuid'
-
           before do
             get "/candidates/confirm/#{uuid}"
           end
@@ -93,24 +87,10 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
             expect(stored_registration_session).to be_completed
           end
 
-          it "creates a candidate" do
-            created = Bookings::Candidate.find_by(gitis_uuid: fake_gitis_uuid)
-            expect(created).not_to be_nil
-          end
-
-          it "assigns contact attrs" do
-            expect(session['gitis_contact']).to include \
-              'firstname' => stored_registration_session.personal_information.first_name,
-              'lastname' => stored_registration_session.personal_information.last_name
-          end
-
           it 'enqueues the create placement request job' do
             expect(Candidates::Registrations::CreatePlacementRequestJob).to \
               have_received(:perform_later).with \
-                uuid,
-                fake_gitis_uuid,
-                'www.example.com',
-                nil
+                uuid, nil, 'www.example.com', nil
           end
 
           it 'redirects to placement request show' do

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -74,11 +74,9 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       context 'registration job not already enqueued' do
         shared_examples 'a successful create' do
           before do
-            allow(Bookings::LogToGitisJob).to \
-              receive(:perform_later).and_return(true)
-
-            allow(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
-              receive(:perform_later).and_return(true)
+            expect(fake_gitis).to receive(:create_entity) do |entity_id, _data|
+              "#{entity_id}(#{fake_gitis_uuid})"
+            end
           end
 
           include_context 'fake gitis with known uuid'
@@ -113,27 +111,13 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
               eq stored_registration_session.school
           end
 
-          it 'enqueues the placement request job' do
+          it 'enqueues the create placement request job' do
             expect(Candidates::Registrations::CreatePlacementRequestJob).to \
               have_received(:perform_later).with \
                 Bookings::PlacementRequest.last.id,
                 uuid,
                 fake_gitis_uuid,
                 'www.example.com'
-          end
-
-          it 'enqueues an accept privacy policy job' do
-            expect(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
-              have_received(:perform_later).with \
-                fake_gitis_uuid,
-                Bookings::Gitis::PrivacyPolicy.default
-          end
-
-          it 'enqueues a log to gitis job' do
-            expect(Bookings::LogToGitisJob).to \
-              have_received(:perform_later).with \
-                fake_gitis_uuid,
-                %r{#{Date.today.to_formatted_s(:gitis)} REQUEST}
           end
 
           it 'redirects to placement request show' do

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -104,20 +104,13 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
               'lastname' => stored_registration_session.personal_information.last_name
           end
 
-          it 'creates a bookings placement request' do
-            expect(Bookings::PlacementRequest.count).to \
-              eq @placement_request_count + 1
-            expect(Bookings::PlacementRequest.last.school).to \
-              eq stored_registration_session.school
-          end
-
           it 'enqueues the create placement request job' do
             expect(Candidates::Registrations::CreatePlacementRequestJob).to \
               have_received(:perform_later).with \
-                Bookings::PlacementRequest.last.id,
                 uuid,
                 fake_gitis_uuid,
-                'www.example.com'
+                'www.example.com',
+                nil
           end
 
           it 'redirects to placement request show' do

--- a/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
@@ -4,6 +4,7 @@ describe Candidates::Registrations::CreatePlacementRequestJob, type: :job do
   include ActiveSupport::Testing::TimeHelpers
 
   let(:token) { SecureRandom.urlsafe_base64 }
+  let(:analytics) { SecureRandom.uuid }
 
   context '#perform' do
     let!(:create_request) do
@@ -22,12 +23,13 @@ describe Candidates::Registrations::CreatePlacementRequestJob, type: :job do
       end
 
       subject! do
-        described_class.perform_later 10, token, nil, 'test.com'
+        described_class.perform_later token, nil, 'test.com', analytics
       end
 
       it "will call Service Object with correct params" do
         expect(Candidates::Registrations::CreatePlacementRequest).to \
-          have_received(:new).with(10, token, nil, 'test.com')
+          have_received(:new).with \
+            token, nil, 'test.com', analytics
       end
     end
 
@@ -40,7 +42,7 @@ describe Candidates::Registrations::CreatePlacementRequestJob, type: :job do
       end
 
       subject! do
-        described_class.perform_later 10, token, nil, 'test.com'
+        described_class.perform_later token, nil, 'test.com', analytics
       end
 
       it 'retrys the job' do

--- a/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 describe Candidates::Registrations::CreatePlacementRequestJob, type: :job do
   include ActiveSupport::Testing::TimeHelpers
+  include_context 'fake gitis'
+
+  before do
+    allow_any_instance_of(described_class).to \
+      receive(:gitis).and_return(fake_gitis)
+  end
 
   let(:token) { SecureRandom.urlsafe_base64 }
   let(:analytics) { SecureRandom.uuid }
@@ -29,7 +35,7 @@ describe Candidates::Registrations::CreatePlacementRequestJob, type: :job do
       it "will call Service Object with correct params" do
         expect(Candidates::Registrations::CreatePlacementRequest).to \
           have_received(:new).with \
-            token, nil, 'test.com', analytics
+            fake_gitis, token, nil, 'test.com', analytics
       end
     end
 

--- a/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
@@ -55,7 +55,7 @@ describe Candidates::Registrations::CreatePlacementRequestJob, type: :job do
         expect(described_class.queue_adapter).to \
           have_received(:enqueue_at).with \
             an_instance_of(described_class),
-            3.seconds.from_now.to_i
+            described_class::RETRYS.first.from_now.to_i
       end
     end
   end

--- a/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
+++ b/spec/jobs/candidates/registrations/create_placement_request_job_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::CreatePlacementRequestJob, type: :job do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:token) { SecureRandom.urlsafe_base64 }
+
+  context '#perform' do
+    let!(:create_request) do
+      double Candidates::Registrations::CreatePlacementRequest, create!: true
+    end
+
+    before do
+      allow(described_class.queue_adapter).to \
+        receive(:perform_enqueued_jobs).and_return(true)
+    end
+
+    context 'on success' do
+      before do
+        allow(Candidates::Registrations::CreatePlacementRequest).to \
+          receive(:new).and_return(create_request)
+      end
+
+      subject! do
+        described_class.perform_later 10, token, nil, 'test.com'
+      end
+
+      it "will call Service Object with correct params" do
+        expect(Candidates::Registrations::CreatePlacementRequest).to \
+          have_received(:new).with(10, token, nil, 'test.com')
+      end
+    end
+
+    context 'on error' do
+      before do
+        allow(described_class.queue_adapter).to \
+          receive(:enqueue_at).and_return(true)
+
+        freeze_time
+      end
+
+      subject! do
+        described_class.perform_later 10, token, nil, 'test.com'
+      end
+
+      it 'retrys the job' do
+        expect(described_class.queue_adapter).to \
+          have_received(:enqueue_at).with \
+            an_instance_of(described_class),
+            3.seconds.from_now.to_i
+      end
+    end
+  end
+end

--- a/spec/services/candidates/registrations/create_placement_request_spec.rb
+++ b/spec/services/candidates/registrations/create_placement_request_spec.rb
@@ -29,7 +29,7 @@ describe Candidates::Registrations::CreatePlacementRequest do
   end
 
   let :candidate_request_confirmation_notification_with_confirmation_link do
-    double NotifyEmail::CandidateRequestConfirmationWithConfirmationLink,
+    double NotifyEmail::CandidateRequestConfirmationNoPii,
       despatch_later!: true
   end
 
@@ -59,7 +59,7 @@ describe Candidates::Registrations::CreatePlacementRequest do
       end
 
       it "notifies the candidate" do
-        expect(NotifyEmail::CandidateRequestConfirmationWithConfirmationLink).to \
+        expect(NotifyEmail::CandidateRequestConfirmationNoPii).to \
           have_received(:from_application_preview).with \
             registration_session.email,
             application_preview,
@@ -78,12 +78,34 @@ describe Candidates::Registrations::CreatePlacementRequest do
       end
     end
 
+    shared_examples 'schedule gitis jobs' do
+      it "schedules accepting the privacy policy" do
+        expect(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
+          have_received(:perform_later).with \
+            contactid,
+            Bookings::Gitis::PrivacyPolicy.default
+      end
+
+      it 'schedules the log to gitis' do
+        expect(Bookings::LogToGitisJob).to \
+          have_received(:perform_later).with \
+            contactid,
+            %r{#{Date.today.to_formatted_s(:gitis)} REQUEST}
+      end
+    end
+
     before do
       allow(NotifyEmail::SchoolRequestConfirmationLinkOnly).to \
         receive(:new) { school_request_confirmation_notification_link_only }
 
-      allow(NotifyEmail::CandidateRequestConfirmationWithConfirmationLink).to \
+      allow(NotifyEmail::CandidateRequestConfirmationNoPii).to \
         receive(:from_application_preview) { candidate_request_confirmation_notification_with_confirmation_link }
+
+      allow(Bookings::LogToGitisJob).to \
+        receive(:perform_later).and_return(true)
+
+      allow(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
+        receive(:perform_later).and_return(true)
 
       registration_store.store! registration_session
     end
@@ -98,6 +120,7 @@ describe Candidates::Registrations::CreatePlacementRequest do
         before { subject.create! }
         include_examples 'sends emails'
         include_examples 'remove from registration session'
+        include_examples 'schedule gitis jobs'
       end
 
       context 'with known gitis contact' do
@@ -107,6 +130,7 @@ describe Candidates::Registrations::CreatePlacementRequest do
 
         include_examples 'sends emails'
         include_examples 'remove from registration session'
+        include_examples 'schedule gitis jobs'
       end
 
       context 'with unknown gitis contact' do

--- a/spec/services/candidates/registrations/create_placement_request_spec.rb
+++ b/spec/services/candidates/registrations/create_placement_request_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe Candidates::Registrations::CreatePlacementRequest do
   include_context 'Stubbed candidates school'
+  include_context 'fake gitis with known uuid'
 
   let(:host) { 'example.com' }
 
@@ -12,12 +13,18 @@ describe Candidates::Registrations::CreatePlacementRequest do
       urn: school_urn
   end
 
+  let(:registration_uuid) { SecureRandom.urlsafe_base64 }
+
   let :registration_store do
     Candidates::Registrations::RegistrationStore.instance
   end
 
   let :registration_session do
-    FactoryBot.build :registration_session, urn: school.urn
+    FactoryBot.build :registration_session, urn: school.urn, uuid: registration_uuid
+  end
+
+  let :personal_information do
+    registration_session.personal_information
   end
 
   let :school_request_confirmation_notification_link_only do
@@ -114,17 +121,41 @@ describe Candidates::Registrations::CreatePlacementRequest do
       allow(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
         receive(:perform_later).and_return(true)
 
-      registration_store.store! registration_session
+      allow(fake_gitis).to receive(:find).and_call_original
+      allow(fake_gitis).to receive(:update_entity).and_call_original
+      allow(fake_gitis).to receive(:create_entity).and_call_original
     end
 
-    subject { described_class.new(uuid, contactid, host, SecureRandom.uuid) }
+    subject do
+      described_class.new \
+        fake_gitis, registration_uuid, contactid, host, SecureRandom.uuid
+    end
 
     context 'with known registration uuid' do
-      let(:uuid) { registration_session.uuid }
+      before { registration_store.store! registration_session }
       let(:contactid) { nil }
 
-      xcontext 'but without gitis contact' do
+      context 'but without gitis contact' do
         before { subject.create! }
+
+        it "does not retrieve the contact from gitis" do
+          expect(fake_gitis).not_to have_received(:find)
+        end
+
+        it "creates a contact in gitis" do
+          expect(fake_gitis.store).to have_received(:create_entity).with \
+            'contacts',
+            hash_including(
+              'firstname' => personal_information.first_name,
+              'lastname' => personal_information.last_name
+            )
+        end
+
+        it "creates a new Candidate record" do
+          candidates = Bookings::Candidate.where(gitis_uuid: fake_gitis_uuid)
+          expect(candidates.count).to eql(1)
+        end
+
         include_examples 'create placement request'
         include_examples 'send emails'
         include_examples 'remove from registration session'
@@ -135,9 +166,21 @@ describe Candidates::Registrations::CreatePlacementRequest do
         let(:contact) { build(:gitis_contact, :persisted) }
         let(:contactid) { contact.id }
 
-        before do
-          create :candidate, gitis_uuid: contactid
-          subject.create!
+        before { subject.create! }
+
+        it "retrieves the contact from gitis" do
+          expect(fake_gitis).to have_received(:find).with(contactid)
+        end
+
+        it "updates the contact in gitis" do
+          expect(fake_gitis.store).to have_received(:update_entity).with \
+            contact.entity_id,
+            hash_including('address1_city' => 'Test town')
+        end
+
+        it "creates a Candidate record" do
+          candidates = Bookings::Candidate.where(gitis_uuid: contactid)
+          expect(candidates.count).to eql(1)
         end
 
         include_examples 'create placement request'
@@ -147,12 +190,29 @@ describe Candidates::Registrations::CreatePlacementRequest do
       end
 
       context 'but unknown gitis contact' do
-        it 'will raise an exception'
+        let(:contactid) { SecureRandom.uuid }
+
+        before do
+          allow(fake_gitis).to receive(:find).with(contactid) {
+            raise Bookings::Gitis::API::UnknownUrlError.new OpenStruct.new(
+              status: 404,
+              headers: {},
+              body: 'Unknown contact'
+            )
+          }
+        end
+
+        it 'will raise an exception' do
+          expect {
+            subject.create!
+          }.to raise_exception(Bookings::Gitis::API::UnknownUrlError)
+
+          expect(Bookings::PlacementRequest.count).to be_zero
+        end
       end
     end
 
     context 'with unknown registration uuid' do
-      let(:uuid) { SecureRandom.urlsafe_base64 }
       let(:contactid) { nil }
 
       it 'will raise an exception' do

--- a/spec/services/candidates/registrations/create_placement_request_spec.rb
+++ b/spec/services/candidates/registrations/create_placement_request_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::CreatePlacementRequest do
+  include_context 'Stubbed candidates school'
+
+  let(:host) { 'example.com' }
+
+  let :school do
+    create :bookings_school, :with_subjects, \
+      name: 'Test School',
+      contact_email: 'test@test.com',
+      urn: school_urn
+  end
+
+  let :registration_store do
+    Candidates::Registrations::RegistrationStore.instance
+  end
+
+  let :registration_session do
+    FactoryBot.build :registration_session, urn: school.urn
+  end
+
+  let :placement_request do
+    FactoryBot.create :placement_request, school: school
+  end
+
+  let :school_request_confirmation_notification_link_only do
+    double NotifyEmail::SchoolRequestConfirmationLinkOnly, despatch_later!: true
+  end
+
+  let :candidate_request_confirmation_notification_with_confirmation_link do
+    double NotifyEmail::CandidateRequestConfirmationWithConfirmationLink,
+      despatch_later!: true
+  end
+
+  let :cancellation_url do
+    %r{\Ahttps://example.com/candidates/cancel/\w{24}\z}
+  end
+
+  let :placement_request_url do
+    %r{\Ahttps://example.com/schools/placement_requests/\d+\z}
+  end
+
+  let :application_preview do
+    Candidates::Registrations::ApplicationPreview.new registration_session
+  end
+
+  describe '#create!' do
+    shared_examples 'sends emails' do
+      it "notifies the school" do
+        expect(NotifyEmail::SchoolRequestConfirmationLinkOnly).to \
+          have_received(:new).with \
+            to: school.notification_emails,
+            school_name: school.name,
+            placement_request_url: placement_request_url
+
+        expect(school_request_confirmation_notification_link_only).to \
+          have_received :despatch_later!
+      end
+
+      it "notifies the candidate" do
+        expect(NotifyEmail::CandidateRequestConfirmationWithConfirmationLink).to \
+          have_received(:from_application_preview).with \
+            registration_session.email,
+            application_preview,
+            cancellation_url
+
+        expect(
+          candidate_request_confirmation_notification_with_confirmation_link
+        ).to have_received :despatch_later!
+      end
+    end
+
+    shared_examples 'remove from registration session' do
+      it 'deletes the registration session from redis' do
+        expect { registration_store.retrieve! registration_session.uuid }.to \
+          raise_error Candidates::Registrations::RegistrationStore::SessionNotFound
+      end
+    end
+
+    before do
+      allow(NotifyEmail::SchoolRequestConfirmationLinkOnly).to \
+        receive(:new) { school_request_confirmation_notification_link_only }
+
+      allow(NotifyEmail::CandidateRequestConfirmationWithConfirmationLink).to \
+        receive(:from_application_preview) { candidate_request_confirmation_notification_with_confirmation_link }
+
+      registration_store.store! registration_session
+    end
+
+    subject { described_class.new(placement_request.id, uuid, contactid, host) }
+
+    context 'with known uuid' do
+      let(:uuid) { registration_session.uuid }
+      let(:contactid) { nil }
+
+      context 'without gitis contact' do
+        before { subject.create! }
+        include_examples 'sends emails'
+        include_examples 'remove from registration session'
+      end
+
+      context 'with known gitis contact' do
+        let(:contact) { build(:gitis_contact) }
+        let(:contactid) { contact.id }
+        before { subject.create! }
+
+        include_examples 'sends emails'
+        include_examples 'remove from registration session'
+      end
+
+      context 'with unknown gitis contact' do
+        it 'will raise an exception'
+      end
+    end
+
+    context 'with unknown uuid' do
+      let(:uuid) { SecureRandom.urlsafe_base64 }
+      let(:contactid) { nil }
+
+      it 'will raise an exception' do
+        expect {
+          subject.create!
+        }.to raise_exception(Candidates::Registrations::RegistrationStore::SessionNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

When Candidate submits a Placement Request it should be accepted even if we cannot talk to the CRM, eg they are performing scheduled maintenance. The data should then be submitted once it does become available.

### Changes proposed in this pull request

1. Moved the various steps performed within `Candidates::Registrations::PlacementRequestsController#create` into a Service Object which either performs tasks, or schedules jobs to perform tasks which can be done asynchronously.
2. Moved use of new `CreatePlacementRequest` Service Object out into a Job which is scheduled at the end of the journey

### Guidance to review
1. Mostly code review - there's quite a bit going on in the service object so theres a question of whether its doing too much?
2. Can be tested by setting `FAKE_CRM=false`
3. Removal of old PlacementRequestJob will move to follow on PR
4. Tracking verified addresses, and allowing CRM lookup to fail will be a follow on PR

