### PR TITLE
Add disabled warning to top of dashboard - SE-1741

### DIFF
--- a/app/views/schools/dashboards/_your_school_is_disabled.html.erb
+++ b/app/views/schools/dashboards/_your_school_is_disabled.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-error-summary" role="alert" tabindex="-1" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    Your school is currently disabled
+  </h2>
+  <div class="govuk-error-summary__body">
+    <p>
+      You need to enable your school for it to appear in candidate
+      search results.
+    </p>
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <%= link_to "Enable #{@current_school.name}",
+          edit_schools_enabled_path,
+          class: 'govuk-se-warning__link govuk-!-font-weight-bold'
+        %>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -14,6 +14,7 @@
 
       <% if @current_school.private_beta? %>
 
+        <%= render partial: 'your_school_is_disabled' if @current_school.disabled? %>
         <%= render partial: 'new_requests_and_bookings' %>
         <%= render partial: 'manage_dates' %>
         <%= render partial: 'account_admin' %>

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -17,6 +17,18 @@ Feature: The School Dashboard
         Then I should see a warning informing me that I need to complete my profile before continuing
         And I should see a 'Update your school profile' link to the 'profile' page
 
+    Scenario: Displaying a warning when the school is disabled
+        Given my school has fully-onboarded
+        And my school is disabled
+        When I am on the 'schools dashboard' page
+        Then I should see a warning that my school is disabled
+
+    Scenario: Displaying no warning when the school is enabled
+        Given my school has fully-onboarded
+        And my school is enabled
+        When I am on the 'schools dashboard' page
+        Then I shouldn't see any warnings
+
     Scenario: Displaying the managing requests section when schools have onboarded
         Given my school has fully-onboarded
         When I am on the 'schools dashboard' page

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -69,3 +69,11 @@ end
 Then("there should be no {string} link") do |link_text|
   expect(page).not_to have_link(link_text)
 end
+
+Then("I should see a warning that my school is disabled") do
+  expect(page).to have_css('.govuk-error-summary h2', text: 'Your school is currently disabled')
+end
+
+Then("I shouldn't see any warnings") do
+  expect(page).not_to have_css('.govuk-error-summary')
+end


### PR DESCRIPTION
### Context

Schools sometimes don't realise that their profiles are disabled and won't appear in results

### Changes proposed in this pull request

Add a warning that is displayed at the top of their dashboard when onboarded schools are disabled

<img width="1008" alt="Screenshot 2019-09-23 at 10 32 26" src="https://user-images.githubusercontent.com/128088/65427663-b937ec80-de0a-11e9-9a39-cbd76439d9d3.png">

### Guidance to review

Ensure it makes sense