### PR TITLE
Add google-analytics to connect-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,7 +27,7 @@
  Rails.application.config.content_security_policy do |policy|
    policy.default_src :self
 
-   policy.connect_src :self, "https://*.visualstudio.com"
+   policy.connect_src :self, "https://*.visualstudio.com", "https://www.google-analytics.com"
    policy.img_src :self, "https://www.google-analytics.com"
    policy.object_src :none
    policy.script_src :self, "'unsafe-inline'",


### PR DESCRIPTION
Content security policy was blocking some of google analytics requests.
Allow google-analytics in the connect-src directive.

### Context

### Changes proposed in this pull request

### Guidance to review
Ensure GA isn't being blocked any more, should see it in the connect-src portion of the content security policy header.