### PR TITLE
Se 1720/remove candidate name from withdrawal email

### DIFF
--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -96,7 +96,6 @@ module Candidates
         NotifyEmail::CandidateBookingCancellation.new(
           to: cancellation.candidate_email,
           school_name: cancellation.school_name,
-          candidate_name: cancellation.candidate_name,
           placement_start_date_with_duration: cancellation.booking.placement_start_date_with_duration,
           school_search_url: new_candidates_school_search_url
         ).despatch_later!

--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -106,7 +106,6 @@ module Candidates
         NotifyEmail::CandidateRequestCancellation.new(
           to: cancellation.candidate_email,
           school_name: cancellation.school_name,
-          candidate_name: cancellation.candidate_name,
           requested_availability: cancellation.dates_requested,
           school_search_url: new_candidates_school_search_url
         ).despatch_later!

--- a/app/notify/notify_email/candidate_booking_cancellation.rb
+++ b/app/notify/notify_email/candidate_booking_cancellation.rb
@@ -1,9 +1,8 @@
 class NotifyEmail::CandidateBookingCancellation < Notify
-  attr_accessor :school_name, :candidate_name, :placement_start_date_with_duration, :school_search_url
+  attr_accessor :school_name, :placement_start_date_with_duration, :school_search_url
 
-  def initialize(to:, school_name:, candidate_name:, placement_start_date_with_duration:, school_search_url:)
+  def initialize(to:, school_name:, placement_start_date_with_duration:, school_search_url:)
     self.school_name                        = school_name
-    self.candidate_name                     = candidate_name
     self.placement_start_date_with_duration = placement_start_date_with_duration
     self.school_search_url                  = school_search_url
     super(to: to)
@@ -12,13 +11,12 @@ class NotifyEmail::CandidateBookingCancellation < Notify
 private
 
   def template_id
-    '12b5984b-be09-44fe-9f79-68aea6108f91'
+    'af2311b2-7b7e-4342-b1da-bba957273b3e'
   end
 
   def personalisation
     {
       school_name: school_name,
-      candidate_name: candidate_name,
       placement_start_date_with_duration: placement_start_date_with_duration,
       school_search_url: school_search_url
     }

--- a/app/notify/notify_email/candidate_booking_cancellation_no_pii.af2311b2-7b7e-4342-b1da-bba957273b3e.md
+++ b/app/notify/notify_email/candidate_booking_cancellation_no_pii.af2311b2-7b7e-4342-b1da-bba957273b3e.md
@@ -1,4 +1,4 @@
-Dear ((candidate_name)),
+Hello,
 
 You've cancelled your school experience booking at ((school_name)) for the following dates:
 

--- a/app/notify/notify_email/candidate_request_cancellation.rb
+++ b/app/notify/notify_email/candidate_request_cancellation.rb
@@ -1,9 +1,8 @@
 class NotifyEmail::CandidateRequestCancellation < Notify
-  attr_accessor :school_name, :candidate_name, :requested_availability, :school_search_url
+  attr_accessor :school_name, :requested_availability, :school_search_url
 
-  def initialize(to:, school_name:, candidate_name:, requested_availability:, school_search_url:)
+  def initialize(to:, school_name:, requested_availability:, school_search_url:)
     self.school_name            = school_name
-    self.candidate_name         = candidate_name
     self.requested_availability = requested_availability
     self.school_search_url      = school_search_url
     super(to: to)
@@ -12,13 +11,12 @@ class NotifyEmail::CandidateRequestCancellation < Notify
 private
 
   def template_id
-    '12370ef4-5146-4732-87c9-76f852b4bfa9'
+    '86b06712-cb58-4cc7-82a1-3748cc9ad671'
   end
 
   def personalisation
     {
       school_name: school_name,
-      candidate_name: candidate_name,
       requested_availability: requested_availability,
       school_search_url: school_search_url
     }

--- a/app/notify/notify_email/candidate_request_cancellation_no_pii.86b06712-cb58-4cc7-82a1-3748cc9ad671.md
+++ b/app/notify/notify_email/candidate_request_cancellation_no_pii.86b06712-cb58-4cc7-82a1-3748cc9ad671.md
@@ -1,4 +1,4 @@
-Dear ((candidate_name)),
+Hello,
 
 You’ve withdrawn your request for school experience at ((school_name)) for the following dates:
 

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -269,7 +269,6 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
             expect(NotifyEmail::CandidateBookingCancellation).to have_received(:new).with \
               to: gitis_contact.email,
               school_name: cancellation.school_name,
-              candidate_name: gitis_contact.full_name,
               placement_start_date_with_duration: cancellation.booking.placement_start_date_with_duration,
               school_search_url: new_candidates_school_search_url
 

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -187,7 +187,6 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
             expect(NotifyEmail::CandidateRequestCancellation).to have_received(:new).with \
               to: gitis_contact.email,
               school_name: cancellation.school_name,
-              candidate_name: gitis_contact.full_name,
               requested_availability: cancellation.dates_requested,
               school_search_url: new_candidates_school_search_url
 

--- a/spec/notify/notify_email/candidate_booking_cancellation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_cancellation_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateBookingCancellation do
-  it_should_behave_like "email template", "12b5984b-be09-44fe-9f79-68aea6108f91",
+  it_should_behave_like "email template", "af2311b2-7b7e-4342-b1da-bba957273b3e",
     school_name: "Springfield Elementary School",
-    candidate_name: "Nelson Muntz",
     placement_start_date_with_duration: "2020-04-05",
     school_search_url: 'https://www.springfield.edu/search'
 end

--- a/spec/notify/notify_email/candidate_request_cancellation_spec.rb
+++ b/spec/notify/notify_email/candidate_request_cancellation_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateRequestCancellation do
-  it_should_behave_like "email template", "12370ef4-5146-4732-87c9-76f852b4bfa9",
+  it_should_behave_like "email template", "86b06712-cb58-4cc7-82a1-3748cc9ad671",
     school_name: "Springfield Elementary School",
-    candidate_name: "Nelson Muntz",
     requested_availability: 'won lottery going on holiday',
     school_search_url: 'https://www.springfield.edu/search'
 end


### PR DESCRIPTION
### Context
Emails sent to the candidate to confirm their cancellation of a booking or placement request included the candidate's name, this is unnecessary pii.

### Changes proposed in this pull request
Removes candidate's name from booking and placement request withdrawal emails.

### Guidance to review
Should look sensible and emails should still work!
