### PR TITLE
Se 1718/schools/dashboard counters

### DIFF
--- a/app/assets/stylesheets/global-styles.scss
+++ b/app/assets/stylesheets/global-styles.scss
@@ -111,3 +111,8 @@ section.govuk-se-letter {
 ul.govuk-se-spaced-list li {
   @include govuk-responsive-margin(2, "bottom");
 }
+
+.govuk-tag-red {
+  @extend .govuk-tag;
+  background-color: govuk-colour("red");
+}

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -6,6 +6,7 @@ module Schools
         .not_cancelled
         .attendance_unlogged
         .accepted
+        .upcoming
         .eager_load(:bookings_subject, bookings_placement_request: :candidate)
         .order(date: :asc)
         .page(params[:page])

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -3,11 +3,8 @@ module Schools
     def index
       @bookings = current_school
         .bookings
-        .not_cancelled
-        .attendance_unlogged
-        .accepted
-        .upcoming
-        .eager_load(:bookings_subject, bookings_placement_request: :candidate)
+        .requiring_attention
+        .eager_load(:bookings_subject, bookings_placement_request: %i(candidate candidate_cancellation school_cancellation))
         .order(date: :asc)
         .page(params[:page])
         .per(50)

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -22,6 +22,10 @@ module Schools
         .find(params[:id])
 
       @booking.bookings_placement_request.fetch_gitis_contact gitis_crm
+
+      if @booking.candidate_cancellation
+        @booking.candidate_cancellation.viewed!
+      end
     end
 
   private

--- a/app/controllers/schools/dashboards_controller.rb
+++ b/app/controllers/schools/dashboards_controller.rb
@@ -5,8 +5,13 @@ module Schools
     def show
       @school = current_school
 
-      @new_requests = current_school.placement_requests.unprocessed.count
-      @new_bookings = current_school.bookings.upcoming.count
+      @requests_requiring_attention = current_school
+        .placement_requests
+        .requiring_attention
+        .count
+
+      @bookings_requiring_attention = current_school.bookings.upcoming.count
+
       @candidate_attendances = current_school
         .bookings
         .previous

--- a/app/controllers/schools/dashboards_controller.rb
+++ b/app/controllers/schools/dashboards_controller.rb
@@ -10,7 +10,10 @@ module Schools
         .requiring_attention
         .count
 
-      @bookings_requiring_attention = current_school.bookings.upcoming.count
+      @bookings_requiring_attention = current_school
+        .bookings
+        .with_unviewed_candidate_cancellation
+        .count
 
       @candidate_attendances = current_school
         .bookings

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -10,6 +10,10 @@ module Schools
       @gitis_contact = placement_request.fetch_gitis_contact(gitis_crm)
 
       @placement_request.viewed!
+
+      if @placement_request.candidate_cancellation
+        @placement_request.candidate_cancellation.viewed!
+      end
     end
 
   private
@@ -18,7 +22,7 @@ module Schools
       current_school
         .placement_requests
         .unbooked
-        .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date)
+        .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date, :booking)
         .order(created_at: 'desc')
     end
 

--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -1,10 +1,8 @@
 module Schools::PlacementRequestsHelper
   def placement_request_status(placement_request)
-    text = if placement_request.cancelled?
-             'Cancelled'
-           elsif !placement_request.viewed?
-             'New'
-           end
+    fail "not applicable for bookings" if placement_request.booking
+
+    text = placement_request.status unless placement_request.status == 'Viewed'
 
     tag.span(text, class: 'govuk-tag') if text
   end

--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -1,9 +1,18 @@
 module Schools::PlacementRequestsHelper
+  HIDDEN_STATUSES = %w(Viewed Booked).freeze
+
   def placement_request_status(placement_request)
-    fail "not applicable for bookings" if placement_request.booking
+    status = placement_request.status
 
-    text = placement_request.status unless placement_request.status == 'Viewed'
+    unless status.in? HIDDEN_STATUSES
 
-    tag.span(text, class: 'govuk-tag') if text
+      css_class = if placement_request.cancelled?
+                    'govuk-tag-red'
+                  else
+                    'govuk-tag'
+                  end
+
+      tag.span status, class: css_class
+    end
   end
 end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -56,6 +56,11 @@ module Bookings
     scope :previous, -> { where(arel_table[:date].lteq(Date.today)) }
     scope :attendance_unlogged, -> { where(attended: nil) }
 
+    scope :with_unviewed_candidate_cancellation, -> do
+      joins(bookings_placement_request: :candidate_cancellation)
+        .where(bookings_placement_request_cancellations: { viewed_at: nil })
+    end
+
     def self.from_confirm_booking(confirm_booking)
       new(
         date: confirm_booking.date,

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -65,7 +65,7 @@ module Bookings
     end
 
     def status
-      "New"
+      bookings_placement_request.status
     end
 
     def placement_start_date_with_duration

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -63,6 +63,18 @@ module Bookings
         .where(bookings_placement_request_cancellations: { viewed_at: nil })
     end
 
+    scope :to_manage, -> do
+      not_cancelled
+      .attendance_unlogged
+      .accepted
+      .upcoming
+    end
+
+    scope :requiring_attention, -> do
+      where(id: with_unviewed_candidate_cancellation.select('id')).or \
+        where(id: to_manage.select('id'))
+    end
+
     def self.from_confirm_booking(confirm_booking)
       new(
         date: confirm_booking.date,

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -1,7 +1,8 @@
 module Bookings
   class Booking < ApplicationRecord
     belongs_to :bookings_placement_request,
-      class_name: 'Bookings::PlacementRequest'
+      class_name: 'Bookings::PlacementRequest',
+      inverse_of: :booking
 
     belongs_to :bookings_subject,
       class_name: 'Bookings::Subject'
@@ -45,6 +46,7 @@ module Bookings
       :contact_uuid,
       :candidate_email,
       :candidate_name,
+      :cancelled?,
       to: :bookings_placement_request
 
     UPCOMING_TIMEFRAME = 2.weeks

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -2,6 +2,7 @@
 # registration
 module Bookings
   class PlacementRequest < ApplicationRecord
+    include ViewTrackable
     include Candidates::Registrations::Behaviours::PlacementPreference
     include Candidates::Registrations::Behaviours::Education
     include Candidates::Registrations::Behaviours::TeachingPreference
@@ -49,9 +50,16 @@ module Bookings
     end
 
     scope :unbooked, -> do
+      without_booking.or booking_not_sent
+    end
+
+    scope :booking_not_sent, -> do
+      left_joins(:booking).where(bookings_bookings: { accepted_at: nil })
+    end
+
+    scope :without_booking, -> do
       left_joins(:booking)
         .where(bookings_bookings: { bookings_placement_request_id: nil })
-        .or(left_joins(:booking).where(bookings_bookings: { accepted_at: nil }))
     end
 
     scope :cancelled, -> do
@@ -66,6 +74,22 @@ module Bookings
       left_joins(:candidate_cancellation, :school_cancellation)
         .where(bookings_placement_request_cancellations: { sent_at: nil })
         .where(school_cancellations_bookings_placement_requests: { sent_at: nil })
+    end
+
+    scope :with_unviewed_canidate_cancellation, -> do
+      left_joins(:candidate_cancellation)
+        .merge Cancellation.unviewed
+    end
+
+    scope :not_cancelled_by_school, -> do
+      left_joins(:school_cancellation)
+        .where(school_cancellations_bookings_placement_requests: { bookings_placement_request_id: nil })
+    end
+
+    scope :requiring_attention, -> do
+      without_booking
+        .with_unviewed_canidate_cancellation
+        .not_cancelled_by_school
     end
 
     default_scope { where.not(candidate_id: nil) }
@@ -91,16 +115,6 @@ module Bookings
 
     def open?
       !closed?
-    end
-
-    def viewed!
-      if viewed_at.nil?
-        update(viewed_at: Time.now)
-      end
-    end
-
-    def viewed?
-      viewed_at.present?
     end
 
     def contact_uuid

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -133,9 +133,13 @@ module Bookings
       created_at.to_date
     end
 
-    # FIXME SE-1130
     def status
-      return 'Cancelled' if cancelled?
+      return 'Candidate cancellation' if booking && candidate_cancellation&.sent?
+      return 'School cancellation'    if booking && school_cancellation&.sent?
+      return 'Booked'                 if booking
+      return 'Withdrawn'              if candidate_cancellation&.sent?
+      return 'Rejected'               if school_cancellation&.sent?
+      return 'Viewed'                 if viewed?
 
       'New'
     end

--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -1,4 +1,9 @@
 class Bookings::PlacementRequest::Cancellation < ApplicationRecord
+  include ViewTrackable
+
+  scope :candidate_cancellation, -> { where cancelled_by: 'candidate' }
+  scope :school_cancellation,    -> { where cancelled_by: 'school' }
+
   belongs_to :placement_request,
     class_name: 'Bookings::PlacementRequest',
     foreign_key: 'bookings_placement_request_id'

--- a/app/models/concerns/view_trackable.rb
+++ b/app/models/concerns/view_trackable.rb
@@ -1,0 +1,18 @@
+module ViewTrackable
+  extend ActiveSupport::Concern
+
+  included do
+    scope :viewed, -> { where.not viewed_at: nil }
+    scope :unviewed, -> { where viewed_at: nil }
+  end
+
+  def viewed!
+    if viewed_at.nil?
+      update!(viewed_at: DateTime.now)
+    end
+  end
+
+  def viewed?
+    viewed_at.present?
+  end
+end

--- a/app/views/schools/confirmed_bookings/_booking_table.html.erb
+++ b/app/views/schools/confirmed_bookings/_booking_table.html.erb
@@ -2,16 +2,20 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col">Name</th>
+      <th class="govuk-table__header" scope="col">Status</th>
       <th class="govuk-table__header" scope="col">Subject</th>
       <th class="govuk-table__header" scope="col">Date booked</th>
       <th class="govuk-table__header"/>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <%- @bookings.each do |booking| -%>
+    <%- bookings.each do |booking| -%>
       <tr class="booking govuk-table__row" data-booking="<%= booking.id %>">
         <td class="name govuk-table__cell">
           <%= booking.candidate_name %>
+        </td>
+        <td class="status govuk-table__cell">
+          <%= placement_request_status(booking) %>
         </td>
         <td class="subject govuk-table__cell">
           <%= booking.bookings_subject.name %>

--- a/app/views/schools/confirmed_bookings/index.html.erb
+++ b/app/views/schools/confirmed_bookings/index.html.erb
@@ -35,12 +35,13 @@
 
     <% else %>
       <p>
-        There are no bookings.
+        There are no upcoming bookings.
       </p>
     <% end %>
 
-    <div>
-      <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path, secondary: true %>
-    </div>
+  </div>
+
+  <div class="govuk-grid-column-full">
+    <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path, secondary: true %>
   </div>
 </div>

--- a/app/views/schools/confirmed_bookings/show.html.erb
+++ b/app/views/schools/confirmed_bookings/show.html.erb
@@ -47,9 +47,23 @@
     </dl>
   </section>
 
-  <div>
-    <%= govuk_link_to 'Cancel booking', new_schools_booking_cancellation_path(@booking), secondary: true %>
-  </div>
+  <% if @booking.candidate_cancellation %>
+    <section id="cancellation-details">
+      <h2>Cancellation details</h2>
+
+      <dl class="govuk-summary-list">
+        <%= summary_row 'Cancellation reason', @booking.candidate_cancellation.reason %>
+        <% if @booking.candidate_cancellation.extra_details.present? %>
+          <%= summary_row 'Additional details', @booking.candidate_cancellation.extra_details %>
+        <% end %>
+        <%= summary_row 'Cancellation sent at', @booking.candidate_cancellation.sent_at.to_date.to_formatted_s(:govuk) %>
+      </dl>
+    </section>
+  <% else %>
+    <div>
+      <%= govuk_link_to 'Cancel booking', new_schools_booking_cancellation_path(@booking), secondary: true %>
+    </div>
+  <% end %>
 
   <div>
     <%= govuk_link_to 'Return to requests and bookings', schools_dashboard_path %>

--- a/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
@@ -6,7 +6,7 @@
   <div id="requests" class="subsection">
     <header class="dashboard-high-priority">
       <%= link_to "Manage requests", schools_placement_requests_path %>
-      <%= numbered_circle(@new_requests, id: 'new-requests-counter', aria_label: 'new placement requests') %>
+      <%= numbered_circle(@requests_requiring_attention, id: 'new-requests-counter', aria_label: 'new placement requests') %>
     </header>
     <p class="govuk-hint">Accept, reject or revisit outstanding requests</p>
   </div>
@@ -14,7 +14,7 @@
   <div id="bookings" class="subsection">
     <header class="dashboard-high-priority">
       <%= link_to "Manage bookings", schools_bookings_path  %>
-      <%= numbered_circle(@new_bookings, id: 'new-bookings-counter', aria_label: 'new upcoming bookings') %>
+      <%= numbered_circle(@bookings_requiring_attention, id: 'new-bookings-counter', aria_label: 'new upcoming bookings') %>
     </header>
     <p class="govuk-hint">View, change or cancel bookings</p>
   </div>

--- a/db/migrate/20190919111332_add_viewed_at_to_bookings_placement_request_cancellations.rb
+++ b/db/migrate/20190919111332_add_viewed_at_to_bookings_placement_request_cancellations.rb
@@ -1,0 +1,5 @@
+class AddViewedAtToBookingsPlacementRequestCancellations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_placement_request_cancellations, :viewed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_105024) do
+ActiveRecord::Schema.define(version: 2019_09_19_111332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 2019_09_16_105024) do
     t.string "cancelled_by", null: false
     t.datetime "sent_at"
     t.text "extra_details"
+    t.datetime "viewed_at"
     t.index ["bookings_placement_request_id"], name: "index_cancellations_on_bookings_placement_request_id"
   end
 

--- a/features/schools/confirmed_bookings/index.feature
+++ b/features/schools/confirmed_bookings/index.feature
@@ -27,7 +27,7 @@ Feature: Viewing all bookings
         Given there are some bookings
         When I am on the 'bookings' page
         Then the bookings table should have the following values:
-			| Heading | Value            |
+			      | Heading | Value            |
             | Name    | Matthew Richards |
             | Subject | Biology          |
         And the booking date should be correct

--- a/features/schools/confirmed_bookings/index.feature
+++ b/features/schools/confirmed_bookings/index.feature
@@ -46,5 +46,5 @@ Feature: Viewing all bookings
     Scenario:
         Given there are no bookings
         When I am on the 'bookings' page
-        Then I should see the text 'There are no bookings'
+        Then I should see the text 'There are no upcoming bookings'
         And I should not see the bookings table

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -52,3 +52,16 @@ Feature: Viewing a booking
             | Teaching stage                          | I want to be a teacher            |
             | Teaching subject                        | First choice: Biology             |
             | Teaching subject                        | Second choice: Biology            |
+
+    Scenario: Without a candidate cancellation
+        Given there is at least one booking
+        When I am viewing my chosen booking
+        Then I should not see a 'Cancellation details' section
+
+    Scenario: Cancellation details
+        Given there is a cancelled booking
+        When I am viewing my chosen booking
+        Then I should see a 'Cancellation details' section with the following values:
+            | Heading              | Value             |
+            | Cancellation reason  | MyText            |
+            | Cancellation sent at | \d{2}\s\w+\s\d{4} |

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -78,7 +78,7 @@ Feature: The School Dashboard
 
     Scenario: Candidate bookings counter
         Given my school has fully-onboarded
-        And there are 3 new bookings
+        And there are 3 unviewed candidate cancellations
         When I am on the 'schools dashboard' page
         Then the 'new bookings counter' should be 3
 

--- a/features/schools/placement_requests/index.feature
+++ b/features/schools/placement_requests/index.feature
@@ -39,7 +39,7 @@ Feature: Viewing all placement requests
     Scenario: Cancelled placement requests
         Given there are some cancelled placement requests
         When I am on the 'placement requests' page
-        Then the cancelled requests should have a status of 'Cancelled'
+        Then the cancelled requests should have a status of 'Withdrawn'
 
     Scenario: Unviewed placement requests
         Given there are some unviewed placement requests

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -10,6 +10,19 @@ Given("there is at least one booking") do
   step "there is 1 booking"
 end
 
+Given("there is a cancelled booking") do
+  unless @school.subjects.where(name: 'Biology').any?
+    @school.subjects << FactoryBot.create(:bookings_subject, name: 'Biology')
+  end
+  @booking = FactoryBot.create :bookings_booking,
+    :cancelled_by_candidate,
+    bookings_school: @school,
+    bookings_subject: @school.subjects.last,
+    date: 1.week.from_now.strftime("%d %B %Y")
+
+  @booking_id = @booking.id
+end
+
 Given("I am viewing my chosen booking") do
   path = path_for('booking', booking_id: @booking_id)
   visit(path)
@@ -154,4 +167,8 @@ end
 Then("the page title should start with {string} and include the booking reference") do |string|
   expect(page.title).to start_with(string)
   expect(page.title).to include(@booking.reference)
+end
+
+Then("I should not see a {string} section") do |string|
+  expect(page).not_to have_css "section##{string.downcase.gsub(' ', '-')}"
 end

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -35,6 +35,11 @@ Given("there are {int} new bookings") do |qty|
   FactoryBot.create_list :bookings_booking, qty, :upcoming, :accepted, bookings_school: @school
 end
 
+Given("there are {int} unviewed candidate cancellations") do |qty|
+  FactoryBot.create_list \
+    :bookings_booking, qty, :cancelled_by_candidate, bookings_school: @school
+end
+
 Given("there are {int} bookings in the past with no attendance logged") do |qty|
   @bookings = FactoryBot.create_list :bookings_booking, qty, bookings_school: @school
   @bookings.each do |b|

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -155,7 +155,7 @@ end
 
 Then("the cancelled requests should have a status of {string}") do |status|
   within('table#placement-requests') do
-    expect(page).to have_css('.govuk-tag', text: /#{status}/i, count: @cancelled_placement_requests_count)
+    expect(page).to have_css('.govuk-tag-red', text: /#{status}/i, count: @cancelled_placement_requests_count)
   end
 end
 

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -51,20 +51,32 @@ describe Schools::PlacementRequestsController, type: :request do
   end
 
   context '#show' do
-    let :placement_request do
-      FactoryBot.create :placement_request, school: school
-    end
-
     before do
       get "/schools/placement_requests/#{placement_request.id}"
     end
 
-    it 'assigns the correct placement_request' do
-      expect(assigns(:placement_request)).to eq placement_request
+    context 'with a new placement request' do
+      let :placement_request do
+        FactoryBot.create :placement_request, school: school
+      end
+
+      it 'assigns the correct placement_request' do
+        expect(assigns(:placement_request)).to eq placement_request
+      end
+
+      it 'renders the show template' do
+        expect(response).to render_template :show
+      end
     end
 
-    it 'renders the show template' do
-      expect(response).to render_template :show
+    context 'with a placement request cancelled by candidate' do
+      let :placement_request do
+        create :placement_request, :cancelled, school: school
+      end
+
+      it 'marks the cancellation as viewed' do
+        expect(placement_request.reload.candidate_cancellation).to be_viewed
+      end
     end
   end
 end

--- a/spec/factories/bookings/bookings_factory.rb
+++ b/spec/factories/bookings/bookings_factory.rb
@@ -47,5 +47,12 @@ FactoryBot.define do
           cancelled_by: 'school'
       end
     end
+
+    trait :with_viewed_candidate_cancellation do
+      cancelled_by_candidate
+      after :create do |bb|
+        bb.candidate_cancellation.viewed!
+      end
+    end
   end
 end

--- a/spec/factories/bookings/placement_request/cancellations.rb
+++ b/spec/factories/bookings/placement_request/cancellations.rb
@@ -7,5 +7,11 @@ FactoryBot.define do
     trait :sent do
       after :build, &:sent!
     end
+
+    trait :viewed do
+      after :build do |cancellation|
+        cancellation.viewed_at = DateTime.now
+      end
+    end
   end
 end

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -33,6 +33,14 @@ FactoryBot.define do
       end
     end
 
+    trait :with_viewed_candidate_cancellation do
+      before :create do |placement_request|
+        placement_request.candidate_cancellation = \
+          FactoryBot.build :cancellation,
+            :sent, :viewed, placement_request: placement_request
+      end
+    end
+
     trait :cancelled_by_school do
       before :create do |placement_request|
         placement_request.school_cancellation = \
@@ -59,6 +67,10 @@ FactoryBot.define do
           bookings_placement_request: placement_request,
           bookings_placement_request_id: placement_request.id
       end
+    end
+
+    trait :viewed do
+      after :create, &:viewed!
     end
   end
 end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -173,6 +173,17 @@ describe Bookings::Booking do
         expect(subject).not_to include(attended, skipped)
       end
     end
+
+    describe '.with_unviewed_candidate_cancellation' do
+      let!(:new_booking) { create :bookings_booking }
+      let!(:with_viewed_candidate_cancellation) { create :bookings_booking, :with_viewed_candidate_cancellation }
+      let!(:with_unviewed_candidate_cancellation) { create :bookings_booking, :cancelled_by_candidate }
+      let!(:with_unviewed_school_cancellation) { create :bookings_booking, :cancelled_by_school }
+
+      subject { described_class.with_unviewed_candidate_cancellation }
+
+      it { is_expected.to match_array [with_unviewed_candidate_cancellation] }
+    end
   end
 
   describe 'Acceptance' do

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -136,6 +136,46 @@ describe Bookings::PlacementRequest, type: :model do
     end
   end
 
+  context '.requiring_attention' do
+    let :school do
+      create :bookings_school, :with_subjects
+    end
+
+    let! :request_pending_decision do
+      create :placement_request, school: school
+    end
+
+    let! :request_with_unviewed_candidate_cancellation do
+      create :placement_request, :cancelled, school: school
+    end
+
+    let! :request_with_viewed_candidate_cancellation do
+      create :placement_request,
+        :with_viewed_candidate_cancellation, school: school
+    end
+
+    let! :request_with_booking do
+      create :placement_request, :booked, school: school
+    end
+
+    let! :request_with_school_cancellation do
+      create :placement_request, :cancelled_by_school, school: school
+    end
+
+    let! :other_schools_request do
+      create :placement_request, school: create(:bookings_school, :with_subjects)
+    end
+
+    subject { school.placement_requests.requiring_attention }
+
+    it { is_expected.to     include request_pending_decision }
+    it { is_expected.to     include request_with_unviewed_candidate_cancellation }
+    it { is_expected.not_to include request_with_viewed_candidate_cancellation }
+    it { is_expected.not_to include request_with_booking }
+    it { is_expected.not_to include request_with_school_cancellation }
+    it { is_expected.not_to include other_schools_request }
+  end
+
   context '.create_from_registration_session' do
     let(:candidate) { create(:candidate) }
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -532,19 +532,45 @@ describe Bookings::PlacementRequest, type: :model do
 
   context '#status' do
     context 'default' do
-      subject { FactoryBot.create :placement_request }
+      subject { create(:placement_request).status }
 
-      it "returns 'pending'" do
-        expect(subject.status).to eq 'New'
-      end
+      it { is_expected.to eq 'New' }
     end
 
-    context 'when cancelled?' do
-      subject { FactoryBot.create :placement_request, :cancelled }
+    context 'when cancelled by candidate' do
+      subject { create(:placement_request, :cancelled).status }
 
-      it "returns 'cancelled'" do
-        expect(subject.status).to eq 'Cancelled'
-      end
+      it { is_expected.to eq 'Withdrawn' }
+    end
+
+    context 'when cancelled by school' do
+      subject { create(:placement_request, :cancelled_by_school).status }
+
+      it { is_expected.to eq 'Rejected' }
+    end
+
+    context 'when viewed' do
+      subject { create(:placement_request, :viewed).status }
+
+      it { is_expected.to eq 'Viewed' }
+    end
+
+    context 'when booked' do
+      subject { create(:placement_request, :booked).status }
+
+      it { is_expected.to eq 'Booked' }
+    end
+
+    context 'when booked and cancelled by candidate' do
+      subject { create(:placement_request, :booked, :cancelled).status }
+
+      it { is_expected.to eq 'Candidate cancellation' }
+    end
+
+    context 'when booked and cancelled by school' do
+      subject { create(:placement_request, :booked, :cancelled_by_school).status }
+
+      it { is_expected.to eq 'School cancellation' }
     end
   end
 


### PR DESCRIPTION
### Context
The counters on the dashboard were confusing users.

### Changes proposed in this pull request
This kept getting larger as I spotted more stuff, didn't think it warranted a pr chain though!

Updates the placement request counter to show new (no booking, no cancellation) placement requests and placement requests with an unviewed candidate cancellation.

Updates the bookings counter to only show those with an unviewed candidate cancellation.

Updates the bookings index page to only show upcoming bookings. Past bookings will appear the confirm attendance section for the school to action.

Adds candidate cancellation details to the booking show template as we were missing that.

Adds a status column to bookings index page and full list of statuses to bookings and placement requests (wording agreed with Fred)

### Guidance to review
Ensure only placement requests that are unbooked and uncancelled, or have an unviewed withdrawal are shown in the notification badge for placement requests.

Ensure only bookings with an unviewed candidate cancellation are shown in the manage bookings notification badge.

Have a poke around the dashboard and ensure everything still works.

We should probably remove cancelled placement requests that have been viewed from the placement requests index table, but that will need checking with Jordan first.