### PR TITLE
Stop reporting no id token errors SE-730

### DIFF
--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -22,11 +22,12 @@ module Schools
     def logout
       id_token = session[:id_token]
 
+      session.clear
+
       if id_token.nil?
         Rails.logger.error 'No id_token present, cannot log out from DfE Sign-in'
+        return redirect_to schools_path
       end
-
-      session.clear
 
       redirect_to(
         URI::HTTPS.build(

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -1,7 +1,6 @@
 module Schools
   class StateMismatchError < StandardError; end
   class AuthFailedError < StandardError; end
-  class NoIDTokenError < StandardError; end
 
   class SessionsController < ApplicationController
     include DFEAuthentication
@@ -24,7 +23,7 @@ module Schools
       id_token = session[:id_token]
 
       if id_token.nil?
-        fail NoIDTokenError, 'No id_token present, cannot log out from DfE Sign-in'
+        Rails.logger.error 'No id_token present, cannot log out from DfE Sign-in'
       end
 
       session.clear

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -196,10 +196,13 @@ describe Schools::SessionsController, type: :request do
 
       before { allow(Rails.logger).to receive(:error).and_return(true) }
 
-      before { subject }
-
       specify 'it should write a message to the error log' do
+        subject
         expect(Rails.logger).to have_received(:error).with(/No id_token present/)
+      end
+
+      specify 'it should redirect directly to the schools path' do
+        expect(subject).to redirect_to(schools_path)
       end
     end
   end

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -194,8 +194,12 @@ describe Schools::SessionsController, type: :request do
     context 'when a session exists but there is no id_token' do
       subject { get(logout_schools_session_path) }
 
-      specify 'it should raise an NoIDTokenError' do
-        expect { subject }.to raise_error(Schools::NoIDTokenError, 'No id_token present, cannot log out from DfE Sign-in')
+      before { allow(Rails.logger).to receive(:error).and_return(true) }
+
+      before { subject }
+
+      specify 'it should write a message to the error log' do
+        expect(Rails.logger).to have_received(:error).with(/No id_token present/)
       end
     end
   end


### PR DESCRIPTION
### Context

Sentry was receiving a lot of NoIDTokenError errors which created a lot of noise 

### Changes proposed in this pull request

When a user is logging out, the fact they have no `id_token` isn't really important enough to warrant an error, so instead of failing just log the error, clear the session and redirect them

### Guidance to review

Ensure it looks sensible and the logout flow works as normal

