### PR TITLE
Add length validation to gitis contact attributes SE-1503

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -31,6 +31,17 @@ module Bookings
 
       validates :email, presence: true, format: /\A.+@.+\..+\z/
 
+      validates :emailaddress1, length: { maximum: 100 }
+      validates :emailaddress2, length: { maximum: 100 }
+      validates :address1_line1, length: { maximum: 250 }
+      validates :address1_line2, length: { maximum: 250 }
+      validates :address1_line3, length: { maximum: 250 }
+      validates :address1_city, length: { maximum: 80 }
+      validates :address1_stateorprovince, length: { maximum: 50 }
+      validates :address1_postalcode, length: { maximum: 20 }
+      validates :telephone1, length: { maximum: 50 }
+      validates :telephone2, length: { maximum: 50 }
+
       def self.channel_creation
         Rails.application.config.x.gitis.channel_creation
       end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -65,6 +65,34 @@ describe Bookings::Gitis::Contact, type: :model do
     end
   end
 
+  describe 'validation' do
+    subject { build :gitis_contact }
+
+    {
+      emailaddress1: 100,
+      emailaddress2: 100,
+      address1_line1: 250,
+      address1_line2: 250,
+      address1_line3: 250,
+      address1_city: 80,
+      address1_stateorprovince: 50,
+      address1_postalcode: 20,
+      telephone1: 50,
+      telephone2: 50
+    }.each do |attribute, max_length|
+      context attribute.to_s do
+        before do
+          subject.send("#{attribute}=", "a" * (max_length + 1))
+          subject.valid?
+        end
+
+        specify "should validate #{attribute} allows maximum length of #{max_length} characters" do
+          expect(subject.errors.messages[attribute]).to include(/is too long \(maximum is #{max_length} characters\)/)
+        end
+      end
+    end
+  end
+
   describe '#created_by_us?' do
     context 'with our record' do
       subject do


### PR DESCRIPTION
### Context

The GITIS API returns errors when attributes that are too long are supplied. The fields lengths are outlined [here](https://docs.microsoft.com/en-us/dynamics365/customer-engagement/developer/entities/contact).

### Changes proposed in this pull request

Add validation in the GITIS Contact model to highlight the problem and prevent the errors from reaching GITIS.

### Guidance to review

Check everything looks ok. Have I added these in the correct place?