### PR TITLE
Add length validations matching the gitis CRM API SE-1503

### DIFF
--- a/app/services/candidates/registrations/contact_information.rb
+++ b/app/services/candidates/registrations/contact_information.rb
@@ -8,10 +8,24 @@ module Candidates
       attribute :postcode
       attribute :phone
 
-      validates :phone, presence: true
+      validates :phone,
+        presence: true,
+        length: { maximum: 50 }
+
       validates :phone, phone: true, if: -> { phone.present? }
-      validates :building, presence: true
-      validates :postcode, presence: true
+
+      validates :building,
+        presence: true,
+        length: { maximum: 250 }
+
+      validates :street, length: { maximum: 250 }
+      validates :town_or_city, length: { maximum: 80 }
+      validates :county, length: { maximum: 50 }
+
+      validates :postcode,
+        presence: true,
+        length: { maximum: 20 }
+
       validate :postcode_is_valid, if: -> { postcode.present? }
 
     private

--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -16,7 +16,7 @@ module Candidates
 
       validates :first_name, presence: true, unless: :read_only
       validates :last_name, presence: true, unless: :read_only
-      validates :email, presence: true
+      validates :email, presence: true, length: { maximum: 100 }
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
       validates :date_of_birth, presence: true, unless: :read_only
       validates :date_of_birth, inclusion: { in: ->(_) { MAX_AGE.years.ago..MIN_AGE.years.ago } }, if: -> { date_of_birth.present? && !read_only }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,18 +103,24 @@ en:
           attributes:
             building:
               blank: "Enter your building"
+              too_long: "Building must be 250 characters or fewer"
             county:
               blank: "Enter your county"
+              too_long: "County must be 50 characters or fewer"
             phone:
               blank: "Enter your telephone number"
               invalid: "Enter a valid telephone number"
+              too_long: "Phone number must be 50 digits or fewer"
             postcode:
               blank: "Enter your postcode"
               invalid: 'Enter a valid postcode'
+              too_long: "Postcode must be 20 characters or fewer"
             street:
               blank: "Enter your street"
+              too_long: "Street must be 250 characters or fewer"
             town_or_city:
               blank: "Enter your town or city"
+              too_long: "Town or city must be 80 characters or fewer"
 
         candidates/registrations/education:
           attributes:
@@ -139,6 +145,7 @@ en:
             email:
               blank: "Enter your email address"
               invalid: "Enter a valid email address"
+              too_long: "Email must be 100 characters or fewer"
             first_name:
               blank: 'Enter your first name'
             last_name:

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -13,50 +13,89 @@ describe Candidates::Registrations::ContactInformation, type: :model do
   end
 
   context 'validations' do
-    it { is_expected.to validate_presence_of :building }
-    it { is_expected.to validate_presence_of :postcode }
-    it { is_expected.to validate_presence_of :phone }
+    context 'building' do
+      it { is_expected.to validate_presence_of :building }
 
-    context 'phone is present' do
-      VALID_NUMBERS = ['01434 634996', '+441434634996', '01234567890'].freeze
-      INVALID_NUMBERS = ['7', 'q', '+4414346349'].freeze
-      BLANK_NUMBERS = ['', ' ', '   '].freeze
+      let(:too_long_msg) { 'Building must be 250 characters or fewer' }
+      it { is_expected.to validate_length_of(:building).is_at_most(250).with_message(too_long_msg) }
+    end
 
-      context 'valid numbers' do
-        VALID_NUMBERS.each do |number|
-          subject { described_class.new phone: number }
-          before { subject.validate }
+    context 'street' do
+      let(:too_long_msg) { 'Street must be 250 characters or fewer' }
 
-          it "permits #{number}" do
-            expect(subject.errors[:phone]).to be_empty
+      it { is_expected.to validate_length_of(:street).is_at_most(250).with_message(too_long_msg) }
+    end
+
+    context 'town_or_city' do
+      let(:too_long_msg) { 'Town or city must be 80 characters or fewer' }
+
+      it { is_expected.to validate_length_of(:town_or_city).is_at_most(80).with_message(too_long_msg) }
+    end
+
+    context 'county' do
+      let(:too_long_msg) { 'County must be 50 characters or fewer' }
+
+      it { is_expected.to validate_length_of(:county).is_at_most(50).with_message(too_long_msg) }
+    end
+
+
+    context 'postcode' do
+      it { is_expected.to validate_presence_of :postcode }
+
+      let(:too_long_msg) { 'Postcode must be 20 characters or fewer' }
+      it { is_expected.to validate_length_of(:postcode).is_at_most(20).with_message(too_long_msg) }
+    end
+
+    context 'phone' do
+      it { is_expected.to validate_presence_of :phone }
+
+      let(:too_long_msg) { 'Phone number must be 50 digits or fewer' }
+      it { is_expected.to validate_length_of(:phone).is_at_most(50).with_message(too_long_msg) }
+
+      context 'phone is present' do
+        VALID_NUMBERS = ['01434 634996', '+441434634996', '01234567890'].freeze
+        INVALID_NUMBERS = ['7', 'q', '+4414346349'].freeze
+        BLANK_NUMBERS = ['', ' ', '   '].freeze
+
+        context 'valid numbers' do
+          VALID_NUMBERS.each do |number|
+            subject { described_class.new phone: number }
+            before { subject.validate }
+
+            it "permits #{number}" do
+              expect(subject.errors[:phone]).to be_empty
+            end
           end
         end
-      end
 
-      context 'invalid numbers' do
-        INVALID_NUMBERS.each do |number|
-          subject { described_class.new phone: number }
-          before { subject.validate }
+        context 'invalid numbers' do
+          INVALID_NUMBERS.each do |number|
+            subject { described_class.new phone: number }
+            before { subject.validate }
 
-          it "doesn't permit #{number}" do
-            expect(subject.errors[:phone]).to eq ["Enter a valid telephone number"]
+            it "doesn't permit #{number}" do
+              expect(subject.errors[:phone]).to eq ["Enter a valid telephone number"]
+            end
           end
         end
-      end
 
-      context 'blank number' do
-        BLANK_NUMBERS.each do |number|
-          subject { described_class.new phone: number }
-          before { subject.validate }
+        context 'blank number' do
+          BLANK_NUMBERS.each do |number|
+            subject { described_class.new phone: number }
+            before { subject.validate }
 
-          it "doesn't permit #{number}" do
-            expect(subject.errors[:phone]).to eq ["Enter your telephone number"]
+            it "doesn't permit #{number}" do
+              expect(subject.errors[:phone]).to eq ["Enter your telephone number"]
+            end
           end
         end
       end
     end
 
     context 'postcode is present' do
+      let(:too_long_msg) { 'Postcode must be 20 characters or fewer' }
+      it { is_expected.to validate_length_of(:postcode).is_at_most(20).with_message(too_long_msg) }
+
       VALID_POSTCODES = [
         'DN55 1PT',
         'CR2 6XH',

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -15,8 +15,11 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
   context 'validations' do
     it { is_expected.to validate_presence_of :first_name }
     it { is_expected.to validate_presence_of :last_name }
-    it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_presence_of :date_of_birth }
+
+    let(:too_long_msg) { 'Email must be 100 characters or fewer' }
+    it { is_expected.to validate_presence_of :email }
+    it { is_expected.to validate_length_of(:email).is_at_most(100).with_message(too_long_msg) }
 
     context 'when read only' do
       subject { described_class.new read_only: true }


### PR DESCRIPTION
### Context

The GITIS API rejects some records that are too long

### Changes proposed in this pull request

Add length validation for various contact and personal information fields that are sent to the GITIS API.

### Guidance to review

Ensure the validations all make sense and match those referenced in the ticket.

```
emailaddress1 = 100
emailaddress2 = 100
address1_line1 = 250
address1_line2 = 250
address1_line3 = 250
address1_city = 80
address1_stateorprovince = 50
address1_postalcode = 20
telephone1 = 50
telephone2 = 50
```