### PR TITLE
Only check that placement requests have either availability or a placement date SE-1776

### DIFF
--- a/app/services/candidates/registrations/behaviours/placement_preference.rb
+++ b/app/services/candidates/registrations/behaviours/placement_preference.rb
@@ -6,12 +6,20 @@ module Candidates
 
         included do
           with_options unless: :dont_validate_availability? do
+            # The 'unless' clauses on the following validations ensure that if
+            # placement requests are created when the school has fixed or flexible
+            # dates selected *then toggles*, the PR won't be left in an invalid state
+            #
+            # At least either the availability or bookings_placement_date_id must
+            # be present
             validates :bookings_placement_date_id,
               presence: true,
-              if: :school_offers_fixed_dates?
+              if: :school_offers_fixed_dates?,
+              unless: -> { availability.present? }
             validates :availability,
               presence: true,
-              if: :school_offers_flexible_dates?
+              if: :school_offers_flexible_dates?,
+              unless: -> { bookings_placement_date_id.present? }
           end
           validates :urn, presence: true
           validates :availability, number_of_words: { less_than: 150 }, if: -> { availability.present? }


### PR DESCRIPTION
### Context

When the placement request is created on a school that has flexible
dates and the school subsequently changes to fixed, the saving context
around the presence of a bookings placement date changes rendering the
existing placement requests invalid.

This problem hasn't yet reared its head but now we are updating the
`viewed_at` timestamp it's possible to trigger it as the placement
request object is invalid.

### Changes proposed in this pull request

Ensuring that either the availability description or placement date
being present should be sufficient and both directions are accounted for

### Guidance to review

Ensure it looks sensible and won't break anything!
