### PR TITLE
Remove duplicate line from schema file

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,7 +162,6 @@ ActiveRecord::Schema.define(version: 2019_09_19_111332) do
     t.string "admin_contact_email_secondary"
     t.boolean "dbs_requires_check"
     t.text "dbs_policy_details"
-    t.string "admin_contact_email_secondary"
     t.boolean "supports_access_needs"
     t.text "access_needs_description"
     t.boolean "disability_confident"


### PR DESCRIPTION
This wasn't doing any harm but showing up in subsequent migrations. Probably caused by a merge.
