### PR TITLE
Stop describe_current_search capitalising searches SE-1114

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -37,14 +37,12 @@ module Candidates::SchoolHelper
   end
 
   def describe_current_search(search)
-    if search.latitude.present? && search.longitude.present?
-      "near me"
-    elsif search.location_name.present?
+    if search.location_name.present?
       "near #{search.location_name}"
-    elsif search.location.to_s.present?
-      "near #{search.location.to_s.humanize}"
+    elsif search.location.present?
+      "near #{search.location}"
     else
-      "matching #{search.query.to_s.humanize}"
+      "matching #{search.query}"
     end
   end
 

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -87,21 +87,6 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
   end
 
   context '.describe_current_search' do
-    context 'with coordinates search' do
-      subject do
-        double('Coords search',
-          latitude: '1',
-          longitude: '2',
-          location: '',
-          location_name: nil,
-          query: '')
-      end
-
-      it('should say near me') do
-        expect(describe_current_search(subject)).to match(/near me/)
-      end
-    end
-
     context 'with location search' do
       context 'and name supplied by search' do
         subject do


### PR DESCRIPTION
### Context

Since the initial implementation of search the way the search is
described has improved to the point where the original location isn't as
important as it was (now we show the result from Geocoder rather than
the search term in most cases).

### Changes proposed in this pull request

To improve the experience when searching for postcodes, the initial
query is no longer capitalised when a match isn't found. This should be
less confusing for the person searching as it will match exactly what
they typed in.

Additionally, now we no longer support search near my location, that
functionality has been removed from the description method and
associated specs

### Guidance to review

Ensure it makes sense and works

The following has changed:

Searching for a partial postcode will display the search term as it was typed, so 'DY3' will be displayed as 'DY3', 'dy3' as 'dy3' etc.

Searching for a 'place' that yields a match will return the matching value, so searching for 'Wo**o**lverhampton' will be displayed as 'Wolverhampton'

Searching for a place that yields no matches will show the search term as it was typed: 'Someplacethatdoesntexist' as 'Someplacethatdoesntexist'.
