### PR TITLE
Prevent blank flexible date submissions SE-1754

### DIFF
--- a/app/controllers/schools/availability_info_controller.rb
+++ b/app/controllers/schools/availability_info_controller.rb
@@ -2,7 +2,9 @@ class Schools::AvailabilityInfoController < Schools::BaseController
   def edit; end
 
   def update
-    if @current_school.update(placement_date_params)
+    @current_school.assign_attributes(placement_date_params)
+
+    if @current_school.save(context: :configuring_availability)
       redirect_to schools_dashboard_path
     else
       render :edit

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -24,8 +24,9 @@ class Bookings::School < ApplicationRecord
     }
 
   validates :availability_info,
-    allow_nil: true,
-    length: { minimum: 3 }
+    presence: true,
+    length: { minimum: 3 },
+    on: :configuring_availability
 
   validates :availability_preference_fixed,
     inclusion: { in: [true, false] },

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -28,7 +28,7 @@
         </fieldset>
       </div>
 
-      <%= form.submit 'Continue' %>
+      <%= form.submit 'Save availability description' %>
     <%- end -%>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -340,6 +340,9 @@ en:
           attributes:
             availability_preference_fixed:
               inclusion: Select an availability preference
+            availability_info:
+              blank: Enter a description of your school's availability
+              too_short: Availability description must be at least 3 characters
         candidates/feedback:
           <<: *feedback_errors
         schools/feedback:

--- a/features/schools/availability_information/edit.feature
+++ b/features/schools/availability_information/edit.feature
@@ -22,11 +22,11 @@ Feature: Editing availability info
     Scenario: Page contents
         Given I am on the 'availability information' page
         Then there should be a 'Describe your school experience availability' text area
-        And the submit button should contain text 'Continue'
+        And the submit button should contain text 'Save availability description'
 
     Scenario: Submitting the form
         Given I am on the 'availability information' page
         When I enter 'Every third Tuesday' into the 'Describe your school experience availability' text area
-        And I submit the form
+        And I click the 'Save availability description' submit button
         Then I should be on the 'schools dashboard' page
         And my school's availabiltiy info should have been updated

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -13,8 +13,14 @@ describe Bookings::School, type: :model do
     end
 
     context 'availability_info' do
-      it { is_expected.to allow_value(nil).for(:availability_info) }
-      it { is_expected.to validate_length_of(:availability_info).is_at_least(3) }
+      context 'with no context' do
+        it { is_expected.not_to validate_presence_of(:availability_info) }
+      end
+
+      context 'when configuring availability' do
+        it { is_expected.to validate_presence_of(:availability_info).on(:configuring_availability) }
+        it { is_expected.to validate_length_of(:availability_info).is_at_least(3).on(:configuring_availability) }
+      end
 
       context 'overwriting empty strings before validation' do
         subject { create(:bookings_school) }


### PR DESCRIPTION
### Context

Schools can currently submit an empty availability description

### Changes proposed in this pull request

The availability info field is covered by new validation that is contextual and will only be applied on the edit availability information page. The minimum character limit is currently
set to 3 characters. The submit button text has been updated from 'Continue' as this is the final step in the journey.

### Guidance to review

Ensure changes make sense.

