### PR TITLE
Use defaults feature on Active Model

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -3,6 +3,10 @@ module Bookings
     class Contact
       include Entity
 
+      def self.channel_creation
+        Rails.application.config.x.gitis.channel_creation
+      end
+
       entity_id_attribute :contactid
 
       entity_attributes :firstname, :lastname, :birthdate, except: :update
@@ -14,7 +18,8 @@ module Bookings
       entity_attributes :telephone1, :address1_telephone1, :telephone2
       entity_attributes :dfe_hasdbscertificate, :dfe_dateofissueofdbscertificate
       entity_attributes :dfe_notesforclassroomexperience
-      entity_attributes :mobilephone, :dfe_channelcreation, except: :update
+      entity_attributes :mobilephone, except: :update
+      entity_attribute  :dfe_channelcreation, except: :update, default: channel_creation
 
       entity_association :dfe_Country, Country
       entity_association :dfe_PreferredTeachingSubject01, TeachingSubject
@@ -31,15 +36,10 @@ module Bookings
 
       validates :email, presence: true, format: /\A.+@.+\..+\z/
 
-      def self.channel_creation
-        Rails.application.config.x.gitis.channel_creation
-      end
-
       def initialize(crm_contact_data = {})
         super # handles populating
 
-        self.dfe_channelcreation  = self.class.channel_creation unless dfe_channelcreation.present?
-        self.dfe_Country          = Country.default unless _dfe_country_value.present?
+        self.dfe_Country = Country.default unless _dfe_country_value.present?
 
         clear_changes_information
 

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -21,7 +21,7 @@ module Bookings
       entity_attributes :mobilephone, except: :update
       entity_attribute  :dfe_channelcreation, except: :update, default: channel_creation
 
-      entity_association :dfe_Country, Country
+      entity_association :dfe_Country, Country, default: Country.default
       entity_association :dfe_PreferredTeachingSubject01, TeachingSubject
       entity_association :dfe_PreferredTeachingSubject02, TeachingSubject
 
@@ -38,10 +38,6 @@ module Bookings
 
       def initialize(crm_contact_data = {})
         super # handles populating
-
-        self.dfe_Country = Country.default unless _dfe_country_value.present?
-
-        clear_changes_information
 
         set_email_address_2_if_blank
         set_telephone_2_if_blank @init_data

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -125,10 +125,12 @@ module Bookings::Gitis
         end
       end
 
-      def entity_attribute(attr_name, internal: false, except: nil)
+      def entity_attribute(attr_name, type = ActiveModel::Type::Value.new,
+        internal: false, except: nil, **options)
+
         except = Array.wrap(except).map(&:to_sym)
 
-        attribute :"#{attr_name}"
+        attribute :"#{attr_name}", type, **options
 
         private :"#{attr_name}" if internal
         private :"#{attr_name}=" if internal
@@ -146,9 +148,12 @@ module Bookings::Gitis
         end
       end
 
-      def entity_attributes(*attr_names, internal: false, except: nil)
+      def entity_attributes(*attr_names, type: ActiveModel::Type::Value.new,
+        internal: false, except: nil, **options)
+
         Array.wrap(attr_names).flatten.each do |attr_name|
-          entity_attribute(attr_name, internal: internal, except: except)
+          entity_attribute attr_name, type,
+            internal: internal, except: except, **options
         end
       end
 

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -161,9 +161,9 @@ module Bookings::Gitis
         model_name.to_s.downcase.split('::').last.pluralize
       end
 
-      def entity_association(attr_name, entity_type)
+      def entity_association(attr_name, entity_type, **options)
         self.association_attribute_names = association_attribute_names + [attr_name.to_s]
-        entity_attribute :"#{attr_name}@odata.bind", except: :select
+        entity_attribute :"#{attr_name}@odata.bind", except: :select, **options
 
         value_name = "_#{attr_name.downcase}_value"
         self.select_attribute_names = select_attribute_names + [value_name]


### PR DESCRIPTION
### Context

Now we use ActiveModel attributes, we can rely on its behaviour to assign the defaults when creating new Contacts.

### Changes proposed in this pull request

1. Use `:default` on attributes instead of custom code in the initializer

### Guidance to review

1. Code review
