### PR TITLE
Reset change tracking after successful write

### DIFF
--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -97,6 +97,7 @@ module Bookings
           entity.entity_id = create_entity entity.entity_id, attrs
         end
 
+        entity.changes_applied
         entity.id
       end
 

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -191,10 +191,14 @@ describe Bookings::Gitis::CRM, type: :model do
         gitis_stub.stub_create_contact_request(sorted_attrs, contactid)
       end
 
-      subject { gitis.write(contact) }
+      subject! { gitis.write(contact) }
 
       it "will return the id of the inserted record" do
         is_expected.to eq(contactid)
+      end
+
+      it "will reset change tracking" do
+        expect(contact.changed).to eql([])
       end
     end
 
@@ -210,8 +214,14 @@ describe Bookings::Gitis::CRM, type: :model do
         )
       end
 
+      subject! { gitis.write(@contact) }
+
       it "will succeed" do
-        expect(gitis.write(@contact)).to eq(contactid)
+        is_expected.to eq(contactid)
+      end
+
+      it "will reset change tracking" do
+        expect(@contact.changed).to eql([])
       end
     end
 


### PR DESCRIPTION
### Context

When we write an Entity to Dynamics, we currently leave the written attributes as marked dirty. Correct behaviour would be to reset the changes information in case the Entity is written a second time.

### Changes proposed in this pull request

1. Clear changes information after a successful write to dynamics.

### Guidance to review

1. Code review

