### PR TITLE
Freeze Entity attribute assignment

### DIFF
--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -130,6 +130,12 @@ module Bookings::Gitis
 
         attribute :"#{attr_name}"
 
+        # freeze the value on assignment since in place changes will break
+        # change tracking
+        define_method :"#{attr_name}=" do |value|
+          write_attribute(:"#{attr_name}", value.freeze)
+        end
+
         private :"#{attr_name}" if internal
         private :"#{attr_name}=" if internal
 

--- a/spec/services/bookings/gitis/entity_spec.rb
+++ b/spec/services/bookings/gitis/entity_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Bookings::Gitis::Entity do
     end
   end
 
-  describe "#changed" do
+  describe "dirty tracking" do
     context 'for unpersisted object' do
       it "will use dirty tracking to return modified attributes since last reset" do
         expect(subject.changed).to eq(%w{firstname lastname})
@@ -83,6 +83,14 @@ RSpec.describe Bookings::Gitis::Entity do
         it "will include name" do
           expect(subject.changed).to eq(%w{firstname})
         end
+      end
+    end
+
+    context 'when modifying attribute in place' do
+      it "will raise exception" do
+        expect {
+          subject.firstname << 'more'
+        }.to raise_exception(FrozenError)
       end
     end
   end


### PR DESCRIPTION
### Context

Modifying a variable which has been assigned will potentially be missed by the change tracking. This will result in changes the user makes not getting written. 

### Changes proposed in this pull request

1. Freeze all attributes on assignment, forcing the developer to overwrite attributes instead of modifying them in place. There by ensuring change tracking notices the changes.

### Guidance to review

1. Code review
