### PR TITLE
Added maintenance mode to take the site offline

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -17,6 +17,10 @@ class PagesController < ApplicationController
 
   def help_and_support_access_needs; end
 
+  def maintenance
+    render status: :service_unavailable
+  end
+
 private
 
   def sanitise_page

--- a/app/views/pages/maintenance.html.erb
+++ b/app/views/pages/maintenance.html.erb
@@ -1,0 +1,20 @@
+<h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p>
+      You will be able to use the service later today.
+    </p>
+
+    <p>
+      We have not saved your answers. When the service is available, you will have to start again.
+    </p>
+
+    <p>
+      Contact
+      <a href="mailto:organise.school-experience@education.gov.uk">
+        organise.school-experience@education.gov.uk
+      </a> if you need further information.
+    </p>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -112,4 +112,6 @@ Rails.application.configure do
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
+
+  config.x.maintenance_mode = %w{1 yes true}.include?(ENV['MAINTENANCE_MODE'].to_s)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -154,4 +154,6 @@ Rails.application.configure do
   config.sass[:style] = :compressed if config.sass
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 70)
+  
+  config.x.maintenance_mode = %w{1 yes true}.include?(ENV['MAINTENANCE_MODE'].to_s)
 end

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -34,4 +34,6 @@ Rails.application.configure do
   config.x.gitis.privacy_consent_id = '10'
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
+
+  config.x.maintenance_mode = false
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -91,4 +91,6 @@ Rails.application.configure do
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
+
+  config.x.maintenance_mode = false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,14 @@ Rails.application.routes.draw do
   get '/healthcheck.txt', to: 'healthchecks#show', as: :healthcheck
   get '/deployment.txt', to: 'healthchecks#deployment', as: :deployment
 
+  if Rails.application.config.x.maintenance_mode
+    match '*path', to: 'pages#maintenance', via: :all
+    root to: 'pages#maintenance'
+  else
+    root to: 'candidates/home#index'
+  end
+
   get "/pages/:page", to: "pages#show"
-  root to: 'candidates/home#index'
 
   get '/privacy_policy', to: 'pages#privacy_policy'
   get '/accessibility_statement', to: 'pages#accessibility_statement'

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -28,4 +28,26 @@ describe PagesController, type: :request do
       end
     end
   end
+
+  describe 'maintenance mode' do
+    before do
+      allow(Rails.application.config.x).to receive(:maintenance_mode) { true }
+      Rails.application.reload_routes!
+    end
+
+    after do
+      allow(Rails.application.config.x).to receive(:maintenance_mode).and_call_original
+      Rails.application.reload_routes!
+    end
+
+    it "will show the maintenance page" do
+      get root_path
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response).to have_attributes body: /service is unavailable/i
+
+      get candidates_root_path
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response).to have_attributes body: /service is unavailable/i
+    end
+  end
 end


### PR DESCRIPTION
### Context

We will need to take the site offline when we move the hosting

### Changes proposed in this pull request

1. Add an environment variable controlled maintenance mode which shows the maintenance page for all requests apart from healthchecks

### Guidance to review

1. set `MAINTENANCE_MODE=1` and check different paths, they should all return 503s with the maintenance page
