### PR TITLE
Updated Contact Details title when the user is known to Gitis

### DIFF
--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -1,8 +1,19 @@
+<%- if candidate_signed_in? -%>
+<% self.page_title = 'Confirm your contact details' %>
+<%- else -%>
 <% self.page_title = 'Enter your contact details' %>
+<%- end -%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Enter your contact details</h1>
+    <h1 class="govuk-heading-l">
+      <%- if candidate_signed_in? -%>
+      <%= 'Confirm your contact details' %>
+      <%- else -%>
+      <%= 'Enter your contact details' %>
+      <%- end -%>
+    </h1>
+
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
         <p class="govuk-body">


### PR DESCRIPTION
### Context

When a candidate is recognised in the CRM, they are actually asked to confirm their Contact Details instead of Enter them.

### Changes proposed in this pull request

1. Update the page title to clarify whether the user is Entering or Confirming their contact details

### Guidance to review
1. Check page title for unrecognised candidate
2. Check page title for recognised candidate
