### PR TITLE
SE-1613 Updated content on Placement Request confirmation screen

### DIFF
--- a/app/views/candidates/registrations/confirmation_emails/show.html.erb
+++ b/app/views/candidates/registrations/confirmation_emails/show.html.erb
@@ -1,28 +1,40 @@
-<% self.page_title = 'Confirm your email' %>
+<% self.page_title = 'Check your email to complete your request' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Verify your school experience request
+      Check your email to complete your request
     </h1>
+
     <p>
-      Click the link in the email we’ve sent to the following email address to
-      verify your request for school experience at <%= @school_name %>:
+      We've sent a link to the following email address:
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li><%= @email %></li>
     </ul>
+
     <p>
-      If you can’t find the message in your inbox:
+      You need to <strong>select the link to confirm your request</strong>
+      for school experience at <%= @school_name %>.
     </p>
+
+    <p>
+      <strong>The link will expire within 24 hours.</strong>
+    </p>
+
+    <p>
+      If you cannot find the message in your inbox:
+    </p>
+
     <ul class="govuk-list govuk-list--bullet">
-      <li>check your spam and any other mailbox folders</li>
+      <li>check your spam and other mailbox folders</li>
     </ul>
+
     <p>
-      If you can’t find or haven’t received the email use the following link to
-      resend it:
+      If you still cannot find or have not received the message and link:
     </p>
+
     <%= govuk_button_to 'Resend link', @resend_link, secondary: true %>
   </div>
 </div>

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -295,7 +295,7 @@ feature 'Candidate Registrations', type: :feature do
     click_button button_text
     expect(page).to have_text 'You need to confirm your details are correct and accept our privacy policy to continue'
     expect(page).not_to have_text \
-      "Click the link in the email we’ve sent to the following email address to verify your request for school experience at Test School:\ntest@example.com"
+      "We've sent a link to the following email address:\ntest@example.com"
 
     # Submit email confirmation form successfully
     check "candidates_registrations_privacy_policy_acceptance"
@@ -304,7 +304,7 @@ feature 'Candidate Registrations', type: :feature do
 
   def complete_email_confirmation_step
     expect(page).to have_text \
-      "Click the link in the email we’ve sent to the following email address to verify your request for school experience at Test School:\n#{email_address}"
+      "We've sent a link to the following email address:\n#{email_address}"
 
     # Click email confirmation link
     visit "/candidates/confirm/#{registration_session.uuid}"


### PR DESCRIPTION
### Context

The confirmation screen at the end of the Candidate journey needs to make it clearer that the Candidate needs to click the link in the email acccount

### Changes proposed in this pull request

1. Updated the content according to the requested changes.

### Guidance to review

1. Verify content is correct

