### PR TITLE
Change update! to update_column to avoid validation

### DIFF
--- a/app/models/concerns/view_trackable.rb
+++ b/app/models/concerns/view_trackable.rb
@@ -8,7 +8,7 @@ module ViewTrackable
 
   def viewed!
     if viewed_at.nil?
-      update!(viewed_at: DateTime.now)
+      update_column(:viewed_at, DateTime.now)
     end
   end
 


### PR DESCRIPTION
This is a reaction to a bug seen in prod where validation failed due to the context of the placement request changing. In this case it was subjects being absent. 

Validation is now bypassed when updating the viewed_at `timestamp`

