### PR TITLE
Allow primary placement dates to be identified SE-1782

### DIFF
--- a/app/controllers/schools/placement_dates/configurations_controller.rb
+++ b/app/controllers/schools/placement_dates/configurations_controller.rb
@@ -8,7 +8,7 @@ module Schools
       end
 
       def create
-        @configuration = ConfigurationForm.new configuration_params
+        @configuration = ConfigurationForm.new configuration_params.merge(supports_subjects: @placement_date.supports_subjects)
 
         if @configuration.save @placement_date
           redirect_to next_step
@@ -20,7 +20,7 @@ module Schools
     private
 
       def next_step
-        if @configuration.available_for_all_subjects
+        if !@configuration.supports_subjects || @configuration.available_for_all_subjects
           schools_placement_dates_path
         else
           new_schools_placement_date_subject_selection_path @placement_date

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -21,6 +21,12 @@ class Schools::PlacementDatesController < Schools::BaseController
       .bookings_placement_dates
       .new(new_placement_date_params)
 
+    # if the user hasn't seen the 'select a phase' option on #new, set
+    # it here based on their available phases
+    if @placement_date.supports_subjects.nil?
+      @placement_date.supports_subjects = school_supports_subjects?
+    end
+
     if @placement_date.save
       next_step @placement_date
     else
@@ -39,6 +45,10 @@ class Schools::PlacementDatesController < Schools::BaseController
   end
 
 private
+
+  def school_supports_subjects?
+    @current_school.phases.any?(&:supports_subjects?)
+  end
 
   def next_step(placement_date)
     if Feature.instance.active? :subject_specific_dates

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -23,8 +23,8 @@ class Schools::PlacementDatesController < Schools::BaseController
 
     # if the user hasn't seen the 'select a phase' option on #new, set
     # it here based on their available phases
-    if @placement_date.supports_subjects.nil?
-      @placement_date.supports_subjects = school_supports_subjects?
+    if !new_placement_date_params.has_key?(:supports_subjects)
+      @placement_date.supports_subjects = current_school.supports_subjects?
     end
 
     if @placement_date.save
@@ -47,7 +47,7 @@ class Schools::PlacementDatesController < Schools::BaseController
 private
 
   def school_supports_subjects?
-    @current_school.phases.any?(&:supports_subjects?)
+    @current_school.supports_subjects?
   end
 
   def next_step(placement_date)

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -66,7 +66,7 @@ private
   end
 
   def new_placement_date_params
-    params.require(:bookings_placement_date).permit(:date, :duration, :active)
+    params.require(:bookings_placement_date).permit(:date, :duration, :active, :supports_subjects)
   end
 
   def edit_placement_date_params

--- a/app/forms/schools/placement_dates/configuration_form.rb
+++ b/app/forms/schools/placement_dates/configuration_form.rb
@@ -12,6 +12,7 @@ module Schools
       validates :max_bookings_count, numericality: { greater_than: 0 }, if: :has_limited_availability
       validates :max_bookings_count, absence: true, unless: :has_limited_availability
       validates :has_limited_availability, inclusion: [true, false]
+      validates :supports_subjects, inclusion: [true, false]
       validates :available_for_all_subjects, inclusion: [true, false], if: :supports_subjects
 
       def self.new_from_date(placement_date)

--- a/app/forms/schools/placement_dates/configuration_form.rb
+++ b/app/forms/schools/placement_dates/configuration_form.rb
@@ -47,7 +47,7 @@ module Schools
       def assign_attributes_to_placement_date(placement_date)
         placement_date.max_bookings_count = max_bookings_count
 
-        if available_for_all_subjects
+        if available_for_all_subjects || !supports_subjects
           placement_date.subject_specific = false
           placement_date.subject_ids = []
           placement_date.published_at = DateTime.now

--- a/app/forms/schools/placement_dates/configuration_form.rb
+++ b/app/forms/schools/placement_dates/configuration_form.rb
@@ -7,11 +7,12 @@ module Schools
       attribute :max_bookings_count, :integer
       attribute :has_limited_availability, :boolean
       attribute :available_for_all_subjects, :boolean
+      attribute :supports_subjects, :boolean
 
       validates :max_bookings_count, numericality: { greater_than: 0 }, if: :has_limited_availability
       validates :max_bookings_count, absence: true, unless: :has_limited_availability
       validates :has_limited_availability, inclusion: [true, false]
-      validates :available_for_all_subjects, inclusion: [true, false]
+      validates :available_for_all_subjects, inclusion: [true, false], if: :supports_subjects
 
       def self.new_from_date(placement_date)
         # Default fields to unselected
@@ -19,7 +20,8 @@ module Schools
           new \
             max_bookings_count: placement_date.max_bookings_count,
             has_limited_availability: placement_date.has_limited_availability?,
-            available_for_all_subjects: !placement_date.subject_specific?
+            available_for_all_subjects: !placement_date.subject_specific?,
+            supports_subjects: placement_date.supports_subjects?
         else
           new
         end

--- a/app/helpers/schools/placement_dates_helper.rb
+++ b/app/helpers/schools/placement_dates_helper.rb
@@ -16,4 +16,14 @@ module Schools::PlacementDatesHelper
 
     [true, false].all? { |value| value.in?(options) }
   end
+
+  def placement_date_subject_description(placement_date)
+    if placement_date.subject_specific?
+      placement_date.subjects.pluck(:name).join(', ')
+    elsif placement_date.supports_subjects?
+      'All subjects'
+    else
+      'Primary'
+    end
+  end
 end

--- a/app/helpers/schools/placement_dates_helper.rb
+++ b/app/helpers/schools/placement_dates_helper.rb
@@ -10,4 +10,10 @@ module Schools::PlacementDatesHelper
   def placement_date_display_class(val)
     val ? "govuk-tag--available" : "govuk-tag--taken"
   end
+
+  def show_subject_support_option(school)
+    options = school.phases.map(&:supports_subjects)
+
+    [true, false].all? { |value| value.in?(options) }
+  end
 end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -183,6 +183,10 @@ class Bookings::School < ApplicationRecord
     end
   end
 
+  def supports_subjects?
+    phases.any?(&:supports_subjects?)
+  end
+
 private
 
   def has_available_dates?

--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -17,9 +17,11 @@
         <%= f.radio_input false %>
       <% end %>
 
-      <%= f.radio_button_fieldset :available_for_all_subjects do |fieldset| %>
-        <%= f.radio_input true %>
-        <%= f.radio_input false %>
+      <%- if @placement_date.supports_subjects? -%>
+        <%= f.radio_button_fieldset :available_for_all_subjects do |fieldset| %>
+          <%= f.radio_input true %>
+          <%= f.radio_input false %>
+        <% end %>
       <% end %>
 
       <%= f.submit 'Continue' %>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -35,11 +35,7 @@
               <%= pluralize(placement_date.duration, 'day') %>
             </td>
             <td class="govuk-table__cell">
-              <% if placement_date.subject_specific? %>
-                <%= placement_date.subjects.pluck(:name).join(',') %>
-              <% else %>
-                All subjects
-              <% end %>
+              <%= placement_date_subject_description(placement_date) %>
             </td>
             <td class="govuk-table__cell status">
               <strong class="govuk-tag <%= placement_date_display_class(placement_date.active) %>">

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -23,6 +23,10 @@
   <%= GovukElementsErrorsHelper.error_summary form.object, 'There is a problem', '' %>
   <%= form.date_field :date, heading: true %>
   <%= form.number_field :duration, width: 3, required: true, label_options: { class: 'govuk-heading-m', overwrite_defaults!: true } %>
+
+  <% if show_subject_support_option(@current_school) %>
+    <%= form.radio_button_fieldset :supports_subjects, choices: [false, true] %>
+  <% end %>
   <%= form.submit 'Continue' %>
 <%- end -%>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,6 +364,7 @@ en:
         availability_preference_fixed: Choose how dates are displayed
       bookings_placement_date:
         date: Enter a start date
+        supports_subjects: Which age groups will candidates be placed with?
       phases: Education phases
       fees: Fees
       subjects: Placement subjects
@@ -486,6 +487,11 @@ en:
       bookings_placement_date:
         duration: How long will it last?
         active: Make this date available to candidates?
+        supports_subjects:
+          # FIXME reword
+          yes: Secondary or college
+          no: Primary or early years
+
       bookings_placement_request_cancellation:
         reason: Cancellation reasons
       candidates_registrations_contact_information:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -488,7 +488,6 @@ en:
         duration: How long will it last?
         active: Make this date available to candidates?
         supports_subjects:
-          # FIXME reword
           yes: Secondary or college
           no: Primary or early years
 

--- a/db/migrate/20190930134841_add_supports_subject_flag_to_bookings_phases.rb
+++ b/db/migrate/20190930134841_add_supports_subject_flag_to_bookings_phases.rb
@@ -1,0 +1,5 @@
+class AddSupportsSubjectFlagToBookingsPhases < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_phases, :supports_subjects, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20190930135110_set_supports_subjects_flag_to_false_for_primary_and_early_years.rb
+++ b/db/migrate/20190930135110_set_supports_subjects_flag_to_false_for_primary_and_early_years.rb
@@ -1,0 +1,10 @@
+class SetSupportsSubjectsFlagToFalseForPrimaryAndEarlyYears < ActiveRecord::Migration[5.2]
+  def up
+    Bookings::Phase.where(name: ['Early years', 'Primary (4 to 11)']).update_all(supports_subjects: false)
+  end
+
+  def down
+    # true is the default
+    Bookings::Phase.update_all(supports_subjects: true)
+  end
+end

--- a/db/migrate/20190930142055_add_supports_subjects_flag_to_bookings_placement_dates.rb
+++ b/db/migrate/20190930142055_add_supports_subjects_flag_to_bookings_placement_dates.rb
@@ -1,0 +1,5 @@
+class AddSupportsSubjectsFlagToBookingsPlacementDates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :bookings_placement_dates, :supports_subjects, :boolean
+  end
+end

--- a/db/migrate/20191008135000_add_subjects_supported_default_value.rb
+++ b/db/migrate/20191008135000_add_subjects_supported_default_value.rb
@@ -1,0 +1,9 @@
+class AddSubjectsSupportedDefaultValue < ActiveRecord::Migration[5.2]
+  def up
+    change_column :bookings_placement_dates, :supports_subjects, :boolean, null: false, default: true
+  end
+
+  def down
+    change_column :bookings_placement_dates, :supports_subjects, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_30_142055) do
+ActiveRecord::Schema.define(version: 2019_10_08_135000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2019_09_30_142055) do
     t.integer "max_bookings_count"
     t.datetime "published_at"
     t.boolean "subject_specific", default: false, null: false
-    t.boolean "supports_subjects"
+    t.boolean "supports_subjects", default: true, null: false
     t.index ["bookings_school_id"], name: "index_bookings_placement_dates_on_bookings_school_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_19_111332) do
+ActiveRecord::Schema.define(version: 2019_09_30_142055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2019_09_19_111332) do
     t.datetime "updated_at", null: false
     t.integer "position"
     t.integer "edubase_id"
+    t.boolean "supports_subjects", default: true, null: false
     t.index ["name"], name: "index_bookings_phases_on_name", unique: true
     t.index ["position"], name: "index_bookings_phases_on_position", unique: true
   end
@@ -75,6 +76,7 @@ ActiveRecord::Schema.define(version: 2019_09_19_111332) do
     t.integer "max_bookings_count"
     t.datetime "published_at"
     t.boolean "subject_specific", default: false, null: false
+    t.boolean "supports_subjects"
     t.index ["bookings_school_id"], name: "index_bookings_placement_dates_on_bookings_school_id"
   end
 

--- a/features/schools/confirmed_bookings/editing_a_date.feature
+++ b/features/schools/confirmed_bookings/editing_a_date.feature
@@ -6,7 +6,7 @@ Feature: Updating a date
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
-        And the scheduled booking date is '02 October 2019'
+        And the scheduled booking date is in the future
 
     Scenario: Page title
         Given there is at least one booking

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -6,7 +6,7 @@ Feature: Viewing a booking
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
-        And the scheduled booking date is '02 October 2019'
+        And the scheduled booking date is in the future
 
     Scenario: Page title
         Given there is at least one booking
@@ -36,10 +36,10 @@ Feature: Viewing a booking
         When I am viewing my chosen booking
         Then I should see a 'Booking details' section with the following values:
             | Heading          | Value                                                                  |
-            | Date             | 02 October 2019                                                        |
             | Subject          | Biology                                                                |
             | DBS certificate  | Yes - Candidate says they have DBS certificate \(not verified by DfE\) |
             | Request received | 08 February 2019                                                       |
+        And the future booking date should be listed
 
     Scenario: Candidate details
         Given there is at least one booking

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -37,3 +37,28 @@ Feature: Creating new placement dates
         And I fill in the form with a future date and duration of 3
         When I submit the form
         Then I should be on the new configuration page for this date
+
+    Scenario: Primary and secondary schools: extra option
+        Given my school is a 'primary and secondary' school
+        And I am on the 'new placement date' page
+        Then I should see radio buttons for 'Which age groups will candidates be placed with?' with the following options:
+          | Primary or early years |
+          | Secondary or college   |
+
+    Scenario: Primary and secondary schools: selecting primary
+        Given my school is a 'primary and secondary' school
+        And I am on the 'new placement date' page
+        When I fill in the form with a future date and duration of 3
+        And I choose 'Primary or early years' from the 'Which age groups will candidates be placed with?' radio buttons
+        And I submit the form
+        Then I should be on the new configuration page for my placement date
+        And there should be no subject specificity option
+
+    Scenario: Primary and secondary schools: selecting primary
+        Given my school is a 'primary and secondary' school
+        And I am on the 'new placement date' page
+        When I fill in the form with a future date and duration of 3
+        And I choose 'Secondary or college' from the 'Which age groups will candidates be placed with?' radio buttons
+        And I submit the form
+        Then I should be on the new configuration page for my placement date
+        And there should be a subject specificity option

--- a/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
@@ -1,36 +1,36 @@
 Feature: Configuring a placement date
     So I can manage placement dates
-    As a primary school administrator
+    As an administrator of a combined primary and secondary school
     I want to be able to specify details about the dates we offer
 
   Background:
       Given I am logged in as a DfE user
-      And my school is a 'primary' school
+      And my school is a 'primary and secondary' school
       And my school is fully-onboarded
+      And I have entered a placement date
 
   Scenario: Page title
-    Given I have entered a placement date
     Then the page's main heading should be the date I just entered
 
   @javascript
   Scenario: Select no max number of bookings
-    Given I have entered a placement date
     When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
     Then there is no 'Enter maximum number of bookings' text area
 
   @javascript
   Scenario: Select max number of bookings
-    Given I have entered a placement date
     When I choose 'Yes' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
     Then there should be a 'Enter maximum number of bookings.' number field
 
-
-  Scenario: The form shouldn't prompt for subject specicifity
-    Given I have entered a placement date
-    Then there should be no "Is this date available for all the subjects you offer?" field
-
-  Scenario: Submitting the form
-    Given I have entered a placement date
+  Scenario: Date is not subject specific
     When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
+    And I choose 'Yes' from the "Is this date available for all the subjects you offer?" radio buttons
     And I submit the form
     Then I should be on the 'placement dates' page
+    And my newly-created placement date should be listed
+
+  Scenario: Date is subject specific
+    Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
+    And I choose 'No' from the "Is this date available for all the subjects you offer?" radio buttons
+    When I submit the form
+    Then I should be on the new subject selection page for this date

--- a/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
@@ -4,10 +4,10 @@ Feature: Configuring a placement date
     I want to be able to specify details about the dates we offer
 
   Background:
-      Given I am logged in as a DfE user
-      And my school is a 'primary and secondary' school
-      And my school is fully-onboarded
-      And I have entered a placement date
+    Given I am logged in as a DfE user
+    And my school is a 'primary and secondary' school
+    And my school is fully-onboarded
+    And I have entered a placement date
 
   Scenario: Page title
     Then the page's main heading should be the date I just entered

--- a/features/schools/placement_dates/primary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_school_configuration.feature
@@ -4,9 +4,9 @@ Feature: Configuring a placement date
     I want to be able to specify details about the dates we offer
 
   Background:
-      Given I am logged in as a DfE user
-      And my school is a 'primary' school
-      And my school is fully-onboarded
+    Given I am logged in as a DfE user
+    And my school is a 'primary' school
+    And my school is fully-onboarded
 
   Scenario: Page title
     Given I have entered a placement date

--- a/features/schools/placement_dates/primary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_school_configuration.feature
@@ -5,31 +5,32 @@ Feature: Configuring a placement date
 
   Background:
       Given I am logged in as a DfE user
+      And my school is a 'primary' school
       And my school is fully-onboarded
-      And I have entered a placement date
 
   Scenario: Page title
+    Given I have entered a placement date
     Then the page's main heading should be the date I just entered
 
   @javascript
   Scenario: Select no max number of bookings
+    Given I have entered a placement date
     When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
     Then there is no 'Enter maximum number of bookings' text area
 
   @javascript
   Scenario: Select max number of bookings
+    Given I have entered a placement date
     When I choose 'Yes' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
     Then there should be a 'Enter maximum number of bookings.' number field
 
-  Scenario: Date is not subject specific
-    Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'Yes' from the "Is this date available for all the subjects you offer?" radio buttons
-    When I submit the form
-    Then I should be on the 'placement dates' page
-    And my newly-created placement date should be listed
 
-  Scenario: Date is subject specific
-    Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'No' from the "Is this date available for all the subjects you offer?" radio buttons
-    When I submit the form
-    Then I should be on the new subject selection page for this date
+  Scenario: The form shouldn't prompt for subject specicifity
+    Given I have entered a placement date
+    Then there should be no "Is this date available for all the subjects you offer?" field
+
+  Scenario: Submitting the form
+    Given I have entered a placement date
+    When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
+    And I submit the form
+    Then I should be on the 'placement dates' page

--- a/features/schools/placement_dates/primary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_school_configuration.feature
@@ -24,7 +24,6 @@ Feature: Configuring a placement date
     When I choose 'Yes' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
     Then there should be a 'Enter maximum number of bookings.' number field
 
-
   Scenario: The form shouldn't prompt for subject specicifity
     Given I have entered a placement date
     Then there should be no "Is this date available for all the subjects you offer?" field

--- a/features/schools/placement_dates/secondary_school_configuration.feature
+++ b/features/schools/placement_dates/secondary_school_configuration.feature
@@ -1,0 +1,36 @@
+Feature: Configuring a placement date
+    So I can manage placement dates
+    As a school administrator
+    I want to be able to specify details about the dates we offer
+
+  Background:
+      Given I am logged in as a DfE user
+      And my school is a 'secondary' school
+      And my school is fully-onboarded
+      And I have entered a placement date
+
+  Scenario: Page title
+    Then the page's main heading should be the date I just entered
+
+  @javascript
+  Scenario: Select no max number of bookings
+    When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
+    Then there is no 'Enter maximum number of bookings' text area
+
+  @javascript
+  Scenario: Select max number of bookings
+    When I choose 'Yes' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
+    Then there should be a 'Enter maximum number of bookings.' number field
+
+  Scenario: Date is not subject specific
+    When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
+    And I choose 'Yes' from the "Is this date available for all the subjects you offer?" radio buttons
+    And I submit the form
+    Then I should be on the 'placement dates' page
+    And my newly-created placement date should be listed
+
+  Scenario: Date is subject specific
+    Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
+    And I choose 'No' from the "Is this date available for all the subjects you offer?" radio buttons
+    When I submit the form
+    Then I should be on the new subject selection page for this date

--- a/features/schools/placement_dates/secondary_school_configuration.feature
+++ b/features/schools/placement_dates/secondary_school_configuration.feature
@@ -1,6 +1,6 @@
 Feature: Configuring a placement date
     So I can manage placement dates
-    As a school administrator
+    As a secondary school administrator
     I want to be able to specify details about the dates we offer
 
   Background:

--- a/features/schools/placement_dates/secondary_school_configuration.feature
+++ b/features/schools/placement_dates/secondary_school_configuration.feature
@@ -4,10 +4,10 @@ Feature: Configuring a placement date
     I want to be able to specify details about the dates we offer
 
   Background:
-      Given I am logged in as a DfE user
-      And my school is a 'secondary' school
-      And my school is fully-onboarded
-      And I have entered a placement date
+    Given I am logged in as a DfE user
+    And my school is a 'secondary' school
+    And my school is fully-onboarded
+    And I have entered a placement date
 
   Scenario: Page title
     Then the page's main heading should be the date I just entered

--- a/features/schools/placement_dates/subject_selection.feature
+++ b/features/schools/placement_dates/subject_selection.feature
@@ -6,6 +6,7 @@ Feature: Selecting subjects for a placement date
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
+        And my school is a 'secondary' school
         And the school has subjects
         And I have entered a placement date
         And the placement date is subject specific

--- a/features/step_definitions/common_school_steps.rb
+++ b/features/step_definitions/common_school_steps.rb
@@ -44,6 +44,9 @@ Given("my school is a {string} school") do |phase|
     @school.phases << FactoryBot.create(:bookings_phase, :primary)
   when 'secondary'
     @school.phases << FactoryBot.create(:bookings_phase, :secondary)
+  when 'primary and secondary'
+    @school.phases << FactoryBot.create(:bookings_phase, :primary)
+    @school.phases << FactoryBot.create(:bookings_phase, :secondary)
   else
     fail "unsupported phase #{phase}"
   end

--- a/features/step_definitions/common_school_steps.rb
+++ b/features/step_definitions/common_school_steps.rb
@@ -37,3 +37,14 @@ Given "my chosen school has the URN {int}" do |int|
   @school.update_attributes(urn: int)
   expect(@school.urn).to eql(int)
 end
+
+Given("my school is a {string} school") do |phase|
+  case phase
+  when 'primary'
+    @school.phases << FactoryBot.create(:bookings_phase, :primary)
+  when 'secondary'
+    @school.phases << FactoryBot.create(:bookings_phase, :secondary)
+  else
+    fail "unsupported phase #{phase}"
+  end
+end

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -199,3 +199,7 @@ def ensure_input_exists(form_group, label_text, field_type, autocomplete: nil)
     expect(form_group).to have_css("input[autocomplete='#{autocomplete}']")
   end
 end
+
+Then("there should be no {string} field") do |label|
+  expect(page).not_to have_content(label)
+end

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -1,5 +1,5 @@
-Given("the scheduled booking date is {string}") do |string|
-  @scheduled_booking_date = string
+Given("the scheduled booking date is in the future") do
+  @scheduled_booking_date = 1.week.from_now.strftime("%d %B %Y")
 end
 
 Given("there are some bookings") do

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -52,3 +52,16 @@ Then "my date should be listed" do
     date.subjects.map(&:name).each { |name| expect(page).to have_text name }
   end
 end
+
+Then("I should be on the new configuration page for my placement date") do
+  pd = Bookings::PlacementDate.last
+  expect(page.current_path).to eql(path_for('new configuration', placement_date_id: pd.id))
+end
+
+Then("there should be no subject specificity option") do
+  expect(page).not_to have_text('Is this date available for all the subjects you offer?')
+end
+
+Then("there should be a subject specificity option") do
+  expect(page).not_to have_css('label', text: 'Is this date available for all the subjects you offer?')
+end

--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -94,3 +94,7 @@ end
 Then("I should see the placement request's duration") do
   expect(page).to have_css('dd', text: "1 day")
 end
+
+Then("the future booking date should be listed") do
+  expect(page).to have_content(@booking.date.to_formatted_s(:govuk))
+end

--- a/spec/controllers/schools/placement_dates_controller_spec.rb
+++ b/spec/controllers/schools/placement_dates_controller_spec.rb
@@ -26,27 +26,9 @@ describe Schools::PlacementDatesController, type: :request do
 
     describe 'setting supports_subjects' do
       let(:option) { false }
-      context 'when supports_subjects has already been set' do
-        let(:params) do
-          base_params.deep_merge(bookings_placement_date: { supports_subjects: option })
-        end
-
-        # set the phase to secondary so that the default would be true to confirm that
-        # the value is ignored and doesn't just match what it'd be set to anyway
-        before do
-          Bookings::School.find_by!(urn: urn).phases << create(:bookings_phase, :secondary)
-        end
-
-        before { subject }
-
-        specify 'the flag should not be updated' do
-          expect(placement_date.supports_subjects).to be option
-        end
-      end
-
       context "when supports_subjects hasn't been set" do
         let(:params) do
-          base_params.deep_merge(bookings_placement_date: { supports_subjects: nil })
+          base_params.deep_merge(bookings_placement_date: {})
         end
 
         context "when the school has only primary" do

--- a/spec/factories/bookings/phase_factory.rb
+++ b/spec/factories/bookings/phase_factory.rb
@@ -6,20 +6,24 @@ FactoryBot.define do
   trait :early_years do
     name { 'Early years' }
     edubase_id { 1 }
+    supports_subjects { false }
   end
 
   trait :primary do
     name { 'Primary (4 to 11)' }
     edubase_id { 2 }
+    supports_subjects { false }
   end
 
   trait :secondary do
     name { 'Secondary (11 to 16)' }
     edubase_id { 4 }
+    supports_subjects { true }
   end
 
   trait :college do
     name { '16 to 18' }
     edubase_id { 6 }
+    supports_subjects { true }
   end
 end

--- a/spec/factories/bookings/placement_dates.rb
+++ b/spec/factories/bookings/placement_dates.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     date { 3.weeks.from_now }
     association :bookings_school, factory: :bookings_school
     published_at { DateTime.now }
+    supports_subjects { true }
 
     trait :in_the_past do
       date { 6.weeks.ago }

--- a/spec/forms/schools/placement_dates/configuration_form_spec.rb
+++ b/spec/forms/schools/placement_dates/configuration_form_spec.rb
@@ -92,6 +92,32 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
           end
         end
 
+        context 'when doesnt support subjects' do
+          let :max_bookings_count do
+            nil
+          end
+
+          let :attributes do
+            {
+              max_bookings_count: max_bookings_count,
+              has_limited_availability: false,
+              supports_subjects: false
+            }
+          end
+
+          it 'sets subject specific' do
+            expect(placement_date).not_to be_subject_specific
+          end
+
+          it 'empties subject_ids' do
+            expect(placement_date.subjects).to be_empty
+          end
+
+          it 'sets published_at' do
+            expect(placement_date).to be_published
+          end
+        end
+
         context 'when not available_for_all_subjects' do
           let :max_bookings_count do
             nil

--- a/spec/forms/schools/placement_dates/configuration_form_spec.rb
+++ b/spec/forms/schools/placement_dates/configuration_form_spec.rb
@@ -78,7 +78,8 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
             {
               max_bookings_count: max_bookings_count,
               has_limited_availability: true,
-              available_for_all_subjects: true
+              available_for_all_subjects: true,
+              supports_subjects: true
             }
           end
 
@@ -100,7 +101,8 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
             {
               max_bookings_count: max_bookings_count,
               has_limited_availability: false,
-              available_for_all_subjects: false
+              available_for_all_subjects: false,
+              supports_subjects: true
             }
           end
 
@@ -150,7 +152,8 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
             {
               max_bookings_count: max_bookings_count,
               has_limited_availability: true,
-              available_for_all_subjects: true
+              available_for_all_subjects: true,
+              supports_subjects: true
             }
           end
 
@@ -169,7 +172,8 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
             {
               max_bookings_count: max_bookings_count,
               has_limited_availability: true,
-              available_for_all_subjects: false
+              available_for_all_subjects: false,
+              supports_subjects: true
             }
           end
 

--- a/spec/helpers/schools/placement_dates_helper_spec.rb
+++ b/spec/helpers/schools/placement_dates_helper_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe Schools::PlacementDatesHelper, type: 'helper' do
+  subject { placement_date_subject_description(pd) }
+
+  describe '#placement_date_subject_description' do
+    context 'when the placement date is subject specific' do
+      let(:subjects) { Bookings::Subject.where(name: %w(Biology Maths)) }
+      let(:pd) { double(Bookings::PlacementDate, subjects: subjects, subject_specific?: true) }
+
+      specify 'should return the subjects list' do
+        expect(subject).to eql('Biology, Maths')
+      end
+    end
+
+    context 'when the placement date supports subjects' do
+      let(:pd) { double(Bookings::PlacementDate, subject_specific?: false, supports_subjects?: true) }
+
+      specify "should return 'All subjects'" do
+        expect(subject).to eql('All subjects')
+      end
+    end
+
+    context "when the placement date doesn't support subjects" do
+      let(:pd) { double(Bookings::PlacementDate, subject_specific?: false, supports_subjects?: false) }
+
+      specify "should return 'Primary'" do
+        expect(subject).to eql('Primary')
+      end
+    end
+  end
+end

--- a/spec/models/bookings/phase_spec.rb
+++ b/spec/models/bookings/phase_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Bookings::Phase, type: :model do
+  describe 'Columns' do
+    it { is_expected.to have_db_column(:supports_subjects).of_type(:boolean).with_options(default: true, null: false) }
+  end
+
   describe "Validation" do
     context "Name" do
       it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -13,6 +13,7 @@ describe Bookings::PlacementDate, type: :model do
     it { is_expected.to have_db_column(:max_bookings_count).of_type(:integer) }
     it { is_expected.to have_db_column(:published_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:subject_specific).of_type(:boolean).with_options(default: false, null: false) }
+    it { is_expected.to have_db_column(:supports_subjects).of_type(:boolean) }
   end
 
   describe 'Validation' do

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -520,5 +520,34 @@ describe Bookings::School, type: :model do
         end
       end
     end
+
+    describe '#supports_subjects?' do
+      let(:phase_ss) { double(Bookings::Phase, supports_subjects?: true) }
+      let(:phase_no_ss) { double(Bookings::Phase, supports_subjects?: false) }
+
+      context 'when all phases support subjects' do
+        before do
+          allow(subject).to receive(:phases).and_return([phase_ss])
+        end
+
+        specify { expect(subject).to be_supports_subjects }
+      end
+
+      context 'when no phases support subjects' do
+        before do
+          allow(subject).to receive(:phases).and_return([phase_no_ss])
+        end
+
+        specify { expect(subject).not_to be_supports_subjects }
+      end
+
+      context "when some phases support subjects and some don't" do
+        before do
+          allow(subject).to receive(:phases).and_return([phase_ss, phase_no_ss])
+        end
+
+        specify { expect(subject).to be_supports_subjects }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

In order to implement subject specific dates we need to identify whether a placement date should be able to support subject specificity. This is required because **primary** schools cannot, giving primary schools the option to make their dates subject-specific is confusing.

### Changes proposed in this pull request

Modify the create placement date 'wizard' so that:

* when the school is _only_ a primary school, set the placement date's `supports_subjects` flag to false and don't allow them to choose subject-specific dates
* when the school _only_ has phases that support subjects, currently _Secondary (11 to 16)_ and _16 to 18_
* when the school has both _primary_ **and** _secondary/16-18_ phases a new option will be visible on the placement date creation screen that will allow administrators to specify whether the date they're adding is for a primary or secondary experience (wording to be revised!)

<img width="505" alt="Screenshot 2019-10-02 at 14 01 13" src="https://user-images.githubusercontent.com/128088/66046366-80d89280-e51d-11e9-9fa3-e9eca2914bc2.png">

### Guidance to review

Ensure the changes make sense and the changes look sensible. Is there a better option than adding a `supports_subjects` flag to the `Bookings::Phase` and `Bookings::PlacementDate`?