### PR TITLE
Remove hard-coded dates from features

### DIFF
--- a/features/schools/confirmed_bookings/editing_a_date.feature
+++ b/features/schools/confirmed_bookings/editing_a_date.feature
@@ -6,7 +6,7 @@ Feature: Updating a date
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
-        And the scheduled booking date is '02 October 2019'
+        And the scheduled booking date is in the future
 
     Scenario: Page title
         Given there is at least one booking

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -6,7 +6,7 @@ Feature: Viewing a booking
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
-        And the scheduled booking date is '02 October 2019'
+        And the scheduled booking date is in the future
 
     Scenario: Page title
         Given there is at least one booking
@@ -36,10 +36,10 @@ Feature: Viewing a booking
         When I am viewing my chosen booking
         Then I should see a 'Booking details' section with the following values:
             | Heading          | Value                                                                  |
-            | Date             | 02 October 2019                                                        |
             | Subject          | Biology                                                                |
             | DBS certificate  | Yes - Candidate says they have DBS certificate \(not verified by DfE\) |
             | Request received | 08 February 2019                                                       |
+        And the future booking date should be listed
 
     Scenario: Candidate details
         Given there is at least one booking

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -1,5 +1,5 @@
-Given("the scheduled booking date is {string}") do |string|
-  @scheduled_booking_date = string
+Given("the scheduled booking date is in the future") do
+  @scheduled_booking_date = 1.week.from_now.strftime("%d %B %Y")
 end
 
 Given("there are some bookings") do

--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -94,3 +94,7 @@ end
 Then("I should see the placement request's duration") do
   expect(page).to have_css('dd', text: "1 day")
 end
+
+Then("the future booking date should be listed") do
+  expect(page).to have_content(@booking.date.to_formatted_s(:govuk))
+end


### PR DESCRIPTION
We had a couple of hard coded 'future' dates that are now in the past. Remove them and replace with something that won't break 🤦🏽‍♂️