### PR TITLE
Exclude cancelled bookings from attendance confirmation SE-1802

### DIFF
--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -35,6 +35,7 @@ module Schools
         .bookings
         .previous
         .attendance_unlogged
+        .not_cancelled
         .accepted
         .eager_load(
           :bookings_placement_request,

--- a/features/schools/confirm_attendance.feature
+++ b/features/schools/confirm_attendance.feature
@@ -19,6 +19,11 @@ Feature: Confirming candidate attendance
         When I am on the 'confirm attendance' page
         Then I should see a table containing those bookings
 
+    Scenario: Not listing cancelled bookings
+        Given there are some cancelled bookings that were scheduled last week
+        When I am on the 'confirm attendance' page
+        Then no bookings should be listed
+
     Scenario: Table contents
         Given there are some bookings that were scheduled last week
         When I am on the 'confirm attendance' page

--- a/features/step_definitions/schools/confirm_attendance_steps.rb
+++ b/features/step_definitions/schools/confirm_attendance_steps.rb
@@ -57,3 +57,27 @@ Then("the other bookings should not be updated") do
     expect(ob).to be_nil
   end
 end
+
+Given("there are some cancelled bookings that were scheduled last week") do
+  @bookings = [
+    FactoryBot.create(
+      :bookings_booking,
+      :cancelled_by_school,
+      bookings_school: @school
+    ),
+    FactoryBot.create(
+      :bookings_booking,
+      :cancelled_by_candidate,
+      bookings_school: @school
+    )
+  ]
+
+  @bookings.each do |booking|
+    booking.date = booking.accepted_at = 4.days.ago
+    booking.save(validate: false)
+  end
+end
+
+Then("no bookings should be listed") do
+  expect(page).to have_text('There are no bookings that need their attendance to be confirmed.')
+end


### PR DESCRIPTION
### Context

Schools were marking cancelled bookings as not-attended due to them not being excluded from the 'confirm attendance' screen

### Changes proposed in this pull request

Jordan Russell masterminded the fix by using the `.not_cancelled` scope to prevent cancelled bookings from being retrieved

### Guidance to review

Sanity check
