### PR TITLE
Allow healthcheck URLs to bypass canonical redirection

### DIFF
--- a/config/initializers/canonical_redirect.rb
+++ b/config/initializers/canonical_redirect.rb
@@ -15,7 +15,8 @@ if ENV['CANONICAL_DOMAIN'].present? || Rails.env.test? || Rails.env.servertest?
       lambda { |match, rack_env| "#{proto}://#{ENV['CANONICAL_DOMAIN']}#{match[1]}" },
       if: Proc.new { |rack_env|
         ENV['CANONICAL_DOMAIN'].present? &&
-          rack_env['HTTP_HOST'] != ENV['CANONICAL_DOMAIN']
+          rack_env['HTTP_HOST'] != ENV['CANONICAL_DOMAIN'] &&
+          !rack_env['PATH_INFO'].in?(%w(/healthcheck.txt /deployment.txt))
       }
   end
 end


### PR DESCRIPTION
### Context

When deploying to Azure using slots, we need to bypass the canonical redirect for the healthcheck urls

### Changes proposed in this pull request

1. Allow bypassing the canonical redirection for /healthcheck.txt
2. Allow bypassing the canonical redirection for /healthcheck.txt

### Guidance to review

1. Code review
2. To test `CANONICAL_DOMAIN=bbc.co.uk bundle exec rails s` - should allow access to `https://localhost:3000/healthcheck.txt`, and redirect for 'https://localhost:3000/'
