### PR TITLE
Gem updates 04 oct 2019

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: c67dea0e8d23d9187ba4ec43dbde920f61927f5d
+  revision: e2443c2932a1a56f488dda68bcab43b586d79427
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)
@@ -100,8 +100,7 @@ GEM
     capybara-screenshot (1.0.23)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (2.0.0)
-      rake (< 13.0)
+    childprocess (3.0.0)
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
@@ -160,12 +159,12 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (0.15.4)
+    faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     foreman (0.85.0)
       thor (~> 0.19.1)
-    geocoder (1.5.1)
+    geocoder (1.5.2)
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -217,9 +216,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.0904)
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
@@ -229,7 +228,7 @@ GEM
     multi_test (0.1.2)
     multipart-post (2.1.1)
     mustermann (1.0.3)
-    nio4r (2.5.1)
+    nio4r (2.5.2)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notifications-ruby-client (4.0.0)
@@ -245,7 +244,7 @@ GEM
       validate_url
       webfinger (>= 1.0.1)
     parallel (1.17.0)
-    parser (2.6.3.0)
+    parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
     pg_search (2.3.0)
@@ -272,7 +271,7 @@ GEM
       httpclient
       json-jwt (>= 1.9.0)
       rack
-    rack-protection (2.0.5)
+    rack-protection (2.0.7)
       rack
     rack-proxy (0.6.5)
       rack
@@ -315,16 +314,16 @@ GEM
       ffi (~> 1.0)
     redis (4.1.3)
     regexp_parser (1.6.0)
-    rgeo (2.0.1)
+    rgeo (2.1.1)
     rgeo-activerecord (6.2.1)
       activerecord (>= 5.0)
       rgeo (>= 1.0.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.4)
+    rspec-expectations (3.8.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.1)
+    rspec-mocks (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-rails (3.8.2)
@@ -335,7 +334,7 @@ GEM
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-support (3.8.2)
+    rspec-support (3.8.3)
     rubocop (0.65.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -345,20 +344,19 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
-    rubocop-rspec (1.33.0)
+    rubocop-rspec (1.35.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.3.0)
+    rubyzip (2.0.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (2.0.1)
+    sassc (2.2.1)
       ffi (~> 1.9)
-      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -368,17 +366,17 @@ GEM
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (3.142.4)
-      childprocess (>= 0.5, < 3.0)
-      rubyzip (~> 1.2, >= 1.2.2)
+    selenium-webdriver (3.142.6)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
-    sinatra (2.0.5)
+    sinatra (2.0.7)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.5)
+      rack-protection (= 2.0.7)
       tilt (~> 2.0)
     slack-notifier (2.3.2)
     spring (2.1.0)
@@ -400,7 +398,7 @@ GEM
       httpclient (>= 2.4)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     timeliness (0.4.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -505,7 +503,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.5.6p201
+   ruby 2.5.7p206
 
 BUNDLED WITH
    1.17.3

--- a/spec/services/schools/dfe_sign_in_api/organisations_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/organisations_spec.rb
@@ -32,12 +32,12 @@ describe Schools::DFESignInAPI::Organisations do
     subject { Schools::DFESignInAPI::Organisations.new(user_guid) }
 
     {
-      400 => Faraday::ClientError,
+      400 => Faraday::BadRequestError,
       404 => Faraday::ResourceNotFound,
       405 => Faraday::ClientError,
-      500 => Faraday::ClientError,
-      502 => Faraday::ClientError,
-      503 => Faraday::ClientError
+      500 => Faraday::ServerError,
+      502 => Faraday::ServerError,
+      503 => Faraday::ServerError
     }.each do |code, error|
       context code.to_s do
         before do


### PR DESCRIPTION
### Context

Various gems have become stale with new versions available

### Changes proposed in this pull request

1. Upgrade to use those versions
2. Amend error classes in tests for the shift from Faraday 0.15 to 0.16

### Guidance to review

1. Do tests continue to pass
