### PR TITLE
SE-1784 Show all upcoming bookings

### DIFF
--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -49,8 +49,6 @@ module Bookings
       :cancelled?,
       to: :bookings_placement_request
 
-    UPCOMING_TIMEFRAME = 2.weeks
-
     scope :not_cancelled, -> { joins(:bookings_placement_request).merge(PlacementRequest.not_cancelled) }
     scope :upcoming, -> { not_cancelled.accepted.future }
 

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -52,10 +52,11 @@ module Bookings
     UPCOMING_TIMEFRAME = 2.weeks
 
     scope :not_cancelled, -> { joins(:bookings_placement_request).merge(PlacementRequest.not_cancelled) }
-    scope :upcoming, -> { not_cancelled.accepted.where(arel_table[:date].between(Time.now..UPCOMING_TIMEFRAME.from_now)) }
+    scope :upcoming, -> { not_cancelled.accepted.future }
 
     scope :accepted, -> { where.not(accepted_at: nil) }
     scope :previous, -> { where(arel_table[:date].lteq(Date.today)) }
+    scope :future, -> { where(arel_table[:date].gteq(Date.today)) }
     scope :attendance_unlogged, -> { where(attended: nil) }
 
     scope :with_unviewed_candidate_cancellation, -> do
@@ -67,7 +68,7 @@ module Bookings
       not_cancelled
       .attendance_unlogged
       .accepted
-      .upcoming
+      .future
     end
 
     scope :requiring_attention, -> do

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -30,18 +30,18 @@ Given("I am viewing my chosen booking") do
 end
 
 And("there is/are {int} booking/bookings") do |count|
-  @scheduled_booking_date ||= 1.week.from_now.strftime("%d %B %Y")
   unless @school.subjects.where(name: 'Biology').any?
     @school.subjects << FactoryBot.create(:bookings_subject, name: 'Biology')
   end
-  @bookings = FactoryBot.create_list(
-    :bookings_booking,
-    count,
-    :with_existing_subject,
-    :accepted,
-    bookings_school: @school,
-    date: @scheduled_booking_date
-  )
+  @bookings = (1..count).map do |index|
+    FactoryBot.create(
+      :bookings_booking,
+      :with_existing_subject,
+      :accepted,
+      bookings_school: @school,
+      date: index.week.from_now.strftime("%d %B %Y")
+    )
+  end
   @booking = @bookings.first
   @booking_id = @booking.id
 end

--- a/spec/models/bookings/profile_publisher_spec.rb
+++ b/spec/models/bookings/profile_publisher_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to be_persisted }
       it { is_expected.to be_valid }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
-      it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
+      it { expect(subject.school.subject_ids.sort).to eql(school_profile.subject_ids.sort) }
       it { expect(subject.school.phase_ids.length).to eql(4) }
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Bookings::ProfilePublisher, type: :model do
       it { is_expected.to be_valid }
       it { is_expected.to eql @initial_profile }
       it { is_expected.to have_attributes(primary_phase: true, secondary_phase: true) }
-      it { expect(subject.school.subject_ids).to eql(school_profile.subject_ids) }
+      it { expect(subject.school.subject_ids.sort).to eql(school_profile.subject_ids.sort) }
       it { expect(subject.school.phase_ids.length).to eql(4) }
     end
   end


### PR DESCRIPTION
### Context

Currently we only show the next 2 weeks worth of upcoming bookings, this prevents the user from seeing accepted bookings further in the future.

### Changes proposed in this pull request

1. Removed the confusing 'upcoming' scope
2. Added a 'future' scope
3. Use the future scope for the needing attention scope which in turn is used to generate the list for the Confirmed bookings screen
4. Changed the Booking factory to create bookings for increasingly far future dates
5. Stop enforcing the date for the confirmed bookings feature, this means it falls back to the 'increasingly far future' date, which in turn means it will test for the presence of a booking beyond the 2 week horizon.

### Guidance to review
1. Code review
2. Testing
