### PR TITLE
Updated content of fees pages

### DIFF
--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -17,14 +17,28 @@
 
     <%= form_for model, url: submission_path do |f| %>
       <%= GovukElementsErrorsHelper.error_summary model, 'There is a problem', '' %>
-      <%= f.pounds_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.99 %>
-      <%= f.text_area :description, rows: 7, width: 'govuk-input--width-15' %>
+
+      <%= f.pounds_field :amount_pounds,
+          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' },
+          width: 5,
+          step: 0.01,
+          min: 0,
+          max: 9999.99 %>
+
+      <%= f.text_area :description, rows: 7 %>
+
       <%= f.radio_button_fieldset :interval do |fieldset| %>
         <% f.object.available_intervals.each do |interval| %>
           <%= fieldset.radio_input interval %>
         <% end %>
       <% end %>
-      <%= f.text_area :payment_method, rows: 7, width: 'govuk-input--width-15' %>
+
+      <%= f.text_area :payment_method, rows: 7,
+        label_options: {
+          overwrite_defaults!: true,
+          class: 'govuk-heading-m'
+        } %>
+
       <%= f.submit 'Continue' %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,9 +52,9 @@ en:
     interval: 'Is this a daily or one-off fee?'
 
   schools_on_boarding_school_fee_labels: &schools_on_boarding_school_fee_labels
-    amount_pounds: 'Enter the number of pounds.'
+    amount_pounds: 'Enter the number of pounds'
     description: 'Explain what the fee covers.'
-    payment_method: 'Explain how the fee is paid. For example, by bank transfer, in cash or via PayPal.'
+    payment_method: 'Explain how the fee is paid'
 
   feedback_errors: &feedback_errors
     attributes:
@@ -476,6 +476,14 @@ en:
         disabled_facilities: 'For example, disabled parking spaces and support for autistic spectrum disorders, dyslexia and hearing impairments'
       schools_on_boarding_experience_outline:
         provides_teacher_training: 'For example, are you a School Direct lead or partner school or do you offer mainstream teacher training placements.'
+      schools_on_boarding_school_fee_hints: &schools_on_boarding_school_fee_hints
+        payment_method: For example, by bank transfer, in cash or via PayPal.
+      schools_on_boarding_administration_fee:
+        <<: *schools_on_boarding_school_fee_hints
+      schools_on_boarding_dbs_fee:
+        <<: *schools_on_boarding_school_fee_hints
+      schools_on_boarding_other_fee:
+        <<: *schools_on_boarding_school_fee_hints
 
     label:
       schools_placement_requests_confirm_booking:
@@ -578,7 +586,7 @@ en:
         <<: *schools_on_boarding_school_fee_labels
       schools_on_boarding_dbs_fee:
         <<: *schools_on_boarding_school_fee_labels
-        payment_method: 'Explain how the fee is paid.'
+        payment_method: 'Explain how the fee is paid'
         description: 'Add extra details'
       schools_on_boarding_other_fee:
         <<: *schools_on_boarding_school_fee_labels

--- a/features/schools/onboarding/administration_fee.feature
+++ b/features/schools/onboarding/administration_fee.feature
@@ -28,16 +28,16 @@ Feature: Administration Fee
   Scenario: Completing the Administration costs step with error
     Given I have entered the following details into the form:
       | Explain what the fee covers. | Nondescript administration |
-      | Explain how the fee is paid. | Travelers cheques          |
+      | Explain how the fee is paid  | Travelers cheques          |
     And I choose 'Daily' from the 'Is this a daily or one-off fee?' radio buttons
     When I submit the form
     Then I should see a validation error message
 
   Scenario: Completing the Administration costs step with error
     Given I have entered the following details into the form:
-      | Enter the number of pounds.  | 100                        |
+      | Enter the number of pounds   | 100                        |
       | Explain what the fee covers. | Nondescript administration |
-      | Explain how the fee is paid. | Travelers cheques          |
+      | Explain how the fee is paid  | Travelers cheques          |
     And I choose 'Daily' from the 'Is this a daily or one-off fee?' radio buttons
     When I submit the form
     Then I should be on the 'Phases' page

--- a/features/schools/onboarding/other_fee.feature
+++ b/features/schools/onboarding/other_fee.feature
@@ -28,16 +28,16 @@ Feature: Other Fee
   Scenario: Completing the Other costs step with error
     Given I have entered the following details into the form:
       | Explain what the fee covers. | Falconry lessons |
-      | Explain how the fee is paid. | Gold sovereigns  |
+      | Explain how the fee is paid  | Gold sovereigns  |
     And I choose 'Daily' from the 'Is this a daily or one-off fee?' radio buttons
     When I submit the form
     Then I should see a validation error message
 
   Scenario: Completing the Other costs step with error
     Given I have entered the following details into the form:
-      | Enter the number of pounds.  | 300                        |
+      | Enter the number of pounds   | 300              |
       | Explain what the fee covers. | Falconry lessons |
-      | Explain how the fee is paid. | Gold sovereigns  |
+      | Explain how the fee is paid  | Gold sovereigns  |
     And I choose 'Daily' from the 'Is this a daily or one-off fee?' radio buttons
     When I submit the form
     Then I should be on the 'Phases' page

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -93,9 +93,9 @@ end
 Given "I have completed the Other costs step" do
   steps %(
     Given I have entered the following details into the form:
-      | Enter the number of pounds.  | 300              |
+      | Enter the number of pounds   | 300              |
       | Explain what the fee covers. | Falconry lessons |
-      | Explain how the fee is paid. | Gold sovereigns  |
+      | Explain how the fee is paid  | Gold sovereigns  |
     And I choose 'Daily' from the 'Is this a daily or one-off fee?' radio buttons
     When I submit the form
   )


### PR DESCRIPTION
### Context

The Admin/DBS/Other Fees pages in the Schools onboarding section are out of sync with the prototype app

### Changes proposed in this pull request

1. Use heading style for 'Enter the number of pounds'
2. Use heading style for 'Explain how the fee is paid'
3. Added a hint to 'Explain how the fee is paid'

### Guidance to review
1. Compare to pages in prototype.
2. Check test suite still passes
