### PR TITLE
Add missing titles on accessibility pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,14 @@ module ApplicationHelper
     end
   end
 
+  def page_heading(heading_txt = nil, **options, &block)
+    options[:class] ||= 'govuk-heading-l'
+    title = heading_txt || capture(&block)
+
+    self.page_title = title
+    content_tag(:h1, title, **options)
+  end
+
   def site_header_text
     @site_header_text || "Get school experience"
   end

--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -2,7 +2,10 @@
   <article class="govuk-grid-column-full">
     <%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
 
-    <h1 class="govuk-heading-l">Accessibility statement for the school experience service</h1>
+    <%= page_heading do %>
+      Accessibility statement for the school experience service
+    <% end %>
+
     <section>
       <p>
         This service is run by the Department for Education (DfE).

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -1,6 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Cookies</h1>
+    <%= page_heading 'Cookies' %>
+
     <section>
       <p>
         This site puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.

--- a/app/views/pages/help_and_support_access_needs.html.erb
+++ b/app/views/pages/help_and_support_access_needs.html.erb
@@ -2,9 +2,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
 
-    <h1 class="govuk-heading-l">
+    <%= page_heading do %>
       Help and support candidates with disability and access needs
-    </h1>
+    <% end %>
 
     <p>
       Read this guidance to find out you can help and support candidates with

--- a/app/views/pages/migration.html.erb
+++ b/app/views/pages/migration.html.erb
@@ -1,4 +1,6 @@
-<h1 class="govuk-heading-xl">Improved school experience service</h1>
+<%= page_heading class: 'govuk-heading-xl' do %>
+  Improved school experience service
+<% end %>
 
 <p>
   You’ll no longer be able to access the School Experience (SEP) Portal to book

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= link_to 'Back', (request.referer || candidates_root_path), class: 'govuk-back-link' %>
 
-  <%= link_to 'Back', (request.referer || candidates_root_path), class: 'govuk-back-link' %>
-
-    <h1 class="govuk-heading-l">Privacy Notice: Get Into Teaching Information
-Service</h1>
+    <%= page_heading do %>
+      Privacy Notice: Get Into Teaching Information Service
+    <% end %>
 
     <%= render @policy_id %>
 

--- a/app/views/pages/service_update.html.erb
+++ b/app/views/pages/service_update.html.erb
@@ -1,8 +1,8 @@
 <div id="service-update" class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
+    <%= page_heading do %>
       Service updates and guidance - <%= service_update_last_updated_at %>
-    </h1>
+    <% end %>
     <p>
       Find out about the latest changes and planned future updates for the service.
     </p>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -102,4 +102,24 @@ describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#page_heading' do
+    context 'with parameter' do
+      subject! { page_heading('My Page Title') }
+      it { is_expected.to eql('<h1 class="govuk-heading-l">My Page Title</h1>') }
+      it { expect(self.page_title).to eql('My Page Title | DfE School Experience') }
+    end
+
+    context 'with block' do
+      subject! { page_heading { 'My Page Title' } }
+      it { is_expected.to eql('<h1 class="govuk-heading-l">My Page Title</h1>') }
+      it { expect(self.page_title).to eql('My Page Title | DfE School Experience') }
+    end
+
+    context 'with custom options' do
+      subject! { page_heading('Page Title', class: 'govuk-heading-xl') }
+      it { is_expected.to eql('<h1 class="govuk-heading-xl">Page Title</h1>') }
+      it { expect(self.page_title).to eql('Page Title | DfE School Experience') }
+    end
+  end
 end


### PR DESCRIPTION
### Context

Some of the simple content pages are missing page titls

### Changes proposed in this pull request

1. Added a helper to assign both page title and write out the page heading
2. Changed various pages to use it

### Guidance to review
1. Code review
2. Test the pages in the Pages controller have an appropriate title in the browser
