### PR TITLE
Expire Gitis tokens at 55 minutes instead of 1 hour

### DIFF
--- a/spec/services/bookings/gitis/auth_spec.rb
+++ b/spec/services/bookings/gitis/auth_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe Bookings::Gitis::Auth do
       it "sets the expires" do
         subject.token
         expect(subject.expires_at).to be_kind_of(Time)
-        expect(subject.expires_at).to be_within(10.seconds).of(1.hour.from_now)
+        # Note we expiry the token early to allow for multiple requests and Gitis running slowly
+        expect(subject.expires_at).to be_within(10.seconds).of(55.minutes.from_now)
       end
     end
 


### PR DESCRIPTION
### Context

Currently we are getting occasional expiries from Gitis tokens. I think this
maybe caused by page queries with multiple gitis requests in them. The first
occurs within the expiry time of the token, the token then expires during this
time window. The second request to gitis then fails because the token has by now
expired.

### Changes proposed in this pull request

1. Expire Gitis tokens at 55 minutes instead of 1 hour
2. Also verify that the retrieved token isn't blank - conceivably possible if Redis is glitchy

### Guidance to review

1. Code review
2. Does gitis still work

