### PR TITLE
SE-1738 Back link problems on access needs page

### DIFF
--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -1,5 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <%= link_to 'Back', :back, class: 'govuk-back-link' %>
+    
     <%= page_heading 'Cookies' %>
 
     <section>

--- a/app/views/pages/help_and_support_access_needs.html.erb
+++ b/app/views/pages/help_and_support_access_needs.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
+    <%= link_to 'Back', :back, class: 'govuk-back-link' %>
 
     <%= page_heading do %>
       Help and support candidates with disability and access needs

--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -1,6 +1,6 @@
 <% self.page_title = 'Privacy policy - Schools' %>
 
- <%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+ <%= link_to 'Back', :back, class: 'govuk-back-link' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">


### PR DESCRIPTION
### Context

The javascript back controller is not compatible with the 'scroll to top' of page behaviour - since that pushes a navigation target onto the stack. Which the back link then pops back off.

### Changes proposed in this pull request

1. Removed the back link js controller from pages with scroll to top.
2. Also added missing back link on cookies page.

### Guidance to review

1. Code review
2. Behaviour test

