### PR TITLE
SE-1686 Update school will contact you language

### DIFF
--- a/app/notify/notify_email/candidate_request_confirmation_no_pii.8ee470a1-0b94-48ee-9fe7-98b7beb8921c.md
+++ b/app/notify/notify_email/candidate_request_confirmation_no_pii.8ee470a1-0b94-48ee-9fe7-98b7beb8921c.md
@@ -9,7 +9,7 @@ You've requested school experience at ((school_name)).
 Here's a copy of your request details which have been forwarded to the school.
 
 * School or college: ((school_name))
-* Availability/preferred dates: ((placement_availability))
+* Availability / start dates: ((placement_availability))
 * What you want to get out of school experience: ((placement_outcome))
 * Degree stage: ((candidate_degree_stage))
 * Degree subject: ((candidate_degree_subject))
@@ -21,7 +21,5 @@ Here's a copy of your request details which have been forwarded to the school.
 ---
 
 # Help and support
-
-If you haven’t heard from the school after 2 weeks email our School Experience Support Team at schoolexperience@ta-recruit.education.gov.uk.
 
 If you'd like to withdraw your school experience request use the following link ((cancellation_url)).

--- a/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
+++ b/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
@@ -12,4 +12,4 @@ View the request – ((placement_request_url))
 
 # Help and support
  
-If you’ve got any feedback, questions or would like to take part in user testing contact us at organise.schoolexperience@education.gov.uk.
+If you’ve got any feedback, questions or would like to take part in user testing email us with your URN at organise.schoolexperience@education.gov.uk.

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -21,7 +21,7 @@
     </p>
 
     <p>
-      We'll email you copy of your request for your records.
+      We'll email you a copy of your request for your records.
     </p>
 
     <p>

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -4,27 +4,28 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        Your school experience request has been sent
+        You've requested school experience at <%= @school_name %>
       </h1>
     </div>
+
     <h3 class="govuk-heading-m">What happens next</h3>
+
     <p>
-      Your request for school experience will be forwarded to
-      <%= @school_name %>.
-    </p>
-    <p class="govuk-!-font-weight-bold">
-      The school will email or call you to discuss your request and experience
-      date. During term time this could typically take up to 2 weeks.
+      You will be contacted about your request. Schools aim to get in touch
+      within 10 working days during term time.
     </p>
 
     <p>
-      We'll email you a copy of your request details to confirm you've requested
-      school experience.
+      If you can't find any messages from the school in your inbox - check your
+      spam and other mailbox folders.
     </p>
 
     <p>
-      This service is still in development. If you would like to make another
-      request, you will have to submit your details again.
+      We'll email you copy of your request for your records.
+    </p>
+
+    <p>
+      <%= govuk_link_to 'Search for school experience', new_candidates_school_search_path %>
     </p>
   </div>
 </div>

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -311,8 +311,7 @@ feature 'Candidate Registrations', type: :feature do
   end
 
   def view_request_acknowledgement_step
-    expect(page).to have_text \
-      "Your request for school experience will be forwarded to Test School."
+    expect(page).to have_text "You've requested school experience at"
   end
 
   def sign_in_via_dashboard(token)


### PR DESCRIPTION
### Context

The confirmation screen at the end of the Candidate creating a Placement Request is out of date with the prototype content.

### Changes proposed in this pull request

1. Bring the page up to date with the content in the prototype for the placement request confirmation page
2. Synced with email content in Notify

