### PR TITLE
Add missing scopes to confirm attendances counter SE-1836

### DIFF
--- a/app/controllers/schools/dashboards_controller.rb
+++ b/app/controllers/schools/dashboards_controller.rb
@@ -18,6 +18,8 @@ module Schools
       @candidate_attendances = current_school
         .bookings
         .previous
+        .not_cancelled
+        .accepted
         .attendance_unlogged
         .count
     end

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -97,6 +97,7 @@ Feature: The School Dashboard
     Scenario: Confirm attendance counter
         Given my school has fully-onboarded
         And there are 2 bookings in the past with no attendance logged
+        And there is a booking in the past that has been cancelled
         When I am on the 'schools dashboard' page
         Then the 'confirm attendance counter' should be 2
 

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -41,12 +41,16 @@ Given("there are {int} unviewed candidate cancellations") do |qty|
 end
 
 Given("there are {int} bookings in the past with no attendance logged") do |qty|
-  @bookings = FactoryBot.create_list :bookings_booking, qty, bookings_school: @school
+  @bookings = FactoryBot.create_list :bookings_booking, qty, :accepted, bookings_school: @school
   @bookings.each do |b|
     b.date = 1.week.ago
     b.attended = nil
     b.save(validate: false)
   end
+end
+
+Given("there is a booking in the past that has been cancelled") do
+  @cancelled_booking = FactoryBot.create(:bookings_booking, :accepted, :cancelled_by_school, bookings_school: @school)
 end
 
 Then("the {string} should be {int}") do |string, int|


### PR DESCRIPTION
### Context

The dashboard counter number was greater than those shown in the confirm attendances list

### Changes proposed in this pull request

Apply the same scopes so cancelled bookings don't affect the counter

### Guidance to review

Ensure it works and looks sensible

