### PR TITLE
Lock sprockets to pre-4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'puma', '~> 4.2'
 # Use SCSS for stylesheets
 gem 'sassc-rails'
 gem "autoprefixer-rails"
+gem "sprockets", "< 4.0.0"
 
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
@@ -71,6 +72,9 @@ gem 'faraday'
 
 gem 'validates_timeliness', '~> 5.0.0.alpha5'
 gem 'activerecord-import'
+
+# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -125,5 +129,3 @@ group :test do
   gem 'capybara-screenshot'
 end
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,6 +492,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
+  sprockets (< 4.0.0)
   tzinfo-data
   uglifier (>= 1.3.0)
   uk_postcode


### PR DESCRIPTION
### Context

We don't yet have a manifest file which sprockets 4.0 requires.

### Changes proposed in this pull request

1. Lock sprockets to the pre-4.0 release


