### PR TITLE
Prevent users from editing the date of bookings

### DIFF
--- a/app/controllers/schools/confirmed_bookings/date_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/date_controller.rb
@@ -2,6 +2,7 @@ module Schools
   module ConfirmedBookings
     class DateController < Schools::BaseController
       before_action :set_booking
+      before_action :check_editable, except: :show
 
       def edit; end
 
@@ -56,6 +57,13 @@ module Schools
         @booking
           .bookings_placement_request
           .fetch_gitis_contact(gitis_crm)
+      end
+
+      def check_editable
+        return true if @booking.editable_date?
+
+        render 'uneditable'
+        false
       end
     end
   end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -151,5 +151,9 @@ module Bookings
     def cancellable?
       in_future? && !cancelled?
     end
+
+    def editable_date?
+      in_future? && !cancelled?
+    end
   end
 end

--- a/app/views/schools/confirmed_bookings/_booking.html.erb
+++ b/app/views/schools/confirmed_bookings/_booking.html.erb
@@ -13,7 +13,11 @@
     <h2>Booking details</h2>
 
     <dl class="govuk-summary-list">
-      <%= summary_row 'Date', booking.date.to_formatted_s(:govuk), edit_schools_booking_date_path(booking) %>
+      <% if booking.editable_date? %>
+        <%= summary_row 'Date', booking.date.to_formatted_s(:govuk), edit_schools_booking_date_path(booking) %>
+      <% else %>
+        <%= summary_row 'Date', booking.date.to_formatted_s(:govuk) %>
+      <% end %>
       <%= summary_row 'Subject', booking.bookings_subject.name %>
       <%= summary_row 'DBS certificate', format_has_dbs_certificate(booking.has_dbs_check) %>
       <%= summary_row 'Request received', booking.received_on.to_formatted_s(:govuk) %>

--- a/app/views/schools/confirmed_bookings/date/uneditable.html.erb
+++ b/app/views/schools/confirmed_bookings/date/uneditable.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= link_to 'Back', request.referer || schools_booking_path(@booking), class: 'govuk-back-link' %>
+
+    <%= page_heading 'Booking date cannot be edited' %>
+
+    <p>
+      The booking you have selected can no longer have the date edited.
+    </p>
+
+    <p>
+      <%= govuk_link_to 'Return to booking', request.referer || schools_booking_date_path, secondary: true %>
+    </p>
+  </div>
+</div>

--- a/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
@@ -17,6 +17,17 @@ describe Schools::ConfirmedBookings::DateController, type: :request do
     specify do
       expect(subject).to render_template(:edit)
     end
+
+    context 'with cancelled booking' do
+      before do
+        booking.bookings_placement_request.create_candidate_cancellation! \
+          attributes_for(:cancellation, :cancelled_by_candidate, :sent)
+      end
+
+      specify do
+        is_expected.to render_template(:uneditable)
+      end
+    end
   end
 
   describe '#update' do
@@ -38,6 +49,19 @@ describe Schools::ConfirmedBookings::DateController, type: :request do
 
       specify 'should update the booking' do
         expect(booking.reload.date).to eql(new_date)
+      end
+    end
+
+    context 'with cancelled booking' do
+      before do
+        booking.bookings_placement_request.create_candidate_cancellation! \
+          attributes_for(:cancellation, :cancelled_by_candidate, :sent)
+
+        subject
+      end
+
+      specify do
+        is_expected.to render_template(:uneditable)
       end
     end
 

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -464,4 +464,21 @@ describe Bookings::Booking do
       it { is_expected.not_to be_cancellable }
     end
   end
+
+  context '#cancellable?' do
+    context 'for uncancelled future booking' do
+      subject { create(:bookings_booking, :accepted) }
+      it { is_expected.to be_editable_date }
+    end
+
+    context 'for cancelled booking' do
+      subject { create(:bookings_booking, :cancelled_by_school) }
+      it { is_expected.not_to be_editable_date }
+    end
+
+    context 'for past booking' do
+      subject { create(:bookings_booking, :previous) }
+      it { is_expected.not_to be_editable_date }
+    end
+  end
 end


### PR DESCRIPTION
### Context

Currently school administrators can edit the date of bookings even when they are in the past or have been cancelled.

### Changes proposed in this pull request

1. Don't provide the change link when its not relevant
2. If the user does end up at the end point (race condition/multiple pages open) - show an error screen instead.

### Guidance to review
1. Code review
2. Manually visit the end point for a cancelled booking
