### PR TITLE
(Subject-specific dates) Add durations to the subject and date options

### DIFF
--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -29,7 +29,7 @@
               <%= f.radio_button_fieldset :subject_and_date_ids,
                 choices: secondary_placement_dates,
                 value_method: :id,
-                text_method: :name
+                text_method: :name_with_duration
               -%>
             </dd>
           </div>

--- a/features/candidates/registrations/subject_and_date_information.feature
+++ b/features/candidates/registrations/subject_and_date_information.feature
@@ -7,6 +7,12 @@ Feature: Selecting a subject and date
         Given my school of choice exists
         And it has 'fixed' availability
 
+    Scenario: Displaying durations
+        Given the school is a 'primary and secondary' school
+        And the school has both primary and secondary dates set up
+        When I am on the 'choose a subject and date' screen for my chosen school
+        Then I should see the duration listed in each radio button label
+
     Scenario: When the school is a primary school
         Given the school is a 'primary' school
         And the school has some primary placement dates set up

--- a/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
@@ -72,3 +72,9 @@ Then("I should be on the {string} page for my chosen school") do |string|
   path = path_for(string, school: @school)
   expect(page.current_path).to eql(path)
 end
+
+Then("I should see the duration listed in each radio button label") do
+  page.all('label').each do |label|
+    expect(label.text).to end_with("(1 day)")
+  end
+end


### PR DESCRIPTION
### Context

Durations weren't being displayed on the subject/date selection screen

### Changes proposed in this pull request

Add missing durations to dates on the subject/date selection screen.

Additionally, subjects are now sorted alphabetically, the screenshot is slightly out-of-date

### Guidance to review

Make sure it looks ok, here's a preview

![Screenshot 2019-10-18 at 09 58 33](https://user-images.githubusercontent.com/128088/67085872-91347280-f197-11e9-96cb-b589bd7cd261.png)

