### PR TITLE
Feature/subject specific dates/refactor registration state

### DIFF
--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -51,12 +51,9 @@ module Candidates
       end
 
       def subject_and_date_information
-        @subject_and_date_information ||= \
-          if @registration_session.school.availability_preference_fixed?
-            @registration_session.subject_and_date_information
-          else
-            false
-          end
+        fail NotImplementedForThisDateType unless has_subject_and_date_information?
+
+        @subject_and_date_information ||= @registration_session.subject_and_date_information
       end
 
       def ==(other)
@@ -95,13 +92,13 @@ module Candidates
       end
 
       def has_subject_and_date_information?
-        !!subject_and_date_information
+        RegistrationState.new(@registration_session).subject_and_date_information_in_journey?
       end
 
       def placement_date_subject
         fail NotImplementedForThisDateType unless has_subject_and_date_information?
 
-        @subject_and_date_information.placement_date_subject
+        subject_and_date_information.placement_date_subject
       end
 
       def placement_date

--- a/app/services/candidates/registrations/registration_state.rb
+++ b/app/services/candidates/registrations/registration_state.rb
@@ -33,8 +33,6 @@ module Candidates
         false
       end
 
-    private
-
       def step_not_completed?(step)
         !step_completed? step
       end

--- a/app/services/candidates/registrations/registration_step.rb
+++ b/app/services/candidates/registrations/registration_step.rb
@@ -14,6 +14,10 @@ module Candidates
         @school ||= Candidates::School.find(urn)
       end
 
+      def completed?
+        valid?
+      end
+
       def persisted?
         created_at.present?
       end

--- a/spec/services/candidates/registrations/registration_state_spec.rb
+++ b/spec/services/candidates/registrations/registration_state_spec.rb
@@ -1,15 +1,79 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::RegistrationState do
-  before do
-    FactoryBot.create :bookings_school, urn: 11048
+  let! :school do
+    create :bookings_school, urn: 11048
+  end
+
+  let :school_with_flexible_dates do
+    create :bookings_school, availability_preference_fixed: false
+  end
+
+  let :school_with_fixed_dates do
+    create :bookings_school, availability_preference_fixed: true
   end
 
   subject { described_class.new registration_session }
 
+  context '#steps' do
+    context 'for a school with flexible dates' do
+      let :registration_session do
+        build :registration_session, urn: school_with_flexible_dates.urn, with: []
+      end
+
+      it 'returns the correct steps' do
+        expect(subject.steps).to eq %i(
+          personal_information
+          contact_information
+          education
+          teaching_preference
+          placement_preference
+          background_check
+        )
+      end
+    end
+
+    context 'for a school with fixed dates' do
+      let :registration_session do
+        build :registration_session, urn: school_with_fixed_dates.urn, with: []
+      end
+
+      it 'returns the correct steps' do
+        expect(subject.steps).to eq %i(
+          subject_and_date_information
+          personal_information
+          contact_information
+          education
+          teaching_preference
+          placement_preference
+          background_check
+        )
+      end
+    end
+  end
+
+  context 'for a school with fixed dates' do
+    context 'without subject_and_date_information' do
+      let :registration_session do
+        build :registration_session, urn: school_with_fixed_dates.urn, with: []
+      end
+
+      it { expect(subject.next_step).to eq :subject_and_date_information }
+    end
+
+    context 'with subject_and_date_information' do
+      let :registration_session do
+        build :registration_session, urn: school_with_fixed_dates.urn,
+          with: %i(subject_and_date_information)
+      end
+
+      it { expect(subject.next_step).to eq :personal_information }
+    end
+  end
+
   context 'without personal information' do
     let :registration_session do
-      Candidates::Registrations::RegistrationSession.new('urn' => '11048')
+      build :registration_session, urn: school.urn, with: []
     end
 
     it { expect(subject.next_step).to eq :personal_information }
@@ -18,7 +82,7 @@ describe Candidates::Registrations::RegistrationState do
 
   context 'with personal information' do
     let :registration_session do
-      FactoryBot.build :registration_session, with: [:personal_information]
+      build :registration_session, urn: school.urn, with: [:personal_information]
     end
 
     it { expect(subject.next_step).to eq :contact_information }
@@ -27,7 +91,7 @@ describe Candidates::Registrations::RegistrationState do
 
   context 'with contact_information' do
     let :registration_session do
-      FactoryBot.build :registration_session,
+      build :registration_session, urn: school.urn,
         with: %i(personal_information contact_information)
     end
 
@@ -37,7 +101,7 @@ describe Candidates::Registrations::RegistrationState do
 
   context 'with education' do
     let :registration_session do
-      FactoryBot.build :registration_session,
+      build :registration_session, urn: school.urn,
         with: %i(personal_information contact_information education)
     end
 
@@ -47,7 +111,7 @@ describe Candidates::Registrations::RegistrationState do
 
   context 'with teaching_preference' do
     let :registration_session do
-      FactoryBot.build :registration_session, with: %i(
+      build :registration_session, urn: school.urn, with: %i(
         personal_information
         contact_information
         education
@@ -61,7 +125,7 @@ describe Candidates::Registrations::RegistrationState do
 
   context 'with placement_preference' do
     let :registration_session do
-      FactoryBot.build :registration_session, with: %i(
+      build :registration_session, urn: school.urn, with: %i(
         personal_information
         contact_information
         education
@@ -76,7 +140,7 @@ describe Candidates::Registrations::RegistrationState do
 
   context 'with background_check' do
     let :registration_session do
-      FactoryBot.build :registration_session, with: %i(
+      build :registration_session, urn: school.urn, with: %i(
         personal_information
         contact_information
         education


### PR DESCRIPTION
### Context
Want to keep the knowledge about which wizard journey(quest) we're on in one place, this was currently being inferred based on if the school had fixed dates.

### Changes proposed in this pull request
Refactors registration state to make it easier to add in new steps.
RegistrationState now generates a <step>_in_journey? method for each step to determine whether it should be shown or not based on the registration_session.

Updates application preview to reference registration_state for whether it needs to show subject_and_date_information

### Guidance to review
Everything should still pass.