### PR TITLE
SE-1876 Ensure user has entered a fully qualified email address

### DIFF
--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -1,7 +1,9 @@
 module Candidates
   module Registrations
     class PersonalInformation < RegistrationStep
-      # multi parameter date fields aren't yet support by AcitveModel so we
+      EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME = %r{\A[^\s@]+@[^\.\s]+\.[^\s]+\z}.freeze
+
+      # multi parameter date fields aren't yet support by ActiveModel so we
       # need to include the support for them from ActiveRecord
       include ActiveRecord::AttributeAssignment
 
@@ -18,6 +20,7 @@ module Candidates
       validates :last_name, presence: true, unless: :read_only
       validates :email, presence: true, length: { maximum: 100 }
       validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
+      validates :email, format: { with: EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME }, if: -> { email.present? }
       validates :date_of_birth, presence: true, unless: :read_only
       validates :date_of_birth, inclusion: { in: ->(_) { MAX_AGE.years.ago..MIN_AGE.years.ago } }, if: -> { date_of_birth.present? && !read_only }
 

--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -43,7 +43,13 @@ module Candidates
       end
 
       def email=(*args)
-        read_only ? email : super
+        if read_only
+          email
+        elsif args.empty? || args.first.nil?
+          super
+        else
+          super(*([args.shift.to_s.strip] + args))
+        end
       end
 
       # Rescue argument error thrown by

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -30,40 +30,27 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     end
 
     context 'email is present' do
-      VALID_EMAILS = ['test@example.com', 'testymctest@gmail.com'].freeze
-      INVALID_EMAILS = ['test.com', 'test@@test.com', 'FFFF'].freeze
+      VALID_EMAILS = ['test@example.com', 'testymctest@gmail.com', 'test%.mctest@domain.co.uk'].freeze
+      INVALID_EMAILS = ['test.com', 'test@@test.com', 'FFFF', 'test@test'].freeze
       BLANK_EMAILS = ['', ' ', '   '].freeze
 
-      context 'valid emails' do
-        VALID_EMAILS.each do |email|
-          subject { described_class.new email: email }
-          before { subject.validate }
+      VALID_EMAILS.each do |email|
+        it { is_expected.to allow_value(email).for(:email) }
+      end
 
-          it "permits #{email}" do
-            expect(subject.errors[:email]).to be_empty
-          end
+      INVALID_EMAILS.each do |email|
+        it "will not allow email address '#{email}'" do
+          is_expected.not_to allow_value(email) \
+            .for(:email)
+            .with_message('Enter a valid email address')
         end
       end
 
-      context 'invalid emails' do
-        INVALID_EMAILS.each do |email|
-          subject { described_class.new email: email }
-          before { subject.validate }
-
-          it "doesn't permit #{email}" do
-            expect(subject.errors[:email]).to eq ['Enter a valid email address']
-          end
-        end
-      end
-
-      context 'blank emails' do
-        BLANK_EMAILS.each do |email|
-          subject { described_class.new email: email }
-          before { subject.validate }
-
-          it "doesn't permit #{email}" do
-            expect(subject.errors[:email]).to eq ['Enter your email address']
-          end
+      BLANK_EMAILS.each do |email|
+        it "will not allow email address '#{email}'" do
+          is_expected.not_to allow_value(email) \
+            .for(:email)
+            .with_message('Enter your email address')
         end
       end
     end

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -30,7 +30,10 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     end
 
     context 'email is present' do
-      VALID_EMAILS = ['test@example.com', 'testymctest@gmail.com', 'test%.mctest@domain.co.uk'].freeze
+      VALID_EMAILS = [
+        'test@example.com', 'testymctest@gmail.com',
+        'test%.mctest@domain.co.uk', ' with@space.com '
+      ].freeze
       INVALID_EMAILS = ['test.com', 'test@@test.com', 'FFFF', 'test@test'].freeze
       BLANK_EMAILS = ['', ' ', '   '].freeze
 


### PR DESCRIPTION
### Context

A user was able to get through the Personal Information email validation with an unqualified domain name - whilst technically valid, this isn't an address type we wish to support. The more normal scenario is its a typo from the user and they've missed part of their address.

### Changes proposed in this pull request

1. Ensure the hostname has multiple component parts

### Guidance to review

I've tried to avoid 'over validating' - particularly since domain names can now be UTF-8, and different systems support different rules for the username component.

1. I've added a couple of additional addresses to be checked in the tests
2. I've reworked the tests to use the shoulda helpers to improve clarity
3. I've added an additional regex on top of the existing regex which is quite loose but does ensure there are multiple parts to the domain name
4. I now strip the whitespace from email addresses to avoid the user being confused when their address looks valid but wont validate.
