### PR TITLE
(Subject-specific dates) Sort subjects on the profile page alphabetically

### DIFF
--- a/app/presenters/candidates/school_presenter.rb
+++ b/app/presenters/candidates/school_presenter.rb
@@ -92,9 +92,10 @@ module Candidates
       secondary_dates
         .group_by(&:date)
         .each
-        .with_object({}) do |(date, placement_date), hash|
+        .with_object({}) { |(date, placement_date), hash|
           hash[date] = placement_date_subjects(placement_date)
-        end
+        }
+        .each_value(&:sort!)
     end
 
   private

--- a/spec/presenters/candidates/school_presenter_spec.rb
+++ b/spec/presenters/candidates/school_presenter_spec.rb
@@ -208,5 +208,30 @@ RSpec.describe Candidates::SchoolPresenter do
     specify "non-specific dates should be described as 'All subjects'" do
       expect(subject.secondary_dates_grouped_by_date[late_date]).to match_array(all_subjects)
     end
+
+    context 'sorting' do
+      let(:date) { 1.day.from_now.to_date }
+
+      let(:physics) { Bookings::Subject.find_by(name: 'Physics') }
+      let(:maths) { Bookings::Subject.find_by(name: 'Maths') }
+      let(:biology) { Bookings::Subject.find_by(name: 'Biology') }
+
+      let(:pd_subjects) { [physics, maths, biology] }
+
+      let(:placement_date_with_multiple_subjects) do
+        build(:bookings_placement_date, date: date, subject_specific: true).tap do |pd|
+          pd.subjects << pd_subjects
+          pd.save
+        end
+      end
+
+      before do
+        allow(subject).to receive(:secondary_dates).and_return(Array.wrap(placement_date_with_multiple_subjects))
+      end
+
+      specify 'subjects should be sorted alphabetically' do
+        expect(subject.secondary_dates_grouped_by_date[date]).to eql(pd_subjects.map(&:name).sort)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

Subjects on the subject-specific dates page were being shown in the order they were added

### Changes proposed in this pull request

Ensure subjects are sorted alphabetically. This isn't done using a scope as we need to make sure 'All subjects' is included

### Guidance to review

Ensure it looks sensible and works

