### PR TITLE
(Subject-specific dates) Publish dates that don't support subjects

### DIFF
--- a/app/forms/schools/placement_dates/configuration_form.rb
+++ b/app/forms/schools/placement_dates/configuration_form.rb
@@ -47,7 +47,7 @@ module Schools
       def assign_attributes_to_placement_date(placement_date)
         placement_date.max_bookings_count = max_bookings_count
 
-        if available_for_all_subjects
+        if available_for_all_subjects || !supports_subjects
           placement_date.subject_specific = false
           placement_date.subject_ids = []
           placement_date.published_at = DateTime.now

--- a/spec/forms/schools/placement_dates/configuration_form_spec.rb
+++ b/spec/forms/schools/placement_dates/configuration_form_spec.rb
@@ -92,6 +92,32 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
           end
         end
 
+        context 'when doesnt support subjects' do
+          let :max_bookings_count do
+            nil
+          end
+
+          let :attributes do
+            {
+              max_bookings_count: max_bookings_count,
+              has_limited_availability: false,
+              supports_subjects: false
+            }
+          end
+
+          it 'sets subject specific' do
+            expect(placement_date).not_to be_subject_specific
+          end
+
+          it 'empties subject_ids' do
+            expect(placement_date.subjects).to be_empty
+          end
+
+          it 'sets published_at' do
+            expect(placement_date).to be_published
+          end
+        end
+
         context 'when not available_for_all_subjects' do
           let :max_bookings_count do
             nil


### PR DESCRIPTION
Dates that don't support subjects were not being shown in the
placement_dates index as they weren't published.

