### PR TITLE
Handle in flight legacy sessions.

### DIFF
--- a/app/services/candidates/registrations/placement_preference.rb
+++ b/app/services/candidates/registrations/placement_preference.rb
@@ -5,6 +5,9 @@ module Candidates
 
       attribute :availability, :string
       attribute :objectives, :string
+
+      # TODO SE-1877 remove this
+      attr_accessor :bookings_placement_date_id
     end
   end
 end

--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -66,8 +66,20 @@ module Candidates
         fetch_attributes BackgroundCheck
       end
 
+      # TODO SE-1877 remove this
+      def legacy_session?
+        fetch_attributes(PlacementPreference).key? 'bookings_placement_date_id'
+      end
+
+      # TODO SE-1877 remove this
       def subject_and_date_information
-        fetch SubjectAndDateInformation
+        if legacy_session?
+          attributes = fetch_attributes PlacementPreference
+          SubjectAndDateInformation.new \
+            attributes.slice "bookings_placement_date_id"
+        else
+          fetch SubjectAndDateInformation
+        end
       end
 
       def subject_and_date_information_attributes

--- a/spec/factories/candidates/registrations/legacy_registration_session.rb
+++ b/spec/factories/candidates/registrations/legacy_registration_session.rb
@@ -1,0 +1,61 @@
+# TODO SE-1877 remove this file
+FactoryBot.define do
+  factory :legacy_registration_session, class: Candidates::Registrations::RegistrationSession do
+    transient do
+      urn { 11048 }
+      bookings_placement_date_id { 16 }
+      timestamp { Date.today }
+    end
+
+    initialize_with do
+      new \
+        "uuid" => "some-uuid",
+          "urn" => urn,
+          "candidates_registrations_personal_information" => {
+            "first_name" => "Testy",
+            "last_name" => "McTest",
+            "email" => "test@example.com",
+            "date_of_birth" => "2000-01-01",
+            "created_at" => timestamp,
+            "updated_at" => timestamp
+          },
+          "candidates_registrations_contact_information" => {
+            "building" => "Test building",
+            "street" => "Test street",
+            "town_or_city" => "Test town",
+            "county" => "Testshire",
+            "postcode" => "TE57 1NG",
+            "phone" => "01234567890",
+            "created_at" => timestamp,
+            "updated_at" => timestamp
+          },
+          "candidates_registrations_background_check" => {
+            "has_dbs_check" => true,
+            "created_at" => timestamp,
+            "updated_at" => timestamp
+          },
+          "candidates_registrations_education" => {
+            "degree_stage" => "Other",
+            "degree_stage_explaination" => "Khan academy, level 3",
+            "degree_subject" => "Bioscience",
+            "created_at" => timestamp,
+            "updated_at" => timestamp
+          },
+          "candidates_registrations_teaching_preference" => {
+            "teaching_stage" => "I’m very sure and think I’ll apply",
+            "subject_first_choice" => "Astronomy",
+            "subject_second_choice" => "History",
+            "created_at" => timestamp,
+            "updated_at" => timestamp
+          },
+          "candidates_registrations_placement_preference" => {
+            "urn" => urn,
+            "availability" => nil,
+            "objectives" => "test the software",
+            "created_at" => timestamp,
+            "updated_at" => timestamp,
+            "bookings_placement_date_id" => bookings_placement_date_id
+          }
+    end
+  end
+end

--- a/spec/services/candidates/registrations/application_preview_spec.rb
+++ b/spec/services/candidates/registrations/application_preview_spec.rb
@@ -315,4 +315,35 @@ describe Candidates::Registrations::ApplicationPreview do
       end
     end
   end
+
+  # TODO SE-1877 remove this
+  context 'with legacy session data' do
+    context 'the school has fixed dates' do
+      let :school do
+        create :bookings_school, :with_subjects, availability_preference_fixed: true
+      end
+
+      let :placement_date do
+        create \
+          :bookings_placement_date,
+          :subject_specific,
+          bookings_school: school,
+          subjects: school.subjects
+      end
+
+      let :registration_session do
+        build \
+          :legacy_registration_session,
+          urn: school.urn,
+          bookings_placement_date_id: placement_date.id
+      end
+
+      context '#placement_availability_description' do
+        it 'returns the placement date' do
+          expect(subject.placement_availability_description).to \
+            eq placement_date.to_s
+        end
+      end
+    end
+  end
 end

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -285,4 +285,45 @@ describe Candidates::Registrations::RegistrationSession do
       expect(registration_session).to be_completed
     end
   end
+
+  # TODO SE-1877 remove this
+  context 'with legacy session data' do
+    context 'the school has fixed dates' do
+      let :school do
+        create :bookings_school, :with_subjects, availability_preference_fixed: true
+      end
+
+      let :placement_date do
+        create \
+          :bookings_placement_date,
+          :subject_specific,
+          bookings_school: school,
+          subjects: school.subjects
+      end
+
+      let :registration_session do
+        build \
+          :legacy_registration_session,
+          urn: school.urn,
+          bookings_placement_date_id: placement_date.id
+      end
+
+      context '#placement_preference' do
+        it 'returns a valid instance' do
+          expect(registration_session.placement_preference).to be_valid
+        end
+      end
+
+      context '#subject_and_date_information' do
+        let :subject_and_date_information do
+          registration_session.subject_and_date_information
+        end
+
+        it 'returns an instance with non subject specific date' do
+          expect(subject_and_date_information.placement_date).to eq placement_date
+          expect(subject_and_date_information.placement_date_subject).to be nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
In flight registrations for fixed date schools need to handle the new
subject specific code.
If the candidate has completed the placement_preference step for a fixed
date school the placement_preference attributes will contain a
bookings_placement_id, we can use this to identify legacy sessions.
We can treat a legacy session for fixed date school as the candidate
having applied for a non subject_specific date and build a valid
subject_and_date_information_step. This will allow the candidate to
continue and also allow any background jobs to work.

bookings_placement_date_id has been readded to placement_preference to
preserve backwards compatability. It has been added as an attr_accessor
so it doesn't show up in the models attributes and overwrite the
bookings_placement_date_id from subject_and_date_information_step when
converting the session to a placement request in
registration_session_as_placement_request.

After 24 hours the changes in this commit can be removed.