### PR TITLE
Se 1839/schools/on boarding/dbs requirement fixes

### DIFF
--- a/app/forms/schools/on_boarding/dbs_requirement.rb
+++ b/app/forms/schools/on_boarding/dbs_requirement.rb
@@ -25,7 +25,6 @@ module Schools
       # Don't show no_dbs_policy_details validation message if the user hasn't
       # selected an option
       with_options if: -> { requires_check == false } do
-        validates :no_dbs_policy_details, presence: true
         validates :dbs_policy_details, absence: true
       end
 

--- a/app/forms/schools/on_boarding/dbs_requirement.rb
+++ b/app/forms/schools/on_boarding/dbs_requirement.rb
@@ -22,8 +22,6 @@ module Schools
         validates :no_dbs_policy_details, absence: true
       end
 
-      # Don't show no_dbs_policy_details validation message if the user hasn't
-      # selected an option
       with_options if: -> { requires_check == false } do
         validates :dbs_policy_details, absence: true
       end

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -70,7 +70,7 @@ module Schools
         else
           [
             'No - Candidates will be accompanied at all times',
-            @school_profile.dbs_requirement.no_dbs_policy_details
+            @school_profile.dbs_requirement.no_dbs_policy_details.presence
           ].compact.join(' - ')
         end
       end

--- a/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
@@ -10,8 +10,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Enter your school experience details
+    </h1>
+
+    <p>
+      These details will help candidates select a school experience.
+    </p>
+
+    <p>
+      You'll be given a chance to check and change the details you enter.
+    </p>
+
     <%= form_for dbs_requirement, url: url, method: method do |f| %>
-      <%= f.radio_button_fieldset :requires_check, page_heading: true do |fieldset| %>
+      <%= f.radio_button_fieldset :requires_check do |fieldset| %>
         <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
         <%= fieldset.radio_input true do  %>

--- a/spec/forms/schools/on_boarding/dbs_requirement_spec.rb
+++ b/spec/forms/schools/on_boarding/dbs_requirement_spec.rb
@@ -57,8 +57,6 @@ describe Schools::OnBoarding::DbsRequirement, type: :model do
     context 'when not dbs_required' do
       before { subject.requires_check = false }
 
-      it { is_expected.to validate_presence_of :no_dbs_policy_details }
-
       context 'word counts' do
         before { subject.no_dbs_policy_details = too_long_text }
         before { subject.validate }


### PR DESCRIPTION
### Changes proposed in this pull request
Removes presence validation on no_dbs_policy_details making the additional details field optional if a school admin selects that they don't require dbs checks.
Adds guidance to the dbs requirements screen (start of the wizard) that is present in the prototype.
 
### Guidance to review
Manual testing if desired: On board a new school, select no for dbs requirements, expect not to have to provide additional details.