### PR TITLE
(Subject-specific dates) Subject and date form improvements

### DIFF
--- a/app/assets/stylesheets/subject-and-date-information.scss
+++ b/app/assets/stylesheets/subject-and-date-information.scss
@@ -1,10 +1,17 @@
-/*
-  FIXME check the usability consequences of doing this
+.subject-and-date-selection {
+  &.subject-and-date-selection--error {
+    border-left: 5px solid govuk-colour('red');
+    padding-left: 2rem;
+  }
 
-  Not really achieveable using the form builder
- */
-.date-selector {
-  fieldset legend {
-    display: none;
+  /*
+    FIXME check the usability consequences of doing this
+
+    Not really achieveable using the form builder
+   */
+  .date-selector {
+    fieldset legend {
+      display: none;
+    }
   }
 }

--- a/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
+++ b/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
@@ -93,9 +93,7 @@ module Candidates
       end
 
       def subject_and_date_params
-        params.require(:candidates_registrations_subject_and_date_information).permit(:subject_and_date_ids).tap do |subject_and_date_info|
-          subject_and_date_info.require(:subject_and_date_ids)
-        end
+        params.require(:candidates_registrations_subject_and_date_information).permit(:subject_and_date_ids)
       end
 
       def extract_subject_and_date_params

--- a/app/helpers/candidates/registrations/subject_and_date_information_helper.rb
+++ b/app/helpers/candidates/registrations/subject_and_date_information_helper.rb
@@ -1,0 +1,7 @@
+module Candidates::Registrations::SubjectAndDateInformationHelper
+  def subject_and_date_section_classes(subject_and_date_information)
+    %w(subject-and-date-selection).tap { |classes|
+      classes << 'subject-and-date-selection--error' if subject_and_date_information.errors.any?
+    }.join(" ")
+  end
+end

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -1,8 +1,8 @@
-<% self.page_title = 'Choose a date' %>
+<% self.page_title = 'Request a school experience date' %>
 
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l">Select a date and subject</h2>
+    <h1 class="govuk-heading-l">Request a school experience date at <%= @school.name %></h1>
     <%= form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
       <%= GovukElementsErrorsHelper.error_summary subject_and_date_information, 'There is a problem', '' %>
 
@@ -46,6 +46,8 @@
 
       <%= f.submit 'Continue' %>
     <% end %>
+
+    <%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
 
   </div>
 </div>

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -6,37 +6,43 @@
     <%= form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
       <%= GovukElementsErrorsHelper.error_summary subject_and_date_information, 'There is a problem', '' %>
 
-      <%- if @primary_placement_dates.any? %>
-        <section class="date-selector date-selector-primary">
-          <h3 class="govuk-heading-m">Primary placement dates</h3>
+      <%= f.hidden_field :subject_and_date_ids %>
 
-          <%= f.radio_button_fieldset :subject_and_date_ids, choices: @primary_placement_dates -%>
-        </section>
-      <%- end -%>
+      <section class="<%= subject_and_date_section_classes(subject_and_date_information) %>">
 
-      <%- if @secondary_placement_dates_grouped_by_date.any? %>
-        <h3 class="govuk-heading-m">Secondary placement dates</h3>
+        <%- if @primary_placement_dates.any? %>
+          <section class="date-selector date-selector-primary">
+            <h3 class="govuk-heading-m">Primary placement dates</h3>
 
-        <dl class="govuk-summary-list govuk-summary-list">
-        <% @secondary_placement_dates_grouped_by_date.each do |date, secondary_placement_dates| %>
+            <%= f.radio_button_fieldset :subject_and_date_ids, choices: @primary_placement_dates -%>
+          </section>
+        <%- end -%>
 
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <%= date.to_formatted_s(:govuk) %>
-            </dt>
+        <%- if @secondary_placement_dates_grouped_by_date.any? %>
+          <h3 class="govuk-heading-m">Secondary placement dates</h3>
 
-            <dd class="govuk-summary-list__value date-selector date-selector-secondary">
-              <%= f.radio_button_fieldset :subject_and_date_ids,
-                choices: secondary_placement_dates,
-                value_method: :id,
-                text_method: :name_with_duration
-              -%>
-            </dd>
-          </div>
+          <dl class="govuk-summary-list govuk-summary-list">
+          <% @secondary_placement_dates_grouped_by_date.each do |date, secondary_placement_dates| %>
+
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <%= date.to_formatted_s(:govuk) %>
+              </dt>
+
+              <dd class="govuk-summary-list__value date-selector date-selector-secondary">
+                <%= f.radio_button_fieldset :subject_and_date_ids,
+                  choices: secondary_placement_dates,
+                  value_method: :id,
+                  text_method: :name_with_duration
+                -%>
+              </dd>
+            </div>
+          <% end %>
+          </dl>
+
         <% end %>
-        </dl>
 
-      <% end %>
+      </section>
 
       <%= f.submit 'Continue' %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,8 @@ en:
 
   subject_and_date_information_errors: &subject_and_date_information_errors
     attributes:
+      bookings_placement_date_id:
+        blank: "Choose a date"
       bookings_placement_dates_subject_id:
         blank: "Choose a subject"
 

--- a/features/candidates/registrations/subject_and_date_information.feature
+++ b/features/candidates/registrations/subject_and_date_information.feature
@@ -7,6 +7,14 @@ Feature: Selecting a subject and date
         Given my school of choice exists
         And it has 'fixed' availability
 
+    Scenario: Heading
+        Given I am on the 'choose a subject and date' screen for my chosen school
+        Then the page's main heading should be 'Request a school experience date at'
+
+    Scenario: Back link
+        Given I am on the 'choose a subject and date' screen for my chosen school
+        Then I should see a back link
+
     Scenario: Displaying durations
         Given the school is a 'primary and secondary' school
         And the school has both primary and secondary dates set up
@@ -20,7 +28,6 @@ Feature: Selecting a subject and date
         And I make no selection
         And I submit the form
         Then I should see an error and the date and subject options should be marked as being incorrect
-
 
     Scenario: When the school is a primary school
         Given the school is a 'primary' school

--- a/features/candidates/registrations/subject_and_date_information.feature
+++ b/features/candidates/registrations/subject_and_date_information.feature
@@ -13,6 +13,15 @@ Feature: Selecting a subject and date
         When I am on the 'choose a subject and date' screen for my chosen school
         Then I should see the duration listed in each radio button label
 
+    Scenario: Displaying errors
+        Given the school is a 'primary' school
+        And the school has some primary placement dates set up
+        When I am on the 'choose a subject and date' screen for my chosen school
+        And I make no selection
+        And I submit the form
+        Then I should see an error and the date and subject options should be marked as being incorrect
+
+
     Scenario: When the school is a primary school
         Given the school is a 'primary' school
         And the school has some primary placement dates set up

--- a/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
@@ -78,3 +78,12 @@ Then("I should see the duration listed in each radio button label") do
     expect(label.text).to end_with("(1 day)")
   end
 end
+
+When("I make no selection") do
+  # do nothing
+end
+
+Then("I should see an error and the date and subject options should be marked as being incorrect") do
+  expect(page).to have_css('.govuk-error-summary', text: /there is a problem/i)
+  expect(page).to have_css('.subject-and-date-selection--error')
+end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -95,3 +95,7 @@ end
 Then("I should see a notification that {string}") do |string|
   expect(page).to have_content(string)
 end
+
+Then("I should see a back link") do
+  expect(page).to have_link("Back", href: 'javascript:history.back()')
+end


### PR DESCRIPTION
### Context

The form was lacking in some areas, namely in error handling, not having a sensible title and lacking a 'back' button 

### Changes proposed in this pull request

Add better error handling, title and back button to the dates and subjects page

### Guidance to review

Ensure it looks sensible, here's the form with errors:

![Screenshot 2019-10-18 at 19 11 59](https://user-images.githubusercontent.com/128088/67119052-37a36680-f1de-11e9-9dcd-5b5db6812c51.png)


