### PR TITLE
Se 1367/flatten registration session

### DIFF
--- a/app/services/candidates/registrations/registration_session.rb
+++ b/app/services/candidates/registrations/registration_session.rb
@@ -38,51 +38,21 @@ module Candidates
         defaults
       end
 
-      def background_check
-        fetch BackgroundCheck
+      RegistrationState::STEPS.each do |step|
+        self.class_eval <<~RUBY, __FILE__, __LINE__ + 1
+          def #{step}
+            fetch #{step.to_s.classify}
+          end
+
+          def #{step}_attributes
+            fetch_attributes #{step.to_s.classify}
+          end
+        RUBY
       end
 
-      def background_check_attributes
-        fetch_attributes BackgroundCheck
-      end
-
-      # TODO add specs for these
-      def contact_information
-        fetch ContactInformation
-      end
-
-      def contact_information_attributes
-        fetch_attributes ContactInformation
-      end
-
-      def personal_information
-        fetch PersonalInformation
-      end
-
-      def personal_information_attributes
-        fetch_attributes PersonalInformation
-      end
-
-      def placement_preference
-        fetch PlacementPreference
-      end
-
-      def placement_preference_attributes
-        fetch_attributes PlacementPreference
-      end
-
-      def education_attributes
-        fetch_attributes Education
-      end
-
-      def education
-        fetch Education
-      end
-
-      def teaching_preference_attributes
-        fetch_attributes TeachingPreference
-      end
-
+      # NOTE
+      # This is a special case as we need to pass in a school to limit
+      # the available subject choices.
       def teaching_preference
         fetch(TeachingPreference).tap { |tp| tp.school = school }
       end

--- a/app/services/candidates/registrations/registration_step.rb
+++ b/app/services/candidates/registrations/registration_step.rb
@@ -4,8 +4,48 @@ module Candidates
       include ActiveModel::Model
       include ActiveModel::Attributes
 
+      TIME_STAMPS = %w(created_at updated_at).freeze
+
       attribute :created_at, :datetime
       attribute :updated_at, :datetime
+
+      # Attempts to populate a new registration_step with attributes from the
+      # session.
+      # Returns an unpersisted instance if no applicable attributes are found.
+      def self.new_from_session(session)
+        instance = new
+        attributes_from_session = session.slice(*instance.attributes_to_persist.keys)
+        created_at, updated_at = attributes_from_session.values_at(*instance.time_stamp_keys)
+        attributes = attributes_from_session.except(*instance.time_stamp_keys).merge \
+          'created_at' => created_at,
+          'updated_at' => updated_at
+
+        instance.assign_attributes attributes
+
+        instance
+      end
+
+      def attributes_to_persist
+        attributes.except(*attributes_to_ignore).merge \
+          created_at_session_key => created_at,
+          updated_at_session_key => updated_at
+      end
+
+      def created_at_session_key
+        "#{model_name.element}_created_at"
+      end
+
+      def updated_at_session_key
+        "#{model_name.element}_updated_at"
+      end
+
+      def time_stamp_keys
+        [created_at_session_key, updated_at_session_key]
+      end
+
+      def attributes_to_ignore
+        TIME_STAMPS
+      end
 
       def persisted?
         created_at.present?

--- a/spec/factories/new_registration_session_factory.rb
+++ b/spec/factories/new_registration_session_factory.rb
@@ -1,0 +1,136 @@
+FactoryBot.define do
+  factory :new_registration_session, class: Candidates::Registrations::RegistrationSession do
+    transient do
+      current_time { DateTime.current }
+      urn { 11048 }
+      placement_date { create(:bookings_placement_date) }
+      uuid { 'some-uuid' }
+
+      with do
+        %i(
+          personal_information
+          contact_information
+          background_check
+          placement_preference
+          education
+          teaching_preference
+        )
+      end
+
+      personal_information do
+        {
+          "first_name"                      => 'Testy',
+          "last_name"                       => 'McTest',
+          "email"                           => 'test@example.com',
+          "date_of_birth"                   => "2000-01-01",
+          "personal_information_created_at" => current_time,
+          "personal_information_updated_at" => current_time
+        }
+      end
+
+      contact_information do
+        {
+          "building"                       => "Test building",
+          "street"                         => "Test street",
+          "town_or_city"                   => "Test town",
+          "county"                         => "Testshire",
+          "postcode"                       => "TE57 1NG",
+          "phone"                          => "01234567890",
+          "contact_information_created_at" => current_time,
+          "contact_information_updated_at" => current_time
+        }
+      end
+
+      background_check do
+        {
+          "has_dbs_check"               => true,
+          "background_check_created_at" => current_time,
+          "background_check_updated_at" => current_time
+        }
+      end
+
+      placement_preference do
+        {
+          "urn"                             => urn,
+          "availability"                    => "Every third Tuesday",
+          "objectives"                      => "test the software",
+          "placement_preference_created_at" => current_time,
+          "placement_preference_updated_at" => current_time
+        }
+      end
+
+      placement_preference_with_placement_date do
+        {
+          "urn"                             => urn,
+          "availability"                    => nil,
+          "objectives"                      => "test the software",
+          "bookings_placement_date_id"      => placement_date.id,
+          "placement_preference_created_at" => current_time,
+          "placement_preference_updated_at" => current_time
+        }
+      end
+
+      education do
+        FactoryBot.attributes_for(:education).stringify_keys.merge(
+          'education_created_at' => current_time,
+          'education_updated_at' => current_time
+        )
+      end
+
+      teaching_preference do
+        FactoryBot.attributes_for(:teaching_preference).stringify_keys.merge(
+          'teaching_preference_created_at' => current_time,
+          'teaching_preference_updated_at' => current_time
+        )
+      end
+    end
+
+    initialize_with do
+      new \
+        with
+          .reduce("uuid" => uuid, "urn" => urn) { |options, step| options.merge(send(step)) }
+    end
+
+    trait :with_placement_date do
+      initialize_with do
+        new \
+          with
+            .tap { |steps| steps.delete :placement_preference }
+            .tap { |steps| steps << :placement_preference_with_placement_date }
+            .reduce("uuid" => uuid, "urn" => urn) { |options, step| options.merge(send(step)) }
+      end
+    end
+
+    trait :with_education do
+      initialize_with do
+        new \
+          %i(
+            personal_information
+            contact_information
+            background_check
+            education
+            placement_preference
+          ).reduce("uuid" => uuid, "urn" => urn) { |options, step| options.merge(send(step)) }
+      end
+    end
+
+    trait :with_teaching_preference do
+      initialize_with do
+        new \
+          %i(
+            personal_information
+            contact_information
+            background_check
+            teaching_preference
+            placement_preference
+        ).reduce("uuid" => uuid, "urn" => urn) { |options, step| options.merge(send(step)) }
+      end
+    end
+
+    trait :with_school do
+      after :build do |reg|
+        Bookings::School.find_by(urn: reg.urn) || FactoryBot.create(:bookings_school, urn: reg.urn)
+      end
+    end
+  end
+end

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -91,7 +91,7 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when education is in session' do
-      # TODO open ticket to remove
+      # TODO SE-1881
       context 'when legacy session' do
         subject { FactoryBot.build :registration_session, :with_education }
 
@@ -122,7 +122,7 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when education in session' do
-      # TODO open ticket to remove
+      # TODO SE-1881
       context 'when legacy session' do
         let :session do
           FactoryBot.build :registration_session, :with_education
@@ -163,7 +163,7 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when teaching_preference is in session' do
-      # TODO open ticket to remove
+      # TODO SE-1881
       context 'when legacy session' do
         subject { FactoryBot.build :registration_session, :with_teaching_preference }
 
@@ -194,7 +194,7 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when teaching_preference is in the session' do
-      # TODO open ticket to remove
+      # TODO SE-1881
       context 'when legacy session' do
         let :session do
           FactoryBot.build \
@@ -272,7 +272,7 @@ describe Candidates::Registrations::RegistrationSession do
     context 'when registration is complete' do
       include_context 'Stubbed candidates school'
 
-      # TODO open ticket to remove
+      # TODO SE-1881
       context 'when legacy session' do
         subject do
           FactoryBot.build :new_registration_session
@@ -351,7 +351,7 @@ describe Candidates::Registrations::RegistrationSession do
   context '#flag_as_completed!' do
     include_context 'Stubbed candidates school'
 
-    # TODO open ticket to remove
+    # TODO SE-1881
     context 'when legacy session' do
       let :registration_session do
         FactoryBot.build :new_registration_session

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -91,11 +91,23 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when education is in session' do
-      subject { FactoryBot.build :registration_session, :with_education }
+      # TODO open ticket to remove
+      context 'when legacy session' do
+        subject { FactoryBot.build :registration_session, :with_education }
 
-      it 'returns the correct attributes' do
-        expect(subject.education_attributes.except('created_at', 'updated_at')).to eq \
-          FactoryBot.attributes_for(:education).stringify_keys
+        it 'returns the correct attributes' do
+          expect(subject.education_attributes.except('created_at', 'updated_at')).to eq \
+            FactoryBot.attributes_for(:education).stringify_keys
+        end
+      end
+
+      context 'when new session' do
+        subject { FactoryBot.build :new_registration_session, :with_education }
+
+        it 'returns the correct attributes' do
+          expect(subject.education_attributes.except('created_at', 'updated_at')).to eq \
+            FactoryBot.attributes_for(:education).stringify_keys
+        end
       end
     end
   end
@@ -110,16 +122,33 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when education in session' do
-      let :session do
-        FactoryBot.build :registration_session, :with_education
+      # TODO open ticket to remove
+      context 'when legacy session' do
+        let :session do
+          FactoryBot.build :registration_session, :with_education
+        end
+
+        subject { session.education }
+
+        it { is_expected.to be_a Candidates::Registrations::Education }
+        it do
+          expect(subject.attributes.except('created_at', 'updated_at')).to \
+            eq FactoryBot.build(:education).attributes.except('created_at', 'updated_at')
+        end
       end
 
-      subject { session.education }
+      context 'when new session' do
+        let :session do
+          FactoryBot.build :new_registration_session, :with_education
+        end
 
-      it { is_expected.to be_a Candidates::Registrations::Education }
-      it do
-        expect(subject.attributes.except('created_at', 'updated_at')).to \
-          eq FactoryBot.build(:education).attributes.except('created_at', 'updated_at')
+        subject { session.education }
+
+        it { is_expected.to be_a Candidates::Registrations::Education }
+        it do
+          expect(subject.attributes.except('created_at', 'updated_at')).to \
+            eq FactoryBot.build(:education).attributes.except('created_at', 'updated_at')
+        end
       end
     end
   end
@@ -134,11 +163,23 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when teaching_preference is in session' do
-      subject { FactoryBot.build :registration_session, :with_teaching_preference }
+      # TODO open ticket to remove
+      context 'when legacy session' do
+        subject { FactoryBot.build :registration_session, :with_teaching_preference }
 
-      it 'returns the correct attributes' do
-        expect(subject.teaching_preference_attributes.except('created_at', 'updated_at')).to eq \
-          FactoryBot.attributes_for(:teaching_preference).stringify_keys
+        it 'returns the correct attributes' do
+          expect(subject.teaching_preference_attributes.except('created_at', 'updated_at')).to eq \
+            FactoryBot.attributes_for(:teaching_preference).stringify_keys
+        end
+      end
+
+      context 'when new session' do
+        subject { FactoryBot.build :new_registration_session, :with_teaching_preference }
+
+        it 'returns the correct attributes' do
+          expect(subject.teaching_preference_attributes.except('created_at', 'updated_at')).to eq \
+            FactoryBot.attributes_for(:teaching_preference).stringify_keys
+        end
       end
     end
   end
@@ -153,22 +194,45 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when teaching_preference is in the session' do
-      let :session do
-        FactoryBot.build \
-          :registration_session, :with_teaching_preference, :with_school
+      # TODO open ticket to remove
+      context 'when legacy session' do
+        let :session do
+          FactoryBot.build \
+            :registration_session, :with_teaching_preference, :with_school
+        end
+
+        subject { session.teaching_preference }
+
+        it { is_expected.to be_a Candidates::Registrations::TeachingPreference }
+
+        it do
+          expect(subject.attributes.except('created_at', 'updated_at')).to \
+            eq FactoryBot.build(:teaching_preference).attributes.except('created_at', 'updated_at')
+        end
+
+        it 'sets the school correctly' do
+          expect(subject.school).to eq session.school
+        end
       end
 
-      subject { session.teaching_preference }
+      context 'when new session' do
+        let :session do
+          FactoryBot.build \
+            :new_registration_session, :with_teaching_preference, :with_school
+        end
 
-      it { is_expected.to be_a Candidates::Registrations::TeachingPreference }
+        subject { session.teaching_preference }
 
-      it do
-        expect(subject.attributes.except('created_at', 'updated_at')).to \
-          eq FactoryBot.build(:teaching_preference).attributes.except('created_at', 'updated_at')
-      end
+        it { is_expected.to be_a Candidates::Registrations::TeachingPreference }
 
-      it 'sets the school correctly' do
-        expect(subject.school).to eq session.school
+        it do
+          expect(subject.attributes.except('created_at', 'updated_at')).to \
+            eq FactoryBot.build(:teaching_preference).attributes.except('created_at', 'updated_at')
+        end
+
+        it 'sets the school correctly' do
+          expect(subject.school).to eq session.school
+        end
       end
     end
   end
@@ -208,16 +272,33 @@ describe Candidates::Registrations::RegistrationSession do
     context 'when registration is complete' do
       include_context 'Stubbed candidates school'
 
-      subject do
-        FactoryBot.build :registration_session
+      # TODO open ticket to remove
+      context 'when legacy session' do
+        subject do
+          FactoryBot.build :new_registration_session
+        end
+
+        before do
+          subject.flag_as_pending_email_confirmation!
+        end
+
+        it 'marks the session as pending_email_confirmation' do
+          expect(subject).to be_pending_email_confirmation
+        end
       end
 
-      before do
-        subject.flag_as_pending_email_confirmation!
-      end
+      context 'when new session' do
+        subject do
+          FactoryBot.build :new_registration_session
+        end
 
-      it 'marks the session as pending_email_confirmation' do
-        expect(subject).to be_pending_email_confirmation
+        before do
+          subject.flag_as_pending_email_confirmation!
+        end
+
+        it 'marks the session as pending_email_confirmation' do
+          expect(subject).to be_pending_email_confirmation
+        end
       end
     end
   end
@@ -270,16 +351,33 @@ describe Candidates::Registrations::RegistrationSession do
   context '#flag_as_completed!' do
     include_context 'Stubbed candidates school'
 
-    let :registration_session do
-      FactoryBot.build :registration_session
+    # TODO open ticket to remove
+    context 'when legacy session' do
+      let :registration_session do
+        FactoryBot.build :new_registration_session
+      end
+
+      before do
+        registration_session.flag_as_completed!
+      end
+
+      it 'marks the registration_session as completed' do
+        expect(registration_session).to be_completed
+      end
     end
 
-    before do
-      registration_session.flag_as_completed!
-    end
+    context 'when new session' do
+      let :registration_session do
+        FactoryBot.build :new_registration_session
+      end
 
-    it 'marks the registration_session as completed' do
-      expect(registration_session).to be_completed
+      before do
+        registration_session.flag_as_completed!
+      end
+
+      it 'marks the registration_session as completed' do
+        expect(registration_session).to be_completed
+      end
     end
   end
 end

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -50,11 +50,12 @@ describe Candidates::Registrations::RegistrationSession do
 
     it 'stores the models attributes under the correct key' do
       expect(
-        session['candidates_registrations_background_check']
+        session
       ).to eq \
         'has_dbs_check' => true,
-        'created_at' => date,
-        'updated_at' => date
+        'background_check_created_at' => date,
+        'background_check_updated_at' => date,
+        'some' => 'information'
     end
 
     it 'doesnt over write other keys' do

--- a/spec/services/candidates/registrations/school_session_spec.rb
+++ b/spec/services/candidates/registrations/school_session_spec.rb
@@ -75,10 +75,8 @@ describe Candidates::Registrations::SchoolSession do
       end
 
       it 'stores the registration in the session' do
-        expect(session).to eq "schools/#{school_urn_1}/registrations" => {
-          'urn' => school_urn_1,
-          personal_information_1.model_name.param_key => personal_information_1.attributes
-        }
+        expect(session).to eq "schools/#{school_urn_1}/registrations" => \
+          personal_information_1.attributes_to_persist.merge('urn' => school_urn_1)
       end
     end
 
@@ -106,14 +104,10 @@ describe Candidates::Registrations::SchoolSession do
 
       it 'stores the registrations for each school seperatley' do
         expect(session).to eq \
-          "schools/#{school_urn_1}/registrations" => {
-            'urn' => school_urn_1,
-            personal_information_1.model_name.param_key => personal_information_1.attributes
-          },
-          "schools/#{school_urn_2}/registrations" => {
-            'urn' => school_urn_2,
-            personal_information_2.model_name.param_key => personal_information_2.attributes
-          }
+          "schools/#{school_urn_1}/registrations" => \
+            personal_information_1.attributes_to_persist.merge('urn' => school_urn_1),
+          "schools/#{school_urn_2}/registrations" => \
+              personal_information_2.attributes_to_persist.merge('urn' => school_urn_2)
       end
     end
 
@@ -139,7 +133,7 @@ describe Candidates::Registrations::SchoolSession do
           include('urn' => school_urn_1)
 
         expect(session["schools/#{school_urn_1}/registrations"]).to \
-          include(personal_information_1.model_name.param_key)
+          include(personal_information_1.attributes_to_persist)
       end
     end
   end


### PR DESCRIPTION
### Context
So that we can move fields between screens without having to restructure our data format each time

### Changes proposed in this pull request
Stores registrations in a flat structure in the session rather than
nesting attributes under a model name.
Delegates how to instantiate a step and what attributes to store to the
RegistrationStep.
All registration_step attribute names, except for time stamps, are
unique so we don't need to name space them to avoid collisions. Only
time stamps will collide so we need to  prefix those with the models
name.

### Guidance to review
Registration details should be stored in a flat structure. Should handle switching branch at any part in the registration without breaking things.
