### PR TITLE
Separate subject and date info logic into registration step SE-1804

### DIFF
--- a/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
+++ b/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
@@ -1,17 +1,7 @@
 module Candidates
   module Registrations
     class SubjectAndDateInformationsController < RegistrationsController
-      before_action :set_school, :set_primary_placement_dates, :set_secondary_placement_dates
-
-      PlacementDateOption = Struct.new(:placement_date_id, :placement_date_subject_id, :name, :duration) do
-        def id
-          [placement_date_id, placement_date_subject_id].compact.join('_')
-        end
-
-        def name_with_duration
-          "#{name} (#{duration} #{'day'.pluralize(duration)})"
-        end
-      end
+      before_action :set_school
 
       def new
         @subject_and_date_information = SubjectAndDateInformation.new(attributes_from_session)
@@ -52,46 +42,6 @@ module Candidates
         @school = current_registration.school
       end
 
-      def set_primary_placement_dates
-        @primary_placement_dates = @school
-          .bookings_placement_dates
-          .in_date_order
-          .not_supporting_subjects
-      end
-
-      def set_secondary_placement_dates
-        @secondary_placement_dates_grouped_by_date =  \
-          secondary_placement_dates.each_value { |v| v.sort_by!(&:name) }
-      end
-
-      def secondary_placement_dates
-        @school
-          .bookings_placement_dates
-          .in_date_order
-          .supporting_subjects
-          .eager_load(placement_date_subjects: :bookings_subject)
-          .published
-          .available
-          .each
-          .with_object({}) do |pd, h|
-            if h.has_key?(pd.date)
-              h[pd.date].concat(placement_date_options(pd))
-            else
-              h[pd.date] = Array.wrap(placement_date_options(pd))
-            end
-          end
-      end
-
-      def placement_date_options(placement_date)
-        if placement_date.placement_date_subjects.any?
-          placement_date.placement_date_subjects.map do |placement_date_subject|
-            PlacementDateOption.new(placement_date.id, placement_date_subject.id, placement_date_subject.bookings_subject.name, placement_date.duration)
-          end
-        else
-          Array.wrap(PlacementDateOption.new(placement_date.id, nil, 'All subjects', placement_date.duration))
-        end
-      end
-
       def subject_and_date_params
         params.require(:candidates_registrations_subject_and_date_information).permit(:subject_and_date_ids)
       end
@@ -107,7 +57,7 @@ module Candidates
       end
 
       def attributes_from_session
-        current_registration.subject_and_date_information_attributes
+        current_registration.subject_and_date_information_attributes.merge(urn: @school.urn)
       end
     end
   end

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -34,7 +34,7 @@ module Candidates
       end
 
       def subject_and_date_ids
-        [bookings_placement_date_id, bookings_placement_dates_subject_id].join('_')
+        [bookings_placement_date_id, bookings_placement_dates_subject_id].compact.join('_')
       end
 
       def primary_placement_dates
@@ -42,6 +42,9 @@ module Candidates
           .bookings_placement_dates
           .in_date_order
           .not_supporting_subjects
+          .map do |date|
+            PlacementDateOption.new(date.id, nil, date.date.to_formatted_s(:govuk), date.duration)
+          end
       end
 
       def secondary_placement_dates_grouped_by_date

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -3,6 +3,16 @@ module Candidates
     class SubjectAndDateInformation < RegistrationStep
       include Behaviours::SubjectAndDateInformation
 
+      PlacementDateOption = Struct.new(:placement_date_id, :placement_date_subject_id, :name, :duration) do
+        def id
+          [placement_date_id, placement_date_subject_id].compact.join('_')
+        end
+
+        def name_with_duration
+          "#{name} (#{duration} #{'day'.pluralize(duration)})"
+        end
+      end
+
       attribute :availability
       attribute :bookings_placement_date_id, :integer
       attribute :bookings_placement_dates_subject_id, :integer
@@ -19,6 +29,41 @@ module Candidates
 
       def subject_and_date_ids
         [bookings_placement_date_id, bookings_placement_dates_subject_id].join('_')
+      end
+
+      def primary_placement_dates
+        school
+          .bookings_placement_dates
+          .in_date_order
+          .not_supporting_subjects
+      end
+
+      def secondary_placement_dates_grouped_by_date
+        school
+          .bookings_placement_dates
+          .in_date_order
+          .supporting_subjects
+          .eager_load(placement_date_subjects: :bookings_subject)
+          .published
+          .available
+          .each
+          .with_object({}) do |pd, h|
+            if h.has_key?(pd.date)
+              h[pd.date].concat(placement_date_options(pd))
+            else
+              h[pd.date] = Array.wrap(placement_date_options(pd))
+            end
+          end
+      end
+
+      def placement_date_options(placement_date)
+        if placement_date.placement_date_subjects.any?
+          placement_date.placement_date_subjects.map do |placement_date_subject|
+            PlacementDateOption.new(placement_date.id, placement_date_subject.id, placement_date_subject.bookings_subject.name, placement_date.duration)
+          end
+        else
+          Array.wrap(PlacementDateOption.new(placement_date.id, nil, 'All subjects', placement_date.duration))
+        end
       end
     end
   end

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -11,6 +11,12 @@ module Candidates
         def name_with_duration
           "#{name} (#{duration} #{'day'.pluralize(duration)})"
         end
+
+        # Sorted here rather than in the db so 'All subjects' (which isn't in the DB)
+        # comes back first
+        def <=>(other)
+          name <=> other.name
+        end
       end
 
       attribute :availability

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -31,7 +31,7 @@
 
               <dd class="govuk-summary-list__value date-selector date-selector-secondary">
                 <%= f.radio_button_fieldset :subject_and_date_ids,
-                  choices: secondary_placement_dates,
+                  choices: secondary_placement_dates.sort,
                   value_method: :id,
                   text_method: :name_with_duration
                 -%>

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -14,7 +14,10 @@
           <section class="date-selector date-selector-primary">
             <h3 class="govuk-heading-m">Primary placement dates</h3>
 
-            <%= f.radio_button_fieldset :subject_and_date_ids, choices: @subject_and_date_information.primary_placement_dates -%>
+            <%= f.radio_button_fieldset :subject_and_date_ids,
+              choices: @subject_and_date_information.primary_placement_dates,
+              value_method: :id,
+              text_method: :name_with_duration -%>
           </section>
         <%- end -%>
 

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -10,19 +10,19 @@
 
       <section class="<%= subject_and_date_section_classes(subject_and_date_information) %>">
 
-        <%- if @primary_placement_dates.any? %>
+        <%- if @subject_and_date_information.primary_placement_dates.any? %>
           <section class="date-selector date-selector-primary">
             <h3 class="govuk-heading-m">Primary placement dates</h3>
 
-            <%= f.radio_button_fieldset :subject_and_date_ids, choices: @primary_placement_dates -%>
+            <%= f.radio_button_fieldset :subject_and_date_ids, choices: @subject_and_date_information.primary_placement_dates -%>
           </section>
         <%- end -%>
 
-        <%- if @secondary_placement_dates_grouped_by_date.any? %>
+        <%- if @subject_and_date_information.secondary_placement_dates_grouped_by_date.any? %>
           <h3 class="govuk-heading-m">Secondary placement dates</h3>
 
           <dl class="govuk-summary-list govuk-summary-list">
-          <% @secondary_placement_dates_grouped_by_date.each do |date, secondary_placement_dates| %>
+          <% @subject_and_date_information.secondary_placement_dates_grouped_by_date.each do |date, secondary_placement_dates| %>
 
             <div class="govuk-summary-list__row">
               <dt class="govuk-summary-list__key">

--- a/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
@@ -19,7 +19,7 @@ Then("I should see the list of primary placement dates") do
   @primary_dates.each do |pd|
     expect(page).to have_css(
       'label',
-      text: "#{pd.date.strftime('%d %B %Y')} (#{pd.duration} day)".downcase
+      text: "#{pd.date.strftime('%d %B %Y')} (#{pd.duration} day)"
     )
   end
 end

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -61,4 +61,48 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       end
     end
   end
+
+  describe 'methods' do
+    describe '#placement_date' do
+      it { is_expected.to respond_to(:placement_date) }
+
+      before { allow(subject).to receive(:bookings_placement_date_id).and_return(1) }
+      before { allow(Bookings::PlacementDate).to receive(:find_by).and_return('a') }
+
+
+      specify 'should find the placement date via its id' do
+        subject.placement_date
+        expect(Bookings::PlacementDate).to have_received(:find_by).with(id: 1)
+      end
+    end
+
+    describe '#placement_date_subject' do
+      it { is_expected.to respond_to(:placement_date_subject) }
+
+      before { allow(subject).to receive(:bookings_placement_dates_subject_id).and_return(1) }
+      before { allow(Bookings::PlacementDateSubject).to receive(:find_by).and_return('a') }
+
+
+      specify 'should find the placement date via its id' do
+        subject.placement_date_subject
+        expect(Bookings::PlacementDateSubject).to have_received(:find_by).with(id: 1)
+      end
+    end
+
+    describe '#subject_and_date_ids' do
+      it { is_expected.to respond_to(:placement_date_subject) }
+
+      let(:bookings_placement_date_id) { 55 }
+      let(:bookings_placement_dates_subject_id) { 66 }
+
+      before do
+        allow(subject).to receive(:bookings_placement_date_id).and_return(bookings_placement_date_id)
+        allow(subject).to receive(:bookings_placement_dates_subject_id).and_return(bookings_placement_dates_subject_id)
+      end
+
+      specify 'should join the placement date and placement date subject ids separated by an underscore' do
+        expect(subject.subject_and_date_ids).to eql("#{bookings_placement_date_id}_#{bookings_placement_dates_subject_id}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

The `SubjectAndDateInformationsController` was a bit heavy

### Changes proposed in this pull request

Move the list-building functionality out to the `Candidates::Registrations::SubjectAndDateInformation` and enforce sorting

### Guidance to review

Ensure it looks sensible and works
