### PR TITLE
SE-1673 Retry GETs to gitis

### DIFF
--- a/app/services/bookings/gitis/api.rb
+++ b/app/services/bookings/gitis/api.rb
@@ -1,14 +1,13 @@
 module Bookings::Gitis
   class API
     ENDPOINT = '/api/data/v9.1'.freeze
-    GET_TIMEOUT_SECS = 25
-    GET_RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
-    GET_RETRY_OPTIONS = {
+    TIMEOUT_SECS = 25
+    RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
+    RETRY_OPTIONS = {
       max: 2,
       methods: %i{get},
       exceptions: (
-        ::Faraday::Request::Retry::DEFAULT_EXCEPTIONS +
-        GET_RETRY_EXCEPTIONS
+        ::Faraday::Request::Retry::DEFAULT_EXCEPTIONS + RETRY_EXCEPTIONS
       ).freeze
     }.freeze
 
@@ -27,7 +26,7 @@ module Bookings::Gitis
       response = connection.get do |req|
         req.url url
         req.headers = get_headers.merge(headers.stringify_keys)
-        req.options.timeout = GET_TIMEOUT_SECS
+        req.options.timeout = TIMEOUT_SECS
         req.params = params if params.any?
       end
 
@@ -78,7 +77,7 @@ module Bookings::Gitis
 
     def connection
       Faraday.new(endpoint_url) do |f|
-        f.request(:retry, GET_RETRY_OPTIONS)
+        f.request(:retry, RETRY_OPTIONS)
         f.adapter(Faraday.default_adapter)
       end
     end

--- a/app/services/bookings/gitis/api.rb
+++ b/app/services/bookings/gitis/api.rb
@@ -1,6 +1,16 @@
 module Bookings::Gitis
   class API
     ENDPOINT = '/api/data/v9.1'.freeze
+    GET_TIMEOUT_SECS = 25
+    GET_RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
+    GET_RETRY_OPTIONS = {
+      max: 2,
+      methods: %i{get},
+      exceptions: (
+        ::Faraday::Request::Retry::DEFAULT_EXCEPTIONS +
+        GET_RETRY_EXCEPTIONS
+      ).freeze
+    }.freeze
 
     attr_reader :endpoint_url, :access_token
 
@@ -17,6 +27,7 @@ module Bookings::Gitis
       response = connection.get do |req|
         req.url url
         req.headers = get_headers.merge(headers.stringify_keys)
+        req.options.timeout = GET_TIMEOUT_SECS
         req.params = params if params.any?
       end
 
@@ -66,7 +77,10 @@ module Bookings::Gitis
   private
 
     def connection
-      Faraday.new(endpoint_url)
+      Faraday.new(endpoint_url) do |f|
+        f.request(:retry, GET_RETRY_OPTIONS)
+        f.adapter(Faraday.default_adapter)
+      end
     end
 
     def get_headers

--- a/app/services/bookings/gitis/auth.rb
+++ b/app/services/bookings/gitis/auth.rb
@@ -3,14 +3,13 @@ module Bookings
     class Auth
       prepend FakeAuth if Rails.application.config.x.gitis.fake_crm
 
-      GET_TIMEOUT_SECS = 25
-      GET_RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
-      GET_RETRY_OPTIONS = {
+      TIMEOUT_SECS = 25
+      RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
+      RETRY_OPTIONS = {
         max: 2,
         methods: %i{post}, # Auth only makes a POST request
         exceptions: (
-          ::Faraday::Request::Retry::DEFAULT_EXCEPTIONS +
-          GET_RETRY_EXCEPTIONS
+          ::Faraday::Request::Retry::DEFAULT_EXCEPTIONS + RETRY_EXCEPTIONS
         ).freeze
       }.freeze
 
@@ -66,7 +65,7 @@ module Bookings
 
       def faraday
         Faraday.new do |f|
-          f.request(:retry, GET_RETRY_OPTIONS)
+          f.request(:retry, RETRY_OPTIONS)
           f.adapter(Faraday.default_adapter)
         end
       end
@@ -75,6 +74,8 @@ module Bookings
         response = faraday.post(auth_url) do |request|
           request.headers['Content-Type'] = 'application/x-www-form-urlencoded'
           request.headers['Accept'] = 'application/json'
+          request.options.timeout = TIMEOUT_SECS
+
           request.body = params.to_query
         end
 

--- a/app/services/bookings/gitis/auth.rb
+++ b/app/services/bookings/gitis/auth.rb
@@ -3,6 +3,17 @@ module Bookings
     class Auth
       prepend FakeAuth if Rails.application.config.x.gitis.fake_crm
 
+      GET_TIMEOUT_SECS = 25
+      GET_RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
+      GET_RETRY_OPTIONS = {
+        max: 2,
+        methods: %i{post}, # Auth only makes a POST request
+        exceptions: (
+          ::Faraday::Request::Retry::DEFAULT_EXCEPTIONS +
+          GET_RETRY_EXCEPTIONS
+        ).freeze
+      }.freeze
+
       CACHE_KEY = 'gitis-auth-token'.freeze
       EXPIRY_MARGIN = 300
       AUTH_URL = "https://login.microsoftonline.com/{tenant_id}/oauth2/token".freeze
@@ -53,8 +64,15 @@ module Bookings
         Addressable::Template.new(AUTH_URL).expand(tenant_id: @tenant_id).to_s
       end
 
+      def faraday
+        Faraday.new do |f|
+          f.request(:retry, GET_RETRY_OPTIONS)
+          f.adapter(Faraday.default_adapter)
+        end
+      end
+
       def retrieve_token
-        response = Faraday.post(auth_url) do |request|
+        response = faraday.post(auth_url) do |request|
           request.headers['Content-Type'] = 'application/x-www-form-urlencoded'
           request.headers['Accept'] = 'application/json'
           request.body = params.to_query

--- a/spec/services/bookings/gitis/auth_spec.rb
+++ b/spec/services/bookings/gitis/auth_spec.rb
@@ -52,6 +52,53 @@ RSpec.describe Bookings::Gitis::Auth do
       end
     end
 
+    context 'with a timeout that gets retried' do
+      before do
+        stub_request(:post, "https://login.microsoftonline.com/#{api.auth_tenant_id}/oauth2/token").
+          with(
+            headers: { 'Accept' => 'application/json' },
+            body: {
+              "grant_type" => "client_credentials",
+              "scope" => "",
+              "client_id" => api.client_id,
+              "client_secret" => api.client_secret,
+              "resource" => api.service_url,
+            }.to_query
+          ).
+          to_timeout.then.
+          to_return(
+            status: 200,
+            headers: { 'Content-Type' => 'application/json' },
+            body: {
+              'token_type' => 'Bearer',
+              'expires_in' => 3600,
+              'resource' => api.service_url,
+              'access_token' => "MY.STUB.TOKEN"
+            }.to_json
+          )
+      end
+
+      subject do
+        described_class.new(
+          client_id: client_id,
+          client_secret: client_secret,
+          tenant_id: tenant_id,
+          service_url: service_url
+        )
+      end
+
+      it "returns a token", :focus do
+        expect(subject.token).to match(/\w+\.\w+\.\w+/)
+      end
+
+      it "sets the expires" do
+        subject.token
+        expect(subject.expires_at).to be_kind_of(Time)
+        # Note we expiry the token early to allow for multiple requests and Gitis running slowly
+        expect(subject.expires_at).to be_within(10.seconds).of(55.minutes.from_now)
+      end
+    end
+
     context "with invalid credentials" do
       before { api.stub_invalid_access_token }
 

--- a/spec/services/bookings/gitis/auth_spec.rb
+++ b/spec/services/bookings/gitis/auth_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Bookings::Gitis::Auth do
         )
       end
 
-      it "returns a token", :focus do
+      it "returns a token" do
         expect(subject.token).to match(/\w+\.\w+\.\w+/)
       end
 


### PR DESCRIPTION
### Context

We do not want to allow indefinite length page requests, so we use Rack::Timeout. Occasionally Gitis will take a long time to respond to a request - this means we are hitting the Rack Timeout.

### Changes proposed in this pull request

1. Add a shorter timeout to API requests - 25 seconds so there is time for a couple of attempts before hitting the page time out.
2. Add the Faraday Retry middleware to make a second request to Gitis if the first one times out.

### Guidance to review

1. Testing
2. Code review

