### PR TITLE
Adds instructions  text to education subject

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: e2443c2932a1a56f488dda68bcab43b586d79427
+  revision: 40dbcb1b3dd19f62052321c45ce40aefaa7e5111
   specs:
     govuk_elements_form_builder (1.2.0)
       govuk_elements_rails (>= 3.0.0)

--- a/app/views/candidates/registrations/educations/_form.html.erb
+++ b/app/views/candidates/registrations/educations/_form.html.erb
@@ -45,7 +45,11 @@
           value_for_no_degree: f.object.no_degree_subject
         },
         label_options: { class: 'govuk-heading-m' }
-      } %>
+      } do %>
+      <p>
+        Select the nearest or equivalent subject.
+      </p>
+      <% end %>
   </section>
 
   <%= f.submit 'Continue' %>


### PR DESCRIPTION
### Context
Prototype has additional text before the select box.

### Changes proposed in this pull request
Add the new text from the prototype.
Bump form builder version to support passing markup to collection_select.

### Guidance to review
The degree subject selector should have the additional text to match the text on [this](https://school-experience-rolling.herokuapp.com/register/account-info) page.