### PR TITLE
Corrected email link on accessibility statement

### DIFF
--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -54,7 +54,11 @@
       </p>
 
       <ul class="govuk-list">
-        <li><%= mail_to 'organise.school-experience@education.gov.uk', aria: { label: 'School experience support email address' } %></li>
+        <li>
+          <%= mail_to 'organise.school-experience@education.gov.uk', 
+                'organise.school-experience@education.gov.uk', 
+                aria: { label: 'School experience support email address' } %>
+        </li>
       </ul>
 
       <p>
@@ -71,7 +75,8 @@
 
       <p>
         If you find any problems that are not listed on this page or think we're
-        not meeting accessibility requirements email <%= mail_to 'organise.school-experience@education.gov.uk' %>.
+        not meeting accessibility requirements email 
+        <%= mail_to 'organise.school-experience@education.gov.uk' %>.
       </p>
     </section>
 


### PR DESCRIPTION
### Context

Aria attributes are currently showing up on a link on the accessibility page.

### Changes proposed in this pull request

1. Correct the mailto syntax to avoid the aria attributes being shown to the user

### Guidance to review

1. Check the page
2. Code check
