### PR TITLE
SE-1302 Render custom page for failed gitis retrieval

### DIFF
--- a/app/controllers/concerns/gitis_access.rb
+++ b/app/controllers/concerns/gitis_access.rb
@@ -9,4 +9,15 @@ module GitisAccess
   def gitis_crm
     Bookings::Gitis::Factory.crm read_from_cache: use_gitis_cache
   end
+
+  def assign_gitis_contacts(models)
+    return models if models.empty?
+
+    contact_uuids = models.map(&:contact_uuid)
+    contacts = gitis_crm.find(contact_uuids).index_by(&:contactid)
+
+    models.each do |model|
+      model.gitis_contact = contacts[model.contact_uuid]
+    end
+  end
 end

--- a/app/controllers/concerns/gitis_access.rb
+++ b/app/controllers/concerns/gitis_access.rb
@@ -17,7 +17,8 @@ module GitisAccess
     contacts = gitis_crm.find(contact_uuids).index_by(&:contactid)
 
     models.each do |model|
-      model.gitis_contact = contacts[model.contact_uuid]
+      model.gitis_contact = contacts[model.contact_uuid] ||
+        Bookings::Gitis::MissingContact.new(model.contact_uuid)
     end
   end
 end

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -52,7 +52,12 @@ module Schools
       end
     end
 
-    def gitis_retrieval_error
+    def gitis_retrieval_error(exception)
+      if Rails.env.production?
+        ExceptionNotifier.notify_exception exception
+        Raven.capture_exception exception
+      end
+
       render 'shared/failed_gitis_connection', status: :service_unavailable
     end
   end

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -16,6 +16,8 @@ module Schools
 
     rescue_from MissingURN, with: -> { redirect_to schools_errors_no_school_path }
     rescue_from SchoolNotRegistered, with: -> { redirect_to schools_errors_not_registered_path }
+    rescue_from Bookings::Gitis::API::BadResponseError, with: :gitis_retrieval_error
+    rescue_from Bookings::Gitis::API::ConnectionFailed, with: :gitis_retrieval_error
 
     def current_school
       urn = session[:urn]
@@ -48,6 +50,10 @@ module Schools
 
         redirect_to schools_dashboard_path
       end
+    end
+
+    def gitis_retrieval_error
+      render 'shared/failed_gitis_connection', status: :service_unavailable
     end
   end
 end

--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -48,16 +48,5 @@ module Schools
         )
         .order(date: 'desc')
     end
-
-    def assign_gitis_contacts(bookings)
-      return bookings if bookings.empty?
-
-      contacts = gitis_crm.find(bookings.map(&:contact_uuid)).index_by(&:id)
-
-      bookings.each do |booking|
-        booking.bookings_placement_request.candidate.gitis_contact = \
-          contacts[booking.contact_uuid]
-      end
-    end
   end
 end

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -23,18 +23,5 @@ module Schools
         @booking.candidate_cancellation.viewed!
       end
     end
-
-  private
-
-    def assign_gitis_contacts(bookings)
-      return bookings if bookings.empty?
-
-      contacts = gitis_crm.find(bookings.map(&:contact_uuid)).index_by(&:id)
-
-      bookings.each do |booking|
-        booking.bookings_placement_request.candidate.gitis_contact = \
-          contacts[booking.contact_uuid]
-      end
-    end
   end
 end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -64,15 +64,5 @@ module Schools
 
       placement_request_urn if other_school_urns.include? placement_request_urn
     end
-
-    def assign_gitis_contacts(reqs)
-      return reqs if reqs.empty?
-
-      contacts = gitis_crm.find(reqs.map(&:contact_uuid)).index_by(&:id)
-
-      reqs.each do |req|
-        req.candidate.gitis_contact = contacts[req.contact_uuid]
-      end
-    end
   end
 end

--- a/app/controllers/schools/previous_bookings_controller.rb
+++ b/app/controllers/schools/previous_bookings_controller.rb
@@ -18,17 +18,6 @@ module Schools
 
   private
 
-    def assign_gitis_contacts(bookings)
-      return bookings if bookings.empty?
-
-      contacts = gitis_crm.find(bookings.map(&:contact_uuid)).index_by(&:id)
-
-      bookings.each do |booking|
-        booking.bookings_placement_request.candidate.gitis_contact = \
-          contacts[booking.contact_uuid]
-      end
-    end
-
     def scope
       current_school.bookings.historical
     end

--- a/app/controllers/schools/withdrawn_requests_controller.rb
+++ b/app/controllers/schools/withdrawn_requests_controller.rb
@@ -21,15 +21,5 @@ module Schools
     def scope
       current_school.placement_requests.withdrawn
     end
-
-    def assign_gitis_contacts(requests)
-      return requests if requests.empty?
-
-      contacts = gitis_crm.find(requests.map(&:contact_uuid)).index_by(&:id)
-
-      requests.each do |req|
-        req.candidate.gitis_contact = contacts[req.contact_uuid]
-      end
-    end
   end
 end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -58,6 +58,7 @@ module Bookings
       :closed?,
       :received_on,
       :gitis_contact,
+      :gitis_contact=,
       :fetch_gitis_contact,
       :contact_uuid,
       :candidate_email,

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -113,7 +113,7 @@ module Bookings
 
     default_scope { where.not(candidate_id: nil) }
 
-    delegate :gitis_contact, :fetch_gitis_contact, to: :candidate
+    delegate :gitis_contact, :gitis_contact=, :fetch_gitis_contact, to: :candidate
 
     def self.create_from_registration_session!(registration_session, analytics_tracking_uuid = nil)
       self.new(

--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -34,6 +34,8 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
     :candidate_email,
     :candidate_name,
     :contact_uuid,
+    :gitis_contact,
+    :gitis_contact=,
     :dates_requested,
     :token,
     :booking,

--- a/app/services/bookings/gitis/api.rb
+++ b/app/services/bookings/gitis/api.rb
@@ -31,6 +31,8 @@ module Bookings::Gitis
       end
 
       parse_response response
+    rescue Faraday::ConnectionFailed
+      raise ConnectionFailed.new(url)
     end
 
     def post(url, params, headers = {})
@@ -58,6 +60,11 @@ module Bookings::Gitis
     end
 
     class UnsupportedAbsoluteUrlError < RuntimeError; end
+    class ConnectionFailed < RuntimeError
+      def initialize(url)
+        super "Connection Failed: #{url}"
+      end
+    end
 
     class BadResponseError < RuntimeError
       def initialize(resp)

--- a/app/services/bookings/gitis/missing_contact.rb
+++ b/app/services/bookings/gitis/missing_contact.rb
@@ -9,7 +9,7 @@ module Bookings
       alias_method :contactid, :id
 
       def full_name
-        'unavailable'
+        'Unavailable'.freeze
       end
       alias_method :firstname, :full_name
       alias_method :lastname, :full_name

--- a/app/services/bookings/gitis/missing_contact.rb
+++ b/app/services/bookings/gitis/missing_contact.rb
@@ -1,0 +1,29 @@
+module Bookings
+  module Gitis
+    class MissingContact
+      attr_reader :id
+
+      def initialize(uuid)
+        @id = uuid
+      end
+      alias_method :contactid, :id
+
+      def full_name
+        'unavailable'
+      end
+      alias_method :firstname, :full_name
+      alias_method :lastname, :full_name
+
+      def emailaddress2
+        nil
+      end
+      alias_method :emailaddress1, :emailaddress2
+      alias_method :email, :emailaddress2
+
+      def birthdate
+        nil
+      end
+      alias_method :date_of_birth, :birthdate
+    end
+  end
+end

--- a/app/views/shared/failed_gitis_connection.html.erb
+++ b/app/views/shared/failed_gitis_connection.html.erb
@@ -1,9 +1,13 @@
+<%- self.page_title = "Sorry, the information is unavailable" %>
+
+<%= link_to 'Back', :back, class: 'govuk-back-link' %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+    <h1 class="govuk-heading-xl">Sorry, the information is unavailable</h1>
 
     <p>
-      We are temporarily unable to retrieve candidate details.
+      We are temporarily unable to retrieve this candidates details.
     </p>
 
     <p>

--- a/app/views/shared/failed_gitis_connection.html.erb
+++ b/app/views/shared/failed_gitis_connection.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Sorry, the service is unavailable</h1>
+
+    <p>
+      We are temporarily unable to retrieve candidate details.
+    </p>
+
+    <p>
+      Please try again in a few minutes.
+    </p>
+
+    <p>
+      If you continue to encounter this problem, contact the Organise School
+      Experience team on
+      <a href="mailto:organise.school-experience@education.gov.uk">
+        organise.school-experience@education.gov.uk
+      </a>
+      for assistance.
+    </p>
+
+    <p>
+      <%= link_to "Return to requests and bookings", schools_dashboard_path %>
+    </p>
+  </div>
+</div>

--- a/lib/apimock/gitis_crm.rb
+++ b/lib/apimock/gitis_crm.rb
@@ -9,11 +9,11 @@ module Apimock
       @service_url = service_url
     end
 
-    def stub_contact_request(uuid, return_params = {})
+    def stub_contact_request(uuid, return_params = {}, status_code = 200)
       stub_request(:get, "#{service_url}#{endpoint}/contacts(#{uuid})?$top=1&$select=#{contact_attributes}").
         with(headers: get_headers).
         to_return(
-          status: 200,
+          status: status_code,
           headers: {
             'Content-Type' => 'application/json; odata.metadata=minimal',
           },
@@ -22,6 +22,13 @@ module Apimock
             'contactid' => uuid
           ).merge(return_params.stringify_keys).to_json
         )
+    end
+
+    def stub_failed_contact_request(uuid)
+      stub_request(:get, "#{service_url}#{endpoint}/contacts(#{uuid})?$top=1&$select=#{contact_attributes}").
+        with(headers: get_headers).
+        to_timeout.
+        then.to_timeout
     end
 
     def stub_multiple_contact_request(uuids, return_params = {})

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -68,6 +68,21 @@ describe Schools::PlacementRequestsController, type: :request do
         expect(response).to render_template('shared/failed_gitis_connection')
       end
     end
+
+    context 'with missing contacts from Gitis' do
+      include_context 'fake gitis'
+
+      before do
+        allow(fake_gitis).to receive(:find).and_return([])
+        get "/schools/placement_requests"
+      end
+
+      it "renders the Gitis connection error page" do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template('show')
+        expect(response).to have_content('unavailable')
+      end
+    end
   end
 
   context '#show' do

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -80,7 +80,7 @@ describe Schools::PlacementRequestsController, type: :request do
       it "renders the Gitis connection error page" do
         expect(response).to have_http_status(:success)
         expect(response).to render_template('index')
-        expect(response.body).to match(/unavailable/)
+        expect(response.body).to match(/Unavailable/)
       end
     end
   end

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -79,8 +79,8 @@ describe Schools::PlacementRequestsController, type: :request do
 
       it "renders the Gitis connection error page" do
         expect(response).to have_http_status(:success)
-        expect(response).to render_template('show')
-        expect(response).to have_content('unavailable')
+        expect(response).to render_template('index')
+        expect(response.body).to match(/unavailable/)
       end
     end
   end

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -17,35 +17,55 @@ describe Schools::PlacementRequestsController, type: :request do
   end
 
   context '#index' do
-    let(:placement_requests) do
+    let!(:placement_requests) do
       FactoryBot.create_list :placement_request, 5, school: school
     end
 
-    before do
-      get '/schools/placement_requests'
-    end
+    context 'for unaccepted placement requests' do
+      before { get '/schools/placement_requests' }
 
-    it 'assigns the placement_requests belonging to the school' do
-      expect(assigns(:placement_requests)).to eq school.placement_requests
-      expect(assigns(:placement_requests).map(&:gitis_contact)).to all \
-        be_kind_of Bookings::Gitis::Contact
-    end
+      it 'assigns the placement_requests belonging to the school' do
+        expect(assigns(:placement_requests)).to eq school.placement_requests
+        expect(assigns(:placement_requests).map(&:gitis_contact)).to all \
+          be_kind_of Bookings::Gitis::Contact
+      end
 
-    it 'renders the index template' do
-      expect(response).to render_template :index
+      it 'renders the index template' do
+        expect(response).to render_template :index
+      end
     end
 
     context 'after placement requests have been accepted' do
       let(:booked) { placement_requests.last }
       before do
-        create(:bookings_booking, :accepted, bookings_placement_request: booked, bookings_school: school)
+        create :bookings_booking, :accepted,
+          bookings_placement_request: booked,
+          bookings_school: school
+
+        get '/schools/placement_requests'
       end
 
-      before { get '/schools/placement_requests' }
-
       specify 'they should be omitted' do
-        expect(assigns(:placement_requests).sort_by(&:id)).to \
-          eq((school.placement_requests - Array.wrap(booked)).sort_by(&:id))
+        expect(assigns(:placement_requests)).to \
+          match_array(school.placement_requests - [booked])
+      end
+    end
+
+    context 'with a timeout response from Gitis' do
+      include_context 'fake gitis'
+
+      let :gitis_exception do
+        Bookings::Gitis::API::BadResponseError.new OpenStruct.new(headers: {})
+      end
+
+      before do
+        allow(fake_gitis).to receive(:find).and_raise gitis_exception
+        get "/schools/placement_requests"
+      end
+
+      it "renders the Gitis connection error page" do
+        expect(response).to have_http_status(:service_unavailable)
+        expect(response).to render_template('shared/failed_gitis_connection')
       end
     end
   end

--- a/spec/services/bookings/gitis/missing_contact_spec.rb
+++ b/spec/services/bookings/gitis/missing_contact_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe Bookings::Gitis::MissingContact do
+  let(:uuid) { SecureRandom.uuid }
+  subject { described_class.new uuid }
+
+  it { is_expected.to have_attributes contactid: uuid, id: uuid }
+  it { is_expected.to have_attributes firstname: 'unavailable' }
+  it { is_expected.to have_attributes lastname: 'unavailable' }
+  it { is_expected.to have_attributes full_name: 'unavailable' }
+  it { is_expected.to have_attributes birthdate: nil }
+  it { is_expected.to have_attributes date_of_birth: nil }
+  it { is_expected.to have_attributes emailaddress1: nil }
+  it { is_expected.to have_attributes emailaddress2: nil }
+  it { is_expected.to have_attributes email: nil }
+end

--- a/spec/services/bookings/gitis/missing_contact_spec.rb
+++ b/spec/services/bookings/gitis/missing_contact_spec.rb
@@ -5,9 +5,9 @@ describe Bookings::Gitis::MissingContact do
   subject { described_class.new uuid }
 
   it { is_expected.to have_attributes contactid: uuid, id: uuid }
-  it { is_expected.to have_attributes firstname: 'unavailable' }
-  it { is_expected.to have_attributes lastname: 'unavailable' }
-  it { is_expected.to have_attributes full_name: 'unavailable' }
+  it { is_expected.to have_attributes firstname: 'Unavailable' }
+  it { is_expected.to have_attributes lastname: 'Unavailable' }
+  it { is_expected.to have_attributes full_name: 'Unavailable' }
   it { is_expected.to have_attributes birthdate: nil }
   it { is_expected.to have_attributes date_of_birth: nil }
   it { is_expected.to have_attributes emailaddress1: nil }

--- a/spec/support/bypass_fake_gitis.rb
+++ b/spec/support/bypass_fake_gitis.rb
@@ -1,3 +1,5 @@
 shared_context "bypass fake Gitis" do
-  before { allow(Rails.application.config.x.gitis).to receive(:fake_crm).and_return(false) }
+  before do
+    allow(Rails.application.config.x.gitis).to receive(:fake_crm).and_return(false)
+  end
 end


### PR DESCRIPTION
### Context

If Gitis stops responding, we should show a page to the user that explains why they are seeing the screen, that it is anticipated to be temporary and to try again later.

### Changes proposed in this pull request

1. Added custom exception handler for gitis errors
2. Added a 'gitis retrieval error' page
3. Populate missing contacts on listings pages with stub objects, this avoids a single missing contact making the entire page unavailable
4. Removed the duplicated instances of bulk fetching gitis contacts

### Guidance to review
1. Code review
2. Testing - 
a. try with an invalid gitis hostname
b. change the guid on a candidate to be something new from `SecureRandom.uuid` - any `index` page showing that contacts data should still work

