### PR TITLE
Allow bookings to be created on current date SE-1875

### DIFF
--- a/app/forms/schools/placement_requests/confirm_booking.rb
+++ b/app/forms/schools/placement_requests/confirm_booking.rb
@@ -11,7 +11,7 @@ module Schools
 
       validates :date,
         timeliness: {
-          after: :today,
+          on_or_after: :today,
           before: -> { 2.years.from_now },
           type: :date
         },

--- a/spec/forms/schools/placement_requests/confirm_booking_spec.rb
+++ b/spec/forms/schools/placement_requests/confirm_booking_spec.rb
@@ -21,8 +21,8 @@ describe Schools::PlacementRequests::ConfirmBooking, type: :model do
     end
 
     context '#date' do
-      let(:past_dates) { [1.week.ago, 1.day.ago, Date.today] }
-      let(:future_dates) { [1.day.from_now, 1.week.from_now, 1.year.from_now] }
+      let(:past_dates) { [1.week.ago, 1.day.ago, Date.yesterday] }
+      let(:future_dates) { [Date.today, 1.day.from_now, 1.week.from_now, 1.year.from_now] }
       let!(:bookings_subject) { create(:bookings_subject) }
 
       specify 'should not allow past dates' do


### PR DESCRIPTION
Previously when placement requests were accepted we were ensuring that
the booking date is *after* the current day. The correct behaviour, for
short notice bookings, would be to ensure that the book is *on or after*
the current day.