### PR TITLE
Fix typo in the word explanation in locales file SE-1886

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,7 +24,7 @@ en:
       degree_stage:
         blank: "Select a degree stage"
       degree_stage_explaination:
-        blank: "Enter an explaination"
+        blank: "Enter an explanation"
       degree_subject:
         blank: "Select a subject"
         inclusion: "Select 'Not applicable' if you don't have a degree or are not studying for one"
@@ -127,7 +127,7 @@ en:
             degree_stage:
               blank: "Select a degree stage"
             degree_stage_explaination:
-              blank: "Enter an explaination"
+              blank: "Enter an explanation"
             degree_subject:
               blank: "Select a subject"
               inclusion: "Select 'Not applicable' if you don't have a degree or are not studying for one"

--- a/features/candidates/registrations/education.feature
+++ b/features/candidates/registrations/education.feature
@@ -17,7 +17,7 @@ Feature: Entering candidate education details
         Given I am on the 'education' page for my school of choice
         And I choose 'Other' as my degree stage
         When I submit the form
-        Then I should see the validation error 'Enter an explaination'
+        Then I should see the validation error 'Enter an explanation'
 
     Scenario: Filling in and submitting the form
         Given I am on the 'education' page for my school of choice


### PR DESCRIPTION
This fix hasn't been been applied to other occurrences of 'explaination'
in attribute names because with the values being stored in Redis and not
controllable by migrations we run the risk of breaking in-flight
registrations.