### PR TITLE
Handle showing requests cancelled by school

### DIFF
--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -5,7 +5,7 @@ module Candidates
       before_action :ensure_placement_request_is_open, except: :show
 
       def show
-        @cancellation = placement_request.candidate_cancellation
+        @cancellation = placement_request.cancellation
       end
 
       def new

--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -53,6 +53,14 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
     end
   end
 
+  def cancelled_by_school?
+    cancelled_by == 'school'
+  end
+
+  def cancelled_by_candidate?
+    cancelled_by == 'candidate'
+  end
+
 private
 
   def placement_request_not_closed

--- a/app/views/candidates/placement_requests/cancellations/_show_booking_cancelled_by_candidate.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_show_booking_cancelled_by_candidate.html.erb
@@ -10,7 +10,7 @@
 
     <h2 class="govuk-heading-m">What happens next</h2>
     <p>
-    Your school experience booking on <%= cancellation.booking_date %> at <%= cancellation.school_name %> has been cancelled.
+      Your school experience booking on <%= booking_date %> at <%= school_name %> has been cancelled.
     </p>
 
     <h2 class="govuk-heading-s">The school will be notified about this cancellation.</h2>

--- a/app/views/candidates/placement_requests/cancellations/_show_booking_cancelled_by_school.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_show_booking_cancelled_by_school.html.erb
@@ -1,0 +1,31 @@
+<% self.page_title = 'Cancelled booking' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Your school experience booking has been cancelled by the school
+      </h1>
+    </div>
+
+    <p>
+      <%= school_name %> has cancelled your school experience for the following
+      dates: <%= dates_requested %>
+    </p>
+
+    <p>
+      Your booking was cancelled for the following reasons: <%= rejection_reasons %>
+    </p>
+
+    <p>
+      Extra details from the school <%= extra_details %>
+    </p>
+
+    <% if Rails.application.config.x.phase >= 5 %>
+      <h2 class="govuk-heading-m">View and request more school experience</h2>
+      <p>
+        <%= link_to 'Your requests and bookings', candidates_dashboard_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_candidate.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_candidate.html.erb
@@ -12,7 +12,7 @@
       What happens next
     </h2>
     <p>
-      Your request for school experience <%= cancellation.school_name %> at has been cancelled.
+      Your request for school experience <%= school_name %> at has been cancelled.
     </p>
     <p>
       <strong>The school will be notified about this cancellation.</strong>

--- a/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_school.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_school.html.erb
@@ -1,0 +1,28 @@
+<% self.page_title = 'Rejected placement request' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Your school experience request has been turned down by the school
+      </h1>
+    </div>
+
+    <p>
+      <%= school_name %> has turned down your school experience request for the following dates: <%= dates_requested %>
+    </p>
+
+    <p>
+      Your request was turned down for the following reasons:
+      <%= rejection_reasons %>
+    </p>
+
+    <p>
+      <%= link_to 'Request school experience at other schools', new_candidates_school_search_path %>
+    </p>
+
+    <p>
+      If you need any further help and support getting school experience or becoming a teacher visit the <%= link_to 'Get Into Teaching website', 'https://getintoteaching.education.gov.uk' %>.
+    </p>
+  </div>
+</div>

--- a/app/views/candidates/placement_requests/cancellations/show.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/show.html.erb
@@ -1,5 +1,28 @@
-<% if @cancellation.booking.present? %>
-  <%= render partial: 'show_booking', locals: { cancellation: @cancellation } %>
+<% if @cancellation.cancelled_by_candidate? %>
+  <% if @cancellation.booking.present? %>
+    <%= render 'show_booking_cancelled_by_candidate',
+      booking_date: @cancellation.booking_date,
+      school_name: @cancellation.school_name
+    %>
+  <% else %>
+    <%= render 'show_placement_request_cancelled_by_candidate',
+      school_name: @cancellation.school_name
+    %>
+  <% end %>
 <% else %>
-  <%= render partial: 'show_placement_request', locals: { cancellation: @cancellation } %>
+  <% if @cancellation.booking.present? %>
+    <%= render 'show_booking_cancelled_by_school',
+      school_name: @cancellation.school.name,
+      dates_requested: @cancellation.dates_requested,
+      rejection_reasons: @cancellation.reason,
+      extra_details: @cancellation.extra_details
+    %>
+  <% else %>
+    <%= render 'show_placement_request_cancelled_by_school',
+      school_name: @cancellation.school.name,
+      dates_requested: @cancellation.dates_requested,
+      rejection_reasons: @cancellation.reason,
+      extra_details: @cancellation.extra_details
+    %>
+  <% end %>
 <% end %>

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -295,24 +295,52 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
   end
 
   context '#show' do
-    let :placement_request do
-      FactoryBot.create :placement_request, :cancelled
-    end
-
     before do
       get \
         "/candidates/placement_requests/#{placement_request.token}/cancellation"
     end
 
-    context 'when does not have a booking' do
-      it 'renders the show template' do
-        expect(response).to render_template :show
+    context 'when cancelled by the candidate' do
+      let :placement_request do
+        create :placement_request, :cancelled
+      end
+
+      context 'when does not have a booking' do
+        it 'renders the show template' do
+          expect(response).to render_template :show
+        end
+      end
+
+      context 'when has a booking' do
+        let :placement_request do
+          create :placement_request, :cancelled, :booked
+        end
+
+        it 'renders the show template' do
+          expect(response).to render_template :show
+        end
       end
     end
 
-    context 'when has a booking' do
-      it 'renders the show template' do
-        expect(response).to render_template :show
+    context 'when cancelled by the school' do
+      let :placement_request do
+        create :placement_request, :cancelled_by_school
+      end
+
+      context 'when does not have a booking' do
+        it 'renders the show template' do
+          expect(response).to render_template :show
+        end
+      end
+
+      context 'when has a booking' do
+        let :placement_request do
+          create :placement_request, :cancelled_by_school, :booked
+        end
+
+        it 'renders the show template' do
+          expect(response).to render_template :show
+        end
       end
     end
   end


### PR DESCRIPTION
# Context
Previously if a candidate followed the cancel placement request link in
the confirmation email to a placement request that the school had
already rejected then they would get an error as we were fetching the
candidate_cancellation which would be nil.

### Changes proposed in this pull request
Add templates to handle candidate viewing school
cancellations/rejections

### Guidance to review
Manual testing if required:
Create a placement request and reject it as the school, visit the cancellation url `/candidates/cancel/<booking.token>`. You should be directed to the appropriate template

Create a booking and cancel it as the school, visit the cancellation url `/candidates/cancel/<placement_request.token>`. You should be directed to the appropriate template.