### PR TITLE
Move "I don't have a degree" down in degree list

### DIFF
--- a/config/candidate_form_options.yml
+++ b/config/candidate_form_options.yml
@@ -1,10 +1,10 @@
 ---
 DEGREE_STAGES:
-  - I don't have a degree and am not studying for one
   - Graduate or postgraduate
   - Final year
   - Second year
   - First year
+  - I don't have a degree and am not studying for one
   - Other
 
 TEACHING_STAGES:


### PR DESCRIPTION
### Context

The **What stage are you at with your degree?** list isn't in the most logical order

### Changes proposed in this pull request

Move _I don't have a degree and am not studying for one_ down to the bottom of the known options (second last, above 'Other')

### Guidance to review

🤷🏽‍♂️



