### PR TITLE
Make the return to dashboard link grey SE-1775

### DIFF
--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -54,6 +54,6 @@
   </p>
 
   <p>
-    <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path %>
+    <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path, secondary: true %>
   </p>
 <% end %>

--- a/features/schools/confirm_attendance.feature
+++ b/features/schools/confirm_attendance.feature
@@ -12,7 +12,7 @@ Feature: Confirming candidate attendance
         Given there are no bookings
         When I am on the 'confirm attendance' page
         Then I should see a notification that 'There are no bookings that need their attendance to be confirmed'
-        And I should see a 'Return to requests and bookings' link to the 'schools dashboard'
+        And I should see a secondary 'Return to requests and bookings' link to the 'schools dashboard'
 
     Scenario: Listing bookings
         Given there are some bookings that were scheduled last week

--- a/features/step_definitions/schools/confirm_attendance_steps.rb
+++ b/features/step_definitions/schools/confirm_attendance_steps.rb
@@ -81,3 +81,7 @@ end
 Then("no bookings should be listed") do
   expect(page).to have_text('There are no bookings that need their attendance to be confirmed.')
 end
+
+Then("I should see a secondary {string} link to the {string}") do |link_text, path|
+  expect(page).to have_link(link_text, href: path_for(path), class: 'govuk-button--secondary')
+end


### PR DESCRIPTION
### Context

When there are no attendances to confirm the button is green, despite it _only_ being a link back to the dashboard (and not an action)

### Changes proposed in this pull request

Make the button secondary (grey) when there are no attendances to confirm

### Guidance to review

Ensure it looks sensible

<img width="523" alt="Screenshot 2019-10-24 at 13 12 05" src="https://user-images.githubusercontent.com/128088/67484370-e7a22500-f65f-11e9-8a97-7d90773370b8.png">


