### PR TITLE
Make non hidden subjects the default scope

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
@@ -54,7 +54,7 @@ module Schools
 
         def set_available_subjects
           school_subjects = @current_school.subjects
-          @available_subjects = (school_subjects&.any? && school_subjects) || Bookings::Subject.available
+          @available_subjects = (school_subjects&.any? && school_subjects) || Bookings::Subject.all
         end
       end
     end

--- a/app/forms/schools/on_boarding/subject_list.rb
+++ b/app/forms/schools/on_boarding/subject_list.rb
@@ -21,7 +21,7 @@ module Schools
       end
 
       def available_subjects
-        Bookings::Subject.available.secondary_subjects
+        Bookings::Subject.secondary_subjects
       end
 
     private

--- a/app/models/bookings/subject.rb
+++ b/app/models/bookings/subject.rb
@@ -20,6 +20,6 @@ class Bookings::Subject < ApplicationRecord
     foreign_key: :bookings_subject_id,
     dependent: :destroy
 
-  scope :available, -> { where.not(hidden: true) }
+  default_scope -> { where.not(hidden: true) }
   scope :secondary_subjects, -> { where(secondary_subject: true) }
 end

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -268,7 +268,7 @@ module Schools
       foreign_key: 'bookings_school_id'
 
     def available_subjects
-      Bookings::Subject.available
+      Bookings::Subject.all
     end
 
     def current_step

--- a/spec/models/bookings/subject_spec.rb
+++ b/spec/models/bookings/subject_spec.rb
@@ -42,11 +42,11 @@ RSpec.describe Bookings::Subject, type: :model do
   end
 
   describe "Scopes" do
-    describe '.available' do
+    describe 'default_scope' do
       let!(:visible) { create(:bookings_subject, hidden: false) }
       let!(:hidden) { create(:bookings_subject, hidden: true) }
 
-      subject { described_class.available.to_a }
+      subject { described_class.all.to_a }
 
       it 'should include non-hidden subjects' do
         is_expected.to include(visible)

--- a/spec/models/bookings/subject_sync_spec.rb
+++ b/spec/models/bookings/subject_sync_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Bookings::SubjectSync do
       end
 
       context "with blacklisted new subject" do
-        subject { Bookings::Subject.where(gitis_uuid: gitis_subject_5.id).first }
+        subject { Bookings::Subject.unscoped.where(gitis_uuid: gitis_subject_5.id).first }
         it { is_expected.to have_attributes(name: gitis_subject_5.dfe_name) }
         it { is_expected.to have_attributes(hidden: true) }
       end

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -11,7 +11,7 @@ shared_context 'Stubbed candidates school' do
   end
 
   let :allowed_subject_choices do
-    Bookings::Subject.available.pluck(:name)
+    Bookings::Subject.pluck(:name)
   end
 
   let :second_subject_choices do


### PR DESCRIPTION
This is set in a sync job to remove certain subjects returned by gitis.
Rather than having to remember to call the available scope everywhere we
can make this the default scope as we never want to show these to the
end user.

### Context
We we're duplicating the call to the available scope in multiple places through out the app (and missed calling it some places).

### Changes proposed in this pull request
Make the available scope the default scope.

### Guidance to review
Change should be sensible. Use of default scope was discussed offline
