### PR TITLE
Stop invalid bookings from being treated as saved SE-1894

### DIFF
--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -4,6 +4,8 @@
   <div class="govuk-grid-column-two-thirds">
      <%= link_to 'Back', schools_booking_path(@booking), class: 'govuk-back-link' %>
 
+     <%= GovukElementsErrorsHelper.error_summary @booking, 'There is a problem', '' %>
+
     <h1>Change the booking date for <%= @booking.gitis_contact.full_name %></h1>
 
     <p>

--- a/config/locales/validates_timeliness.en.yml
+++ b/config/locales/validates_timeliness.en.yml
@@ -1,7 +1,7 @@
 en:
   errors:
     messages:
-      invalid_date: "is not a valid date"
+      invalid_date: "Enter a valid date"
       invalid_time: "is not a valid time"
       invalid_datetime: "is not a valid date"
       is_at: "must be at %{restriction}"

--- a/features/schools/confirmed_bookings/editing_a_date.feature
+++ b/features/schools/confirmed_bookings/editing_a_date.feature
@@ -25,6 +25,13 @@ Feature: Updating a date
             | Label        | Type |
             | Booking date | date |
 
+    Scenario: When validation fails
+        Given there is at least one booking
+        And I am on the 'change booking date' page for my booking
+        When I change the date to an invalid date
+        And I submit the form
+        Then I should see the validation error 'Enter a valid date'
+
     Scenario: Changing a date
         Given there is at least one booking
         And I am on the 'change booking date' page for my booking

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -30,7 +30,7 @@ Feature: Creating new placement dates
         Given I am on the 'new placement date' page
         And I fill in the 'Enter a start date' date field with an invalid date of 31st September next year
         When I submit the form
-        Then I should see an error message stating 'is not a valid date'
+        Then I should see an error message stating 'Enter a valid date'
 
     Scenario: Filling in and submitting the form
         Given I am on the 'new placement date' page

--- a/features/step_definitions/schools/bookings/editing_a_date_steps.rb
+++ b/features/step_definitions/schools/bookings/editing_a_date_steps.rb
@@ -44,7 +44,3 @@ end
 When("I change the date to an invalid date") do
   step "I fill in the date field 'Booking date' with 200-100-900"
 end
-
-Then("I should see a validation error") do
-  pending # Write code here that turns the phrase above into concrete actions
-end

--- a/features/step_definitions/schools/bookings/editing_a_date_steps.rb
+++ b/features/step_definitions/schools/bookings/editing_a_date_steps.rb
@@ -40,3 +40,11 @@ end
 Then("there should be a link to the {string} screen") do |string|
   expect(page).to have_link(string, href: path_for('bookings'))
 end
+
+When("I change the date to an invalid date") do
+  step "I fill in the date field 'Booking date' with 200-100-900"
+end
+
+Then("I should see a validation error") do
+  pending # Write code here that turns the phrase above into concrete actions
+end

--- a/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/confirm_booking_controller_spec.rb
@@ -92,7 +92,7 @@ describe Schools::PlacementRequests::Acceptance::ConfirmBookingController, type:
       end
 
       specify "should include an 'invalid date' error" do
-        expect(response.body).to match(/not a valid date/)
+        expect(response.body).to match(/Enter a valid date/)
       end
     end
   end


### PR DESCRIPTION
### Context

The change_booking_date method always returned true, even when the
booking wasn't saved.

### Changes proposed in this pull request

This process has been simplified by moving the
logic up to the if statement and removing the wrapping transaction.

Also, add a missing error summary to the page and specs covering the
behaviour.

### Guidance to review

Ensure it looks sensible and new features cover the behaviour