### PR TITLE
Feature flag has_limited_availability

### DIFF
--- a/app/forms/schools/placement_dates/configuration_form.rb
+++ b/app/forms/schools/placement_dates/configuration_form.rb
@@ -10,7 +10,7 @@ module Schools
 
       validates :max_bookings_count, numericality: { greater_than: 0 }, if: :has_limited_availability
       validates :max_bookings_count, absence: true, unless: :has_limited_availability
-      validates :has_limited_availability, inclusion: [true, false]
+      validates :has_limited_availability, inclusion: [true, false], if: -> { Feature.instance.active? :capped_bookings }
       validates :available_for_all_subjects, inclusion: [true, false]
 
       def self.new_from_date(placement_date)

--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -7,15 +7,20 @@
     <%= form_for @configuration, method: :post, url: schools_placement_date_configuration_path(@placement_date) do |f| %>
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
-      <%= f.radio_button_fieldset :has_limited_availability do |fieldset| %>
-        <p>
-          Once you’ve accepted the maximum number of bookings this date will not be shown to candidates.
-        </p>
-        <%= f.radio_input true do %>
-          <%= f.number_field :max_bookings_count, class: 'govuk-!-width-one-half' %>
+      <% if Feature.instance.active? :capped_bookings %>
+        <%= f.radio_button_fieldset :has_limited_availability do |fieldset| %>
+          <p>
+            Once you’ve accepted the maximum number of bookings this date will not be shown to candidates.
+          </p>
+          <%= f.radio_input true do %>
+            <%= f.number_field :max_bookings_count, class: 'govuk-!-width-one-half' %>
+          <% end %>
+          <%= f.radio_input false %>
         <% end %>
-        <%= f.radio_input false %>
       <% end %>
+
+      <% # Ensure the form submits with out error if no option is selected %>
+      <%= f.hidden_field :available_for_all_subjects, value: nil %>
 
       <%= f.radio_button_fieldset :available_for_all_subjects do |fieldset| %>
         <%= f.radio_input true %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,6 +83,7 @@ Rails.application.configure do
     subject_specific_dates
     candidate_requirement_ab_test
     access_needs_journey
+    capped_bookings
   )
 
   # dfe signin redirects back to https, so force it

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -17,6 +17,7 @@ Rails.application.configure do
     subject_specific_dates
     candidate_requirement_ab_test
     access_needs_journey
+    capped_bookings
   )
 
   # dfe signin config, should be in credentials or env vars

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,6 +74,7 @@ Rails.application.configure do
     subject_specific_dates
     candidate_requirement_ab_test
     access_needs_journey
+    capped_bookings
   )
 
   config.x.base_url = 'https://some-host'


### PR DESCRIPTION
The do you have limited availability section of the placement_date form
was added as it was in the prototype at the time of implementing subject
specific dates, however it's a seperate piece of work.  This has been
feature flagged off, until the canidate side of the work has been done.
All placement dates will have no limit to the maximum number of
bookings, until the feature is enabled.

### Context

### Changes proposed in this pull request

### Guidance to review
Manual testing:
Disable the feature 'capped_bookings' in development, set up a new subject specific date, it should work as expected,