### PR TITLE
Remove no-longer-accurate text from hints

### DIFF
--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -19,18 +19,8 @@
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
       <%= f.pounds_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.99, label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } %>
 
-      <%= f.text_area :description, rows: 4, width: 'full', label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
-        <span class="govuk-hint">
-          For example, ‘The fee covers the cost of carrying out your DBS check’
-          or ‘We won’t charge you a fee if you have an enhanced DBS certificate
-          which is less than 2 years old’
-        </span>
-      <% end %>
-      <%= f.text_area :payment_method, rows: 4, width: 'full', label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
-        <span class="govuk-hint">
-          For example, by bank transfer, in cash or via PayPal.
-        </span>
-      <% end %>
+      <%= f.text_area :description, rows: 4, width: 'full', label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } %>
+      <%= f.text_area :payment_method, rows: 4, width: 'full', label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } %>
       <%= f.submit 'Continue' %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -494,6 +494,7 @@ en:
         <<: *schools_on_boarding_school_fee_hints
       schools_on_boarding_dbs_fee:
         <<: *schools_on_boarding_school_fee_hints
+        description: For example, 'The fee covers the cost of carrying out your DBS check'.
       schools_on_boarding_other_fee:
         <<: *schools_on_boarding_school_fee_hints
 


### PR DESCRIPTION
### Context

Some hint text is no longer accurate

### Changes proposed in this pull request

Replace the hint text and standardise on using the locales file so spacing is consistent on the form

### Guidance to review

Does it look ok?

![Screenshot 2019-10-25 at 11 34 15](https://user-images.githubusercontent.com/128088/67565237-d539f100-f71c-11e9-9460-327ecac7803f.png)

