### PR TITLE
Show subject specific date on placement request show SE-1898

### DIFF
--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -40,8 +40,8 @@
     <h2>Request details</h2>
 
     <dl class="placement-details govuk-summary-list">
-      <div class="date-requested govuk-summary-list__row">
 
+      <div class="date-requested govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Dates requested
         </dt>
@@ -49,6 +49,17 @@
           <%= @placement_request.dates_requested %>
         </dd>
       </div>
+
+      <% if @placement_request.subject.present? %>
+        <div class="date-requested govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            Requested subject
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= @placement_request.requested_subject %>
+          </dd>
+        </div>
+      <% end %>
 
       <div class="date-received-on govuk-summary-list__row">
         <dt class="govuk-summary-list__key">

--- a/features/schools/placement_dates/show.feature
+++ b/features/schools/placement_dates/show.feature
@@ -1,0 +1,4 @@
+Feature: Editing placement dates
+    So I view a placement date
+    As a school administrator
+    I want to be able to update and delete records

--- a/features/schools/placement_requests/show.feature
+++ b/features/schools/placement_requests/show.feature
@@ -17,10 +17,10 @@ Feature: Viewing a placement request
         Given there is at least one placement request
         When I am on the placement request page
         Then I should see a 'Personal details' section with the following values:
-            | Heading             | Value                                                                |
+            | Heading             | Value                                                                 |
             | Address             | First Line, Second Line, Third Line, Manchester, Manchester, TE57 1NG |
-            | UK telephone number | 07123 456789                                                         |
-            | Email address       | second@thisaddress.com                                               |
+            | UK telephone number | 07123 456789                                                          |
+            | Email address       | second@thisaddress.com                                                |
 
     Scenario: Request details
         Given there is at least one placement request
@@ -29,6 +29,12 @@ Feature: Viewing a placement request
             | Heading         | Value                         |
             | Dates requested | Any time during November 2019 |
             | DBS certificate | Yes                           |
+
+    Scenario: Request details
+        Given there is at least one subject-specific placement request for 'Maths'
+        When I am on the placement request page
+        Then I should see a 'Request details' section with the following values:
+            | Requested subject | Maths                         |
 
     Scenario: Candidate details
         Given there is at least one placement request

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -25,6 +25,34 @@ Given("there is at least one placement request") do
     degree_subject: 'Law'
 end
 
+Given("there is at least one subject-specific placement request for {string}") do |subject_name|
+  @requested_subject = Bookings::Subject.find_by(name: subject_name)
+
+  @placement_date = FactoryBot.build(
+    :bookings_placement_date,
+    bookings_school: @school,
+    subject_specific: true,
+    supports_subjects: true
+  ).tap do |pd|
+    pd.subjects << @requested_subject
+    pd.save
+  end
+
+  @placement_request = FactoryBot.create \
+    :placement_request,
+    school: @school,
+    created_at: '2094-02-08',
+    availability: 'Any time during November 2019',
+    teaching_stage: 'I’ve applied for teacher training',
+    has_dbs_check: true,
+    objectives: 'To learn different teaching styles and what life is like in a classroom.',
+    degree_stage: 'Final year',
+    degree_subject: 'Law',
+    bookings_placement_date_id: @placement_date.id,
+    bookings_placement_dates_subject_id: @placement_date.subjects.first.id,
+    bookings_subject_id: @requested_subject.id
+end
+
 When("I am on a placement request page") do
   visit path_for 'placement request', placement_request: @placement_request
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1898

### Context

When subject-specific bookings are made the school _should_ be able to see the selected subject on the placement request screen. It's currently omitted

### Changes proposed in this pull request

Add requested subject to the placement request show screen. It should only be displayed for subject-specific requests.

### Guidance to review

Ensure it looks ok

<img width="493" alt="Screenshot 2019-10-28 at 13 43 38" src="https://user-images.githubusercontent.com/128088/67683316-133b4d00-f989-11e9-9131-1aff693737c8.png">


