### PR TITLE
Removes access_needs_journey feature flag

### DIFF
--- a/app/controllers/schools/on_boarding/candidate_experience_details_controller.rb
+++ b/app/controllers/schools/on_boarding/candidate_experience_details_controller.rb
@@ -51,8 +51,6 @@ module Schools
           :parking_provided,
           :parking_details,
           :nearby_parking_details,
-          :disabled_facilities,
-          :disabled_facilities_details,
           :start_time,
           :end_time,
           :times_flexible,

--- a/app/forms/schools/on_boarding/candidate_experience_detail.rb
+++ b/app/forms/schools/on_boarding/candidate_experience_detail.rb
@@ -15,8 +15,6 @@ module Schools
       attribute :parking_provided, :boolean
       attribute :parking_details, :string
       attribute :nearby_parking_details, :string
-      attribute :disabled_facilities, :boolean
-      attribute :disabled_facilities_details, :string
       attribute :start_time, :string
       attribute :end_time, :string
       attribute :times_flexible, :boolean
@@ -31,11 +29,6 @@ module Schools
       validates :parking_provided, inclusion: [true, false]
       validates :parking_details, presence: true, if: :parking_provided
       validates :nearby_parking_details, presence: true, if: -> { !parking_provided && !parking_provided.nil? }
-
-      with_options unless: -> { Feature.instance.active? :access_needs_journey } do
-        validates :disabled_facilities, inclusion: [true, false]
-        validates :disabled_facilities_details, presence: true, if: :disabled_facilities
-      end
 
       validates :start_time, presence: true
       validates :start_time, format: { with: SCHOOL_TIME_FORMAT }, if: -> { start_time.present? }
@@ -54,8 +47,6 @@ module Schools
           parking_provided,
           parking_details,
           nearby_parking_details,
-          disabled_facilities,
-          disabled_facilities_details,
           start_time,
           end_time,
           times_flexible,
@@ -71,8 +62,6 @@ module Schools
           parking_provided: parking_provided,
           parking_details: parking_details,
           nearby_parking_details: nearby_parking_details,
-          disabled_facilities: disabled_facilities,
-          disabled_facilities_details: disabled_facilities_details,
           start_time: start_time,
           end_time: end_time,
           times_flexible: times_flexible,

--- a/app/forms/schools/on_boarding/current_step.rb
+++ b/app/forms/schools/on_boarding/current_step.rb
@@ -124,27 +124,22 @@ module Schools
       end
 
       def access_needs_support_required?
-        return false unless Feature.instance.active? :access_needs_journey
-
         @school_profile.access_needs_support.dup.invalid?
       end
 
       def access_needs_detail_required?
-        return false unless Feature.instance.active? :access_needs_journey
         return false unless @school_profile.access_needs_support.supports_access_needs?
 
         @school_profile.access_needs_detail.dup.invalid?
       end
 
       def disability_confident_required?
-        return false unless Feature.instance.active? :access_needs_journey
         return false unless @school_profile.access_needs_support.supports_access_needs?
 
         @school_profile.disability_confident.dup.invalid?
       end
 
       def access_needs_policy_required?
-        return false unless Feature.instance.active? :access_needs_journey
         return false unless @school_profile.access_needs_support.supports_access_needs?
 
         @school_profile.access_needs_policy.dup.invalid?

--- a/app/models/bookings/profile.rb
+++ b/app/models/bookings/profile.rb
@@ -71,18 +71,16 @@ class Bookings::Profile < ApplicationRecord
   validates :other_fee_interval, inclusion: AVAILABLE_INTERVALS, if: :other_fee_assigned
   validates :other_fee_payment_method, presence: true, if: :other_fee_assigned
 
-  if Feature.instance.active? :access_needs_journey
-    validates :supports_access_needs, inclusion: [true, false]
-    validates :access_needs_description, presence: true, if: :supports_access_needs?
-    validates :disability_confident, inclusion: [true, false], if: :supports_access_needs?
-    validates :has_access_needs_policy, inclusion: [true, false], if: :supports_access_needs?
-    validates :access_needs_policy_url, presence: true, if: :has_access_needs_policy?
+  validates :supports_access_needs, inclusion: [true, false]
+  validates :access_needs_description, presence: true, if: :supports_access_needs?
+  validates :disability_confident, inclusion: [true, false], if: :supports_access_needs?
+  validates :has_access_needs_policy, inclusion: [true, false], if: :supports_access_needs?
+  validates :access_needs_policy_url, presence: true, if: :has_access_needs_policy?
 
-    validates :access_needs_description, absence: true, unless: :supports_access_needs?
-    validates :disability_confident, absence: true, unless: :supports_access_needs?
-    validates :has_access_needs_policy, absence: true, unless: :supports_access_needs?
-    validates :access_needs_policy_url, absence: true, unless: :has_access_needs_policy?
-  end
+  validates :access_needs_description, absence: true, unless: :supports_access_needs?
+  validates :disability_confident, absence: true, unless: :supports_access_needs?
+  validates :has_access_needs_policy, absence: true, unless: :supports_access_needs?
+  validates :access_needs_policy_url, absence: true, unless: :has_access_needs_policy?
 
   before_validation :nilify_blank_fields
   before_validation :strip_fields

--- a/app/models/bookings/profile_attributes_convertor.rb
+++ b/app/models/bookings/profile_attributes_convertor.rb
@@ -11,7 +11,6 @@ module Bookings
 
       convert_dbs_required
       convert_individual_requirements
-      convert_nillable
       convert_dress_code
       convert_teacher_training
       convert_admin_details
@@ -23,7 +22,7 @@ module Bookings
       convert_fees(:administration)
       convert_fees(:dbs)
       convert_fees(:other)
-      convert_access_needs if Feature.instance.active? :access_needs_journey
+      convert_access_needs
 
       output
     end
@@ -68,13 +67,6 @@ module Bookings
             :candidate_requirement_requirements_details)
       end
       # rubocop:enable ConditionalAssignment
-    end
-
-    def convert_nillable
-      # TODO not needed if disabled_facilities feature is on
-      output[:disabled_facilities] = \
-        conditional_assign(:candidate_experience_detail_disabled_facilities,
-          :candidate_experience_detail_disabled_facilities_details)
     end
 
     def convert_dress_code

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -181,8 +181,6 @@ module Schools
         %w(candidate_experience_detail_parking_provided parking_provided),
         %w(candidate_experience_detail_parking_details parking_details),
         %w(candidate_experience_detail_nearby_parking_details nearby_parking_details),
-        %w(candidate_experience_detail_disabled_facilities disabled_facilities),
-        %w(candidate_experience_detail_disabled_facilities_details disabled_facilities_details),
         %w(candidate_experience_detail_start_time start_time),
         %w(candidate_experience_detail_end_time end_time),
         %w(candidate_experience_detail_times_flexible times_flexible),

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -193,15 +193,6 @@ module Schools
         end
       end
 
-      # TODO remove this
-      def disability_and_access_needs
-        if @school_profile.candidate_experience_detail.disabled_facilities
-          'Yes - ' + @school_profile.candidate_experience_detail.disabled_facilities_details
-        else
-          'No'
-        end
-      end
-
       def supports_access_needs?
         @school_profile.access_needs_support.supports_access_needs?
       end

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -87,11 +87,9 @@
       </ul>
     </div>
 
-    <% if Feature.instance.active? :access_needs_journey %>
-      <% if @presenter.supports_access_needs? %>
-        <%= render partial: 'candidates/schools/access_needs_statement.html.erb',
-          locals: { presenter: @presenter } %>
-      <% end %>
+    <% if @presenter.supports_access_needs? %>
+      <%= render partial: 'candidates/schools/access_needs_statement.html.erb',
+        locals: { presenter: @presenter } %>
     <% end %>
 
     <% if include_candidate_request_links %>
@@ -192,16 +190,6 @@
         <%- end -%>
 
         <%= simple_format @presenter.parking_details %>
-      <% end %>
-
-      <% unless Feature.instance.active? :access_needs_journey %>
-        <%= dlist_item 'Accessibility details', id: 'accessibility-details' do %>
-          <%- if @presenter.disabled_facilities.present? -%>
-            <%= simple_format @presenter.disabled_facilities %>
-          <%- else -%>
-            <em>No information supplied</em>
-          <%- end -%>
-        <% end %>
       <% end %>
 
       <%= dlist_item 'Teacher training offered', id: 'school-teacher-training-info' do %>

--- a/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
@@ -41,15 +41,6 @@
         <% end %>
       <% end %>
 
-      <% unless Feature.instance.active? :access_needs_journey %>
-        <%= f.radio_button_fieldset :disabled_facilities do |fieldset| %>
-          <%= f.radio_input true do %>
-            <%= f.text_area :disabled_facilities_details, rows: 7 %>
-          <% end %>
-          <%= f.radio_input false %>
-        <% end %>
-      <% end %>
-
       <div class="govuk-form-group">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
           <h1 class="govuk-fieldset__heading">

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -44,17 +44,11 @@
     <dl class="govuk-summary-list">
       <%= summary_row 'Dress code', @profile.dress_code, edit_schools_on_boarding_candidate_experience_detail_path %>
       <%= summary_row 'Parking', @profile.parking, edit_schools_on_boarding_candidate_experience_detail_path %>
-      <% if Feature.instance.active? :access_needs_journey %>
-        <%= summary_row 'Show disabilites and access needs support', @profile.supports_access_needs_description, edit_schools_on_boarding_access_needs_support_path %>
-
-        <% if @profile.supports_access_needs? %>
-          <%= summary_row 'Disability and access needs', @profile.disability_and_access_needs_description, edit_schools_on_boarding_access_needs_detail_path %>
-          <%= summary_row 'Disability Confident employer scheme', @profile.disability_confident_scheme, edit_schools_on_boarding_disability_confident_path %>
-          <%= summary_row 'Disability and access needs policy', @profile.disability_and_access_needs_policy, edit_schools_on_boarding_access_needs_policy_path %>
-        <% end %>
-
-      <% else %>
-        <%= summary_row 'Disability and access needs', @profile.disability_and_access_needs, edit_schools_on_boarding_candidate_experience_detail_path %>
+      <%= summary_row 'Show disabilites and access needs support', @profile.supports_access_needs_description, edit_schools_on_boarding_access_needs_support_path %>
+      <% if @profile.supports_access_needs? %>
+        <%= summary_row 'Disability and access needs', @profile.disability_and_access_needs_description, edit_schools_on_boarding_access_needs_detail_path %>
+        <%= summary_row 'Disability Confident employer scheme', @profile.disability_confident_scheme, edit_schools_on_boarding_disability_confident_path %>
+        <%= summary_row 'Disability and access needs policy', @profile.disability_and_access_needs_policy, edit_schools_on_boarding_access_needs_policy_path %>
       <% end %>
       <%= summary_row 'Start time', @profile.start_time, edit_schools_on_boarding_candidate_experience_detail_path %>
       <%= summary_row 'Finish time', @profile.end_time, edit_schools_on_boarding_candidate_experience_detail_path %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,7 +82,6 @@ Rails.application.configure do
   config.x.features = %i(
     subject_specific_dates
     candidate_requirement_ab_test
-    access_needs_journey
   )
 
   # dfe signin redirects back to https, so force it

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -154,7 +154,7 @@ Rails.application.configure do
     config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
   end
 
-  config.x.features = %i(candidate_requirement_ab_test access_needs_journey)
+  config.x.features = %i(candidate_requirement_ab_test)
 
   config.sass[:style] = :compressed if config.sass
 

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -16,7 +16,6 @@ Rails.application.configure do
   config.x.features = %i(
     subject_specific_dates
     candidate_requirement_ab_test
-    access_needs_journey
   )
 
   # dfe signin config, should be in credentials or env vars

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -73,7 +73,6 @@ Rails.application.configure do
   config.x.features = %i(
     subject_specific_dates
     candidate_requirement_ab_test
-    access_needs_journey
   )
 
   config.x.base_url = 'https://some-host'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,12 +96,10 @@ Rails.application.routes.draw do
       resource :subjects, only: %i(new create edit update)
       resource :description, only: %i(new create edit update)
       resource :candidate_experience_detail, only: %i(new create edit update)
-      if Feature.instance.active? :access_needs_journey
-        resource :access_needs_support, only: %i(new create edit update)
-        resource :access_needs_detail, only: %i(new create edit update)
-        resource :disability_confident, only: %i(new create edit update)
-        resource :access_needs_policy, only: %i(new create edit update)
-      end
+      resource :access_needs_support, only: %i(new create edit update)
+      resource :access_needs_detail, only: %i(new create edit update)
+      resource :disability_confident, only: %i(new create edit update)
+      resource :access_needs_policy, only: %i(new create edit update)
       resource :experience_outline, only: %i(new create edit update)
       resource :admin_contact, only: %i(new create edit update)
       resource :profile, only: :show

--- a/spec/factories/schools/on_boarding/candidate_experience_detail_factory.rb
+++ b/spec/factories/schools/on_boarding/candidate_experience_detail_factory.rb
@@ -9,8 +9,6 @@ FactoryBot.define do
     parking_provided { true }
     parking_details { 'Plenty of spaces' }
     nearby_parking_details { nil }
-    disabled_facilities { false }
-    disabled_facilities_details { '' }
     start_time { '8:15am' }
     end_time { '4:30pm' }
     times_flexible { true }
@@ -19,11 +17,6 @@ FactoryBot.define do
     trait :without_parking do
       parking_provided { false }
       nearby_parking_details { 'Public car park across the street' }
-    end
-
-    trait :with_disabled_facilities do
-      disabled_facilities { true }
-      disabled_facilities_details { 'Full wheelchair access and hearing loops' }
     end
 
     trait :without_flexible_times do

--- a/spec/factories/schools/school_profile_factory.rb
+++ b/spec/factories/schools/school_profile_factory.rb
@@ -102,7 +102,6 @@ FactoryBot.define do
 
     transient do
       parking { true }
-      disabled_facilities { false }
       times_flexible { true }
     end
 
@@ -112,10 +111,6 @@ FactoryBot.define do
 
         if evaluator.parking == false
           traits << :without_parking
-        end
-
-        if evaluator.disabled_facilities
-          traits << :with_disabled_facilities
         end
 
         if evaluator.times_flexible == false

--- a/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
+++ b/spec/forms/schools/on_boarding/candidate_experience_detail_spec.rb
@@ -12,8 +12,6 @@ describe Schools::OnBoarding::CandidateExperienceDetail, type: :model do
     it { is_expected.to respond_to :parking_provided }
     it { is_expected.to respond_to :parking_details }
     it { is_expected.to respond_to :nearby_parking_details }
-    it { is_expected.to respond_to :disabled_facilities }
-    it { is_expected.to respond_to :disabled_facilities_details }
     it { is_expected.to respond_to :start_time }
     it { is_expected.to respond_to :end_time }
     it { is_expected.to respond_to :times_flexible }
@@ -27,9 +25,6 @@ describe Schools::OnBoarding::CandidateExperienceDetail, type: :model do
     it { is_expected.not_to allow_value(nil).for :smart_casual }
     it { is_expected.not_to allow_value(nil).for :other_dress_requirements }
     it { is_expected.not_to allow_value(nil).for :parking_provided }
-    unless Feature.instance.active? :access_needs_journey
-      it { is_expected.not_to allow_value(nil).for :disabled_facilities }
-    end
     it { is_expected.to validate_presence_of :start_time }
     it { is_expected.to validate_presence_of :end_time }
     it { is_expected.not_to allow_value(nil).for :times_flexible }
@@ -54,13 +49,6 @@ describe Schools::OnBoarding::CandidateExperienceDetail, type: :model do
       subject { described_class.new parking_provided: false }
       it { is_expected.not_to validate_presence_of :parking_details }
       it { is_expected.to validate_presence_of :nearby_parking_details }
-    end
-
-    context 'when disabled_facilities' do
-      unless Feature.instance.active? :access_needs_journey
-        subject { described_class.new disabled_facilities: true }
-        it { is_expected.to validate_presence_of :disabled_facilities_details }
-      end
     end
 
     context 'start and end times' do

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
   describe "#profile_attrs" do
     context 'with completed profile' do
       let(:completed_attrs) do
-        build(:school_profile, :completed, disabled_facilities: true).attributes
+        build(:school_profile, :completed).attributes
       end
 
       subject do
@@ -17,7 +17,6 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       it { is_expected.to include(dbs_policy_details: 'Must have recent dbs check') }
       it { is_expected.to include(individual_requirements: 'Gotta go fast') }
       it { is_expected.to include(description_details: 'Horse archery') }
-      it { is_expected.to include(disabled_facilities: 'Full wheelchair access and hearing loops') }
       it { is_expected.to include(dress_code_business: true) }
       it { is_expected.to include(dress_code_cover_tattoos: true) }
       it { is_expected.to include(dress_code_remove_piercings: true) }
@@ -62,7 +61,7 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
 
     context 'with completed profile with blank fields' do
       let(:model_attrs) do
-        model = build(:school_profile, :completed, disabled_facilities: true)
+        model = build(:school_profile, :completed)
         model.dbs_requirement_requires_check = false
         model.dbs_requirement_dbs_policy_details = ''
         model.dbs_requirement_no_dbs_policy_details = ''
@@ -95,7 +94,6 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
       it { is_expected.to include(dbs_policy_details: nil) }
       it { is_expected.to include(individual_requirements: nil) }
       it { is_expected.to include(description_details: nil) }
-      it { is_expected.to include(disabled_facilities: nil) }
       it { is_expected.to include(dress_code_other_details: nil) }
       it { is_expected.to include(admin_contact_email: nil) }
       it { is_expected.to include(admin_contact_email_secondary: nil) }

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -132,14 +132,6 @@ describe Schools::SchoolProfile, type: :model do
     end
 
     it do
-      is_expected.to have_db_column(:candidate_experience_detail_disabled_facilities).of_type :boolean
-    end
-
-    it do
-      is_expected.to have_db_column(:candidate_experience_detail_disabled_facilities_details).of_type :string
-    end
-
-    it do
       is_expected.to have_db_column(:candidate_experience_detail_start_time).of_type :string
     end
 
@@ -475,8 +467,6 @@ describe Schools::SchoolProfile, type: :model do
         parking_provided
         parking_details
         nearby_parking_details
-        disabled_facilities
-        disabled_facilities_details
         start_time
         end_time
         times_flexible

--- a/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
@@ -325,32 +325,6 @@ describe Schools::OnBoarding::SchoolProfilePresenter do
     end
   end
 
-  context '#disability_and_access_needs' do
-    context 'when disability and access needs facilities not present' do
-      let :profile do
-        FactoryBot.build :school_profile, :with_candidate_experience_detail
-      end
-
-      it 'returns no' do
-        expect(subject.disability_and_access_needs).to eq 'No'
-      end
-    end
-
-    context 'when disability and access needs facilities present' do
-      let :profile do
-        FactoryBot.build \
-          :school_profile,
-          :with_candidate_experience_detail,
-          disabled_facilities: true
-      end
-
-      it 'returns the description' do
-        expect(subject.disability_and_access_needs).to \
-          eq 'Yes - Full wheelchair access and hearing loops'
-      end
-    end
-  end
-
   context '#start_time' do
     let :profile do
       FactoryBot.build :school_profile, :with_candidate_experience_detail


### PR DESCRIPTION
Removes the branching on access_needs_journey. Removes the old
disabled_facilities and disabled_facilities_details that were on the
candidate experience details question screen.

### JIRA Ticket Number
SE-1843

### Context
The new access_needs_journey has been in place for a while now so the feature flags are just generating noise.

### Changes proposed in this pull request
Remove the access_needs_journey and the old code that supported the access needs questions on the candidate experience screen.

### Guidance to review
Nothing should be broken. Manual testing, on board a new school, should work as expected.
