### PR TITLE
(Subject-specific dates) Add the duration to dates on the school profile

### DIFF
--- a/app/presenters/candidates/school_presenter.rb
+++ b/app/presenters/candidates/school_presenter.rb
@@ -94,16 +94,16 @@ module Candidates
       secondary_dates
         .group_by(&:date)
         .each
-        .with_object({}) { |(date, placement_date), hash|
-          hash[date] = placement_date_subjects(placement_date)
+        .with_object({}) { |(date, placement_dates), hash|
+          hash[date] = placement_date_subjects(placement_dates)
         }
         .each_value(&:sort!)
     end
 
   private
 
-    def placement_date_subjects(placement_date)
-      placement_date
+    def placement_date_subjects(placement_dates)
+      placement_dates
         .flat_map do |pd|
           if pd.has_subjects?
             pd.subjects.map { |s| subject_with_duration(s.name, pd) }

--- a/app/presenters/candidates/school_presenter.rb
+++ b/app/presenters/candidates/school_presenter.rb
@@ -104,8 +104,21 @@ module Candidates
 
     def placement_date_subjects(placement_date)
       placement_date
-        .flat_map { |pd| pd.has_subjects? ? pd.subjects.map(&:name) : 'All subjects' }
-        .uniq
+        .flat_map do |pd|
+          if pd.has_subjects?
+            pd.subjects.map { |s| subject_with_duration(s.name, pd) }
+          else
+            subject_with_duration('All subjects', pd)
+          end
+        end
+    end
+
+    def subject_with_duration(subject_name, placement_date)
+      "%<subject>s (%<duration>d %<unit>s)" % {
+        subject: subject_name,
+        duration: placement_date.duration,
+        unit: "day".pluralize(placement_date.duration)
+      }
     end
 
     def dbs_requirement

--- a/spec/presenters/candidates/school_presenter_spec.rb
+++ b/spec/presenters/candidates/school_presenter_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Candidates::SchoolPresenter do
   describe '#secondary_dates_grouped_by_date' do
     let(:early_date) { 1.week.from_now.to_date }
     let(:late_date) { 1.month.from_now.to_date }
-    let(:all_subjects) { Array.wrap('All subjects') }
+    let(:all_subjects) { Array.wrap('All subjects (1 day)') }
 
     let(:placement_date_early_with_maths) do
       build(:bookings_placement_date, date: early_date, subject_specific: true).tap do |pd|
@@ -202,7 +202,7 @@ RSpec.describe Candidates::SchoolPresenter do
     end
 
     specify 'dates with subject specific and non-specific dates should list both' do
-      expect(subject.secondary_dates_grouped_by_date[early_date]).to match_array(all_subjects.concat(%w(Maths)))
+      expect(subject.secondary_dates_grouped_by_date[early_date]).to match_array(all_subjects.concat(["Maths (1 day)"]))
     end
 
     specify "non-specific dates should be described as 'All subjects'" do
@@ -230,7 +230,7 @@ RSpec.describe Candidates::SchoolPresenter do
       end
 
       specify 'subjects should be sorted alphabetically' do
-        expect(subject.secondary_dates_grouped_by_date[date]).to eql(pd_subjects.map(&:name).sort)
+        expect(subject.secondary_dates_grouped_by_date[date]).to eql(pd_subjects.map(&:name).map { |s| "#{s} (1 day)" }.sort)
       end
     end
   end


### PR DESCRIPTION


### JIRA Ticket Number

SE-1804

### Context

Durations had been unintentionally omitted from the date/subject list

### Changes proposed in this pull request

They have now been added, the layout matches the following page

### Guidance to review

Ensure it looks ok and the code makes sense

![Screenshot 2019-10-29 at 13 31 59](https://user-images.githubusercontent.com/128088/67772775-907ec480-fa52-11e9-8a5b-37554f1f6b23.png)

