### PR TITLE
Remove placement_date_subject_and_id from BPRs

### DIFF
--- a/app/services/candidates/registrations/behaviours/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/behaviours/subject_and_date_information.rb
@@ -10,11 +10,6 @@ module Candidates
             if: :school_offers_fixed_dates?,
             unless: :dont_validate_availability?
 
-          validates :bookings_placement_dates_subject_id,
-            presence: true,
-            if: :for_subject_specific_date?,
-            unless: :dont_validate_placement_date_subject?
-
           validates :bookings_placement_date_id,
             presence: true,
             if: :for_subject_specific_date?,

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -26,6 +26,10 @@ module Candidates
 
       validates :bookings_placement_date_id, presence: true
 
+      validates :bookings_placement_dates_subject_id,
+        presence: true,
+        if: :for_subject_specific_date?
+
       def placement_date
         @placement_date ||= Bookings::PlacementDate.find_by(id: bookings_placement_date_id)
       end

--- a/db/migrate/20191029134926_remove_bookings_placement_dates_subjects_from_bookings_placement_requests.rb
+++ b/db/migrate/20191029134926_remove_bookings_placement_dates_subjects_from_bookings_placement_requests.rb
@@ -1,0 +1,7 @@
+class RemoveBookingsPlacementDatesSubjectsFromBookingsPlacementRequests < ActiveRecord::Migration[5.2]
+  require_relative '20191015152254_add_bookings_placement_dates_subject_id_to_bookings_placement_requests'
+
+  def change
+    revert AddBookingsPlacementDatesSubjectIdToBookingsPlacementRequests
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_25_215847) do
+ActiveRecord::Schema.define(version: 2019_10_29_134926) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,10 +111,8 @@ ActiveRecord::Schema.define(version: 2019_10_25_215847) do
     t.uuid "analytics_tracking_uuid"
     t.datetime "viewed_at"
     t.bigint "candidate_id"
-    t.integer "bookings_placement_dates_subject_id"
     t.bigint "bookings_subject_id"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
-    t.index ["bookings_placement_dates_subject_id"], name: "index_bookings_placement_requests_dates_subject_id"
     t.index ["bookings_school_id"], name: "index_bookings_placement_requests_on_bookings_school_id"
     t.index ["bookings_subject_id"], name: "index_bookings_placement_requests_on_bookings_subject_id"
     t.index ["candidate_id"], name: "index_bookings_placement_requests_on_candidate_id"
@@ -410,7 +408,6 @@ ActiveRecord::Schema.define(version: 2019_10_25_215847) do
   add_foreign_key "bookings_placement_dates", "bookings_schools"
   add_foreign_key "bookings_placement_request_cancellations", "bookings_placement_requests"
   add_foreign_key "bookings_placement_requests", "bookings_candidates", column: "candidate_id"
-  add_foreign_key "bookings_placement_requests", "bookings_placement_date_subjects", column: "bookings_placement_dates_subject_id", name: "bookings_placement_requests_date_subject_id"
   add_foreign_key "bookings_placement_requests", "bookings_placement_dates"
   add_foreign_key "bookings_placement_requests", "bookings_schools"
   add_foreign_key "bookings_placement_requests", "bookings_subjects"

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -49,7 +49,6 @@ Given("there is at least one subject-specific placement request for {string}") d
     degree_stage: 'Final year',
     degree_subject: 'Law',
     bookings_placement_date_id: @placement_date.id,
-    bookings_placement_dates_subject_id: @placement_date.subjects.first.id,
     bookings_subject_id: @requested_subject.id
 end
 


### PR DESCRIPTION
### JIRA Ticket Number
SE-1804

### Context
This column is no longer used by bookings_placement_requests as we store
the date and the subject separately on the placement_request

### Changes proposed in this pull request
Removes the bookings_placement_dates_subject_id from bookings_placement_request.
Moves the validation for this field out of the validations that are shared with placement_request to the SubjectAndDateInformation model.

### Guidance to review
Not sure on the revert migration, it's probably best to remove the migration that added this column from the subject_specific_date work before it's merged to master.
