### PR TITLE
Update validations on SubjectAndDateInformation

### DIFF
--- a/app/services/candidates/registrations/behaviours/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/behaviours/subject_and_date_information.rb
@@ -5,29 +5,20 @@ module Candidates
         extend ActiveSupport::Concern
 
         included do
-          validates :bookings_placement_date_id,
-            presence: true,
-            if: :school_offers_fixed_dates?,
-            unless: :dont_validate_availability?
+          with_options unless: :creating_placement_request_from_registration_session? do
+            validates :bookings_placement_date_id,
+              presence: true,
+              if: :school_offers_fixed_dates?
 
-          validates :bookings_placement_dates_subject_id,
-            presence: true,
-            if: :for_subject_specific_date?,
-            unless: :dont_validate_placement_date_subject?
-
-          validates :bookings_placement_date_id,
-            presence: true,
-            if: :for_subject_specific_date?,
-            unless: :dont_validate_placement_date_subject?
+            validates :bookings_placement_dates_subject_id,
+              presence: true,
+              if: :for_subject_specific_date?
+          end
         end
 
       private
 
-        def dont_validate_availability?
-          validation_context == :creating_placement_request_from_registration_session
-        end
-
-        def dont_validate_placement_date_subject?
+        def creating_placement_request_from_registration_session?
           validation_context == :creating_placement_request_from_registration_session
         end
 

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -24,8 +24,6 @@ module Candidates
       attribute :bookings_placement_dates_subject_id, :integer
       attribute :bookings_subject_id, :integer
 
-      validates :bookings_placement_date_id, presence: true
-
       def placement_date
         @placement_date ||= Bookings::PlacementDate.find_by(id: bookings_placement_date_id)
       end


### PR DESCRIPTION
### JIRA Ticket Number
SE-1804

### Context
We we're getting a duplicate presence validation error on
bookings_placement_date_id when no date is selected on the subject and
date information screen.

### Changes proposed in this pull request
Removes the duplicate presence validation.
Simplifies the validation conditionals.

### Guidance to review
Apply for school experience as a candidate at a school with subject specific dates, dont select a date, expect to only see one validation error.

