### PR TITLE
Replace storing placement_date_subject with subject

### DIFF
--- a/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
+++ b/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
@@ -54,7 +54,6 @@ module Candidates
 
         {
           bookings_placement_date_id: bookings_placement_date_id,
-          bookings_placement_dates_subject_id: bookings_placement_dates_subject_id,
           bookings_subject_id: bookings_subject_id
         }
       end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -13,6 +13,10 @@ module Bookings
 
     validates_presence_of :candidate, unless: :pre_phase3_record?
 
+    validates :subject, presence: true,
+      if: -> { placement_date&.subject_specific? },
+      unless: :dont_validate_placement_date_subject?
+
     belongs_to :school,
       class_name: 'Bookings::School',
       foreign_key: :bookings_school_id

--- a/app/services/candidates/registrations/registration_as_placement_request.rb
+++ b/app/services/candidates/registrations/registration_as_placement_request.rb
@@ -22,7 +22,6 @@ module Candidates
         non_pii_models.inject({}) { |kept_attrs, model_name|
           kept_attrs.merge attributes_for(model_name)
         }.merge("bookings_school_id" => school_id)
-         .except("bookings_placement_dates_subject_id")
       end
 
     private

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -21,21 +21,20 @@ module Candidates
 
       attribute :availability
       attribute :bookings_placement_date_id, :integer
-      attribute :bookings_placement_dates_subject_id, :integer
       attribute :bookings_subject_id, :integer
 
       validates :bookings_placement_date_id, presence: true
-
-      validates :bookings_placement_dates_subject_id,
-        presence: true,
-        if: :for_subject_specific_date?
+      validates :bookings_subject_id, presence: true, if: :for_subject_specific_date?
 
       def placement_date
         @placement_date ||= Bookings::PlacementDate.find_by(id: bookings_placement_date_id)
       end
 
       def placement_date_subject
-        @placement_date_subject ||= Bookings::PlacementDateSubject.find_by(id: bookings_placement_dates_subject_id)
+        @placement_date_subject ||= Bookings::PlacementDateSubject.find_by(
+          bookings_placement_date_id: bookings_placement_date_id,
+          bookings_subject_id: bookings_subject_id
+        )
       end
 
       def bookings_subject
@@ -43,7 +42,7 @@ module Candidates
       end
 
       def subject_and_date_ids
-        [bookings_placement_date_id, bookings_placement_dates_subject_id].compact.join('_')
+        [placement_date, placement_date_subject].compact.map(&:id).join('_')
       end
 
       def primary_placement_dates

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
     attributes:
       bookings_placement_date_id:
         blank: "Choose a date"
-      bookings_placement_dates_subject_id:
+      bookings_subject_id:
         blank: "Choose a subject"
 
   placement_preference_errors: &placement_preference_errors

--- a/spec/controllers/candidates/registrations/subject_and_date_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_and_date_informations_controller_spec.rb
@@ -124,7 +124,7 @@ describe Candidates::Registrations::SubjectAndDateInformationsController, type: 
         end
       end
 
-      let(:placement_date_subject) { secondary_placement_date.subjects.first }
+      let(:placement_date_subject) { secondary_placement_date.placement_date_subjects.first }
 
       let(:params) do
         {
@@ -142,10 +142,10 @@ describe Candidates::Registrations::SubjectAndDateInformationsController, type: 
         ).to eql(secondary_placement_date.id)
       end
 
-      specify 'correctly stores the secondary placement date subject in the registration session' do
+      specify 'correctly stores the secondary subject in the registration session' do
         expect(
-          session.to_h.dig('schools/11048/registrations', 'candidates_registrations_subject_and_date_information', 'bookings_placement_dates_subject_id')
-        ).to be(placement_date_subject.id)
+          session.to_h.dig('schools/11048/registrations', 'candidates_registrations_subject_and_date_information', 'bookings_subject_id')
+        ).to be(bookings_subject.id)
       end
     end
   end

--- a/spec/factories/candidates/registrations/subject_and_date_information_factory.rb
+++ b/spec/factories/candidates/registrations/subject_and_date_information_factory.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :subject_and_date_information, class: Candidates::Registrations::SubjectAndDateInformation do
     bookings_placement_date_id { create(:bookings_placement_date).id }
-    bookings_placement_dates_subject_id { nil }
     bookings_subject_id { nil }
   end
 end

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -365,7 +365,6 @@ describe Bookings::PlacementRequest, type: :model do
         let! :subject_and_date_information do
           build :subject_and_date_information,
             bookings_placement_date_id: placement_date.id,
-            bookings_placement_dates_subject_id: placement_date.placement_date_subjects.first.id,
             bookings_subject_id: placement_date.placement_date_subjects.first.bookings_subject.id
         end
 


### PR DESCRIPTION
Store the subject_id (along with the placmeent_date_id) on the
SubjectAndDateInformation model rather than the
bookings_placement_dates_subject_id.
This allows the school to remove a subject from a date with out
invalidating inflight registrations. 

### JIRA Ticket Number
SE-1804

### Context
bookings_placement_dates_subject_id has been removed from bookings_placement_requests to allow schools to remove a subject from a subject specific placement_date. We can do the same for the subject_and_date_information model to allow schools to remove a subject from a date without invalidating inflight registration_sessions.

### Changes proposed in this pull request
Remove bookings_placement_dates_subject_id from subject_and_date_information model, instead store the subject_id.

### Guidance to review
Should make sense and not have broken anything!
