### PR TITLE
(Subject-specfic dates) rework combined ids SE-1804

### DIFF
--- a/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
+++ b/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
@@ -8,9 +8,9 @@ module Candidates
       end
 
       def create
-        @subject_and_date_information = SubjectAndDateInformation.new(attributes_from_session)
-
-        @subject_and_date_information.assign_attributes(extract_subject_and_date_params)
+        @subject_and_date_information = SubjectAndDateInformation
+          .new(attributes_from_session)
+          .tap { |info| info.set_subject_and_date_ids(subject_and_date_params) }
 
         if @subject_and_date_information.valid?
           persist @subject_and_date_information
@@ -25,8 +25,9 @@ module Candidates
       end
 
       def update
-        @subject_and_date_information = SubjectAndDateInformation.new(attributes_from_session)
-        @subject_and_date_information.assign_attributes(extract_subject_and_date_params)
+        @subject_and_date_information = SubjectAndDateInformation
+          .new(attributes_from_session)
+          .tap { |info| info.set_subject_and_date_ids(subject_and_date_params) }
 
         if @subject_and_date_information.valid?
           persist @subject_and_date_information
@@ -44,18 +45,6 @@ module Candidates
 
       def subject_and_date_params
         params.require(:candidates_registrations_subject_and_date_information).permit(:subject_and_date_ids)
-      end
-
-      def extract_subject_and_date_params
-        bookings_placement_date_id, bookings_placement_dates_subject_id = \
-          *subject_and_date_params.dig('subject_and_date_ids').split('_')
-
-        bookings_subject_id = Bookings::PlacementDateSubject.find_by(id: bookings_placement_dates_subject_id)&.bookings_subject_id
-
-        {
-          bookings_placement_date_id: bookings_placement_date_id,
-          bookings_subject_id: bookings_subject_id
-        }
       end
 
       def attributes_from_session

--- a/app/models/bookings/placement_date_subject.rb
+++ b/app/models/bookings/placement_date_subject.rb
@@ -13,7 +13,7 @@ class Bookings::PlacementDateSubject < ApplicationRecord
   # date and are presented with a single list of options that contains subjects
   # AND placement dates
   def combined_id
-    [bookings_subject.id, id].join("_")
+    [bookings_placement_date.id, id].join("_")
   end
 
 private

--- a/app/models/bookings/placement_date_subject.rb
+++ b/app/models/bookings/placement_date_subject.rb
@@ -9,6 +9,13 @@ class Bookings::PlacementDateSubject < ApplicationRecord
     inclusion: { in: :allowed_subject_choices },
     if: :bookings_subject_id
 
+  # this combined id is used when candidates are choosing a subject specific
+  # date and are presented with a single list of options that contains subjects
+  # AND placement dates
+  def combined_id
+    [bookings_subject.id, id].join("_")
+  end
+
 private
 
   def allowed_subject_choices

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -37,7 +37,17 @@ module Candidates
       end
 
       def subject_and_date_ids
-        [placement_date, placement_date_subject].compact.map(&:id).join('_')
+        placement_date_subject&.combined_id || placement_date&.id
+      end
+
+      def set_subject_and_date_ids(subject_and_date_params)
+        bookings_placement_date_id, bookings_placement_dates_subject_id = \
+          *subject_and_date_params.dig('subject_and_date_ids').split('_')
+
+        bookings_subject_id = Bookings::PlacementDateSubject.find_by(id: bookings_placement_dates_subject_id)&.bookings_subject_id
+
+        self.bookings_placement_date_id = bookings_placement_date_id
+        self.bookings_subject_id        = bookings_subject_id
       end
 
       def primary_placement_dates

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -55,8 +55,12 @@ module Candidates
           .bookings_placement_dates
           .in_date_order
           .not_supporting_subjects
-          .map do |date|
-            PlacementDateOption.new(date.id, date.date.to_formatted_s(:govuk), date.duration)
+          .map do |placement_date|
+            PlacementDateOption.new(
+              placement_date.id,
+              placement_date.date.to_formatted_s(:govuk),
+              placement_date.duration
+            )
           end
       end
 

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -3,11 +3,7 @@ module Candidates
     class SubjectAndDateInformation < RegistrationStep
       include Behaviours::SubjectAndDateInformation
 
-      PlacementDateOption = Struct.new(:placement_date_id, :placement_date_subject_id, :name, :duration) do
-        def id
-          [placement_date_id, placement_date_subject_id].compact.join('_')
-        end
-
+      PlacementDateOption = Struct.new(:id, :name, :duration) do
         def name_with_duration
           "#{name} (#{duration} #{'day'.pluralize(duration)})"
         end
@@ -50,7 +46,7 @@ module Candidates
           .in_date_order
           .not_supporting_subjects
           .map do |date|
-            PlacementDateOption.new(date.id, nil, date.date.to_formatted_s(:govuk), date.duration)
+            PlacementDateOption.new(date.id, date.date.to_formatted_s(:govuk), date.duration)
           end
       end
 
@@ -75,10 +71,10 @@ module Candidates
       def placement_date_options(placement_date)
         if placement_date.placement_date_subjects.any?
           placement_date.placement_date_subjects.map do |placement_date_subject|
-            PlacementDateOption.new(placement_date.id, placement_date_subject.id, placement_date_subject.bookings_subject.name, placement_date.duration)
+            PlacementDateOption.new(placement_date_subject.combined_id, placement_date_subject.bookings_subject.name, placement_date.duration)
           end
         else
-          Array.wrap(PlacementDateOption.new(placement_date.id, nil, 'All subjects', placement_date.duration))
+          Array.wrap(PlacementDateOption.new(placement_date.id, 'All subjects', placement_date.duration))
         end
       end
     end

--- a/spec/models/bookings/placement_date_subject_spec.rb
+++ b/spec/models/bookings/placement_date_subject_spec.rb
@@ -27,4 +27,21 @@ describe Bookings::PlacementDateSubject, type: :model do
       end
     end
   end
+
+  describe 'methods' do
+    describe '#combined_id' do
+      let(:placement_date) { create(:bookings_placement_date) }
+      let(:chosen_subject) { create(:bookings_subject) }
+      subject do
+        Bookings::PlacementDateSubject.create(
+          bookings_placement_date: placement_date,
+          bookings_subject: chosen_subject
+        )
+      end
+
+      specify 'should be the bookings_placement_date id and own id delimited by an underscore' do
+        expect(subject.combined_id).to eql("#{placement_date.id}_#{subject.id}")
+      end
+    end
+  end
 end

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -101,7 +101,13 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
 
       let!(:bookings_placement_date) { create :bookings_placement_date, bookings_school: school }
       let!(:bookings_subject) { create :bookings_subject, schools: [school] }
-      let!(:bookings_placement_dates_subject) { create :bookings_placement_date_subject, bookings_placement_date: bookings_placement_date, bookings_subject: bookings_subject }
+      let!(:bookings_placement_dates_subject) do
+        create(
+          :bookings_placement_date_subject,
+          bookings_placement_date: bookings_placement_date,
+          bookings_subject: bookings_subject
+        )
+      end
 
       before do
         subject.bookings_placement_date_id = bookings_placement_date.id
@@ -109,7 +115,7 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       end
 
       specify 'should join the placement date and placement date subject ids separated by an underscore' do
-        expect(subject.subject_and_date_ids).to eql("#{bookings_placement_date.id}_#{bookings_placement_dates_subject.id}")
+        expect(subject.subject_and_date_ids).to eql(bookings_placement_dates_subject.combined_id)
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1804

### Context

There was some repetition and messiness around the struct used for building the combined list of subjects and dates

### Changes proposed in this pull request

Simplify the subject and date ids serialising and deserialising and move most of the logic surrounding it to the `SubjectAndDateInformation` object

### Guidance to review

Ensure everything makes sense and is actually tidier than before!
