### PR TITLE
Remove column default on supports_subjects

### DIFF
--- a/db/migrate/20191031105854_remove_column_default_from_bookings_placement_dates_subject_specific.rb
+++ b/db/migrate/20191031105854_remove_column_default_from_bookings_placement_dates_subject_specific.rb
@@ -1,0 +1,5 @@
+class RemoveColumnDefaultFromBookingsPlacementDatesSubjectSpecific < ActiveRecord::Migration[5.2]
+  def change
+    change_column :bookings_placement_dates, :supports_subjects, :boolean, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_29_134926) do
+ActiveRecord::Schema.define(version: 2019_10_31_105854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2019_10_29_134926) do
     t.integer "max_bookings_count"
     t.datetime "published_at"
     t.boolean "subject_specific", default: false, null: false
-    t.boolean "supports_subjects", default: true, null: false
+    t.boolean "supports_subjects"
     t.index ["bookings_school_id"], name: "index_bookings_placement_dates_on_bookings_school_id"
   end
 


### PR DESCRIPTION
This caused the supports subjects radio button to be pre selected. We
want to leave this up to the school to decide.

### JIRA Ticket Number
SE-1804

### Context
Review of subject specific dates pr flagged that supports subjects radio button was being preselected.

### Changes proposed in this pull request
Remove the column default (and the null constraint) for supports_subjects on placement_dates

### Guidance to review
Shouldn't have broken anything, shouldn't effect existing placement dates which will be treated as non subject specific.