### PR TITLE
Standardise subject and date info controller

### DIFF
--- a/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
+++ b/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
@@ -8,9 +8,7 @@ module Candidates
       end
 
       def create
-        @subject_and_date_information = SubjectAndDateInformation
-          .new(attributes_from_session)
-          .tap { |info| info.set_subject_and_date_ids(subject_and_date_params) }
+        @subject_and_date_information = SubjectAndDateInformation.new(subject_and_date_params)
 
         if @subject_and_date_information.valid?
           persist @subject_and_date_information
@@ -25,9 +23,8 @@ module Candidates
       end
 
       def update
-        @subject_and_date_information = SubjectAndDateInformation
-          .new(attributes_from_session)
-          .tap { |info| info.set_subject_and_date_ids(subject_and_date_params) }
+        @subject_and_date_information = SubjectAndDateInformation.new(attributes_from_session)
+        @subject_and_date_information.assign_attributes(subject_and_date_params)
 
         if @subject_and_date_information.valid?
           persist @subject_and_date_information
@@ -44,11 +41,17 @@ module Candidates
       end
 
       def subject_and_date_params
-        params.require(:candidates_registrations_subject_and_date_information).permit(:subject_and_date_ids)
+        params
+          .require(:candidates_registrations_subject_and_date_information)
+          .permit(:subject_and_date_ids)
+          .merge(urn: @school.urn)
       end
 
       def attributes_from_session
-        current_registration.subject_and_date_information_attributes.merge(urn: @school.urn)
+        current_registration
+          .subject_and_date_information_attributes
+          .except('created_at')
+          .merge(urn: @school.urn)
       end
     end
   end

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -40,9 +40,8 @@ module Candidates
         placement_date_subject&.combined_id || placement_date&.id
       end
 
-      def set_subject_and_date_ids(subject_and_date_params)
-        bookings_placement_date_id, bookings_placement_dates_subject_id = \
-          *subject_and_date_params.dig('subject_and_date_ids').split('_')
+      def subject_and_date_ids=(subject_and_date_id)
+        bookings_placement_date_id, bookings_placement_dates_subject_id = subject_and_date_id.split('_')
 
         bookings_subject_id = Bookings::PlacementDateSubject.find_by(id: bookings_placement_dates_subject_id)&.bookings_subject_id
 

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -118,5 +118,29 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
         expect(subject.subject_and_date_ids).to eql(bookings_placement_dates_subject.combined_id)
       end
     end
+
+    describe '#subject_and_date_ids=' do
+      let!(:bookings_placement_date) { create :bookings_placement_date, bookings_school: school }
+      let!(:bookings_subject) { create :bookings_subject, schools: [school] }
+      let!(:bookings_placement_dates_subject) do
+        create(
+          :bookings_placement_date_subject,
+          bookings_placement_date: bookings_placement_date,
+          bookings_subject: bookings_subject
+        )
+      end
+
+      before do
+        subject.subject_and_date_ids = bookings_placement_dates_subject.combined_id
+      end
+
+      it 'sets the bookings_subject correctly' do
+        expect(subject.bookings_subject).to eq bookings_subject
+      end
+
+      it 'sets the placement_date correctly' do
+        expect(subject.placement_date).to eq bookings_placement_date
+      end
+    end
   end
 end


### PR DESCRIPTION
Updates the subject and date information to match the other
registrations controllers.  We can have `subject_and_date_ids=` do all
the lifting of splitting the param and finding the right date and
subject (if applicable) then we can just pass the params straight in
like a normal rails controller.

### JIRA Ticket Number
SE-1804

### Context

### Changes proposed in this pull request

### Guidance to review

