### PR TITLE
Make back button on confirm attendance screen a secondary button

### DIFF
--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -54,6 +54,6 @@
   </p>
 
   <p>
-    <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path %>
+    <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path, secondary: true %>
   </p>
 <% end %>


### PR DESCRIPTION
### JIRA Ticket Number

From Mak's testing

### Context

The back link buttons from various screens in the school dashboard are all secondary buttons apart from the button on the confirm attendance screen.

### Changes proposed in this pull request

1. Make the button on the confirm attendance screen a secondary button


