### PR TITLE
SE-1876 Handle host name ending in dot

### DIFF
--- a/app/services/candidates/registrations/behaviours/education.rb
+++ b/app/services/candidates/registrations/behaviours/education.rb
@@ -17,9 +17,9 @@ module Candidates
           validates :degree_subject, inclusion: { in: :available_degree_subjects },
             if: -> { degree_subject.present? && degree_stage_requires_subject? }
           validates :degree_subject, inclusion: [NO_DEGREE_SUBJECT],
-            if: -> { degree_subject.present? && degree_stage.present? && !degree_stage_requires_subject? }
+            if: :degree_stage_requires_n_a_subject?
           validates :degree_subject, exclusion: [NO_DEGREE_SUBJECT],
-            if: -> { degree_subject.present? && degree_stage.present? && degree_stage_requires_subject? }
+            if: :degree_stage_requires_subject_in_subjects_list?
         end
 
         def available_degree_stages
@@ -50,6 +50,18 @@ module Candidates
 
         def degree_stage_explaination_required?
           requires_explanation_for_degree_stage? degree_stage
+        end
+
+        def degree_stage_requires_subject_in_subjects_list?
+          degree_subject.present? &&
+            degree_stage.present? &&
+            degree_stage_requires_subject?
+        end
+
+        def degree_stage_requires_n_a_subject?
+          degree_subject.present? &&
+            degree_stage.present? &&
+            !degree_stage_requires_subject?
         end
       end
     end

--- a/app/services/candidates/registrations/behaviours/education.rb
+++ b/app/services/candidates/registrations/behaviours/education.rb
@@ -14,9 +14,12 @@ module Candidates
           validates :degree_stage, inclusion: { in: :available_degree_stages }, if: -> { degree_stage.present? }
           validates :degree_stage_explaination, presence: true, if: :degree_stage_explaination_required?
           validates :degree_subject, presence: true
-          validates :degree_subject, inclusion: { in: :available_degree_subjects }, if: -> { degree_subject.present? }
-          validates :degree_subject, inclusion: [NO_DEGREE_SUBJECT], if: -> { degree_stage.present? && !degree_stage_requires_subject? }
-          validates :degree_subject, exclusion: [NO_DEGREE_SUBJECT], if: -> { degree_stage.present? && degree_stage_requires_subject? }
+          validates :degree_subject, inclusion: { in: :available_degree_subjects },
+            if: -> { degree_subject.present? && degree_stage_requires_subject? }
+          validates :degree_subject, inclusion: [NO_DEGREE_SUBJECT],
+            if: -> { degree_subject.present? && degree_stage.present? && !degree_stage_requires_subject? }
+          validates :degree_subject, exclusion: [NO_DEGREE_SUBJECT],
+            if: -> { degree_subject.present? && degree_stage.present? && degree_stage_requires_subject? }
         end
 
         def available_degree_stages

--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -1,8 +1,6 @@
 module Candidates
   module Registrations
     class PersonalInformation < RegistrationStep
-      EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME = %r{\A[^\s@]+@[^\.\s]+\.[^\s]+\z}.freeze
-
       # multi parameter date fields aren't yet support by ActiveModel so we
       # need to include the support for them from ActiveRecord
       include ActiveRecord::AttributeAssignment
@@ -19,8 +17,7 @@ module Candidates
       validates :first_name, presence: true, unless: :read_only
       validates :last_name, presence: true, unless: :read_only
       validates :email, presence: true, length: { maximum: 100 }
-      validates :email, format: { with: URI::MailTo::EMAIL_REGEXP }, if: -> { email.present? }
-      validates :email, format: { with: EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME }, if: -> { email.present? }
+      validates :email, email_format: true, if: -> { email.present? }
       validates :date_of_birth, presence: true, unless: :read_only
       validates :date_of_birth, inclusion: { in: ->(_) { MAX_AGE.years.ago..MIN_AGE.years.ago } }, if: -> { date_of_birth.present? && !read_only }
 

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -1,0 +1,21 @@
+class EmailFormatValidator < ActiveModel::EachValidator
+  EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME = %r{\A[^\s@]+@[^\.\s]+\.[^\s]+\z}.freeze
+
+  def validate_each(record, attribute, value)
+    unless value.present? && is_an_email_uri?(value) && is_fqdn?(value)
+      record.errors.add(attribute, :invalid)
+    end
+  end
+
+private
+
+  # ensure it's a HTTP/HTTPS uri with at least one '.' in the hostname
+  # note that HTTPS inherits from HTTP
+  def is_an_email_uri?(value)
+    !!value.to_s.match?(URI::MailTo::EMAIL_REGEXP)
+  end
+
+  def is_fqdn?(value)
+    !!value.to_s.match?(EMAIL_WITH_FULLY_QUALIFIED_HOSTNAME)
+  end
+end

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -9,8 +9,6 @@ class EmailFormatValidator < ActiveModel::EachValidator
 
 private
 
-  # ensure it's a HTTP/HTTPS uri with at least one '.' in the hostname
-  # note that HTTPS inherits from HTTP
   def is_an_email_uri?(value)
     !!value.to_s.match?(URI::MailTo::EMAIL_REGEXP)
   end

--- a/lib/shoulda_matcher_duplicate_messages.rb
+++ b/lib/shoulda_matcher_duplicate_messages.rb
@@ -1,0 +1,11 @@
+module ShouldaMatcherDuplicateMessages
+protected
+
+  def messages_match?
+    super && messages_not_duplicated?
+  end
+
+  def messages_not_duplicated?
+    matched_messages == matched_messages.uniq
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -99,3 +99,6 @@ end
 # Ensure load time injection of FakeCRM happens early enough
 require_dependency 'bookings/gitis/auth'
 require_dependency 'bookings/gitis/crm'
+
+require 'shoulda_matcher_duplicate_messages'
+Shoulda::Matchers::ActiveModel::Validator.prepend ShouldaMatcherDuplicateMessages

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -34,7 +34,12 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
         'test@example.com', 'testymctest@gmail.com',
         'test%.mctest@domain.co.uk', ' with@space.com '
       ].freeze
-      INVALID_EMAILS = ['test.com', 'test@@test.com', 'FFFF', 'test@test'].freeze
+
+      INVALID_EMAILS = [
+        'test.com', 'test@@test.com', 'FFFF', 'test@test',
+        'test@test.'
+      ].freeze
+
       BLANK_EMAILS = ['', ' ', '   '].freeze
 
       VALID_EMAILS.each do |email|

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe EmailFormatValidator do
+  class TestModel
+    include ActiveModel::Model
+    attr_accessor :email_address
+    validates :email_address, email_format: true
+  end
+
+  before { instance.valid? }
+  subject { instance.errors.to_h }
+
+  context 'invalid addresses' do
+    [
+      'test.com', 'test@@test.com', 'FFFF', 'test@test', 'test@test.'
+    ].each do |email_address|
+      let(:instance) { TestModel.new(email_address: email_address) }
+
+      it "#{email_address} should not be valid" do
+        is_expected.to include email_address: 'is invalid'
+      end
+    end
+  end
+
+  context 'valid addresses' do
+    [
+      'test@example.com', 'testymctest@gmail.com', 'test%.mctest@domain.co.uk'
+    ].each do |email_address|
+      let(:instance) { TestModel.new(email_address: email_address) }
+
+      it "#{email_address} should be valid" do
+        is_expected.not_to include :email_address
+      end
+    end
+  end
+end

--- a/spec/validators/website_validator_spec.rb
+++ b/spec/validators/website_validator_spec.rb
@@ -25,7 +25,7 @@ describe WebsiteValidator do
     ['https://www.bbc.co.uk', 'http://bbc.co.uk', 'http://news.bbc.co.uk'].each do |valid_website|
       it "#{valid_website} should be valid" do
         expect(errors).not_to receive('add')
-        validator.validate_each(model, "website", "https://www.bbc.co.uk")
+        validator.validate_each(model, "website", valid_website)
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1876

### Context

If the user uses an email address with a dot in the hostname, but not fully qualified then they see 2 validation errors on the field instead of a single one, eg `testuser@btinternet.`

### Changes proposed in this pull request

1. Added a monkey patch to the shoulda-matchers to avoid matching a validation error message if it occurs multiple times.
2. Added a test to the PersonalInformation spec to test addresses like `testuser@btinternet.`
3. Combined the regexes for checking emails into an EmailFormatValidator to ensure the message is only once
4. Used the validator for PersonalInformation model
5. Fixed a bug in the Education behaviour which was validating the degree subject against both the full list and the ['Not applicable'] list in some scenarios.

### Guidance to review

1. Code review
2. Testing
3. Particular consideration should be given to the last commit, changing the validations on the Education behaviour - I believe this is correct and the tests pass but a second pair of eyes reviewing the logic would be good.