### PR TITLE
Simplify form setup by not merging params

### DIFF
--- a/app/controllers/schools/placement_dates/configurations_controller.rb
+++ b/app/controllers/schools/placement_dates/configurations_controller.rb
@@ -8,7 +8,8 @@ module Schools
       end
 
       def create
-        @configuration = ConfigurationForm.new configuration_params.merge(supports_subjects: @placement_date.supports_subjects)
+        @configuration = ConfigurationForm.new configuration_params
+        @configuration.supports_subjects = @placement_date.supports_subjects
 
         if @configuration.save @placement_date
           redirect_to next_step


### PR DESCRIPTION
### JIRA Ticket Number

SE-1804

### Context

The line initialising the `ConfigurationForm` was a bit long

### Changes proposed in this pull request

Shorten it by splitting out the assignment to a separate line

### Guidance to review

🤷🏽‍♂️
