### PR TITLE
Ensure primary and secondary dates are .available

### DIFF
--- a/app/presenters/candidates/school_presenter.rb
+++ b/app/presenters/candidates/school_presenter.rb
@@ -78,14 +78,14 @@ module Candidates
     def primary_dates
       school
         .bookings_placement_dates
-        .in_date_order
+        .available
         .not_supporting_subjects
     end
 
     def secondary_dates
       school
         .bookings_placement_dates
-        .in_date_order
+        .available
         .supporting_subjects
         .eager_load(:placement_date_subjects, :subjects).available
     end

--- a/spec/factories/bookings/placement_dates.rb
+++ b/spec/factories/bookings/placement_dates.rb
@@ -21,5 +21,9 @@ FactoryBot.define do
     trait :subject_specific do
       subject_specific { true }
     end
+
+    trait :not_supporting_subjects do
+      supports_subjects { false }
+    end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1804

### Context

The primary and secondary date queries sent from the `SchoolPresenter` weren't limited as much as they should be

### Changes proposed in this pull request

Use the `.available` scope rather than `.in_date_order`, not only does it sort them correctly but it prevents unpublished, past or inactive ones from being included in the record set. This was applied to both primary and secondary dates

### Guidance to review

Ensure code looks correct and tests encompass behaviour

