### PR TITLE
Feature/subject specific dates ui tweaks se 1804 13

### DIFF
--- a/app/assets/stylesheets/school-profile.scss
+++ b/app/assets/stylesheets/school-profile.scss
@@ -11,3 +11,10 @@
     display: none;
   }
 }
+
+.secondary-placement-dates {
+  dt {
+    width: 12rem;
+    min-width: 12rem;
+  }
+}

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -1,7 +1,8 @@
 <% self.page_title = 'Request a school experience date' %>
+<%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
 
 <div class="govuk-grid-row" id="placement-preference">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Request a school experience date at <%= @school.name %></h1>
     <%= form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
       <%= GovukElementsErrorsHelper.error_summary subject_and_date_information, 'There is a problem', '' %>
@@ -49,8 +50,6 @@
 
       <%= f.submit 'Continue' %>
     <% end %>
-
-    <%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
 
   </div>
 </div>

--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -23,7 +23,7 @@
       <h4 class="govuk-heading-m">Upcoming dates</h4>
     <%- end -%>
 
-    <dl class="govuk-summary-list govuk-summary-list--no-border">
+    <dl class="secondary-placement-dates govuk-summary-list govuk-summary-list--no-border">
       <%- secondary_dates_grouped_by_date.each do |date, subjects| -%>
 
         <div class="govuk-summary-list__row">

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -10,7 +10,7 @@
 <h1>Manage dates</h1>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
 
     <%- if @placement_dates.any? -%>
       <table id="placement-dates" class="govuk-table">


### PR DESCRIPTION
### JIRA Ticket Number

SE-1804

### Context

There are some small improvements to be made to the overall look of the subject-specific date screens

### Changes proposed in this pull request

* Make the date/subject selection and dates management screens full width
* Fix the minimum width for the date `dt` tags on the school profile, now they remain `12rem` wide and the subjects/durations begin to wrap before the date (this is very closely followed by the page switching to mobile and everything becomes clear again)

![Screenshot 2019-11-01 at 15 47 55](https://user-images.githubusercontent.com/128088/68039518-338a4500-fcc4-11e9-80d4-f35edcebf0bb.png)


### Guidance to review

Ensure it looks ok and makes sense
