### PR TITLE
Se 1804 dedup presenting dates

### DIFF
--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -62,6 +62,9 @@ module Bookings
     # don't yet teach a specific subject - primary and early years
     scope :not_supporting_subjects, -> { where(supports_subjects: false) }
 
+    scope :primary, -> { available.not_supporting_subjects.published }
+    scope :secondary, -> { available.supporting_subjects.published }
+
     def to_s
       "%<date>s (%<duration>d %<unit>s)" % {
         date: date.to_formatted_s(:govuk),

--- a/app/models/candidates/placement_date_option.rb
+++ b/app/models/candidates/placement_date_option.rb
@@ -1,0 +1,43 @@
+class Candidates::PlacementDateOption
+  # Show what subjects are on offer for a given date
+  def self.for_secondary_date(placement_date)
+    if placement_date.placement_date_subjects.any?
+      placement_date.placement_date_subjects.map do |placement_date_subject|
+        new(
+          placement_date_subject.combined_id,
+          placement_date_subject.bookings_subject.name,
+          placement_date.duration,
+          placement_date.date
+        )
+      end
+    else
+      Array.wrap(
+        new(
+          placement_date.id,
+          'All subjects',
+          placement_date.duration,
+          placement_date.date
+        )
+      )
+    end
+  end
+
+  attr_accessor :id, :name, :duration, :date
+
+  def initialize(id, name, duration, date)
+    @id = id
+    @name = name
+    @duration = duration
+    @date = date
+  end
+
+  def name_with_duration
+    "#{name} (#{duration} #{'day'.pluralize(duration)})"
+  end
+
+  # Sorted here rather than in the db so 'All subjects' (which isn't in the DB)
+  # comes back first
+  def <=>(other)
+    name <=> other.name
+  end
+end

--- a/app/presenters/candidates/school_presenter.rb
+++ b/app/presenters/candidates/school_presenter.rb
@@ -92,34 +92,13 @@ module Candidates
 
     def secondary_dates_grouped_by_date
       secondary_dates
+        .map(&PlacementDateOption.method(:for_secondary_date))
+        .flatten
         .group_by(&:date)
-        .each
-        .with_object({}) { |(date, placement_dates), hash|
-          hash[date] = placement_date_subjects(placement_dates)
-        }
         .each_value(&:sort!)
     end
 
   private
-
-    def placement_date_subjects(placement_dates)
-      placement_dates
-        .flat_map do |pd|
-          if pd.has_subjects?
-            pd.subjects.map { |s| subject_with_duration(s.name, pd) }
-          else
-            subject_with_duration('All subjects', pd)
-          end
-        end
-    end
-
-    def subject_with_duration(subject_name, placement_date)
-      "%<subject>s (%<duration>d %<unit>s)" % {
-        subject: subject_name,
-        duration: placement_date.duration,
-        unit: "day".pluralize(placement_date.duration)
-      }
-    end
 
     def dbs_requirement
       if profile.dbs_requires_check?

--- a/app/presenters/candidates/school_presenter.rb
+++ b/app/presenters/candidates/school_presenter.rb
@@ -76,17 +76,13 @@ module Candidates
     end
 
     def primary_dates
-      school
-        .bookings_placement_dates
-        .available
-        .not_supporting_subjects
+      school.bookings_placement_dates.primary
     end
 
     def secondary_dates
       school
         .bookings_placement_dates
-        .available
-        .supporting_subjects
+        .secondary
         .eager_load(:placement_date_subjects, :subjects).available
     end
 

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -3,18 +3,6 @@ module Candidates
     class SubjectAndDateInformation < RegistrationStep
       include Behaviours::SubjectAndDateInformation
 
-      PlacementDateOption = Struct.new(:id, :name, :duration, :date) do
-        def name_with_duration
-          "#{name} (#{duration} #{'day'.pluralize(duration)})"
-        end
-
-        # Sorted here rather than in the db so 'All subjects' (which isn't in the DB)
-        # comes back first
-        def <=>(other)
-          name <=> other.name
-        end
-      end
-
       attribute :availability
       attribute :bookings_placement_date_id, :integer
       attribute :bookings_subject_id, :integer
@@ -70,20 +58,9 @@ module Candidates
           .in_date_order
           .supporting_subjects
           .eager_load(placement_date_subjects: :bookings_subject)
-          .published
-          .available
-          .flat_map(&method(:placement_date_options))
+          .map(&PlacementDateOption.method(:for_secondary_date))
+          .flatten
           .group_by(&:date)
-      end
-
-      def placement_date_options(placement_date)
-        if placement_date.placement_date_subjects.any?
-          placement_date.placement_date_subjects.map do |placement_date_subject|
-            PlacementDateOption.new(placement_date_subject.combined_id, placement_date_subject.bookings_subject.name, placement_date.duration, placement_date.date)
-          end
-        else
-          Array.wrap(PlacementDateOption.new(placement_date.id, 'All subjects', placement_date.duration, placement_date.date))
-        end
       end
     end
   end

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -40,8 +40,8 @@ module Candidates
       def primary_placement_dates
         school
           .bookings_placement_dates
+          .primary
           .in_date_order
-          .not_supporting_subjects
           .map do |placement_date|
             PlacementDateOption.new(
               placement_date.id,
@@ -55,8 +55,8 @@ module Candidates
       def secondary_placement_dates_grouped_by_date
         school
           .bookings_placement_dates
+          .secondary
           .in_date_order
-          .supporting_subjects
           .eager_load(placement_date_subjects: :bookings_subject)
           .map(&PlacementDateOption.method(:for_secondary_date))
           .flatten

--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -35,7 +35,7 @@
           <dd class="govuk-summary-list__value">
             <ul class="govuk-list">
               <% subjects.each do |subject| %>
-                <li><%= subject %></li>
+                <li><%= subject.name_with_duration %></li>
               <% end %>
             </ul>
           </dd>

--- a/spec/presenters/candidates/school_presenter_spec.rb
+++ b/spec/presenters/candidates/school_presenter_spec.rb
@@ -239,11 +239,11 @@ RSpec.describe Candidates::SchoolPresenter do
     end
 
     specify 'dates with subject specific and non-specific dates should list both' do
-      expect(subject.secondary_dates_grouped_by_date[early_date]).to match_array(all_subjects.concat(["Maths (1 day)"]))
+      expect(subject.secondary_dates_grouped_by_date[early_date].map(&:name_with_duration)).to match_array(all_subjects.concat(["Maths (1 day)"]))
     end
 
     specify "non-specific dates should be described as 'All subjects'" do
-      expect(subject.secondary_dates_grouped_by_date[late_date]).to match_array(all_subjects)
+      expect(subject.secondary_dates_grouped_by_date[late_date].map(&:name_with_duration)).to match_array(all_subjects)
     end
 
     context 'sorting' do
@@ -267,7 +267,7 @@ RSpec.describe Candidates::SchoolPresenter do
       end
 
       specify 'subjects should be sorted alphabetically' do
-        expect(subject.secondary_dates_grouped_by_date[date]).to eql(pd_subjects.map(&:name).map { |s| "#{s} (1 day)" }.sort)
+        expect(subject.secondary_dates_grouped_by_date[date].map(&:name_with_duration)).to eql(pd_subjects.map(&:name).map { |s| "#{s} (1 day)" }.sort)
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number
SE-1804

### Context
Fixing one of Jeremy's comments about duplication

### Changes proposed in this pull request
Presenting subject specific dates for a school was duplicated between
candidates/schools#show and the subject_and_date_information forms.

Add a class method to placement_date_option that handles building
placement_date_options for a given date to avoid this duplication.

### Guidance to review
Should all still work the same as before
