### PR TITLE
Record feedback referrers SE-1774

### DIFF
--- a/app/controllers/candidates/feedbacks_controller.rb
+++ b/app/controllers/candidates/feedbacks_controller.rb
@@ -3,7 +3,7 @@ module Candidates
     def show; end
 
     def new
-      @feedback = Candidates::Feedback.new
+      @feedback = Candidates::Feedback.new referrer_params
     end
 
     def create
@@ -18,6 +18,10 @@ module Candidates
 
   private
 
+    def referrer_params
+      { referrer: request.env['HTTP_REFERER'] }
+    end
+
     def feedback_params
       params.require(:candidates_feedback).permit \
         :reason_for_using_service,
@@ -25,7 +29,8 @@ module Candidates
         :rating,
         :improvements,
         :successful_visit,
-        :unsuccessful_visit_explanation
+        :unsuccessful_visit_explanation,
+        :referrer
     end
   end
 end

--- a/app/controllers/schools/feedbacks_controller.rb
+++ b/app/controllers/schools/feedbacks_controller.rb
@@ -5,7 +5,7 @@ module Schools
     def show; end
 
     def new
-      @feedback = Schools::Feedback.new
+      @feedback = Schools::Feedback.new referrer_params
     end
 
     def create
@@ -21,6 +21,10 @@ module Schools
 
   private
 
+    def referrer_params
+      { referrer: request.env['HTTP_REFERER'] }
+    end
+
     def feedback_params
       params.require(:schools_feedback).permit \
         :reason_for_using_service,
@@ -28,7 +32,8 @@ module Schools
         :rating,
         :improvements,
         :successful_visit,
-        :unsuccessful_visit_explanation
+        :unsuccessful_visit_explanation,
+        :referrer
     end
   end
 end

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -7,6 +7,8 @@
         Help us improve the manage school experience service.
       </p>
 
+      <%= f.hidden_field :referrer %>
+
       <%= f.radio_button_fieldset :reason_for_using_service do |fieldset| %>
         <% f.object.reasons_for_using_service.each do |option| %>
           <% if f.object.requires_explanation? option %>

--- a/db/migrate/20191104112809_add_referrer_to_feedbacks.rb
+++ b/db/migrate/20191104112809_add_referrer_to_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddReferrerToFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :feedbacks, :referrer, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_24_080833) do
+ActiveRecord::Schema.define(version: 2019_11_04_112809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -306,6 +306,7 @@ ActiveRecord::Schema.define(version: 2019_09_24_080833) do
     t.integer "urn"
     t.boolean "successful_visit"
     t.text "unsuccessful_visit_explanation"
+    t.string "referrer"
   end
 
   create_table "schools_on_boarding_profile_subjects", force: :cascade do |t|

--- a/features/candidates/feedback.feature
+++ b/features/candidates/feedback.feature
@@ -42,3 +42,9 @@ Feature: Feedback
       And I enter 'Keep up the good work' into the 'How could we improve the service? (optional)' field
       When I click the 'Submit feedback' button
       Then I should see the text 'Thank you for your feedback.'
+
+    Scenario: Recording the referrer
+        Given I am on the 'find a school' page prior to giving feedback
+        When I click 'Give feedback', fill in and submit the candidate feedback form
+        Then I should see the text 'Thank you for your feedback.'
+        And my referrer should have been recorded

--- a/features/schools/feedback.feature
+++ b/features/schools/feedback.feature
@@ -5,9 +5,9 @@ Feature: Feedback
 
     Background:
         Given I am logged in as a DfE user
-        And I am on the 'new schools feedback' page
 
     Scenario: Page contents
+        Given I am on the 'new schools feedback' page
         Then I should see radio buttons for 'What did you come to do on the service?' with the following options:
             | Set up a new school or schools on the service       |
             | Manage your school experience requests and bookings |
@@ -29,18 +29,26 @@ Feature: Feedback
 
     @javascript
     Scenario: Completing the form with error
-        Then I choose 'Something else' from the 'What did you come to do on the service?' radio buttons
+        Given I am on the 'new schools feedback' page
+        When I choose 'Something else' from the 'What did you come to do on the service?' radio buttons
         And I choose 'Satisfied' from the 'Overall, how did you feel about the service you received?' radio buttons
         And I enter 'Keep up the good work' into the 'How could we improve the service? (optional)' field
-        When I click the 'Submit feedback' button
+        And I click the 'Submit feedback' button
         Then I should see an error
 
     @javascript
     Scenario: Completing the form successfully
-        Then I choose 'Something else' from the 'What did you come to do on the service?' radio buttons
+        Given I am on the 'new schools feedback' page
+        When I choose 'Something else' from the 'What did you come to do on the service?' radio buttons
         And I enter 'Test the software' into the 'Tell us what you came here to do. Do not include any information that could identify you personally - such as your name' field
         And I choose 'Satisfied' from the 'Overall, how did you feel about the service you received?' radio buttons
         And I choose 'Yes' from the 'Did you achieve what you wanted from your visit?' radio buttons
         And I enter 'Keep up the good work' into the 'How could we improve the service? (optional)' field
-        When I click the 'Submit feedback' button
+        And I click the 'Submit feedback' button
         Then I should see the text 'Thank you for your feedback.'
+
+    Scenario: Recording the referrer
+        Given I am on the 'dbs requirements' page prior to giving feedback
+        When I click 'Give feedback', fill in and submit the school feedback form
+        Then I should see the text 'Thank you for your feedback.'
+        And my referrer should have been recorded

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -1,0 +1,32 @@
+Given("I am on the {string} page prior to giving feedback") do |string|
+  path_for(string).tap do |p|
+    visit(p)
+    expect(page.current_path).to eql(p)
+    @referrer = page.current_url
+    expect(@referrer).to start_with('http')
+  end
+end
+
+When("I click {string}, fill in and submit the candidate feedback form") do |string|
+  click_link(string)
+  steps %(
+    When I choose 'Make a school experience request' from the 'What did you come to do on the service?' radio buttons
+    And I choose 'Yes' from the 'Did you achieve what you wanted from your visit?' radio buttons
+    And I choose 'Satisfied' from the 'Overall, how did you feel about the service you received?' radio buttons
+    Then I click the 'Submit feedback' button
+  )
+end
+
+When("I click {string}, fill in and submit the school feedback form") do |string|
+  click_link(string)
+  steps %(
+    When I choose 'Set up a new school or schools on the service' from the 'What did you come to do on the service?' radio buttons
+    And I choose 'Yes' from the 'Did you achieve what you wanted from your visit?' radio buttons
+    And I choose 'Satisfied' from the 'Overall, how did you feel about the service you received?' radio buttons
+    Then I click the 'Submit feedback' button
+  )
+end
+
+Then("my referrer should have been recorded") do
+  expect(Feedback.last.referrer).to eql(@referrer)
+end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1774

### Context

We currently don't know what stage of the process people are at when they leave feedback

### Changes proposed in this pull request

This change adds a `referrer` field to the feedback record that is set based on the page they were last on before clicking 'Give feedback'. This isn't guaranteed to give an accurate view on the state of the user; they _may_ have already completed their transaction and have returned to the home page. It should give an indication, though, and is likely to provide some useful information on what people are doing when they feel the need to offer an opinion of the service.

### Guidance to review

Ensure the changes look sensible
