### PR TITLE
Added pagination to Placement Requests listing in Schools dashboard

### DIFF
--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -7,7 +7,6 @@ module Schools
         .eager_load(:bookings_subject, bookings_placement_request: %i(candidate candidate_cancellation school_cancellation))
         .order(date: :asc)
         .page(params[:page])
-        .per(50)
 
       assign_gitis_contacts @bookings
     end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -24,6 +24,7 @@ module Schools
         .unbooked
         .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date, :booking)
         .order(created_at: 'desc')
+        .page(params[:page])
     end
 
     def placement_request

--- a/app/controllers/schools/previous_bookings_controller.rb
+++ b/app/controllers/schools/previous_bookings_controller.rb
@@ -6,7 +6,6 @@ module Schools
           %i(candidate candidate_cancellation school_cancellation))
         .order(date: :desc)
         .page(params[:page])
-        .per(50)
 
       assign_gitis_contacts @bookings
     end

--- a/app/controllers/schools/withdrawn_requests_controller.rb
+++ b/app/controllers/schools/withdrawn_requests_controller.rb
@@ -4,7 +4,6 @@ module Schools
       @requests = scope
         .includes(:candidate, :candidate_cancellation, placement_date: :subjects)
         .page(params[:page])
-        .per(50)
 
       assign_gitis_contacts @requests
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -108,6 +108,19 @@ module ApplicationHelper
     end
   end
 
+  def pagination_bar(query)
+    content_tag :div, class: 'pagination-info higher' do
+      content_tag(:div, page_entries_info(query), class: 'pagination-slice') +
+        paginate(query)
+    end
+  end
+
+  def pagination_lower(query)
+    content_tag :div, class: 'pagination-info lower' do
+      paginate query
+    end
+  end
+
 private
 
   def valid_user?(user)

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -11,6 +11,7 @@ class Bookings::SchoolSearch < ApplicationRecord
 
   REGION = 'England'.freeze
   GEOCODER_PARAMS = { maxRes: 1 }.freeze
+  PER_PAGE = 15
 
   def self.available_orders
     AVAILABLE_ORDERS.map
@@ -32,6 +33,7 @@ class Bookings::SchoolSearch < ApplicationRecord
       .includes(%i{subjects phases})
       .reorder(order_by(requested_order))
       .page(self.page)
+      .per(PER_PAGE)
   end
 
   def total_count

--- a/app/views/schools/confirmed_bookings/index.html.erb
+++ b/app/views/schools/confirmed_bookings/index.html.erb
@@ -20,18 +20,11 @@
     </p>
 
     <% if @bookings.any? %>
-      <div class="pagination-info higher">
-        <div class="pagination-slice">
-          <%= page_entries_info @bookings %>
-        </div>
-        <%= paginate @bookings %>
-      </div>
+      <%= pagination_bar @bookings %>
 
       <%= render partial: 'schools/confirmed_bookings/booking_table', locals: { bookings: @bookings } %>
 
-      <div class="pagination-info lower">
-        <%= paginate @bookings %>
-      </div>
+      <%= pagination_lower @bookings %>
 
     <% else %>
       <p>

--- a/app/views/schools/placement_requests/index.html.erb
+++ b/app/views/schools/placement_requests/index.html.erb
@@ -13,9 +13,20 @@
     <p>
       You'll need to refer to <strong>your own records</strong> for any requests received before this date.
     </p>
+    
+    <% if @placement_requests.any? %>
+      <%= pagination_bar @placement_requests %>
 
-    <%= render partial: 'schools/placement_requests/placement_requests_table',
-      locals: { placement_requests: @placement_requests } %>
+      <%= render partial: 'schools/placement_requests/placement_requests_table',
+        locals: { placement_requests: @placement_requests } %>
+
+      <%= pagination_lower @placement_requests %>
+
+    <% else %>
+      <p>
+        There are no requests.
+      </p>
+    <% end %>    
 
     <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path, secondary: true %>
   </div>

--- a/app/views/schools/previous_bookings/index.html.erb
+++ b/app/views/schools/previous_bookings/index.html.erb
@@ -10,18 +10,11 @@
     <%= page_heading 'Previous bookings' %>
 
     <% if @bookings.any? %>
-      <div class="pagination-info higher">
-        <div class="pagination-slice">
-          <%= page_entries_info @bookings %>
-        </div>
-        <%= paginate @bookings %>
-      </div>
+      <%= pagination_bar @bookings %>
 
       <%= render 'table', bookings: @bookings %>
 
-      <div class="pagination-info lower">
-        <%= paginate @bookings %>
-      </div>
+      <%= pagination_lower @bookings %>
 
     <% else %>
       <p>

--- a/app/views/schools/withdrawn_requests/index.html.erb
+++ b/app/views/schools/withdrawn_requests/index.html.erb
@@ -10,13 +10,8 @@
     <%= page_heading 'Withdrawn requests' %>
 
     <% if @requests.any? %>
-      <div class="pagination-info higher">
-        <div class="pagination-slice">
-          <%= page_entries_info @requests %>
-        </div>
-        <%= paginate @requests %>
-      </div>
-
+      <%= pagination_bar @requests %>
+    
       <table id="withdrawn-requests" class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
@@ -61,9 +56,7 @@
         </tbody>
       </table>
 
-      <div class="pagination-info lower">
-        <%= paginate @requests %>
-      </div>
+      <%= pagination_lower @requests %>
 
     <% else %>
       <p>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 15
+  config.default_per_page = 50
   # config.max_per_page = nil
   config.window = 4
   config.outer_window = 5

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,11 @@ en:
         dress_code_remove_piercings: Remove piercings
         dress_code_smart_casual: Smart casual
 
+    models:
+      bookings/placement_request:
+        one: Request
+        other: Requests
+
   helpers:
     fieldset:
       order: Sorted by


### PR DESCRIPTION
### Context

Placement Requests currently shows all requests on a single page.

No ticket number but uncapped database queries are a bad idea - and Gitis cannot return more than 130 items in a single request.

### Changes proposed in this pull request

Added pagination to Placement Requests listing in Schools dashboard

1. Standardised pagination handling into helpers
2. Changed default pagination to be 50, rather than override it everywhere
3. Changed SchoolSearch to set its own pagination limit
4. Added pagination and 'no requests' message to placement requests listing

### Guidance to review

1. Code review
2. Testing - Within the schools dashboard - Placement requests, Confirmed Bookings, Withdrawn Requests, Cancelled Requests and Previous Bookings should all still work fine. There should now be pagination on the Placement Requests screen