### PR TITLE
Stop raising errors for session expiry

### DIFF
--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -180,6 +180,26 @@ describe Schools::SessionsController, type: :request do
         expect(subject).to redirect_to(schools_dashboard_path)
       end
     end
+
+    context 'when the session has timed out' do
+      let(:message) { 'sessionexpired' }
+      let(:expired_auth_callback_path) { "/auth/callback?error=#{message}" }
+
+      before do
+        allow(Rails.logger).to receive(:warn).and_return(true)
+      end
+
+      subject { get expired_auth_callback_path }
+
+      specify 'should log that the session has expired' do
+        subject
+        expect(Rails.logger).to have_received(:warn).with('DfE Sign-in session expiry error, restarting login process')
+      end
+
+      specify 'should redirect to the school dashboard' do
+        expect(subject).to redirect_to(schools_dashboard_path)
+      end
+    end
   end
 
   describe '#logout' do


### PR DESCRIPTION
### JIRA Ticket Number

SE-1857

### Context

Sometimes, for reasons unknown, users reach our OIDC callback path
`/auth/callback` with the param `?error=sessionexpired`. We previously
treated this as an AuthFailedError but that was causing too much noise
in our error reporting.

Having asked on the DfE Sign-in Slack channel and getting no response I
had a search on GitHub and other teams are manually handling this
error[0][1].


### Changes proposed in this pull request

This PR implements that approach, users who are redirected back with the
sessionexpired error, instead of raising AuthFailedError will raise
SessionExpiredError. This is handled by session_expired_failure which
redirects instead of reporting the error to Sentry via Raven.

Users will be redirected to `/schools/dashboard` which will, in turn,
send them back to DfE Sign-in where they will log in again.

### Guidance to review

Ensure the changes look sensible. Tested locally by manually navigating to `/auth/callback?error=sessionexpired` while logged in and was successfully redirected to the dashboard (which, if the session had have timed out, would have caused me to bounce back to DfE Sign-in).

[0] https://github.com/DFE-Digital/manage-courses-frontend/blob/master/config/initializers/omniauth.rb#L19
[1] https://github.com/DFE-Digital/login.dfe.support/blob/master/src/infrastructure/oidc/index.js#L74




