### PR TITLE
SE-1804 Use subject id instead of placement date subject

### DIFF
--- a/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
+++ b/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
@@ -43,7 +43,7 @@ module Candidates
       def subject_and_date_params
         params
           .require(:candidates_registrations_subject_and_date_information)
-          .permit(:subject_and_date_ids)
+          .permit(:date_and_subject_ids)
           .merge(urn: @school.urn)
       end
 

--- a/app/models/bookings/placement_date_subject.rb
+++ b/app/models/bookings/placement_date_subject.rb
@@ -10,9 +10,9 @@ class Bookings::PlacementDateSubject < ApplicationRecord
     if: :bookings_subject_id
 
   # this combined id is used when candidates are choosing a subject specific
-  # date and are presented with a single list of options that contains subjects
-  # AND placement dates
-  def combined_id
+  # date and are presented with a single list of options that contain
+  # placement dates and subjects
+  def date_and_subject_id
     [bookings_placement_date.id, bookings_subject_id].join("_")
   end
 

--- a/app/models/bookings/placement_date_subject.rb
+++ b/app/models/bookings/placement_date_subject.rb
@@ -13,7 +13,7 @@ class Bookings::PlacementDateSubject < ApplicationRecord
   # date and are presented with a single list of options that contains subjects
   # AND placement dates
   def combined_id
-    [bookings_placement_date.id, id].join("_")
+    [bookings_placement_date.id, bookings_subject_id].join("_")
   end
 
 private

--- a/app/models/candidates/placement_date_option.rb
+++ b/app/models/candidates/placement_date_option.rb
@@ -4,7 +4,7 @@ class Candidates::PlacementDateOption
     if placement_date.placement_date_subjects.any?
       placement_date.placement_date_subjects.map do |placement_date_subject|
         new(
-          placement_date_subject.combined_id,
+          placement_date_subject.date_and_subject_id,
           placement_date_subject.bookings_subject.name,
           placement_date.duration,
           placement_date.date

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -25,7 +25,7 @@ module Candidates
       end
 
       def subject_and_date_ids
-        placement_date_subject&.combined_id || placement_date&.id
+        placement_date_subject&.date_and_subject_id || placement_date&.id
       end
 
       def subject_and_date_ids=(subject_and_date_id)

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -29,12 +29,7 @@ module Candidates
       end
 
       def subject_and_date_ids=(subject_and_date_id)
-        bookings_placement_date_id, bookings_placement_dates_subject_id = subject_and_date_id.split('_')
-
-        bookings_subject_id = Bookings::PlacementDateSubject.find_by(id: bookings_placement_dates_subject_id)&.bookings_subject_id
-
-        self.bookings_placement_date_id = bookings_placement_date_id
-        self.bookings_subject_id        = bookings_subject_id
+        self.bookings_placement_date_id, self.bookings_subject_id = subject_and_date_id.split('_')
       end
 
       def primary_placement_dates

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -8,6 +8,8 @@ module Candidates
       attribute :bookings_subject_id, :integer
 
       validates :bookings_subject_id, presence: true, if: :for_subject_specific_date?
+      validates :placement_date_subject, presence: true, if:
+        -> { for_subject_specific_date? && bookings_subject_id }
 
       def placement_date
         @placement_date ||= Bookings::PlacementDate.find_by(id: bookings_placement_date_id)

--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -24,12 +24,12 @@ module Candidates
         @bookings_subject ||= Bookings::Subject.find_by(id: bookings_subject_id)
       end
 
-      def subject_and_date_ids
+      def date_and_subject_ids
         placement_date_subject&.date_and_subject_id || placement_date&.id
       end
 
-      def subject_and_date_ids=(subject_and_date_id)
-        self.bookings_placement_date_id, self.bookings_subject_id = subject_and_date_id.split('_')
+      def date_and_subject_ids=(pair)
+        self.bookings_placement_date_id, self.bookings_subject_id = pair.split('_')
       end
 
       def primary_placement_dates

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -7,7 +7,7 @@
     <%= form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
       <%= GovukElementsErrorsHelper.error_summary subject_and_date_information, 'There is a problem', '' %>
 
-      <%= f.hidden_field :subject_and_date_ids %>
+      <%= f.hidden_field :date_and_subject_ids %>
 
       <section class="<%= subject_and_date_section_classes(subject_and_date_information) %>">
 
@@ -15,7 +15,7 @@
           <section class="date-selector date-selector-primary">
             <h3 class="govuk-heading-m">Primary placement dates</h3>
 
-            <%= f.radio_button_fieldset :subject_and_date_ids,
+            <%= f.radio_button_fieldset :date_and_subject_ids,
               choices: @subject_and_date_information.primary_placement_dates,
               value_method: :id,
               text_method: :name_with_duration -%>
@@ -34,7 +34,7 @@
               </dt>
 
               <dd class="govuk-summary-list__value date-selector date-selector-secondary">
-                <%= f.radio_button_fieldset :subject_and_date_ids,
+                <%= f.radio_button_fieldset :date_and_subject_ids,
                   choices: secondary_placement_dates.sort,
                   value_method: :id,
                   text_method: :name_with_duration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
         blank: "Choose a date"
       bookings_subject_id:
         blank: "Choose a subject"
+      placement_date_subject:
+        blank: "Choose a subject"
 
   placement_preference_errors: &placement_preference_errors
     attributes:

--- a/spec/controllers/candidates/registrations/subject_and_date_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_and_date_informations_controller_spec.rb
@@ -129,7 +129,7 @@ describe Candidates::Registrations::SubjectAndDateInformationsController, type: 
       let(:params) do
         {
           candidates_registrations_subject_and_date_information: {
-            subject_and_date_ids: [secondary_placement_date.id, placement_date_subject.id].join('_')
+            subject_and_date_ids: [secondary_placement_date.id, bookings_subject.id].join('_')
           }
         }
       end

--- a/spec/controllers/candidates/registrations/subject_and_date_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/subject_and_date_informations_controller_spec.rb
@@ -63,7 +63,7 @@ describe Candidates::Registrations::SubjectAndDateInformationsController, type: 
       let(:params) do
         {
           candidates_registrations_subject_and_date_information: {
-            subject_and_date_ids: primary_placement_date.id
+            date_and_subject_ids: primary_placement_date.id
           }
         }
       end
@@ -92,7 +92,7 @@ describe Candidates::Registrations::SubjectAndDateInformationsController, type: 
       let(:params) do
         {
           candidates_registrations_subject_and_date_information: {
-            subject_and_date_ids: secondary_placement_date.id
+            date_and_subject_ids: secondary_placement_date.id
           }
         }
       end
@@ -129,7 +129,7 @@ describe Candidates::Registrations::SubjectAndDateInformationsController, type: 
       let(:params) do
         {
           candidates_registrations_subject_and_date_information: {
-            subject_and_date_ids: [secondary_placement_date.id, bookings_subject.id].join('_')
+            date_and_subject_ids: [secondary_placement_date.id, bookings_subject.id].join('_')
           }
         }
       end

--- a/spec/models/bookings/placement_date_subject_spec.rb
+++ b/spec/models/bookings/placement_date_subject_spec.rb
@@ -40,7 +40,7 @@ describe Bookings::PlacementDateSubject, type: :model do
       end
 
       specify 'should be the bookings_placement_date id and own id delimited by an underscore' do
-        expect(subject.combined_id).to eql("#{placement_date.id}_#{subject.id}")
+        expect(subject.combined_id).to eql("#{placement_date.id}_#{chosen_subject.id}")
       end
     end
   end

--- a/spec/models/bookings/placement_date_subject_spec.rb
+++ b/spec/models/bookings/placement_date_subject_spec.rb
@@ -29,7 +29,7 @@ describe Bookings::PlacementDateSubject, type: :model do
   end
 
   describe 'methods' do
-    describe '#combined_id' do
+    describe '#date_and_subject_id' do
       let(:placement_date) { create(:bookings_placement_date) }
       let(:chosen_subject) { create(:bookings_subject) }
       subject do
@@ -40,7 +40,7 @@ describe Bookings::PlacementDateSubject, type: :model do
       end
 
       specify 'should be the bookings_placement_date id and own id delimited by an underscore' do
-        expect(subject.combined_id).to eql("#{placement_date.id}_#{chosen_subject.id}")
+        expect(subject.date_and_subject_id).to eql("#{placement_date.id}_#{chosen_subject.id}")
       end
     end
   end

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -29,11 +29,19 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       context 'when the placement date is not subject-specific' do
         let(:placement_date) { create(:bookings_placement_date, subject_specific: false) }
 
-        before { subject.bookings_placement_date_id = placement_date.id }
+#        before { subject.bookings_placement_date_id = placement_date.id }
+#
+#        specify 'should not validate the presence of bookings_subject_id' do
+#          expect(subject).to be_valid
+#        end
 
-        specify 'should not validate the presence of bookings_placement_dates_subject_id' do
-          expect(subject).to be_valid
+        subject do
+          described_class.new \
+            urn: school.urn,
+            bookings_placement_date_id: placement_date.id
         end
+
+        it { is_expected.not_to validate_presence_of :bookings_subject_id }
       end
 
       context 'when the placement date is subject-specific' do
@@ -48,15 +56,16 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
           end
         end
 
-        before { subject.bookings_placement_date_id = placement_date.id }
-        before { subject.valid? }
-
-        specify 'should validate the presence of bookings_subject_id' do
-          expect(subject).not_to be_valid
+        subject do
+          described_class.new \
+            urn: school.urn,
+            bookings_placement_date_id: placement_date.id
         end
 
-        specify 'should fail validation with an appropriate message' do
-          expect(subject.errors.messages[:bookings_subject_id]).to include("Choose a subject")
+        specify 'should validate the presence of bookings_subject_id' do
+          is_expected.to \
+            validate_presence_of(:bookings_subject_id).
+              with_message('Choose a subject')
         end
       end
     end

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -96,7 +96,7 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       end
     end
 
-    describe '#subject_and_date_ids' do
+    describe '#date_and_subject_ids' do
       it { is_expected.to respond_to(:placement_date_subject) }
 
       let!(:bookings_placement_date) { create :bookings_placement_date, bookings_school: school }
@@ -115,11 +115,11 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       end
 
       specify 'should join the placement date and placement date subject ids separated by an underscore' do
-        expect(subject.subject_and_date_ids).to eql(bookings_placement_dates_subject.date_and_subject_id)
+        expect(subject.date_and_subject_ids).to eql(bookings_placement_dates_subject.date_and_subject_id)
       end
     end
 
-    describe '#subject_and_date_ids=' do
+    describe '#date_and_subject_ids=' do
       let!(:bookings_placement_date) { create :bookings_placement_date, bookings_school: school }
       let!(:bookings_subject) { create :bookings_subject, schools: [school] }
       let!(:bookings_placement_dates_subject) do
@@ -131,7 +131,7 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       end
 
       before do
-        subject.subject_and_date_ids = bookings_placement_dates_subject.date_and_subject_id
+        subject.date_and_subject_ids = bookings_placement_dates_subject.date_and_subject_id
       end
 
       it 'sets the bookings_subject correctly' do

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -115,7 +115,7 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       end
 
       specify 'should join the placement date and placement date subject ids separated by an underscore' do
-        expect(subject.subject_and_date_ids).to eql(bookings_placement_dates_subject.combined_id)
+        expect(subject.subject_and_date_ids).to eql(bookings_placement_dates_subject.date_and_subject_id)
       end
     end
 
@@ -131,7 +131,7 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       end
 
       before do
-        subject.subject_and_date_ids = bookings_placement_dates_subject.combined_id
+        subject.subject_and_date_ids = bookings_placement_dates_subject.date_and_subject_id
       end
 
       it 'sets the bookings_subject correctly' do

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -29,12 +29,6 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
       context 'when the placement date is not subject-specific' do
         let(:placement_date) { create(:bookings_placement_date, subject_specific: false) }
 
-#        before { subject.bookings_placement_date_id = placement_date.id }
-#
-#        specify 'should not validate the presence of bookings_subject_id' do
-#          expect(subject).to be_valid
-#        end
-
         subject do
           described_class.new \
             urn: school.urn,

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -56,16 +56,35 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
           end
         end
 
-        subject do
-          described_class.new \
-            urn: school.urn,
-            bookings_placement_date_id: placement_date.id
+        context 'and no date subject specified' do
+          subject do
+            described_class.new \
+              urn: school.urn,
+              bookings_placement_date_id: placement_date.id
+          end
+
+          specify 'should validate the presence of bookings_subject_id' do
+            is_expected.to \
+              validate_presence_of(:bookings_subject_id).
+                with_message('Choose a subject')
+          end
         end
 
-        specify 'should validate the presence of bookings_subject_id' do
-          is_expected.to \
-            validate_presence_of(:bookings_subject_id).
-              with_message('Choose a subject')
+        context 'and invalid date subject specified' do
+          # race scenario if school removes subject from date whilst
+          # candidate is viewing it
+
+          subject do
+            described_class.new \
+              urn: school.urn,
+              bookings_placement_date_id: placement_date.id,
+              bookings_subject_id: 999999
+          end
+
+          specify 'should validate the presence of bookings_placement_date_subject' do
+            is_expected.not_to be_valid
+            expect(subject.errors.full_messages).to include('Choose a subject')
+          end
         end
       end
     end


### PR DESCRIPTION
### Context

The combined_id currently represents placement date id and placement date subject id. This is partly redundant information, and will also unnecessarily fail if a school accidentally removes a placement date subject, then subsequently adds it back in - whilst the user is applying.

In general the placement_date_subject_ids are just join ids and treated as very ephemeral, and so shouldn't be being exposed to the users.

### Changes proposed in this pull request

1. Use placement date id and bookings subject id for the combined id
2. Whilst I'd originally used the reference combined_id - date_and_subject_id better represents what this holds.
3. Rename references to subject_and_date_ids to date_and_subject_ids which better reference what they hold
4. Validate SubjectAndDateInformation to ensure there is a PlacementDateSubject corresponding to the date_id and subject_id the candidate has supplied

### Guidance to review

1. Code review
2. Testing
