### PR TITLE
Added strong_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,8 @@ gem 'activerecord-import'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+gem 'strong_migrations'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    strong_migrations (0.4.2)
+      activerecord (>= 5)
     swd (1.1.2)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
@@ -492,6 +494,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   sprockets (< 4.0.0)
+  strong_migrations
   tzinfo-data
   uglifier (>= 1.3.0)
   uk_postcode


### PR DESCRIPTION
### Context

One of the PRs required the removal of a column. This would have been done without first stopping the application from using the column, it was caught at code review but could have been caught earlier by automated processes. 

### Changes proposed in this pull request

1. Adding `strong_migrations` gem should reduce the likelyhood of accidental removal of still in use database columns.

### Guidance to review

1. Code review
