### PR TITLE
Offer school change when navigating to placement request SE-1878

### DIFF
--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -2,7 +2,7 @@ module Schools
   class WrongSchoolError < StandardError
     attr_reader :urn
 
-    def initialize(urn)
+    def initialize(urn:)
       @urn = urn
       super
     end
@@ -42,7 +42,7 @@ module Schools
       current_school.placement_requests.find params[:id]
     rescue ActiveRecord::RecordNotFound => e
       if (other_school_urn = user_has_access_via_another_school)
-        return raise WrongSchoolError.new(other_school_urn)
+        return raise WrongSchoolError.new(urn: other_school_urn)
       end
 
       raise e

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -1,5 +1,16 @@
 module Schools
+  class WrongSchoolError < StandardError
+    attr_reader :urn
+
+    def initialize(urn)
+      @urn = urn
+      super
+    end
+  end
+
   class PlacementRequestsController < Schools::BaseController
+    rescue_from WrongSchoolError, with: :switch_school
+
     def index
       @placement_requests = placement_requests
       assign_gitis_contacts(@placement_requests)
@@ -7,6 +18,7 @@ module Schools
 
     def show
       @placement_request = placement_request
+
       @gitis_contact = placement_request.fetch_gitis_contact(gitis_crm)
 
       @placement_request.viewed!
@@ -28,6 +40,32 @@ module Schools
 
     def placement_request
       current_school.placement_requests.find params[:id]
+    rescue ActiveRecord::RecordNotFound => e
+      if (other_school_urn = user_has_access_via_another_school)
+        return raise WrongSchoolError.new(other_school_urn)
+      end
+
+      raise e
+    end
+
+    def switch_school(exception)
+      redirect_to schools_switch_path(urn: exception.urn)
+    end
+
+    def user_has_access_via_another_school
+      return false unless DFESignInAPI::Client.enabled?
+
+      placement_request_urn = Bookings::PlacementRequest
+        .eager_load(:school)
+        .find(params[:id])
+        .school
+        .urn
+
+      dfe_sign_in_organisations.urns.delete(placement_request_urn)
+    end
+
+    def dfe_sign_in_organisations
+      DFESignInAPI::Organisations.new(current_user.sub)
     end
 
     def assign_gitis_contacts(reqs)

--- a/app/controllers/schools/switch_controller.rb
+++ b/app/controllers/schools/switch_controller.rb
@@ -1,5 +1,5 @@
 module Schools
-  class SwitchController < ApplicationController
+  class SwitchController < Schools::BaseController
     # Remove the current session and redirect to the dashboard, this will
     # trigger the standard OIDC flow
     #
@@ -15,6 +15,10 @@ module Schools
       session[:other_urns]   = nil
 
       redirect_to(schools_dashboard_path)
+    end
+
+    def show
+      @school = Bookings::School.find_by(urn: params[:urn])
     end
   end
 end

--- a/app/controllers/schools/switch_controller.rb
+++ b/app/controllers/schools/switch_controller.rb
@@ -1,5 +1,5 @@
 module Schools
-  class SwitchController < Schools::BaseController
+  class SwitchController < ApplicationController
     # Remove the current session and redirect to the dashboard, this will
     # trigger the standard OIDC flow
     #
@@ -18,7 +18,8 @@ module Schools
     end
 
     def show
-      @school = Bookings::School.find_by(urn: params[:urn])
+      @current_school = Bookings::School.find_by(urn: session[:urn])
+      @other_school   = Bookings::School.find_by(urn: params[:urn])
     end
   end
 end

--- a/app/views/schools/switch/show.html.erb
+++ b/app/views/schools/switch/show.html.erb
@@ -1,9 +1,16 @@
 <h1 class="govuk-heading-l">You're trying to view a placement request for another school</h1>
 
-<p>
-  You're currently logged in to <strong><%= @current_school.name %></strong>, you
-  need to change to <strong><%= @school.name %></strong> in order to view it.
-</p>
+<% if @school.present? %>
+  <p>
+    You're currently logged in to <strong><%= @current_school.name %></strong>, you
+    need to change to <strong><%= @school.name %></strong> in order to view it.
+  </p>
+<% else %>
+  <p>
+    You're currently logged in to <strong><%= @current_school.name %></strong> and
+    this placement request belongs to another school.
+  </p>
+<% end %>
 
 <%= link_to 'Change school', new_schools_switch_path, class: 'govuk-button govuk-!-margin-right-1' %>
 

--- a/app/views/schools/switch/show.html.erb
+++ b/app/views/schools/switch/show.html.erb
@@ -1,0 +1,10 @@
+<h1 class="govuk-heading-l">You're trying to view a placement request for another school</h1>
+
+<p>
+  You're currently logged in to <strong><%= @current_school.name %></strong>, you
+  need to change to <strong><%= @school.name %></strong> in order to view it.
+</p>
+
+<%= link_to 'Change school', new_schools_switch_path, class: 'govuk-button govuk-!-margin-right-1' %>
+
+<%= link_to 'Return to the dashboard', schools_dashboard_path, class: "govuk-button govuk-button--secondary" %>

--- a/app/views/schools/switch/show.html.erb
+++ b/app/views/schools/switch/show.html.erb
@@ -1,9 +1,9 @@
 <h1 class="govuk-heading-l">You're trying to view a placement request for another school</h1>
 
-<% if @school.present? %>
+<% if @other_school.present? %>
   <p>
     You're currently logged in to <strong><%= @current_school.name %></strong>, you
-    need to change to <strong><%= @school.name %></strong> in order to view it.
+    need to change to <strong><%= @other_school.name %></strong> in order to view it.
   </p>
 <% else %>
   <p>

--- a/app/views/schools/switch/show.html.erb
+++ b/app/views/schools/switch/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">You're trying to view a placement request for another school</h1>
+<h1 class="govuk-heading-l">You're trying to view a request for another school</h1>
 
 <% if @other_school.present? %>
   <p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     resource :session, only: %i(show) do
       get :logout
     end
-    resource :switch, only: %i(new), controller: 'switch'
+    resource :switch, only: %i(new show), controller: 'switch'
     resource :dashboard, only: :show
     resource :contact_us, only: :show, controller: 'contact_us'
     resource :toggle_enabled, only: %i(edit update), as: 'enabled', controller: 'toggle_enabled'

--- a/spec/views/schools/switch/show.html.erb_spec.rb
+++ b/spec/views/schools/switch/show.html.erb_spec.rb
@@ -7,7 +7,7 @@ describe 'schools/switch/show.html.erb', type: :view do
   context 'when a URN param is present' do
     let(:other_school) { create(:bookings_school) }
 
-    before { assign :school, other_school }
+    before { assign :other_school, other_school }
     before { render }
 
     specify 'should render the page with information about the schools' do
@@ -17,7 +17,6 @@ describe 'schools/switch/show.html.erb', type: :view do
   end
 
   context 'when no URN param is present' do
-    before { assign :current_school, school }
     before { render }
 
     specify 'should render the page with information about the current school only' do

--- a/spec/views/schools/switch/show.html.erb_spec.rb
+++ b/spec/views/schools/switch/show.html.erb_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe 'schools/switch/show.html.erb', type: :view do
+  let(:school) { create(:bookings_school) }
+  before { assign :current_school, school }
+
+  context 'when a URN param is present' do
+    let(:other_school) { create(:bookings_school) }
+
+    before { assign :school, other_school }
+    before { render }
+
+    specify 'should render the page with information about the schools' do
+      expect(response).to match(school.name)
+      expect(response).to match(other_school.name)
+    end
+  end
+
+  context 'when no URN param is present' do
+    before { assign :current_school, school }
+    before { render }
+
+    specify 'should render the page with information about the current school only' do
+      expect(response).to match(school.name)
+      expect(response).to match(/this placement request belongs to another school/)
+    end
+  end
+end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1878

### Context

When users are navigating directly to placement requests (potentially other things too, but at the moment only placement requests are linked to from emails) and are already logged into the web application as another school they'll receive a 404. This is confusing for them as it's not clear why they can't see the record

### Changes proposed in this pull request

When the DfE Sign-in API is turned on we'll be able to work out the other schools a user has access to, we can then prompt them to change school:

<img width="959" alt="Screenshot 2019-11-05 at 16 20 59" src="https://user-images.githubusercontent.com/128088/68303073-0ad6c680-009b-11ea-9c0a-3baa89a08688.png">

This is a stop gap until true multi-school behaviour lands but it should improve the UX in the short term.

### Guidance to review

Ensure everything looks sensible. Some considerations:

* Should we move exception types up to `app/errors`?
* Are there any ways I've overlooked where a user can navigate directly to a resource that belongs to another school from outside the app? I _think_ the placement request confirmation email is the only way but might've missed something
* Does the wording look ok on the error page @fredbrenton?