### PR TITLE
Add the missing 'r' to understand

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -549,7 +549,7 @@ en:
           <ul class=\"govuk-list govuk-list--bullet\">
             <li>the details you've provided are correct</li>
             <li>you've read our <a href=\"/privacy_policy\" class=\"govuk-link\">privacy policy</a></li>
-            <li>you undestand your personal details will be used by DfE's
+            <li>you understand your personal details will be used by DfE's
             <a href=\"https://getintoteaching.education.gov.uk/\" class=\"govuk-link\">Get Into Teaching Information Service</a>
             to provide you with tailored advice and information about teaching
             training and a career as a teacher</li>"


### PR DESCRIPTION
Simple typo fix by adding missing letter

