### PR TITLE
Se 1697/add phase select to school searches

### DIFF
--- a/app/controllers/candidates/school_searches_controller.rb
+++ b/app/controllers/candidates/school_searches_controller.rb
@@ -8,6 +8,6 @@ class Candidates::SchoolSearchesController < ApplicationController
 private
 
   def search_params
-    params.permit(:location, :latitude, :longitude)
+    params.permit(:location, :latitude, :longitude, :age_group)
   end
 end

--- a/app/controllers/candidates/school_searches_controller.rb
+++ b/app/controllers/candidates/school_searches_controller.rb
@@ -8,6 +8,6 @@ class Candidates::SchoolSearchesController < ApplicationController
 private
 
   def search_params
-    params.permit(:location, :latitude, :longitude, :age_group)
+    params.permit(:location, :age_group)
   end
 end

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -40,7 +40,7 @@ private
   def search_params
     params.permit(
       :query, :location, :latitude, :longitude, :page,
-      :distance, :max_fee, :order, phases: [], subjects: []
+      :distance, :max_fee, :order, :age_group, phases: [], subjects: []
     )
   end
 

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -32,15 +32,13 @@ class Candidates::SchoolsController < ApplicationController
 private
 
   def location_present?
-    search_params[:location].present? || (
-      search_params[:latitude].present? && search_params[:latitude].present?
-    )
+    search_params[:location].present?
   end
 
   def search_params
     params.permit(
-      :query, :location, :latitude, :longitude, :page,
-      :distance, :max_fee, :order, :age_group, phases: [], subjects: []
+      :query, :location, :page, :distance, :max_fee, :order, :age_group,
+      phases: [], subjects: []
     )
   end
 

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -105,7 +105,7 @@ module Candidates::SchoolHelper
   end
 
   def school_new_search_params
-    params.permit(:location, :latitude, :longitude, :age_group).reject { |_, v| v.blank? }
+    params.permit(:location, :age_group).reject { |_, v| v.blank? }
   end
 
   def dlist_item(key, attrs = {}, &block)

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -105,7 +105,7 @@ module Candidates::SchoolHelper
   end
 
   def school_new_search_params
-    params.permit(:location, :latitude, :longitude).reject { |_, v| v.blank? }
+    params.permit(:location, :latitude, :longitude, :age_group).reject { |_, v| v.blank? }
   end
 
   def dlist_item(key, attrs = {}, &block)

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -19,8 +19,7 @@ module Candidates
       ['90', 'up to £90']
     ].freeze
 
-    attr_accessor :query, :location, :order, :latitude,
-                  :longitude, :page, :analytics_tracking_uuid
+    attr_accessor :query, :location, :order, :page, :analytics_tracking_uuid
     attr_reader :distance, :max_fee
 
     delegate :location_name, :has_coordinates?, to: :school_search
@@ -122,9 +121,7 @@ module Candidates
     end
 
     def valid_search?
-      query.present? ||
-        (location.present? && distance.present?) ||
-        (longitude.present? && latitude.present? && distance.present?)
+      query.present? || (location.present? && distance.present?)
     end
 
     def filtering_results?
@@ -144,7 +141,7 @@ module Candidates
     def school_search
       @school_search ||= Bookings::SchoolSearch.new(
         query: query,
-        location: location_or_coords,
+        location: location,
         radius: distance,
         subjects: subjects,
         phases: phases,
@@ -153,14 +150,6 @@ module Candidates
         page: page,
         analytics_tracking_uuid: analytics_tracking_uuid
       )
-    end
-
-    def location_or_coords
-      if latitude.present? && longitude.present?
-        { latitude: latitude, longitude: longitude }
-      else
-        location
-      end
     end
   end
 end

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -23,6 +23,11 @@
           <%= f.collection_select :distance,
                 Candidates::SchoolSearch.distances, :first, :last %>
 
+          <%= f.radio_button_fieldset :age_group,
+            choices: Candidates::SchoolSearch.age_group_options,
+            text_method: :to_s,
+            value_method: :name %>
+
           <div class="school-search-form__submit">
             <div class="govuk-form-group">
               <%= f.submit 'Search', name: nil, aria: { label: 'Search for schools offering school experience' } %>

--- a/app/views/candidates/schools/_search_panel.html.erb
+++ b/app/views/candidates/schools/_search_panel.html.erb
@@ -13,8 +13,6 @@
         <%= f.hidden_field :query %>
         <%= f.hidden_field :location %>
         <%= f.hidden_field :distance %>
-        <%= f.hidden_field :latitude %>
-        <%= f.hidden_field :longitude %>
 
         <%= f.collection_check_boxes :subjects, Candidates::School.subjects, :first, :last %>
         <%= f.hidden_field :order %>

--- a/app/views/candidates/schools/_search_panel.html.erb
+++ b/app/views/candidates/schools/_search_panel.html.erb
@@ -1,0 +1,26 @@
+<aside class="govuk-grid-column-one-third filter-list" aria-label="Filter search results">
+  <div data-controller="collapsible" id="search-filter">
+    <button data-action="collapsible#toggle">
+      Filter the results
+    </button>
+
+    <div data-target="collapsible.panel">
+      <%= link_to 'Skip to search results', '#search-results', class: 'govuk-skip-link', id: 'skip-to-results' %>
+      <%= form_for search, as: '',
+            method: :get,
+            html: {class: "collapsible__content"} do |f| %>
+
+        <%= f.hidden_field :query %>
+        <%= f.hidden_field :location %>
+        <%= f.hidden_field :distance %>
+        <%= f.hidden_field :latitude %>
+        <%= f.hidden_field :longitude %>
+
+        <%= f.collection_check_boxes :subjects, Candidates::School.subjects, :first, :last %>
+        <%= f.hidden_field :order %>
+
+        <%= f.submit 'Update schools list', name: nil %>
+      <% end %>
+    </div>
+  </div>
+</aside>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -40,8 +40,6 @@
         <%= f.hidden_field :query %>
         <%= f.hidden_field :location %>
         <%= f.hidden_field :distance %>
-        <%= f.hidden_field :latitude %>
-        <%= f.hidden_field :longitude %>
         <% for phase_id in f.object.phases %>
           <%= f.hidden_field :phases, multiple: true, value: phase_id, id: nil %>
         <% end %>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -8,34 +8,9 @@
 </div>
 
 <div class="govuk-grid-row">
-  <aside class="govuk-grid-column-one-third filter-list" aria-label="Filter search results">
-    <div data-controller="collapsible" id="search-filter">
-      <button data-action="collapsible#toggle">
-        Filter the results
-      </button>
-
-      <div data-target="collapsible.panel">
-        <%= link_to 'Skip to search results', '#search-results', class: 'govuk-skip-link', id: 'skip-to-results' %>
-        <%= form_for @search, as: '',
-              method: :get,
-              html: {class: "collapsible__content"} do |f| %>
-
-          <%= f.hidden_field :query %>
-          <%= f.hidden_field :location %>
-          <%= f.hidden_field :distance %>
-          <%= f.hidden_field :latitude %>
-          <%= f.hidden_field :longitude %>
-
-          <%= f.collection_check_boxes :phases, Candidates::School.phases, :first, :last %>
-
-          <%= f.collection_check_boxes :subjects, Candidates::School.subjects, :first, :last %>
-          <%= f.hidden_field :order %>
-
-          <%= f.submit 'Update schools list', name: nil %>
-        <% end %>
-      </div>
-    </div>
-  </aside>
+  <% if @search.secondary_search? %>
+    <%= render "search_panel", { search: @search } %>
+  <% end %>
 
   <section class="govuk-grid-column-two-thirds" id="search-results" aria-label="Search results">
     <%- if @search.subjects.any? || @search.phases.any? -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,6 +91,13 @@ en:
   activemodel:
     errors:
       models:
+        candidates/school_search:
+          attributes:
+            age_group:
+              inclusion: 'Select the kind of school you want experience at'
+            location:
+              too_short: Must be at least 3 characters
+
         candidates/registrations/subject_preference:
           <<: *subject_preference_errors
 
@@ -349,10 +356,6 @@ en:
           attributes:
             reason:
               blank: 'Cancellation reason is required'
-        bookings/school_search:
-          attributes:
-            location:
-              too_short: Must be at least 3 characters
         bookings/school:
           attributes:
             availability_preference_fixed:
@@ -371,6 +374,7 @@ en:
 
   helpers:
     fieldset:
+      age_group: 'What kind of school do you want experience at?'
       order: Sorted by
       schools_placement_requests_confirm_booking:
         date: Confirm experience date

--- a/features/candidates/schools/search/results/filtering.feature
+++ b/features/candidates/schools/search/results/filtering.feature
@@ -5,31 +5,27 @@ Feature: Filtering school search results
 
     Background:
         Given the phases 'Primary' and 'Secondary' exist
-
-    Scenario: Filtering by Education Phase
-        Given I have searched for 'Manchester' and am on the results page
-        Then I should see a 'Education phases' filter on the left
-        And it should have the hint text 'Select all that apply'
-        And it should have checkboxes for the following items:
-            | Primary   |
-            | Secondary |
-
-    Scenario: Filtering by Subject
         Given there are some subjects
-        When I have searched for 'Manchester' and am on the results page
+
+    Scenario: Filtering by Primary
+        When I have searched for 'Secondary' experience in 'Manchester' and am on the results page
         Then I should see a 'Subjects' filter on the left
         And it should have the hint text 'Select all that apply'
         And it should have checkboxes for all subjects
 
+    Scenario: Filtering by Secondary
+        When I have searched for 'Primary' experience in 'Manchester' and am on the results page
+        Then I should not see a 'Subjects' filter on the left
+
     @javascript
     Scenario: Filtering while searching by current location
+        Given the subjects 'Maths' and 'Art' exist
         Given there there are schools with the following attributes:
-            | Name              | Phase     | Location   |
-            | Manchester School | Secondary | Manchester |
-            | Rochdale School   | Secondary | Rochdale   |
-            | Burnley School    | Primary   | Burnley    |
-        And I have provided a point in 'Bury' as my location
-        And there are both 'Primary' and 'Secondary' schools in the results
-        And I check the 'Secondary' filter box
+            | Name              | Phase     | Location   | Subjects |
+            | Manchester School | Secondary | Manchester | Maths    |
+            | Rochdale School   | Secondary | Rochdale   | Art      |
+            | Burnley School    | Primary   | Burnley    |          |
+        And I have provided a point in 'Bury' as my location for 'Secondary' experience
+        And I check the 'Maths' filter box
         When I click the 'Update schools list' button
-        Then only 'Secondary' schools should remain in the results
+        Then only schools teaching 'Maths' are visible

--- a/features/candidates/schools/search/results/no_results.feature
+++ b/features/candidates/schools/search/results/no_results.feature
@@ -5,6 +5,6 @@ Feature: Schools search page contents
 
     Scenario: No results in expanded area
         Given there are no schools in or around my search location
-        When I search for schools within 5 miles
+        When I search for 'Secondary' schools within 5 miles
         Then the results page should include a warning that no results were found
         And there should be a link to Get into teaching

--- a/features/candidates/schools/search/results/pagination.feature
+++ b/features/candidates/schools/search/results/pagination.feature
@@ -3,55 +3,58 @@ Feature: School search result pagination
     As a potential candidate
     I want to be able to browse through results by page
 
+    Background:
+        Given the phases 'Primary' and 'Secondary' exist
+
     Scenario: Pagination links are not displayed when there isn't a full page of results
-        Given there are 6 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 6 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         Then I should not see pagination links
 
     Scenario: Pagination links are displayed when there is more than one page of results
-        Given there are 17 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 17 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         Then I should see pagination links
 
     Scenario: Current page should not be a hyperlink
-        Given there are 18 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         Then pagination page 1 should not be a hyperlink
 
     Scenario: Other pages should be hyperlinks
-        Given there are 18 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         Then pagination page 2 should be a hyperlink
 
     Scenario: Next link
-        Given there are 18 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         Then there should be a 'Next' link in the pagination
 
     Scenario: Previous link
-        Given there are 18 schools in 'London'
-        And I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        And I have searched for 'Secondary' experience in 'London' and am on the results page
         When I navigate to the second page of results
         Then there should be a 'Previous' link in the pagination
 
     Scenario: Bottom-of-the-page navigation
-        Given there are 18 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         Then there should be 2 sets of pagination links
 
     Scenario: Bottom-of-the-page on last page
-        Given there are 18 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         And I navigate to the second page of results
         Then there should be 1 set of pagination links
 
     Scenario: Pagination description on page one
-        Given there are 18 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         Then the pagination description should say 'Showing 1–15 of 18 results'
 
     Scenario: Pagination description on page two
-        Given there are 18 schools in 'London'
-        When I have searched for 'London' and am on the results page
+        Given there are 18 'Secondary' schools in 'London'
+        When I have searched for 'Secondary' experience in 'London' and am on the results page
         And I navigate to the second page of results
         Then the pagination description should say 'Showing 16–18 of 18 results'

--- a/features/candidates/schools/search/results/results.feature
+++ b/features/candidates/schools/search/results/results.feature
@@ -8,8 +8,8 @@ Feature: Schools search page contents
         And there are some schools with a range of fees containing the word 'Manchester'
 
     Scenario: Search result contents
-        Given I have searched for 'Manchester' and am on the results page
-        And there are 3 results
+        Given I have searched for 'Secondary' experience in 'Manchester' and am on the results page
+        And there are 2 results
         Then each result should have the following information
             | Address     |
             | Education   |
@@ -20,6 +20,6 @@ Feature: Schools search page contents
     Scenario: No closeby results
         Given there are no schools near my search location
         But there are some schools just outside it
-        When I search for schools within 5 miles
+        When I search for 'Secondary' schools within 5 miles
         Then the results page should include a warning that my search radius was expanded
         And the results from further out are displayed

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -15,7 +15,7 @@ Feature: Schools search page sorting
         When I select 'Distance' from the 'Sorted by' radio buttons
         Then the results should be sorted by distance, nearest to furthest
 
-  #@javascript
+   @javascript
     Scenario: Sorting by distance when searching by current location
         Given there there are schools with the following attributes:
             | Name              | Location   |
@@ -27,7 +27,7 @@ Feature: Schools search page sorting
         When I select 'Distance' from the 'Sorted by' radio buttons
         Then the results should be sorted by distance, nearest to furthest
 
-  #@javascript
+    @javascript
     Scenario: When sorted by distance the mileage should increase
         Given there there are schools with the following attributes:
             | Name              | Location   |

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -15,26 +15,26 @@ Feature: Schools search page sorting
         When I select 'Distance' from the 'Sorted by' radio buttons
         Then the results should be sorted by distance, nearest to furthest
 
-    @javascript
+  #@javascript
     Scenario: Sorting by distance when searching by current location
         Given there there are schools with the following attributes:
             | Name              | Location   |
             | Manchester School | Manchester |
             | Rochdale School   | Rochdale   |
             | Burnley School    | Burnley    |
-        And I have provided a point in 'Bury' as my location
+        And I have provided a point in 'Bury' as my location for 'Secondary' experience
         And I have changed the sort order to 'Name'
         When I select 'Distance' from the 'Sorted by' radio buttons
         Then the results should be sorted by distance, nearest to furthest
 
-    @javascript
+  #@javascript
     Scenario: When sorted by distance the mileage should increase
         Given there there are schools with the following attributes:
             | Name              | Location   |
             | Manchester School | Manchester |
             | Rochdale School   | Rochdale   |
             | Burnley School    | Burnley    |
-        And I have provided a point in 'Bury' as my location
+        And I have provided a point in 'Bury' as my location for 'Secondary' experience
         And I have changed the sort order to 'Name'
         When I select 'Distance' from the 'Sorted by' radio buttons
         Then the distance should be ordered from low to high
@@ -46,7 +46,7 @@ Feature: Schools search page sorting
             | Manton School              | Manchester |
             | Mansfield School           | Rochdale   |
             | Manningtree Primary School | Burnley    |
-        And I have searched for 'Man' and am on the results page
+        And I have searched for 'Secondary' experience in 'Man' and am on the results page
         And the sort order has defaulted to 'Distance'
         When I select 'Name' from the 'Sorted by' radio buttons
         Then the results should be sorted by name, lowest to highest

--- a/features/candidates/schools/search/search.feature
+++ b/features/candidates/schools/search/search.feature
@@ -3,6 +3,9 @@ Feature: Schools search page
     As a potential candidate
     I want to be able to search for schools in my area
 
+    Background:
+        Given the phases 'Primary' and 'Secondary' exist
+
     Scenario: Page contents
         Given I am on the 'find a school' page
         Then the page's main header should be 'Search for school experience'
@@ -26,10 +29,15 @@ Feature: Schools search page
         Then the 'location' input should require at least '3' characters
 
     Scenario: Navigating back to the search form
-        Given I search for schools near 'Rochdale'
+        Given I search for 'Primary schools' schools near 'Rochdale'
         When I click back on the results screen
         Then the location input should be populated with 'Rochdale'
+        And the age group input should be populated with 'Primary schools'
 
     Scenario: Entering an invalid search
-        Given I have made an invalid search for schools near 'Ex'
+        Given I have made an invalid search for 'Primary schools' schools near 'Ex'
         Then I should see an error message stating 'Must be at least 3 characters'
+
+    Scenario: Not choosing an age range
+        Given I have made an invalid search for '' schools near 'Rochdale'
+        Then I should see an error message stating 'Select the kind of school you want experience at'

--- a/features/candidates/schools/show/full_school_details.feature
+++ b/features/candidates/schools/show/full_school_details.feature
@@ -23,15 +23,15 @@ Feature: School show page (enhanced data)
 
     Scenario: Education phase (singular)
         Given the phases 'Primary' and 'Secondary' exist
-        And the school is a 'Primary' school
+        And the school is a 'Primary (4 to 11)' school
         When I am on the profile page for the chosen school
         Then the age range should be 'Primary'
 
     Scenario: Education phase (Multiple)
         Given the phases 'Primary' and 'Secondary' exist
-        And the school is a 'Primary' and 'Secondary' school
+        And the school is a 'Primary (4 to 11)' and 'Secondary (11 to 16)' school
         When I am on the profile page for the chosen school
-        Then the age range should be 'Primary and Secondary'
+        Then the age range should be 'Primary (4 to 11) and Secondary (11 to 16)'
 
     Scenario: Subjects
         Given some subjects exist

--- a/features/step_definitions/candidates/schools/pagination_steps.rb
+++ b/features/step_definitions/candidates/schools/pagination_steps.rb
@@ -1,5 +1,5 @@
 Given("there are {int} {string} schools in {string}") do |count, age_group, town|
-  FactoryBot.create_list(:bookings_school, count, age_group.downcase.to_sym,  name: town)
+  FactoryBot.create_list(:bookings_school, count, age_group.downcase.to_sym, name: town)
   expect(Bookings::School.count).to eql(count)
 end
 

--- a/features/step_definitions/candidates/schools/pagination_steps.rb
+++ b/features/step_definitions/candidates/schools/pagination_steps.rb
@@ -1,5 +1,5 @@
-Given("there are {int} schools in {string}") do |count, town|
-  FactoryBot.create_list(:bookings_school, count, name: town)
+Given("there are {int} {string} schools in {string}") do |count, age_group, town|
+  FactoryBot.create_list(:bookings_school, count, age_group.downcase.to_sym,  name: town)
   expect(Bookings::School.count).to eql(count)
 end
 

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -54,7 +54,7 @@ Then("I should see a/an {string} filter on the left") do |label|
   end
 end
 
-Then("I should not see a/an {string} filter on the left") do |label|
+Then("I should not see a/an {string} filter on the left") do |_|
   expect(page).not_to have_css '#search-filter'
 end
 

--- a/features/step_definitions/candidates/schools/search_steps.rb
+++ b/features/step_definitions/candidates/schools/search_steps.rb
@@ -28,8 +28,8 @@ Then("the submit button should be labelled {string}") do |string|
   end
 end
 
-Given("I have made an invalid search for schools near {string}") do |string|
+Given("I have made an invalid search for {string} schools near {string}") do |phase, location|
   path = candidates_schools_path
-  visit(candidates_schools_path(location: string))
+  visit(candidates_schools_path(location: location, age_group: phase))
   expect(page.current_path).to eql(path)
 end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -31,18 +31,8 @@ Given("I have provided {string} as my location") do |location|
   expect(path_with_query).to eql(path)
 end
 
-Given("I have provided a point in {string} as my location for {string} experience") do |centre, age_group|
-  points = {
-    "Bury" => {
-      "latitude" => 53.593,
-      "longitude" => -2.289
-    }
-  }
-
-  point = points[centre]
-  fail "No point found for #{centre}" unless point.present?
-
-  path = candidates_schools_path(latitude: point["latitude"], longitude: point["longitude"], distance: 25, age_group: age_group.downcase)
+Given("I have provided a point in {string} as my location for {string} experience") do |location, age_group|
+  path = candidates_schools_path(location: location, distance: 25, age_group: age_group.downcase)
   visit(path)
   path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
   expect(path_with_query).to eql(path)

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Candidates::SchoolsController, type: :request do
+  let!(:primary_phase) { create :bookings_phase, :primary }
+  let!(:secondary_phase) { create :bookings_phase, :secondary }
+  let!(:college_phase) { create :bookings_phase, :college }
+
   context "GET #index with search params" do
     let(:query_params) {
       {
@@ -9,7 +13,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         latitude: '53.481',
         longitude: '-2.241',
         distance: '10',
-        phases: %w{1},
+        age_group: 'primary',
         subjects: %w{2 3},
         max_fee: '30',
         order: 'Name'
@@ -23,7 +27,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       expect(assigns(:search).location).to eq('Manchester')
       expect(assigns(:search).latitude).to eq('53.481')
       expect(assigns(:search).longitude).to eq('-2.241')
-      expect(assigns(:search).phases).to eq([1])
+      expect(assigns(:search).phases).to eq([primary_phase.id])
       expect(assigns(:search).subjects).to eq([2, 3])
       expect(assigns(:search).max_fee).to eq('30')
       expect(assigns(:search).order).to eq('Name')

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -10,8 +10,6 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       {
         query: 'Something',
         location: 'Manchester',
-        latitude: '53.481',
-        longitude: '-2.241',
         distance: '10',
         age_group: 'primary',
         subjects: %w{2 3},
@@ -25,8 +23,6 @@ RSpec.describe Candidates::SchoolsController, type: :request do
     it "assigns params to search model" do
       expect(assigns(:search).query).to eq('Something')
       expect(assigns(:search).location).to eq('Manchester')
-      expect(assigns(:search).latitude).to eq('53.481')
-      expect(assigns(:search).longitude).to eq('-2.241')
       expect(assigns(:search).phases).to eq([primary_phase.id])
       expect(assigns(:search).subjects).to eq([2, 3])
       expect(assigns(:search).max_fee).to eq('30')
@@ -42,8 +38,6 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         {
           query: 'Something',
           location: '',
-          latitude: '',
-          longitude: '',
           distance: '10',
           phases: %w{1},
           subjects: %w{2 3},
@@ -56,7 +50,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         expect(subject).to redirect_to(new_candidates_school_search_path)
       end
 
-      context 'when coordinates are blank and location is present' do
+      context 'when location is present' do
         let(:query_params_with_location) do
           query_params.merge(location: 'Rochdale')
         end
@@ -66,14 +60,14 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         specify { expect(response).to have_http_status(:success) }
       end
 
-      context 'when coordinates are present and location is blank' do
-        let(:query_params_with_coordinates) do
-          query_params.merge(latitude: 53.479, longitude: -245)
+      context 'when location is absent' do
+        let(:query_params_with_location) do
+          query_params.merge(location: nil)
         end
 
-        before { get candidates_schools_path(query_params_with_coordinates) }
+        before { get candidates_schools_path(query_params_with_location) }
 
-        specify { expect(response).to have_http_status(:success) }
+        specify { expect(response).to redirect_to new_candidates_school_search_path }
       end
     end
 

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -294,26 +294,6 @@ RSpec.describe Candidates::SchoolSearch do
       it('should be valid') { expect(subject.valid_search?).to be true }
     end
 
-    context 'with latitude and distance' do
-      subject { described_class.new(latitude: '-2.241', distance: '10') }
-      it('should be invalid') { expect(subject.valid_search?).to be false }
-    end
-
-    context 'with longitude and distance' do
-      subject { described_class.new(longitude: '53.481', distance: '10') }
-      it('should be invalid') { expect(subject.valid_search?).to be false }
-    end
-
-    context 'with latitude, longitude and distance' do
-      subject do
-        described_class.new(
-          distance: '10', longitude: '53.481', latitude: '-2.241'
-        )
-      end
-
-      it('should be valid') { expect(subject.valid_search?).to be true }
-    end
-
     context 'with query, location and distance' do
       subject do
         described_class.new(

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe "candidates/schools/index.html.erb", type: :view do
+  let!(:primary_phase) { create :bookings_phase, :primary }
+  let!(:secondary_phase) { create :bookings_phase, :secondary }
+  let!(:college_phase) { create :bookings_phase, :college }
+
   context 'with fresh search' do
     before do
       assign(:search, Candidates::SchoolSearch.new)
@@ -8,29 +12,30 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
     end
   end
 
+  before do
+    allow(Candidates::School).to receive(:subjects).and_return(
+      [[1, 'Computer science'], [2, 'Maths'], [3, 'English']]
+    )
+
+    @school = build(:bookings_school)
+    @search = Candidates::SchoolSearch.new(
+      query: query,
+      age_group: age_group,
+      max_fee: max_fee,
+      subjects: subject_ids
+    )
+    allow(@search).to receive(:results).and_return(Kaminari.paginate_array([@school]).page(1))
+
+    assign :search, @search
+
+    render
+  end
+
   context 'filtering existing search' do
-    before do
-      allow(Candidates::School).to receive(:subjects).and_return(
-        [[1, 'Computer science'], [2, 'Maths'], [3, 'English']]
-      )
-
-      allow(Candidates::School).to receive(:phases).and_return(
-        [[1, 'Primary'], [2, 'Seconday'], [3, '16 to 18']]
-      )
-
-      @school = build(:bookings_school)
-      @search = Candidates::SchoolSearch.new(
-        query: 'Manchester',
-        phases: %w{3},
-        max_fee: '60',
-        subjects: %w{1 3}
-      )
-      allow(@search).to receive(:results).and_return(Kaminari.paginate_array([@school]).page(1))
-
-      assign :search, @search
-
-      render
-    end
+    let(:query) { 'Manchester' }
+    let(:age_group) { 'secondary' }
+    let(:max_fee) { '60' }
+    let(:subject_ids) { %w{1 3} }
 
     it "shows search results" do
       expect(rendered).to match(/School experience matching/)
@@ -43,16 +48,32 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
       expect(rendered).to have_unchecked_field 'subjects[]', count: 1
     end
 
-    it "shows filled in phases filter" do
-      expect(rendered).to have_css '#search-filter'
-      expect(rendered).to have_checked_field 'phases[]', count: 1
-      expect(rendered).to have_unchecked_field 'phases[]', count: 2
-    end
-
     it "shows results" do
       expect(rendered).to have_css '.school-result'
       expect(rendered).to have_css '.school-result h2', text: @school.name
       expect(rendered).to have_css '.school-result .govuk-summary-list__key', count: 3
+    end
+  end
+
+  context 'Layout' do
+    let(:query) { 'Manchester' }
+    let(:max_fee) { '60' }
+    let(:subject_ids) { nil }
+
+    context 'Search for primary experience' do
+      let(:age_group) { 'primary' }
+
+      it 'hides the subjects filters' do
+        expect(rendered).not_to have_css '#search-filter'
+      end
+    end
+
+    context 'Search for secondary experience' do
+      let(:age_group) { 'secondary' }
+
+      it 'shows the subjects filters' do
+        expect(rendered).to have_css '#search-filter'
+      end
     end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number
SE-1697

### Context
User research indicated we should allow the candidate to specify the age group they want experience for.

### Changes proposed in this pull request
Adds a primary and secondary selector to the candidate school search screen.
The selected field sets the phases on the candidate school search.
Removes left over references to longitude and latitude from when we had find my location button.

### Guidance to review
Manual testing, perform a school search filter by age group, expect to only see schools that offer that age group. When viewing primary school search results the subjects filter side bar is hidden.