### PR TITLE
Change the warning link to point to availability preferences SE-1833

### DIFF
--- a/app/views/schools/dashboards/_no_availability_info_warning.html.erb
+++ b/app/views/schools/dashboards/_no_availability_info_warning.html.erb
@@ -3,6 +3,6 @@
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
     You have no availability information, your school will not appear in candidate
-    searches. <%= link_to "Enter dates", edit_schools_availability_info_path %>
+    searches. <%= link_to "Enter dates", schools_availability_preference_path %>
   </strong>
 </div>


### PR DESCRIPTION
### JIRA Ticket Number

SE-1833

### Context

The link on the warning went straight to the availability description edit page

### Changes proposed in this pull request

Since the warning was added we've opted to send flexible users via the preferences screen in the hope they'll notice that fixed dates are an option and switch. The warning now follows the same behaviour

### Guidance to review

Ensure it makes sense
