### PR TITLE
Validate booking not cancelled on setting attended

### DIFF
--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -13,7 +13,7 @@ module Schools
 
     def update
       bookings = unlogged_bookings.where(id: bookings_params.keys). \
-        includes(bookings_placement_request: :candidate)
+        includes(bookings_placement_request: %i(candidate candidate_cancellation school_cancellation))
       attendance = Schools::Attendance.new(bookings: bookings, bookings_params: bookings_params)
 
       if attendance.save

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -29,6 +29,7 @@ module Bookings
     validates :bookings_subject, presence: true
     validates :bookings_school, presence: true
     validates :duration, presence: true, numericality: { greater_than: 0 }
+    validates :attended, inclusion: [nil], if: -> { bookings_placement_request&.cancelled? }
 
     delegate \
       :availability,

--- a/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations_controller_spec.rb
@@ -104,7 +104,7 @@ describe Schools::ConfirmedBookings::CancellationsController, type: :request do
         end
 
         it 'creates the cancellation' do
-          expect(placement_request.school_cancellation.reason).to \
+          expect(placement_request.reload.school_cancellation.reason).to \
             eq "school's out for summer"
         end
 

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -76,6 +76,35 @@ describe Bookings::Booking do
           end
         end
       end
+
+      context 'attended' do
+        context 'when cancelled by candidate' do
+          subject { create :bookings_booking, :cancelled_by_candidate }
+
+          specify 'does not allow attended to be set' do
+            expect(subject).not_to allow_value(true).for :attended
+            expect(subject).not_to allow_value(false).for :attended
+          end
+        end
+
+        context 'when cancelled by school' do
+          subject { create :bookings_booking, :cancelled_by_school }
+
+          specify 'does not allow attended to be set' do
+            expect(subject).not_to allow_value(true).for :attended
+            expect(subject).not_to allow_value(false).for :attended
+          end
+        end
+
+        context 'when not cancelled' do
+          subject { create :bookings_booking }
+
+          specify 'allows attended to be set' do
+            expect(subject).to allow_value(true).for :attended
+            expect(subject).to allow_value(false).for :attended
+          end
+        end
+      end
     end
   end
 

--- a/spec/models/schools/attendance_spec.rb
+++ b/spec/models/schools/attendance_spec.rb
@@ -35,11 +35,25 @@ describe Schools::Attendance do
   end
 
   describe '#save' do
-    before { subject.save }
+    context 'when booking cancelled' do
+      before do
+        create :cancellation, :sent, placement_request: booking_1.bookings_placement_request
+        bookings.each(&:reload)
+        subject.save
+      end
 
-    specify 'should correctly update bookings with param values' do
-      bookings_params.each do |id, status|
-        expect(Bookings::Booking.find(id).attended).to be(status)
+      specify 'should not update cancelled bookings' do
+        expect(booking_1.reload.attended).to be nil
+      end
+    end
+
+    context 'when booking not cancelled' do
+      before { subject.save }
+
+      specify 'should correctly update bookings with param values' do
+        bookings_params.each do |id, status|
+          expect(Bookings::Booking.find(id).attended).to be(status)
+        end
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number
SE-1841

### Context
To prevent bookings getting in an inconsistent state validate the booking is not cancelled when updating acceptance.

### Changes proposed in this pull request
Add validation to ensure Booking#attended is nil if booking is cancelled.

### Guidance to review
Should look sensible, is there a better way to validate a field is nil?