### PR TITLE
Updating subject specific date copy SE-1915

### DIFF
--- a/app/services/candidates/registrations/subject_and_date_information.rb
+++ b/app/services/candidates/registrations/subject_and_date_information.rb
@@ -34,8 +34,20 @@ module Candidates
         self.bookings_placement_date_id, self.bookings_subject_id = pair.split('_')
       end
 
+      def has_primary_dates?
+        primary_placement_dates.any?
+      end
+
+      def has_secondary_dates?
+        secondary_placement_dates_grouped_by_date.any?
+      end
+
+      def has_primary_and_secondary_dates?
+        has_primary_dates? && has_secondary_dates?
+      end
+
       def primary_placement_dates
-        school
+        @primary_placement_dates ||= school
           .bookings_placement_dates
           .primary
           .in_date_order
@@ -50,7 +62,7 @@ module Candidates
       end
 
       def secondary_placement_dates_grouped_by_date
-        school
+        @secondary_placement_dates_grouped_by_date ||= school
           .bookings_placement_dates
           .secondary
           .in_date_order

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -9,9 +9,16 @@
 
       <%= f.hidden_field :date_and_subject_ids %>
 
+      <p>
+        Choose a date.
+        <% if @subject_and_date_information.has_primary_and_secondary_dates? %>
+          For secondary school dates you can also choose a school experience subject.
+        <% end %>
+      </p>
+
       <section class="<%= subject_and_date_section_classes(subject_and_date_information) %>">
 
-        <%- if @subject_and_date_information.primary_placement_dates.any? %>
+        <%- if @subject_and_date_information.has_primary_dates? %>
           <section class="date-selector date-selector-primary">
             <h3 class="govuk-heading-m">Primary school dates</h3>
 
@@ -22,7 +29,7 @@
           </section>
         <%- end -%>
 
-        <%- if @subject_and_date_information.secondary_placement_dates_grouped_by_date.any? %>
+        <%- if @subject_and_date_information.has_secondary_dates? %>
           <h3 class="govuk-heading-m">Secondary school dates</h3>
 
           <dl class="govuk-summary-list govuk-summary-list">

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -13,7 +13,7 @@
 
         <%- if @subject_and_date_information.primary_placement_dates.any? %>
           <section class="date-selector date-selector-primary">
-            <h3 class="govuk-heading-m">Primary placement dates</h3>
+            <h3 class="govuk-heading-m">Primary school dates</h3>
 
             <%= f.radio_button_fieldset :date_and_subject_ids,
               choices: @subject_and_date_information.primary_placement_dates,
@@ -23,7 +23,7 @@
         <%- end -%>
 
         <%- if @subject_and_date_information.secondary_placement_dates_grouped_by_date.any? %>
-          <h3 class="govuk-heading-m">Secondary placement dates</h3>
+          <h3 class="govuk-heading-m">Secondary school dates</h3>
 
           <dl class="govuk-summary-list govuk-summary-list">
           <% @subject_and_date_information.secondary_placement_dates_grouped_by_date.each do |date, secondary_placement_dates| %>

--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -2,9 +2,9 @@
   <%- if primary_dates.any? -%>
 
     <%- if secondary_dates_grouped_by_date.any? -%>
-      <h4 class="govuk-heading-m">Upcoming primary dates</h4>
+      <h4 class="govuk-heading-m">Primary school dates</h4>
     <%- else -%>
-      <h4 class="govuk-heading-m">Upcoming dates</h4>
+      <h4 class="govuk-heading-m">Dates</h4>
     <%- end -%>
 
     <ul class="govuk-list">
@@ -18,9 +18,9 @@
   <%- if secondary_dates_grouped_by_date.any? -%>
 
     <%- if secondary_dates_grouped_by_date.any? -%>
-      <h4 class="govuk-heading-m">Upcoming secondary dates</h4>
+      <h4 class="govuk-heading-m">Secondary school dates</h4>
     <%- else -%>
-      <h4 class="govuk-heading-m">Upcoming dates</h4>
+      <h4 class="govuk-heading-m">Dates</h4>
     <%- end -%>
 
     <dl class="secondary-placement-dates govuk-summary-list govuk-summary-list--no-border">

--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -19,6 +19,10 @@
 
       <%- if @placement_date.supports_subjects? -%>
         <%= f.radio_button_fieldset :available_for_all_subjects do |fieldset| %>
+          <p>
+          Tell us if the experience is about a specific subject <strong>or</strong> a general
+            experience and not about a specific subject.
+          </p>
           <%= f.radio_input true %>
           <%= f.radio_input false %>
         <% end %>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -60,7 +60,7 @@
 </div>
 
 <div>
-  <%= govuk_link_to "Add dates", new_schools_placement_date_path %>
+  <%= govuk_link_to "Add a date", new_schools_placement_date_path %>
 </div>
 
 <div>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = "Create a placement date" %>
+<%- self.page_title = "Add a date" %>
 
 <%
   self.breadcrumbs = {
@@ -8,10 +8,10 @@
   }
 %>
 
-<h1>Create a placement date</h1>
+<h1>Add a date</h1>
 
 <p>
-  Enter the start date and tell us how long it will last.
+  Enter a start date and tell us how long the experience will last.
 </p>
 
 <p>

--- a/app/views/schools/placement_dates/subject_selections/new.html.erb
+++ b/app/views/schools/placement_dates/subject_selections/new.html.erb
@@ -1,11 +1,15 @@
-<% self.page_title = 'Manage date subjects' %>
+<% self.page_title = 'Select school experience subjects' %>
 
-<h1>Tell us which of the subjects you offer are available for this date?</h1>
+<h1>Select school experience subjects</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @subject_selection, method: :post, url: schools_placement_date_subject_selection_path(@placement_date) do |f| %>
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+
+      <p>
+        Tell us which subjects you offer for this date and select continue
+      </p>
 
       <%= f.check_box_input :available_for_all_subjects %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -459,7 +459,7 @@ en:
 
       schools_placement_dates_configuration_form:
         has_limited_availability: Is there a maximum number of bookings you’ll accept for this date?
-        available_for_all_subjects: Is this date available for all the subjects you offer?
+        available_for_all_subjects: Select type of experience
 
       schools_placement_dates_subject_selection:
         subject_ids: Select all that apply
@@ -529,7 +529,6 @@ en:
         supports_subjects:
           yes: Secondary including secondary schools, sixth-forms, colleges and 16 to 18 years
           no: Primary including early years, key stage 1 and key stage 2
-
       bookings_placement_request_cancellation:
         reason: Cancellation reasons
       candidates_registrations_contact_information:
@@ -693,6 +692,9 @@ en:
         has_limited_availability:
           true: 'Yes'
           false: 'No'
+        available_for_all_subjects:
+          false: About a specific subject
+          true: General / not subject specific experience
         max_bookings_count: 'Enter maximum number of bookings.'
       schools_placement_dates_subject_selection:
         available_for_all_subjects: 'All subjects'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -462,7 +462,7 @@ en:
         available_for_all_subjects: Select type of experience
 
       schools_placement_dates_subject_selection:
-        subject_ids: Select all that apply
+        subject_ids: Select all that apply.
 
       candidates_feedback:
         <<: *feedback_fieldset

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -392,8 +392,8 @@ en:
         enabled: Turn requests on or off
         availability_preference_fixed: Choose how dates are displayed
       bookings_placement_date:
-        date: Enter a start date
-        supports_subjects: Which age groups will candidates be placed with?
+        date: Enter start date
+        supports_subjects: Select school experience phase
       phases: Education phases
       fees: Fees
       subjects: Subjects
@@ -478,8 +478,8 @@ en:
           Requests that are already in-progress will continue as normal.
         availability_preference_fixed: Select how you'd like to present school experience dates to candidates.
       bookings_placement_date:
-        date: For example, 01 09 2019
-        duration: Enter number of days
+        date: For example, 01 09 2020.
+        duration: Enter number of days.
       phases: Select all that apply
       max_fee: Schools may charge
       subjects: Select all that apply
@@ -527,8 +527,8 @@ en:
         duration: How long will it last?
         active: Make this date available to candidates?
         supports_subjects:
-          yes: Secondary or college
-          no: Primary or early years
+          yes: Secondary including secondary schools, sixth-forms, colleges and 16 to 18 years
+          no: Primary including early years, key stage 1 and key stage 2
 
       bookings_placement_request_cancellation:
         reason: Cancellation reasons

--- a/features/schools/placement_dates/index.feature
+++ b/features/schools/placement_dates/index.feature
@@ -31,7 +31,7 @@ Feature: Listing placement dates
 
     Scenario: The add a new placement date button
         Given I am on the 'placement dates' page
-        Then there should be a 'Add dates' link to the new placement date page
+        Then there should be a 'Add a date' link to the new placement date page
 
     Scenario: Warning displayed when there are no dates
         Given my school has no placement dates

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -9,7 +9,7 @@ Feature: Creating new placement dates
 
     Scenario: Page title
         Given I am on the 'new placement date' page
-        Then the page title should be 'Create a placement date'
+        Then the page title should be 'Add a date'
 
     Scenario: Breadcrumbs
         Given I am on the 'new placement date' page
@@ -23,12 +23,12 @@ Feature: Creating new placement dates
         Given I am on the 'new placement date' page
         Then I should see a form with the following fields:
             | Label                  | Type   |
-            | Enter a start date     | date   |
+            | Enter start date       | date   |
             | How long will it last? | number |
 
     Scenario: Preventing invalid dates from being added
         Given I am on the 'new placement date' page
-        And I fill in the 'Enter a start date' date field with an invalid date of 31st September next year
+        And I fill in the 'Enter start date' date field with an invalid date of 31st September next year
         When I submit the form
         Then I should see an error message stating 'is not a valid date'
 
@@ -41,24 +41,24 @@ Feature: Creating new placement dates
     Scenario: Primary and secondary schools: extra option
         Given my school is a 'primary and secondary' school
         And I am on the 'new placement date' page
-        Then I should see radio buttons for 'Which age groups will candidates be placed with?' with the following options:
-          | Primary or early years |
-          | Secondary or college   |
+        Then I should see radio buttons for 'Select school experience phase' with the following options:
+          | Primary including early years, key stage 1 and key stage 2                      |
+          | Secondary including secondary schools, sixth-forms, colleges and 16 to 18 years |
 
     Scenario: Primary and secondary schools: selecting primary
         Given my school is a 'primary and secondary' school
         And I am on the 'new placement date' page
         When I fill in the form with a future date and duration of 3
-        And I choose 'Primary or early years' from the 'Which age groups will candidates be placed with?' radio buttons
+        And I choose 'Primary including early years, key stage 1 and key stage 2' from the 'Select school experience phase' radio buttons
         And I submit the form
         Then I should be on the new configuration page for my placement date
         And there should be no subject specificity option
 
-    Scenario: Primary and secondary schools: selecting primary
+    Scenario: Primary and secondary schools: selecting secondary
         Given my school is a 'primary and secondary' school
         And I am on the 'new placement date' page
         When I fill in the form with a future date and duration of 3
-        And I choose 'Secondary or college' from the 'Which age groups will candidates be placed with?' radio buttons
+        And I choose 'Secondary including secondary schools, sixth-forms, colleges and 16 to 18 years' from the 'Select school experience phase' radio buttons
         And I submit the form
         Then I should be on the new configuration page for my placement date
         And there should be a subject specificity option

--- a/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
@@ -24,13 +24,13 @@ Feature: Configuring a placement date
 
   Scenario: Date is not subject specific
     When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'Yes' from the "Is this date available for all the subjects you offer?" radio buttons
+    And I choose 'General / not subject specific experience' from the "Select type of experience" radio buttons
     And I submit the form
     Then I should be on the 'placement dates' page
     And my newly-created placement date should be listed
 
   Scenario: Date is subject specific
     Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'No' from the "Is this date available for all the subjects you offer?" radio buttons
+    And I choose 'About a specific subject' from the "Select type of experience" radio buttons
     When I submit the form
     Then I should be on the new subject selection page for this date

--- a/features/schools/placement_dates/secondary_school_configuration.feature
+++ b/features/schools/placement_dates/secondary_school_configuration.feature
@@ -24,13 +24,13 @@ Feature: Configuring a placement date
 
   Scenario: Date is not subject specific
     When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'Yes' from the "Is this date available for all the subjects you offer?" radio buttons
+    And I choose 'General / not subject specific experience' from the "Select type of experience" radio buttons
     And I submit the form
     Then I should be on the 'placement dates' page
     And my newly-created placement date should be listed
 
   Scenario: Date is subject specific
     Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'No' from the "Is this date available for all the subjects you offer?" radio buttons
+    And I choose 'About a specific subject' from the "Select type of experience" radio buttons
     When I submit the form
     Then I should be on the new subject selection page for this date

--- a/features/schools/placement_dates/subject_selection.feature
+++ b/features/schools/placement_dates/subject_selection.feature
@@ -12,7 +12,7 @@ Feature: Selecting subjects for a placement date
         And the placement date is subject specific
 
     Scenario: Page title
-        Then the page's main heading should be 'Tell us which of the subjects you offer are available for this date?'
+        Then the page's main heading should be 'Select school experience subjects'
 
     Scenario: Page content
         Then I should see a list of subjects the school offers

--- a/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
@@ -14,7 +14,7 @@ When("I am on the {string} screen for my chosen school") do |page_name|
 end
 
 Then("I should see the list of primary placement dates") do
-  expect(page).to have_css('h3', text: 'Primary placement dates')
+  expect(page).to have_css('h3', text: 'Primary school dates')
 
   @primary_dates.each do |pd|
     expect(page).to have_css(

--- a/features/step_definitions/schools/placement_dates/new_steps.rb
+++ b/features/step_definitions/schools/placement_dates/new_steps.rb
@@ -1,7 +1,7 @@
 Given("I fill in the form with a future date and duration of {int}") do |int|
   @date = 1.week.from_now
   @duration = int
-  step "I fill in the date field 'Enter a start date' with #{@date.strftime('%d-%m-%Y')}"
+  step "I fill in the date field 'Enter start date' with #{@date.strftime('%d-%m-%Y')}"
   fill_in "How long will it last?", with: @duration
 end
 

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -9,7 +9,7 @@ end
 Given "the placement date is subject specific" do
   steps %(
     Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'No' from the "Is this date available for all the subjects you offer?" radio buttons
+    And I choose 'About a specific subject' from the "Select type of experience" radio buttons
     And I submit the form
   )
 end

--- a/spec/services/candidates/registrations/subject_and_date_information_spec.rb
+++ b/spec/services/candidates/registrations/subject_and_date_information_spec.rb
@@ -164,5 +164,52 @@ describe Candidates::Registrations::SubjectAndDateInformation, type: :model do
         expect(subject.placement_date).to eq bookings_placement_date
       end
     end
+
+    describe '#has_primary_dates?' do
+      subject { described_class.new }
+      context 'when primary dates are present' do
+        before { allow(subject).to receive(:primary_placement_dates).and_return(%w(yes)) }
+
+        it { is_expected.to have_primary_dates }
+      end
+
+      context 'when no primary dates are present' do
+        before { allow(subject).to receive(:primary_placement_dates).and_return([]) }
+
+        it { is_expected.not_to have_primary_dates }
+      end
+    end
+
+    describe '#has_secondary_dates?' do
+      subject { described_class.new }
+      context 'when secondary dates are present' do
+        before { allow(subject).to receive(:secondary_placement_dates_grouped_by_date).and_return(%w(yes)) }
+
+        it { is_expected.to have_secondary_dates }
+      end
+
+      context 'when no secondary dates are present' do
+        before { allow(subject).to receive(:secondary_placement_dates_grouped_by_date).and_return({}) }
+
+        it { is_expected.not_to have_secondary_dates }
+      end
+    end
+
+    describe '#has_primary_and_secondary_dates?' do
+      subject { described_class.new }
+      context 'when secondary dates are present' do
+        before { allow(subject).to receive(:primary_placement_dates).and_return(%w(yes)) }
+        before { allow(subject).to receive(:secondary_placement_dates_grouped_by_date).and_return(%w(yes)) }
+
+        it { is_expected.to have_primary_and_secondary_dates }
+      end
+
+      context 'when no secondary dates are present' do
+        before { allow(subject).to receive(:secondary_placement_dates_grouped_by_date).and_return({}) }
+        before { allow(subject).to receive(:primary_placement_dates).and_return([]) }
+
+        it { is_expected.not_to have_primary_and_secondary_dates }
+      end
+    end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1915

### Context

The copy in the prototype had progressed and this should bring the Rails app up to date

### Changes proposed in this pull request

Make various text changes and, for the conditional help sentence on the subject/date selection screen add some helper methods to reduce the logic in the view.

### Guidance to review

Ensure everything makes sense. Only real discrepancy between this and the prototype is that as the form builder doesn't support radio button hints the text is inline with the label - this looks clear to me

