### PR TITLE
Add photo id candidate requirement

### DIFF
--- a/app/controllers/schools/on_boarding/candidate_requirements_selections_controller.rb
+++ b/app/controllers/schools/on_boarding/candidate_requirements_selections_controller.rb
@@ -49,6 +49,8 @@ module Schools
           :has_or_working_towards_degree,
           :live_locally,
           :maximum_distance_from_school,
+          :provide_photo_identification,
+          :photo_identification_details,
           :other,
           :other_details
       end

--- a/app/forms/schools/on_boarding/candidate_requirements_selection.rb
+++ b/app/forms/schools/on_boarding/candidate_requirements_selection.rb
@@ -6,6 +6,8 @@ module Schools
       attribute :has_or_working_towards_degree, :boolean
       attribute :live_locally, :boolean
       attribute :maximum_distance_from_school, :integer
+      attribute :provide_photo_identification, :boolean
+      attribute :photo_identification_details, :string
       attribute :other, :boolean
       attribute :other_details, :string
 
@@ -13,10 +15,12 @@ module Schools
       validates :not_on_another_training_course, inclusion: [true, false]
       validates :has_or_working_towards_degree, inclusion: [true, false]
       validates :live_locally, inclusion: [true, false]
+      validates :provide_photo_identification, inclusion: [true, false]
       validates :other, inclusion: [true, false]
       validates :maximum_distance_from_school, presence: true, if: :live_locally
       validates :maximum_distance_from_school, numericality: { greater_than: 0 }, if: :maximum_distance_from_school
       validates :maximum_distance_from_school, absence: true, unless: :live_locally
+      validates :photo_identification_details, presence: true, if: :provide_photo_identification
       validates :other_details, presence: true, if: :other
       validates :other_details, absence: true, unless: :other
 
@@ -26,6 +30,8 @@ module Schools
         has_or_working_towards_degree,
         live_locally,
         maximum_distance_from_school,
+        provide_photo_identification,
+        photo_identification_details,
         other,
         other_details
       )
@@ -35,6 +41,8 @@ module Schools
           has_or_working_towards_degree: has_or_working_towards_degree,
           live_locally: live_locally,
           maximum_distance_from_school: maximum_distance_from_school,
+          provide_photo_identification: provide_photo_identification,
+          photo_identification_details: photo_identification_details,
           other: other,
           other_details: other_details
       end
@@ -48,6 +56,7 @@ module Schools
 
       def ux_fix
         self.maximum_distance_from_school = nil unless live_locally
+        self.photo_identification_details = nil unless provide_photo_identification
         self.other_details = nil unless other
       end
     end

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -84,6 +84,8 @@ module Schools
           %w(candidate_requirements_selection_has_or_working_towards_degree has_or_working_towards_degree),
           %w(candidate_requirements_selection_live_locally live_locally),
           %w(candidate_requirements_selection_maximum_distance_from_school maximum_distance_from_school),
+          %w(candidate_requirements_selection_provide_photo_identification provide_photo_identification),
+          %w(candidate_requirements_selection_photo_identification_details photo_identification_details),
           %w(candidate_requirements_selection_other other),
           %w(candidate_requirements_selection_other_details other_details)
       ],

--- a/app/presenters/schools/on_boarding/candidate_requirements_selection_presenter.rb
+++ b/app/presenters/schools/on_boarding/candidate_requirements_selection_presenter.rb
@@ -29,6 +29,10 @@ module Schools
           output << "They must live within #{distance} #{miles} from the school"
         end
 
+        if provide_photo_identification?
+          output << photo_identification_details
+        end
+
         if other?
           output << other_details
         end
@@ -61,13 +65,23 @@ module Schools
         @attributes.fetch :candidate_requirements_selection_live_locally
       end
 
-      def other?
-        @attributes.fetch :candidate_requirements_selection_other
-      end
-
       def maximum_distance_from_school
         @attributes.fetch \
           :candidate_requirements_selection_maximum_distance_from_school
+      end
+
+      def provide_photo_identification?
+        @attributes.fetch \
+          :candidate_requirements_selection_provide_photo_identification
+      end
+
+      def photo_identification_details
+        @attributes.fetch \
+          :candidate_requirements_selection_photo_identification_details
+      end
+
+      def other?
+        @attributes.fetch :candidate_requirements_selection_other
       end
 
       def other_details

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -28,6 +28,9 @@
         <%= fieldset.check_box_input :live_locally do %>
           <%= f.number_field :maximum_distance_from_school %>
         <% end %>
+        <%= fieldset.check_box_input :provide_photo_identification do %>
+          <%= f.text_field :photo_identification_details %>
+        <% end %>
         <%= fieldset.check_box_input :other do %>
           <%= f.text_field :other_details %>
         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,8 @@ en:
               blank: "Enter how close to your school a candidate must live"
               not_a_number: 'Enter a valid number for how close to your school a candidate must live'
               greater_than: 'Enter a number greater than 0 for how close to your school a candidate must live'
+            photo_identification_details:
+              blank: 'Provide details'
             other_details:
               blank: 'Provide details'
         schools/on_boarding/candidate_requirement:
@@ -573,6 +575,8 @@ en:
         has_or_working_towards_degree: "They must have or be working towards a degree"
         live_locally: "They must live locally"
         maximum_distance_from_school: "Tell us within how many miles of your school. For example, 20 miles."
+        provide_photo_identification: "They must provide photo ID"
+        photo_identification_details: "Provide details. For example, passport or driving licence."
         other: "Other"
         other_details: "Provide details."
       schools_on_boarding_candidate_requirement:

--- a/db/migrate/20191108132921_add_photo_id_requirements_to_schools_school_profiles.rb
+++ b/db/migrate/20191108132921_add_photo_id_requirements_to_schools_school_profiles.rb
@@ -1,0 +1,6 @@
+class AddPhotoIdRequirementsToSchoolsSchoolProfiles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :schools_school_profiles, :candidate_requirements_selection_provide_photo_identification, :boolean
+    add_column :schools_school_profiles, :candidate_requirements_selection_photo_identification_details, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_04_112809) do
+ActiveRecord::Schema.define(version: 2019_11_08_132921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -394,6 +394,8 @@ ActiveRecord::Schema.define(version: 2019_11_04_112809) do
     t.boolean "disability_confident_is_disability_confident"
     t.boolean "access_needs_policy_has_access_needs_policy"
     t.string "access_needs_policy_url"
+    t.boolean "candidate_requirements_selection_provide_photo_identification"
+    t.text "candidate_requirements_selection_photo_identification_details"
     t.index ["bookings_school_id"], name: "index_schools_school_profiles_on_bookings_school_id"
   end
 

--- a/spec/factories/schools/on_boarding/candidate_requirements_selection_factory.rb
+++ b/spec/factories/schools/on_boarding/candidate_requirements_selection_factory.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     has_or_working_towards_degree { true }
     live_locally { true }
     maximum_distance_from_school { 8 }
+    provide_photo_identification { true }
+    photo_identification_details { 'Make sure photo is clear' }
     other { true }
     other_details { 'Some other requirements' }
   end

--- a/spec/forms/schools/on_boarding/candidate_requirements_selection_spec.rb
+++ b/spec/forms/schools/on_boarding/candidate_requirements_selection_spec.rb
@@ -7,6 +7,8 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
     it { is_expected.to respond_to :has_or_working_towards_degree }
     it { is_expected.to respond_to :live_locally }
     it { is_expected.to respond_to :maximum_distance_from_school }
+    it { is_expected.to respond_to :provide_photo_identification }
+    it { is_expected.to respond_to :photo_identification_details }
     it { is_expected.to respond_to :other }
     it { is_expected.to respond_to :other_details }
   end
@@ -33,6 +35,30 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
 
       it 'removes maximum_distance_from_school' do
         expect(subject.maximum_distance_from_school).to be nil
+      end
+    end
+
+    context 'when provide_photo_identification is selected' do
+      before do
+        subject.provide_photo_identification = true
+        subject.photo_identification_details = 'photo details'
+        subject.valid?
+      end
+
+      it 'doesnt remove photo_identification_details' do
+        expect(subject.photo_identification_details).to eq 'photo details'
+      end
+    end
+
+    context 'when provide_photo_identification is not selected' do
+      before do
+        subject.provide_photo_identification = false
+        subject.photo_identification_details = 'photo details'
+        subject.valid?
+      end
+
+      it 'removes photo_identification_details' do
+        expect(subject.photo_identification_details).to be nil
       end
     end
 
@@ -71,6 +97,18 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
       context 'when the live_locally is not selected' do
         before { subject.live_locally = false }
         it { is_expected.not_to validate_presence_of :maximum_distance_from_school }
+      end
+    end
+
+    context 'photo_identification_details' do
+      context 'when provide_photo_identification is selected' do
+        before { subject.provide_photo_identification = true }
+        it { is_expected.to validate_presence_of :photo_identification_details }
+      end
+
+      context 'when provide_photo_identification is not selected' do
+        before { subject.provide_photo_identification = false }
+        it { is_expected.not_to validate_presence_of :photo_identification_details }
       end
     end
 

--- a/spec/models/bookings/profile_attributes_convertor_spec.rb
+++ b/spec/models/bookings/profile_attributes_convertor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
 
       it { is_expected.to include(dbs_requires_check: true) }
       it { is_expected.to include(dbs_policy_details: 'Must have recent dbs check') }
-      it { is_expected.to include(individual_requirements: "Must be applying to or have applied to our, or a partner school's, teacher training course. Must have a degree. They must live within 8 miles from the school. Some other requirements") }
+      it { is_expected.to include(individual_requirements: "Must be applying to or have applied to our, or a partner school's, teacher training course. Must have a degree. They must live within 8 miles from the school. Make sure photo is clear. Some other requirements") }
       it { is_expected.to include(description_details: 'Horse archery') }
       it { is_expected.to include(dress_code_business: true) }
       it { is_expected.to include(dress_code_cover_tattoos: true) }
@@ -72,6 +72,7 @@ RSpec.describe Bookings::ProfileAttributesConvertor, type: :model do
         model.candidate_requirements_selection_other = false
         model.candidate_requirements_selection_not_on_another_training_course = false
         model.candidate_requirements_selection_has_or_working_towards_degree = false
+        model.candidate_requirements_selection_provide_photo_identification = false
         model.description_details = ' '
         model.candidate_experience_detail_disabled_facilities = false
         model.candidate_experience_detail_other_dress_requirements = false

--- a/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
@@ -151,7 +151,7 @@ describe Schools::OnBoarding::SchoolProfilePresenter do
 
       it 'returns yes with the requirements' do
         expect(subject.individual_requirements).to eq \
-          "Must be applying to or have applied to our, or a partner school's, teacher training course. Must have a degree. They must live within 8 miles from the school. Some other requirements"
+          "Must be applying to or have applied to our, or a partner school's, teacher training course. Must have a degree. They must live within 8 miles from the school. Make sure photo is clear. Some other requirements"
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number
SE-1885

### Context
Prototype has been updated to include another candidate requirement option.

### Changes proposed in this pull request
Adds provide_photo_identification and photo_identification_details to
schools profile.

### Guidance to review
Manual testing if required: On board a new school or edit an existing school. On the candidate requirements step chose the photo id requirement, enter some details, complete the rest of the wizard. Visit the school profile as a candidate, expect the photo requirement details you entered to be present.