### PR TITLE
Add step defs for subject specific date scenarios SE-1804

### DIFF
--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -1,4 +1,4 @@
-<div>
+<div id="date-and-subject-summary">
   <%- if primary_dates.any? -%>
 
     <%- if secondary_dates_grouped_by_date.any? -%>

--- a/features/candidates/schools/show/upcoming_placement_dates.feature
+++ b/features/candidates/schools/show/upcoming_placement_dates.feature
@@ -5,25 +5,29 @@ Feature: Displaying a school's upcoming dates
 
     Scenario: When my school has flexible dates
         Given my school of choice has 'flexible' dates
+        And the school is fully-onboarded
         When I am on the profile page for the chosen school
         Then there should be no breakdown of dates at all
 
     Scenario: The presence of the dates list
         Given my school of choice has 'fixed' dates
+        And the school is fully-onboarded
+        And the school has some primary placement dates set up
         When I am on the profile page for the chosen school
         Then I should see a breakdown of upcoming dates and subjects
 
     Scenario: The dates list contents
         Given my school of choice has 'fixed' dates
+        And the school is fully-onboarded
         And the following dates have been added:
-            | Date             | Subjects                |
-            | 1 week from now  | None                    |
-            | 1 week from now  | English, Maths          |
-            | 2 weeks from now | English, Maths, Biology |
-            | 3 weeks from now | None                    |
+            | Weeks from now | Subjects                |
+            | 1              | None                    |
+            | 1              | English, Maths          |
+            | 2              | English, Maths, Biology |
+            | 3              | None                    |
         When I am on the profile page for the chosen school
         Then I should see the following list of available dates and subjects:
-            | Date             | Subjects                     |
-            | 1 week from now  | All subjects, English, Maths |
-            | 2 weeks from now | English, Maths, Biology      |
-            | 3 weeks from now | All subjects                 |
+            | Weeks from now | Subjects                     |
+            | 1              | All subjects, English, Maths |
+            | 2              | English, Maths, Biology      |
+            | 3              | All subjects                 |


### PR DESCRIPTION
### JIRA Ticket Number

SE-1804

### Context

There were a few cucumber scenarios around displaying the school profile page to candidates with fixed (subject-specific) dates that had no step definitions

### Changes proposed in this pull request

Add them and make sure they work

### Guidance to review

Does it look sensible?
