### PR TITLE
Truncate the length of school names

### DIFF
--- a/app/services/bookings/gitis/event_logger.rb
+++ b/app/services/bookings/gitis/event_logger.rb
@@ -4,7 +4,7 @@ module Bookings
       attr_reader :type, :subject
 
       NOTES_HEADER = "RECORDED   ACTION                 EXP DATE   URN    NAME".freeze
-      LOG_LINE = "%10<recorded>s %-22<action>s %8<date>s %-6<urn>s %<name>s".freeze
+      LOG_LINE = "%10<recorded>s %-22<action>s %8<date>s %-6<urn>s %.25<name>s".freeze
 
       class << self
         def entry(type, subject)


### PR DESCRIPTION
### JIRA Ticket Number

SE-1942

### Context

We're hitting a length limit occasionally on the log field in Gitis. This is normally caused by overlong school names.

### Changes proposed in this pull request

1. Shorten the school name to 25 chars since we also include the URN.

### Guidance to review

1. Code review
