### PR TITLE
Remove candidate name from Rejection emails

### DIFF
--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -43,7 +43,6 @@ module Schools
           NotifyEmail::CandidateRequestRejection.new(
             to: cancellation.candidate_email,
             school_name: cancellation.school_name,
-            candidate_name: cancellation.candidate_name,
             rejection_reasons: cancellation.reason,
             extra_details: cancellation.extra_details,
             dates_requested: cancellation.dates_requested,

--- a/app/notify/notify_email/candidate_request_rejection.rb
+++ b/app/notify/notify_email/candidate_request_rejection.rb
@@ -1,15 +1,13 @@
 class NotifyEmail::CandidateRequestRejection < Notify
   attr_accessor \
     :school_name,
-    :candidate_name,
     :rejection_reasons,
     :extra_details,
     :dates_requested,
     :school_search_url
 
-  def initialize(to:, school_name:, candidate_name:, rejection_reasons:, extra_details:, dates_requested:, school_search_url:)
+  def initialize(to:, school_name:, rejection_reasons:, extra_details:, dates_requested:, school_search_url:)
     self.school_name       = school_name
-    self.candidate_name    = candidate_name
     self.rejection_reasons = rejection_reasons
     self.extra_details     = extra_details
     self.dates_requested   = dates_requested
@@ -20,13 +18,12 @@ class NotifyEmail::CandidateRequestRejection < Notify
 private
 
   def template_id
-    '577100df-1dae-405e-8500-947b85edf76e'
+    '74f84226-539a-43b0-b887-d8ffc9348965'
   end
 
   def personalisation
     {
       school_name: school_name,
-      candidate_name: candidate_name,
       rejection_reasons: rejection_reasons,
       extra_details: extra_details,
       dates_requested: dates_requested,

--- a/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
+++ b/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
@@ -1,4 +1,4 @@
-Dear ((candidate_name)),
+Hello,
 
 ((school_name)) has turned down your school experience request for the following dates: 
 * ((dates_requested))

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -65,7 +65,6 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
         expect(NotifyEmail::CandidateRequestRejection).to have_received(:new).with \
           to: gitis_contact.email,
           school_name: cancellation.school_name,
-          candidate_name: gitis_contact.full_name,
           rejection_reasons: cancellation.reason,
           extra_details: cancellation.extra_details,
           dates_requested: cancellation.dates_requested,

--- a/spec/notify/notify_email/candidate_request_rejection_spec.rb
+++ b/spec/notify/notify_email/candidate_request_rejection_spec.rb
@@ -1,9 +1,8 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateRequestRejection do
-  it_should_behave_like "email template", "577100df-1dae-405e-8500-947b85edf76e",
+  it_should_behave_like "email template", "74f84226-539a-43b0-b887-d8ffc9348965",
     school_name: "Springfield Elementary School",
-    candidate_name: "Nelson Muntz",
     rejection_reasons: "Failed security checks",
     extra_details: 'HawHaw',
     dates_requested: 'Whenever really',


### PR DESCRIPTION
Avoid sending unnecessary pii

### JIRA Ticket Number
SE-1752

### Context
We we're sending over the candidate name in the email for the sake of the greeting.

### Changes proposed in this pull request
Replace the candidate name in the email with just 'Hello'

### Guidance to review
Rejection email sent to the candidate should not include their name.

