### PR TITLE
Disable forgery protection for schools namespace

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -3,6 +3,8 @@ module Schools
   class MissingURN < StandardError; end
 
   class BaseController < ApplicationController
+    self.forgery_protection_origin_check = false
+
     include GitisAccess
     include DFEAuthentication
     before_action :require_auth


### PR DESCRIPTION
We've been getting a number of Invalid authenticity token errors on
production due to a null origin header being present.
Looking in sentry this seems to have only effected schools, the most
likely explanation is due to their firewall settings or some type of do
not track plugin.
Disabling this check so schools can continue to use the service.

### JIRA Ticket Number
SE-1947

### Context

### Changes proposed in this pull request

### Guidance to review
Set the Origin header to 'null', make a post request in the schools namespace, expect not to be shown the session expired page.

