### PR TITLE
Fix building debug branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
     displayName: 'Tag Docker image (built from master)'
 
   - script: |
-      docker tag $(DOCKER_HUB_REPO):$(imageTag) $(DOCKER_HUB_REPO):debug
+      docker tag $(DOCKER_HUB_REPO):$(imageTag) $(DOCKER_HUB_REPO):$(imageTag)-debug
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/debug'))
     displayName: 'Tag Docker image (built from debug)'
 
@@ -94,13 +94,13 @@ jobs:
       tags: latest
 
   - task: Docker@2
-    displayName: 'Push :master to DockerHub'
+    displayName: 'Push :debug to DockerHub'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/debug'))
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
       repository: $(DOCKER_HUB_REPO)
       command: push
-      tags: debug
+      tags: $(imageTag)-debug
 
   - task: Bash@3
     name: mtrx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,12 @@ jobs:
   - script: |
       docker tag $(DOCKER_HUB_REPO):$(imageTag) $(DOCKER_HUB_REPO):latest
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-    displayName: 'Push Docker image (built from master)'
+    displayName: 'Tag Docker image (built from master)'
+
+  - script: |
+      docker tag $(DOCKER_HUB_REPO):$(imageTag) $(DOCKER_HUB_REPO):debug
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/debug'))
+    displayName: 'Tag Docker image (built from debug)'
 
   - script: docker run --rm $(DOCKER_HUB_REPO):$(imageTag) brakeman --no-pager
     displayName: Run the Brakeman security scan
@@ -72,7 +77,7 @@ jobs:
     displayName: Run the GovUK Lint check
 
   - task: Docker@2
-    displayName: 'push to docker hub'
+    displayName: 'Push tagged image to DockerHub'
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
       repository: $(DOCKER_HUB_REPO)
@@ -80,13 +85,22 @@ jobs:
       tags: $(imageTag)
 
   - task: Docker@2
-    displayName: 'push to docker hub'
+    displayName: 'Push :latest to DockerHub'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     inputs:
       containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
       repository: $(DOCKER_HUB_REPO)
       command: push
       tags: latest
+
+  - task: Docker@2
+    displayName: 'Push :master to DockerHub'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/debug'))
+    inputs:
+      containerRegistry: $(DOCKER_HUB_CONNECTION_NAME)
+      repository: $(DOCKER_HUB_REPO)
+      command: push
+      tags: debug
 
   - task: Bash@3
     name: mtrx


### PR DESCRIPTION
### JIRA Ticket Number

SE-1934

### Context

To enable use of the deletion strategy in Database Cleaner we need to be able to debug the pipeline. Currently debug builds have gotten broken at some point.

### Changes proposed in this pull request

1. Tag the debug image
2. Upload the debug image to dockerhub for use within CD
3. Disambiguate names of some other steps

### Guidance to review

1. Do pipeline changes make sense
