### PR TITLE
SE-1951 Handle credentials in url

### DIFF
--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -28,5 +28,6 @@ When("I click {string}, fill in and submit the school feedback form") do |string
 end
 
 Then("my referrer should have been recorded") do
-  expect(Feedback.last.referrer).to eql(@referrer)
+  referrer_with_credentials = @referrer.gsub(/(https?:\/\/)([^\/]+@)?/, '\1')
+  expect(Feedback.last.referrer).to match(referrer_with_credentials)
 end

--- a/features/step_definitions/feedback_steps.rb
+++ b/features/step_definitions/feedback_steps.rb
@@ -28,6 +28,6 @@ When("I click {string}, fill in and submit the school feedback form") do |string
 end
 
 Then("my referrer should have been recorded") do
-  referrer_with_credentials = @referrer.gsub(/(https?:\/\/)([^\/]+@)?/, '\1')
-  expect(Feedback.last.referrer).to match(referrer_with_credentials)
+  referrer_without_credentials = @referrer.gsub(/(https?:\/\/)([^\/]+@)?/, '\1')
+  expect(Feedback.last.referrer).to match(referrer_without_credentials)
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1951

### Context

Currently the tests feedback in cucumber are doing a full string match on the URL - but the url requested includes credentials, but the url compared with has them removed.

### Changes proposed in this pull request

1. Strip the credentials out from the referrer prior to comparison

### Guidance to review

1. Code check
2. Does it pass CD (going to set `debug`) to match this branch so look for a release with matching SHA
