### PR TITLE
Add manage schools link to candidates home page SE-1835

### DIFF
--- a/app/views/candidates/home/index.html.erb
+++ b/app/views/candidates/home/index.html.erb
@@ -7,7 +7,7 @@
 
     <p>
       Use this service if you want to request school experience in a primary
-      and secondary school in England.
+      or secondary school in England.
     </p>
 
     <p>
@@ -63,11 +63,11 @@
 
   <div class="govuk-grid-column-one-third column-top-border">
     <aside class="app-related-items" role="complementary">
-      <h2 class="govuk-heading-m" id="subsection-title">
-        Helpful information
-      </h2>
-
       <nav role="navigation" aria-labelledby="subsection-title">
+        <h2 class="govuk-heading-m" id="subsection-title">
+          Helpful information
+        </h2>
+
         <ul class="govuk-list govuk-!-font-size-16 govuk-se-spaced-list">
           <li>
             <a href="https://getintoteaching.education.gov.uk/" class="govuk-!-font-weight-bold">
@@ -89,6 +89,13 @@
               Types of school<span class="govuk-visually-hidden">in Subsection</span>
             </a>
           </li>
+        </ul>
+
+        <h2 class="govuk-heading-m" id="subsection-title">
+          If you're a school
+        </h2>
+
+        <ul class="govuk-list govuk-!-font-size-16 govuk-se-spaced-list">
           <li>
             <%= link_to schools_path, class: "govuk-!-font-weight-bold" do %>
               Manage school experience <span class="govuk-visually-hidden">in Subsection</span>

--- a/features/step_definitions/candidates/landing_page_steps.rb
+++ b/features/step_definitions/candidates/landing_page_steps.rb
@@ -2,7 +2,7 @@ Then("the leading paragraph should provide me with a summary of the service") do
   within('.govuk-main-wrapper div > p:first-of-type') do
     [
       'Use this service',
-      'request school experience in a primary and secondary school',
+      'request school experience in a primary or secondary school',
       'England'
     ].each do |snippet|
       expect(page).to have_text(snippet)


### PR DESCRIPTION

### JIRA Ticket Number

SE-1835

### Context

Link to manage schools isn't obvious

### Changes proposed in this pull request

Make it more obvious. Also reword 'primary and secondary' to 'primary or secondary' so it makes sense.

### Guidance to review

Do the changes make sense?
