### PR TITLE
Try rewording the experience type radio buttons

### DIFF
--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -24,8 +24,8 @@
 
         <%= f.radio_button_fieldset :available_for_all_subjects do |fieldset| %>
           <p>
-          Tell us if the experience is about a specific subject <strong>or</strong> a general
-            experience and not about a specific subject.
+            Tell us if this is a general experience <strong>or</strong> is
+            specific to a subject.
           </p>
           <%= f.radio_input true %>
           <%= f.radio_input false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,15 +717,12 @@ en:
         early_years: 'Early years foundation stage (EYFS)'
 
       schools_placement_dates_configuration_form:
-        available_for_all_subjects:
-          true: 'Yes'
-          false: 'No'
         has_limited_availability:
           true: 'Yes'
           false: 'No'
         available_for_all_subjects:
-          false: About a specific subject
-          true: General / not subject specific experience
+          true: 'General experience'
+          false: 'Specific to a subject'
         max_bookings_count: 'Enter maximum number of bookings.'
       schools_placement_dates_subject_selection:
         available_for_all_subjects: 'All subjects'

--- a/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
@@ -24,13 +24,13 @@ Feature: Configuring a placement date
 
   Scenario: Date is not subject specific
     When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'General / not subject specific experience' from the "Select type of experience" radio buttons
+    And I choose 'General experience' from the "Select type of experience" radio buttons
     And I submit the form
     Then I should be on the 'placement dates' page
     And my newly-created placement date should be listed
 
   Scenario: Date is subject specific
     Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'About a specific subject' from the "Select type of experience" radio buttons
+    And I choose 'Specific to a subject' from the "Select type of experience" radio buttons
     When I submit the form
     Then I should be on the new subject selection page for this date

--- a/features/schools/placement_dates/secondary_school_configuration.feature
+++ b/features/schools/placement_dates/secondary_school_configuration.feature
@@ -24,13 +24,13 @@ Feature: Configuring a placement date
 
   Scenario: Date is not subject specific
     When I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'General / not subject specific experience' from the "Select type of experience" radio buttons
+    And I choose 'General experience' from the "Select type of experience" radio buttons
     And I submit the form
     Then I should be on the 'placement dates' page
     And my newly-created placement date should be listed
 
   Scenario: Date is subject specific
     Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'About a specific subject' from the "Select type of experience" radio buttons
+    And I choose 'Specific to a subject' from the "Select type of experience" radio buttons
     When I submit the form
     Then I should be on the new subject selection page for this date

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -9,7 +9,7 @@ end
 Given "the placement date is subject specific" do
   steps %(
     Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons
-    And I choose 'About a specific subject' from the "Select type of experience" radio buttons
+    And I choose 'Specific to a subject' from the "Select type of experience" radio buttons
     And I submit the form
   )
 end


### PR DESCRIPTION
This is hopefully simpler and more direct without losing any meaning

### JIRA Ticket Number

N/A

### Context

This is how the radio buttons used to look:

<img width="674" alt="Screenshot 2019-11-12 at 13 40 00" src="https://user-images.githubusercontent.com/128088/68679064-0efd5b00-0557-11ea-80a6-61d6b64c3223.png">

### Changes proposed in this pull request

It seemed a bit clunky, we tried to streamline it slightly

<img width="510" alt="Screenshot 2019-11-12 at 13 39 30" src="https://user-images.githubusercontent.com/128088/68679120-2b999300-0557-11ea-86fa-e7aaa0593d24.png">

### Guidance to review

Still make sense? No typos?
