### PR TITLE
SE-1934 Use deletion strategy for Database Cleaner

### DIFF
--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -3,6 +3,7 @@ require 'database_cleaner/prevent_disabling_referential_integrity'
 truncation_options = { except: %w(schema_migrations spatial_ref_sys) }
 deletion_options = {
   only: %w(
+    events schools_school_profiles
     bookings_placement_request_cancellations
     bookings_bookings bookings_placement_requests
     candidates_session_tokens bookings_candidates

--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -1,3 +1,5 @@
+require 'database_cleaner/prevent_disabling_referential_integrity'
+
 exceptions = { except: %w{schema_migrations spatial_ref_sys} }
 
 DatabaseCleaner.clean_with :truncation, exceptions

--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -1,10 +1,20 @@
 require 'database_cleaner/prevent_disabling_referential_integrity'
 
-exceptions = { except: %w{schema_migrations spatial_ref_sys} }
+truncation_options = { except: %w(schema_migrations spatial_ref_sys) }
+deletion_options = {
+  only: %w(
+    bookings_placement_request_cancellations
+    bookings_bookings bookings_placement_requests
+    candidates_session_tokens bookings_candidates
+    bookings_profiles bookings_placement_date_subjects bookings_placement_dates
+    bookings_schools_subjects bookings_schools_phases bookings_schools
+    bookings_subjects bookings_phases
+  )
+}
 
-DatabaseCleaner.clean_with :truncation, exceptions
-DatabaseCleaner.strategy = :deletion, exceptions
-Cucumber::Rails::Database.javascript_strategy = :deletion, exceptions
+DatabaseCleaner.clean_with :truncation, truncation_options
+DatabaseCleaner.strategy = :deletion, deletion_options
+Cucumber::Rails::Database.javascript_strategy = :deletion, deletion_options
 if ENV['DEBUG_DATABASE_CLEANER'].present?
   ActiveRecord::Base.logger = Logger.new(STDOUT)
 end

--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -1,8 +1,8 @@
 exceptions = { except: %w{schema_migrations spatial_ref_sys} }
 
-DatabaseCleaner.clean_with(:truncation, exceptions)
-DatabaseCleaner.strategy = :truncation, exceptions
-Cucumber::Rails::Database.javascript_strategy = :truncation, exceptions
+DatabaseCleaner.clean_with :truncation, exceptions
+DatabaseCleaner.strategy = :deletion, exceptions
+Cucumber::Rails::Database.javascript_strategy = :deletion, exceptions
 if ENV['DEBUG_DATABASE_CLEANER'].present?
   ActiveRecord::Base.logger = Logger.new(STDOUT)
 end

--- a/lib/database_cleaner/prevent_disabling_referential_integrity.rb
+++ b/lib/database_cleaner/prevent_disabling_referential_integrity.rb
@@ -1,0 +1,8 @@
+module PreventDisablingReferentialIntegrity
+  def disable_referential_integrity
+    yield
+  end
+end
+
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter \
+  .include PreventDisablingReferentialIntegrity


### PR DESCRIPTION
### JIRA Ticket Number

SE-1934

### Context

Currently Database Cleaner in CD is very slow - which makes all the cucumber tests slow. This is caused by the slow truncate support on Azure hosted Postgres.

### Changes proposed in this pull request

1. Use a truncate strategy at the start of a test run
2. Use delete strategy to wrap individual tests
3. Remove the disabling of referential integrity since this isn't supported with the database account used
4. Added a manually maintained list of tables and the order to delete_all on them.

### Guidance to review

1. Sanity check
2. Opinion on manually maintained list of tables to clean - seems a fair trade off to me and may become more beneficial if we increase release frequency.
