### PR TITLE
Fix typo'd label

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -564,6 +564,7 @@ en:
         subject_second_choice: "Second choice"
       candidates_registrations_education:
         degree_subject: If you have or are studying for a degree, tell us about your degree subject
+        degree_stage_explaination: 'Degree stage explanation'
       candidates_registrations_subject_preference:
         degree_stage: What stage are you at with your degree?
         degree_stage_explaination: "Explain"


### PR DESCRIPTION
### JIRA Ticket Number

### Context
Typo fix, the revealing panel on degree stage was using the incorrectly spelt field name :shame:

### Changes proposed in this pull request
Added text to the local file for the field with the correct spelling

### Guidance to review

