### PR TITLE
Improve the validation messages for date of birth SE-1966

### DIFF
--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -19,7 +19,12 @@ module Candidates
       validates :email, presence: true, length: { maximum: 100 }
       validates :email, email_format: true, if: -> { email.present? }
       validates :date_of_birth, presence: true, unless: :read_only
-      validates :date_of_birth, inclusion: { in: ->(_) { MAX_AGE.years.ago..MIN_AGE.years.ago } }, if: -> { date_of_birth.present? && !read_only }
+      validates :date_of_birth,
+        timeliness: {
+          on_or_before: MIN_AGE.years.ago,
+          on_or_after: MAX_AGE.years.ago
+        },
+        if: -> { date_of_birth.present? && !read_only }
 
       def full_name
         return nil unless first_name && last_name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,7 +165,8 @@ en:
               blank: "Enter your full name"
             date_of_birth:
               blank: "Enter your date of birth"
-              inclusion: "Enter a valid date of birth. You must be at least 18 years old"
+              on_or_before: "Enter a valid date of birth. You must be at least 18 years old"
+              on_or_after: "Enter a valid date of birth. You must be younger than 100 years old"
 
         candidates/registrations/placement_preference:
           <<: *placement_preference_errors

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -118,7 +118,7 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
 
         it 'is invalid' do
           expect(subject.errors[:date_of_birth]).to eq [
-            'Enter a valid date of birth. You must be at least 18 years old'
+            'Enter a valid date of birth. You must be younger than 100 years old'
           ]
         end
       end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1966

### Context

The date of birth validation message only accounts for the possibility that a candidate is too young

### Changes proposed in this pull request

Split the validation so being too young and too old are checked separately.

The upper age limit is 100 years old 👵🏼👴🏻

### Guidance to review

Ensure it makes sense

<img width="654" alt="Screenshot 2019-11-13 at 15 39 00" src="https://user-images.githubusercontent.com/128088/68780312-03c92e80-062e-11ea-8082-402b22f96c72.png">

