### PR TITLE
Improve placement date missing date validation SE-1969

### DIFF
--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -30,13 +30,15 @@ module Bookings
         less_than: 100
       }
 
+
+    validates :date, presence: true
     validates :date,
       timeliness: {
         on_or_after: :today,
         before: -> { 2.years.from_now },
         type: :date
       },
-      presence: true,
+      if: -> { date.present? },
       on: :create
 
     with_options if: :published? do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -379,6 +379,7 @@ en:
         bookings/placement_date:
           attributes:
             date:
+              blank: Enter a start date
               on_or_after: Date must not be in the past
         bookings/bookings:
           attributes:

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -30,7 +30,7 @@ Feature: Creating new placement dates
         Given I am on the 'new placement date' page
         And I fill in the 'Enter start date' date field with an invalid date of 31st September next year
         When I submit the form
-        Then I should see an error message stating 'Enter a valid date'
+        Then I should see an error message stating 'Enter a start date'
 
     Scenario: Filling in and submitting the form
         Given I am on the 'new placement date' page


### PR DESCRIPTION
### JIRA Ticket Number

SE-1969

### Context

Two validation messages appear when no date is entered, one of them hasn't been overridden

### Changes proposed in this pull request

Separate the validations out (a missing date isn't invalid) and add some improved text for the missing date error

### Guidance to review

Ensure changes make sense

<img width="288" alt="Screenshot 2019-11-14 at 08 53 47" src="https://user-images.githubusercontent.com/128088/68843565-3f143d80-06c0-11ea-8cb4-6915eb899992.png">

