### PR TITLE
Skip configuration for primary dates

### DIFF
--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -51,7 +51,7 @@ private
   end
 
   def next_step(placement_date)
-    if Feature.instance.active? :subject_specific_dates
+    if Feature.instance.active?(:subject_specific_dates) && placement_date.supports_subjects?
       redirect_to new_schools_placement_date_configuration_path(placement_date)
     else
       placement_date.update! published_at: DateTime.now

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -33,10 +33,11 @@ Feature: Creating new placement dates
         Then I should see an error message stating 'Enter a valid date'
 
     Scenario: Filling in and submitting the form
-        Given I am on the 'new placement date' page
-        And I fill in the form with a future date and duration of 3
-        When I submit the form
-        Then I should be on the new configuration page for this date
+        Given my school is a 'primary' school
+        And I am on the 'new placement date' page
+        When I fill in the form with a future date and duration of 3
+        And I submit the form
+        Then I should be on the 'placement dates' page
 
     Scenario: Primary and secondary schools: extra option
         Given my school is a 'primary and secondary' school
@@ -51,8 +52,7 @@ Feature: Creating new placement dates
         When I fill in the form with a future date and duration of 3
         And I choose 'Primary including early years, key stage 1 and key stage 2' from the 'Select school experience phase' radio buttons
         And I submit the form
-        Then I should be on the new configuration page for my placement date
-        And there should be no subject specificity option
+        Then I should be on the 'placement dates' page
 
     Scenario: Primary and secondary schools: selecting secondary
         Given my school is a 'primary and secondary' school

--- a/features/schools/placement_dates/primary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_school_configuration.feature
@@ -1,3 +1,6 @@
+# this feature is awaiting capping, until then there is no configuration
+# for primary dates
+@wip
 Feature: Configuring a placement date
     So I can manage placement dates
     As a primary school administrator


### PR DESCRIPTION
Until capped dates have been implemented there's no need to show the
configuration screen for primary dates. Currently when the capped flag
is disabled the screen is entirely empty. Also mark the associated
features as @wip for the time being

### JIRA Ticket Number

SE-1989

