### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"
+    target_branch: "master"
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"
+    target_branch: "master"
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "daily"
+    target_branch: "master"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,11 +2,11 @@ version: 1
 update_configs:
   - package_manager: "ruby:bundler"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "weekly"
     target_branch: "master"
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "weekly"
     target_branch: "master"
   - package_manager: "docker"
     directory: "/"


### PR DESCRIPTION
### JIRA Ticket Number

None

### Context

Currently we have both our own dependantbot setup, which predates the GitHub acquisition, runs against `master` and runs correctly but will presumably be retired eventually. 

We also have an automatically added GitHub one that runs against `development` which is incorrect.

### Changes proposed in this pull request

1. Added a `.dependabot/config.yml` to correctly configure the GitHub version, which will then allow us to disable the version we'd added prior to the GitHub acquisition.

### Guidance to review

1. Sanity check

