### PR TITLE
SE-1955 Handle unset env vars

### DIFF
--- a/app/services/schools/dfe_sign_in_api/client.rb
+++ b/app/services/schools/dfe_sign_in_api/client.rb
@@ -6,9 +6,9 @@ module Schools
       def self.enabled?
         Rails.application.config.x.dfe_sign_in_api_enabled &&
           [
-            ENV.fetch('DFE_SIGNIN_API_CLIENT'),
-            ENV.fetch('DFE_SIGNIN_API_SECRET')
-          ].map(&:presence).all?
+            ENV.fetch('DFE_SIGNIN_API_CLIENT', nil),
+            ENV.fetch('DFE_SIGNIN_API_SECRET', nil)
+          ].all?(&:present?)
       end
       delegate :enabled?, to: :class
 
@@ -16,9 +16,9 @@ module Schools
         enabled? &&
           Rails.application.config.x.dfe_sign_in_api_role_check_enabled &&
           [
-            ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID'),
-            ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID')
-          ].map(&:presence).all?
+            ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID', nil),
+            ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID', nil)
+          ].all?(&:present?)
       end
       delegate :role_check_enabled?, to: :class
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-1955

### Context

Relates to deploying earlier work around the DfE Sign In API - currently we error if env vars are not set, but just disable features if they are blank.

### Changes proposed in this pull request

1. Just disable features if all required env vars are not set.

### Guidance to review

1. Code review
