### PR TITLE
Add subject editing to placement dates SE-1985

### DIFF
--- a/app/forms/schools/placement_dates/subject_selection.rb
+++ b/app/forms/schools/placement_dates/subject_selection.rb
@@ -15,7 +15,7 @@ module Schools
             available_for_all_subjects: !placement_date.subject_specific?,
             subject_ids: placement_date.subject_ids
         else
-          new
+          new subject_ids: placement_date.subject_ids
         end
       end
 

--- a/features/schools/placement_dates/subject_selection.feature
+++ b/features/schools/placement_dates/subject_selection.feature
@@ -33,3 +33,8 @@ Feature: Selecting subjects for a placement date
         When I submit the form
         Then I should be on the 'placement dates' page
         And my date should be listed
+
+    Scenario: Already-selected subjects should be checked
+        Given I have previously selected 'Biology'
+        When I try to edit the subjects for my newly-created placement date
+        Then the 'Biology' checkbox should be checked

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -14,6 +14,25 @@ Given "the placement date is subject specific" do
   )
 end
 
+Given "I have previously selected {string}" do |subject_name|
+  # pick biology from the subjects list and continue
+  check(subject_name)
+  click_button('Continue')
+
+  expect(page.current_path).to eql(path_for('placement dates'))
+  expect(page).to have_content(subject_name)
+end
+
+When "I try to edit the subjects for my newly-created placement date" do
+  path = path_for('new subject selection', placement_date_id: Bookings::PlacementDate.last.id)
+  visit path
+  expect(page.current_path).to eql(path)
+end
+
+Then("the {string} checkbox should be checked") do |subject_name|
+  expect(get_input(page, subject_name)).to be_checked
+end
+
 Then "the page's main heading should be the date I just entered" do
   date = @school.bookings_placement_dates.last
   expected_title = "#{date.date.to_formatted_s(:govuk)} (#{date.duration} days)"

--- a/spec/forms/schools/placement_dates/subject_selection_spec.rb
+++ b/spec/forms/schools/placement_dates/subject_selection_spec.rb
@@ -43,7 +43,7 @@ describe Schools::PlacementDates::SubjectSelection, type: :model do
 
       it 'returns a new subject_selection without attributes set' do
         expect(subject.available_for_all_subjects).to eq nil
-        expect(subject.subject_ids).to eq nil
+        expect(subject.subject_ids).to be_empty
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1985

### Context

Changing the dates for existing placement dates wasn't pre-selecting the subjects in the list

### Changes proposed in this pull request

Change the `SubjectSelection` initialisation so subject_ids are always assigned and add a scenario covering the behaviour

### Guidance to review

Ensure it makes sense
