### PR TITLE
Improve supports subjects validation SE-1981

### DIFF
--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -26,7 +26,7 @@ class Schools::PlacementDatesController < Schools::BaseController
 
     if @placement_date.valid?
       unless new_placement_date_params.has_key?(:supports_subjects)
-        @placement_date.assign_attributes(supports_subjects: current_school.supports_subjects?)
+        @placement_date.assign_attributes(supports_subjects: school_supports_subjects?)
       end
 
       @placement_date.save
@@ -49,7 +49,7 @@ class Schools::PlacementDatesController < Schools::BaseController
 private
 
   def school_supports_subjects?
-    @current_school.supports_subjects?
+    @current_school.has_secondary_phase?
   end
 
   def next_step(placement_date)

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -23,11 +23,13 @@ class Schools::PlacementDatesController < Schools::BaseController
 
     # if the user hasn't seen the 'select a phase' option on #new, set
     # it here based on their available phases
-    unless new_placement_date_params.has_key?(:supports_subjects)
-      @placement_date.supports_subjects = current_school.supports_subjects?
-    end
 
-    if @placement_date.save
+    if @placement_date.valid?
+      unless new_placement_date_params.has_key?(:supports_subjects)
+        @placement_date.assign_attributes(supports_subjects: current_school.supports_subjects?)
+      end
+
+      @placement_date.save
       next_step @placement_date
     else
       render :new

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -39,6 +39,13 @@ module Bookings
       presence: true,
       on: :create
 
+    # users manually selecting this only happens when schools are both primary
+    # and secondary, otherwise it's automatically set in the controller
+    validates :supports_subjects,
+      inclusion: [true, false],
+      on: :create,
+      if: -> { bookings_school&.primary_and_secondary? }
+
     with_options if: :published? do
       validates :max_bookings_count, numericality: { greater_than: 0, allow_nil: true }
       validates :subjects, presence: true, if: %i(subject_specific? published?)

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -44,7 +44,7 @@ module Bookings
     validates :supports_subjects,
       inclusion: [true, false],
       on: :create,
-      if: -> { bookings_school&.primary_and_secondary? }
+      if: -> { bookings_school&.has_primary_and_secondary_phases? }
 
     with_options if: :published? do
       validates :max_bookings_count, numericality: { greater_than: 0, allow_nil: true }

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -43,7 +43,6 @@ module Bookings
     # and secondary, otherwise it's automatically set in the controller
     validates :supports_subjects,
       inclusion: [true, false],
-      on: :create,
       if: -> { bookings_school&.has_primary_and_secondary_phases? }
 
     with_options if: :published? do

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -188,6 +188,14 @@ class Bookings::School < ApplicationRecord
     phases.any?(&:supports_subjects?)
   end
 
+  def does_not_support_subjects?
+    phases.any? { |p| !p.supports_subjects? }
+  end
+
+  def primary_and_secondary?
+    supports_subjects? && does_not_support_subjects?
+  end
+
 private
 
   def has_available_dates?

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -184,16 +184,16 @@ class Bookings::School < ApplicationRecord
     end
   end
 
-  def supports_subjects?
+  def has_secondary_phase?
     phases.any?(&:supports_subjects?)
   end
 
-  def does_not_support_subjects?
+  def has_primary_phase?
     phases.any? { |p| !p.supports_subjects? }
   end
 
-  def primary_and_secondary?
-    supports_subjects? && does_not_support_subjects?
+  def has_primary_and_secondary_phases?
+    has_primary_phase? && has_secondary_phase?
   end
 
 private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -380,6 +380,9 @@ en:
           attributes:
             date:
               on_or_after: Date must not be in the past
+            supports_subjects:
+              inclusion: Select a school experience phase
+
         bookings/bookings:
           attributes:
             date:

--- a/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
+++ b/features/schools/placement_dates/primary_and_secondary_school_configuration.feature
@@ -7,7 +7,7 @@ Feature: Configuring a placement date
     Given I am logged in as a DfE user
     And my school is a 'primary and secondary' school
     And my school is fully-onboarded
-    And I have entered a placement date
+    And I have entered a secondary placement date for a multi-phase school
 
   Scenario: Page title
     Then the page's main heading should be the date I just entered

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -6,6 +6,17 @@ Given "I have entered a placement date" do
   )
 end
 
+Given "I have entered a secondary placement date for a multi-phase school" do
+  secondary_label = "Secondary including secondary schools"
+
+  steps %(
+    Given I am on the 'new placement date' page
+    And I fill in the form with a future date and duration of 3
+    And I choose '#{secondary_label}' from the 'Select school experience phase' radio buttons
+    And I submit the form
+  )
+end
+
 Given "the placement date is subject specific" do
   steps %(
     Given I choose 'No' from the "Is there a maximum number of bookings you’ll accept for this date?" radio buttons

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -527,32 +527,86 @@ describe Bookings::School, type: :model do
       end
     end
 
-    describe '#supports_subjects?' do
+    describe 'subject support' do
       let(:phase_supporting_subjects) { double(Bookings::Phase, supports_subjects?: true) }
       let(:phase_not_supporting_subjects) { double(Bookings::Phase, supports_subjects?: false) }
 
-      context 'when all phases support subjects' do
-        before do
-          allow(subject).to receive(:phases).and_return([phase_supporting_subjects])
+      describe '#supports_subjects?' do
+        context 'when all phases support subjects' do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_supporting_subjects])
+          end
+
+          specify { expect(subject).to be_supports_subjects }
         end
 
-        specify { expect(subject).to be_supports_subjects }
+        context 'when no phases support subjects' do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects])
+          end
+
+          specify { expect(subject).not_to be_supports_subjects }
+        end
+
+        context "when some phases support subjects and some don't" do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_supporting_subjects, phase_not_supporting_subjects])
+          end
+
+          specify { expect(subject).to be_supports_subjects }
+        end
       end
 
-      context 'when no phases support subjects' do
-        before do
-          allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects])
+      describe '#does_not_support_subjects?' do
+        context 'when all phases support subjects' do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_supporting_subjects])
+          end
+
+          specify { expect(subject).not_to be_does_not_support_subjects }
         end
 
-        specify { expect(subject).not_to be_supports_subjects }
+        context 'when no phases support subjects' do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects])
+          end
+
+          specify { expect(subject).to be_does_not_support_subjects }
+        end
+
+        context "when some phases support subjects and some don't" do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_supporting_subjects, phase_not_supporting_subjects])
+          end
+
+          specify { expect(subject).to be_does_not_support_subjects }
+        end
       end
 
-      context "when some phases support subjects and some don't" do
-        before do
-          allow(subject).to receive(:phases).and_return([phase_supporting_subjects, phase_not_supporting_subjects])
+      describe '#primary_and_secondary?' do
+        context 'when primary but not secondary' do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects])
+          end
+
+          specify { expect(subject).not_to be_primary_and_secondary }
         end
 
-        specify { expect(subject).to be_supports_subjects }
+        context 'when secondary but not primary' do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_supporting_subjects])
+          end
+
+          specify { expect(subject).not_to be_primary_and_secondary }
+        end
+
+        context 'when primary and secondary' do
+          before do
+            allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects, phase_supporting_subjects])
+          end
+
+          specify { expect(subject).to be_primary_and_secondary }
+        end
       end
     end
   end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -531,13 +531,13 @@ describe Bookings::School, type: :model do
       let(:phase_supporting_subjects) { double(Bookings::Phase, supports_subjects?: true) }
       let(:phase_not_supporting_subjects) { double(Bookings::Phase, supports_subjects?: false) }
 
-      describe '#supports_subjects?' do
+      describe '#has_secondary_phase?' do
         context 'when all phases support subjects' do
           before do
             allow(subject).to receive(:phases).and_return([phase_supporting_subjects])
           end
 
-          specify { expect(subject).to be_supports_subjects }
+          specify { expect(subject).to be_has_secondary_phase }
         end
 
         context 'when no phases support subjects' do
@@ -545,7 +545,7 @@ describe Bookings::School, type: :model do
             allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects])
           end
 
-          specify { expect(subject).not_to be_supports_subjects }
+          specify { expect(subject).not_to be_has_secondary_phase }
         end
 
         context "when some phases support subjects and some don't" do
@@ -553,17 +553,17 @@ describe Bookings::School, type: :model do
             allow(subject).to receive(:phases).and_return([phase_supporting_subjects, phase_not_supporting_subjects])
           end
 
-          specify { expect(subject).to be_supports_subjects }
+          specify { expect(subject).to be_has_secondary_phase }
         end
       end
 
-      describe '#does_not_support_subjects?' do
+      describe '#has_primary_phase?' do
         context 'when all phases support subjects' do
           before do
             allow(subject).to receive(:phases).and_return([phase_supporting_subjects])
           end
 
-          specify { expect(subject).not_to be_does_not_support_subjects }
+          specify { expect(subject).not_to be_has_primary_phase }
         end
 
         context 'when no phases support subjects' do
@@ -571,7 +571,7 @@ describe Bookings::School, type: :model do
             allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects])
           end
 
-          specify { expect(subject).to be_does_not_support_subjects }
+          specify { expect(subject).to be_has_primary_phase }
         end
 
         context "when some phases support subjects and some don't" do
@@ -579,17 +579,17 @@ describe Bookings::School, type: :model do
             allow(subject).to receive(:phases).and_return([phase_supporting_subjects, phase_not_supporting_subjects])
           end
 
-          specify { expect(subject).to be_does_not_support_subjects }
+          specify { expect(subject).to be_has_primary_phase }
         end
       end
 
-      describe '#primary_and_secondary?' do
+      describe '#has_primary_and_secondary_phases?' do
         context 'when primary but not secondary' do
           before do
             allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects])
           end
 
-          specify { expect(subject).not_to be_primary_and_secondary }
+          specify { expect(subject).not_to be_has_primary_and_secondary_phases }
         end
 
         context 'when secondary but not primary' do
@@ -597,7 +597,7 @@ describe Bookings::School, type: :model do
             allow(subject).to receive(:phases).and_return([phase_supporting_subjects])
           end
 
-          specify { expect(subject).not_to be_primary_and_secondary }
+          specify { expect(subject).not_to be_has_primary_and_secondary_phases }
         end
 
         context 'when primary and secondary' do
@@ -605,7 +605,7 @@ describe Bookings::School, type: :model do
             allow(subject).to receive(:phases).and_return([phase_not_supporting_subjects, phase_supporting_subjects])
           end
 
-          specify { expect(subject).to be_primary_and_secondary }
+          specify { expect(subject).to be_has_primary_and_secondary_phases }
         end
       end
     end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1981

### Context

When failing to enter a placement date, when the form is re-rendered the `supports_subjects` flag had been already set by `#create`.

### Changes proposed in this pull request

Now instead of setting the flag in the previous manner regardless of the
situation it's only set if validation has passed and there's a new
validation rule that ensures it's been set manually if the school
supports primary and secondary phases (ie has at least one phase that
does support subjects and one that doesn't)

![Screenshot 2019-11-15 at 14 09 39](https://user-images.githubusercontent.com/128088/68949425-e624d200-07b1-11ea-9925-6d46036484dc.png)

### Guidance to review

Do the changes look sensible? Could the new methods on `Bookings::School` be better named? They look ok to me without being too wordy, but perhaps I've overlooked something

