### PR TITLE
Add missing duration validation message when blank

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,6 +378,8 @@ en:
               too_short: Availability description must be at least 3 characters
         bookings/placement_date:
           attributes:
+            duration:
+              blank: Enter a duration
             date:
               on_or_after: Date must not be in the past
         bookings/bookings:


### PR DESCRIPTION
### JIRA Ticket Number

N/A

### Context

There was no validation message when duration was blank, it reverted to Rails' default

### Changes proposed in this pull request

Set the validation message

### Guidance to review

Ensure it's sensible
