### PR TITLE
SE-1986 incorrect flow after date change

### DIFF
--- a/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
+++ b/app/controllers/candidates/registrations/subject_and_date_informations_controller.rb
@@ -19,11 +19,11 @@ module Candidates
       end
 
       def edit
-        @subject_and_date_information = SubjectAndDateInformation.new(attributes_from_session)
+        @subject_and_date_information = current_registration.subject_and_date_information
       end
 
       def update
-        @subject_and_date_information = SubjectAndDateInformation.new(attributes_from_session)
+        @subject_and_date_information = current_registration.subject_and_date_information
         @subject_and_date_information.assign_attributes(subject_and_date_params)
 
         if @subject_and_date_information.valid?


### PR DESCRIPTION
### JIRA Ticket Number

SE-1986

### Context

If the Candidate goes back to edit their subject from the Summary screen, they are then taken through the personal info and contact info steps.

This is caused by the #edit screen for SubjectAndDateInfo sending a POST not a PATCH, that in turn is caused by the controller not loading existing date for the #edit and #update actions.

### Changes proposed in this pull request

1. Change edit action to load from current_registration
2. Change update action to load from current_registration

### Guidance to review

Note: This PR contains only the code fix. Tests will follow on in separate PR but those are going to take longer to write and I want to get this through for QA

1. Code review
