### PR TITLE
Display degree_stage_explaination (sic)

### DIFF
--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -26,7 +26,6 @@ module Candidates
         to: :@contact_information
 
       delegate \
-        :degree_stage,
         :degree_subject,
         to: :@education
 
@@ -135,6 +134,13 @@ module Candidates
 
       def teaching_subject_second_choice
         subject_second_choice
+      end
+
+      def degree_stage
+        [
+          @education.degree_stage,
+          @education.degree_stage_explaination
+        ].map(&:presence).compact.join("\n")
       end
 
       def dbs_check_document

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -101,6 +101,9 @@
         </dt>
         <dd class="govuk-summary-list__value">
           <%= @placement_request.degree_stage %>
+          <% if @placement_request.degree_stage_explaination.present? %>
+            - <%= @placement_request.degree_stage_explaination %>
+          <% end %>
         </dd>
       </div>
 


### PR DESCRIPTION
If the user has entered something in this field make sure it is surfaced
in the preview, emails, and when the school views the placement request.

### JIRA Ticket Number
SE-1967

### Context
We weren't surfacing this field in the ui

### Changes proposed in this pull request

### Guidance to review
Complete the candidate registration wizard choosing other as a degree stage, expect to see the degree stage explanation on application preview. Finish the wizard, view the placement request as the school, expect to see the degree stage explanation on the placement request show view

