### PR TITLE
Add missing validation text

### DIFF
--- a/app/forms/schools/placement_requests/add_more_details.rb
+++ b/app/forms/schools/placement_requests/add_more_details.rb
@@ -12,6 +12,7 @@ module Schools
       validates :contact_name, presence: true
       validates :contact_number, presence: true
       validates :contact_email, presence: true
+      validates :contact_email, email_format: true, if: -> { contact_email.present? }
       validates :location, presence: true
 
       def self.for_school(school)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -346,6 +346,7 @@ en:
               not_a_number: "Enter a valid number for maximum number of bookings you'll accept for this date"
             subjects:
               blank: 'Select which subjects are available for this date'
+
         schools/placement_requests/add_more_details:
           attributes:
             contact_name:
@@ -354,8 +355,19 @@ en:
               blank: 'Enter a contact phone number'
             contact_email:
               blank: 'Enter a contact email address'
+              invalid: 'Enter a valid email address'
             location:
               blank: 'Enter a location for the candidate to report to'
+
+        schools/placement_requests/confirm_booking:
+          attributes:
+            placement_details:
+              blank: 'Provide details for the experience'
+
+        schools/placement_requests/review_and_send_email:
+          attributes:
+            candidate_instructions:
+              blank: 'Provide candidate instructions'
 
   activerecord:
     errors:

--- a/spec/forms/schools/placement_requests/add_more_details_spec.rb
+++ b/spec/forms/schools/placement_requests/add_more_details_spec.rb
@@ -17,6 +17,17 @@ describe Schools::PlacementRequests::AddMoreDetails, type: :model do
         expect(subject).to validate_presence_of(attribute_name).with_message(/\AEnter a/)
       end
     end
+
+    context 'contact_email' do
+      context 'when present but invalid' do
+        ['candidate@example'].each do |value|
+          it do
+            is_expected.not_to allow_value(value).for(:contact_email).with_message \
+              'Enter a valid email address'
+          end
+        end
+      end
+    end
   end
 
   describe 'Methods' do


### PR DESCRIPTION
### JIRA Ticket Number
SE-1979

### Context
We were falling back to the default rails validations in a few spots on
the create booking wizard.

Also we were missing a validation to ensure the format of the contact_email is
correct.

### Changes proposed in this pull request
Add missing error messages to locales file. Add validation for format of contact email

### Guidance to review
Should look sensible and have correct spelling!
