### PR TITLE
Ensure the params match the bookings

### DIFF
--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -28,12 +28,10 @@ module Schools
       params
         .select { |key, _| key.match(/\A\d+\z/) }
         .transform_keys(&:to_i)
-        .select { |key, _|
-          # Avoid throwing key error if the user hits back button then
-          # resubmits the form causing the params to no longer match up with
-          # the unlogged_bookings.
-          unlogged_bookings.ids.include? key
-        }
+        .slice(*unlogged_bookings.ids)
+        # Avoid throwing key error if the user hits back button then
+        # resubmits the form causing the params to no longer match up with
+        # the unlogged_bookings.
     end
 
     def unlogged_bookings

--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -28,6 +28,12 @@ module Schools
       params
         .select { |key, _| key.match(/\A\d+\z/) }
         .transform_keys(&:to_i)
+        .select { |key, _|
+          # Avoid throwing key error if the user hits back button then
+          # resubmits the form causing the params to no longer match up with
+          # the unlogged_bookings.
+          unlogged_bookings.ids.include? key
+        }
     end
 
     def unlogged_bookings


### PR DESCRIPTION
# JIRA Ticket Number
SE-1936

### Context
If the user hits the back button in the browser then resubmits the form
then some of the bookings in the params might not be in the
unlogged_bookings collection, causing an error to be thrown in the
School::Attendance object.

### Changes proposed in this pull request
Reject any params that don't correspond to an unlogged_booking.

### Guidance to review
Testing.

From the confirm attendance screen, mark some bookings as attended or not, submit the form, hit back in the browser, re submit the form, expect there to be no error.