### PR TITLE
Remove duplicates before sending emails

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -2,7 +2,7 @@ class Notify
   attr_accessor :to
 
   def initialize(to:)
-    self.to = Array.wrap to
+    self.to = Array.wrap(to).uniq
   end
 
   def despatch_later!

--- a/spec/notify/notify_spec.rb
+++ b/spec/notify/notify_spec.rb
@@ -19,6 +19,14 @@ describe Notify do
     specify 'should assign an array of email address' do
       expect(subject.to).to match_array(to)
     end
+
+    context 'with duplicates' do
+      let(:to) { ['somename@somecompany.org', 'somename@somecompany.org'] }
+
+      specify 'should remove duplicates' do
+        expect(subject.to).to match_array(to.uniq)
+      end
+    end
   end
 
   describe 'Methods' do


### PR DESCRIPTION
### JIRA Ticket Number
SE-1994

### Context
A school was receiving duplicates emails as they had entered the same email address for primary and secondary contact.

### Changes proposed in this pull request
De-dup email recipients before sending emails

### Guidance to review

