### PR TITLE
Se 1727/show cancellation reason on placement request show

### DIFF
--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -15,4 +15,14 @@ module Schools::PlacementRequestsHelper
       tag.span status, class: css_class
     end
   end
+
+  def cancellation_noun(cancellation)
+    if cancellation.cancelled_by_candidate?
+      'Withdrawal'
+    elsif cancellation.cancelled_by_school?
+      'Rejection'
+    else
+      fail 'cancellation not sent'
+    end
+  end
 end

--- a/app/views/schools/placement_requests/_cancellation.html.erb
+++ b/app/views/schools/placement_requests/_cancellation.html.erb
@@ -6,5 +6,7 @@
     <% if cancellation.extra_details.present? %>
       <%= summary_row 'Extra details', cancellation.extra_details %>
     <% end %>
+    <%= summary_row 'Date cancellation received', cancellation.sent_at.to_date.to_formatted_s(:govuk) %>
+    <%= summary_row 'Cancelled by', cancellation.cancelled_by.humanize %>
   </dl>
 </section>

--- a/app/views/schools/placement_requests/_cancellation.html.erb
+++ b/app/views/schools/placement_requests/_cancellation.html.erb
@@ -1,0 +1,10 @@
+<section id="cancellation-details">
+  <h2><%= cancellation_noun cancellation %> details</h2>
+
+  <dl class="govuk-summary-list">
+    <%= summary_row 'Reason', cancellation.reason %>
+    <% if cancellation.extra_details.present? %>
+      <%= summary_row 'Extra details', cancellation.extra_details %>
+    <% end %>
+  </dl>
+</section>

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -1,8 +1,19 @@
 <%= link_to 'Back', schools_placement_requests_path, class: 'govuk-back-link' %>
 
-<h1>Request from <%= @gitis_contact.full_name %></h1>
+<% if @placement_request.candidate_cancellation&.sent? %>
+  <h1><%= @gitis_contact.full_name %> has withdrawn their request</h1>
+<% elsif @placement_request.school_cancellation&.sent? %>
+  <h1>This request from <%= @gitis_contact.full_name %> has been rejected</h1>
+<% else %>
+  <h1>Request from <%= @gitis_contact.full_name %></h1>
+<% end %>
 
 <div class="school-request">
+
+  <% if @placement_request.cancelled? %>
+    <%= render "cancellation", cancellation: @placement_request.cancellation %>
+  <% end %>
+
   <section id="personal-details">
     <h2>Personal details</h2>
 

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -1,3 +1,13 @@
+<% self.page_title = "Request #{@placement_request.id}" %>
+
+<%
+  self.breadcrumbs = {
+    @current_school.name => schools_dashboard_path,
+    'Requests' => schools_placement_requests_path,
+    "Request" => nil
+  }
+%>
+
 <%= link_to 'Back', schools_placement_requests_path, class: 'govuk-back-link' %>
 
 <% if @placement_request.candidate_cancellation&.sent? %>

--- a/app/views/schools/withdrawn_requests/show.html.erb
+++ b/app/views/schools/withdrawn_requests/show.html.erb
@@ -14,13 +14,7 @@
       Cancellation from <%= @withdrawn_request.candidate_name %>
     </h1>
 
-    <section id="cancellation-details">
-      <h2>Cancellation details</h2>
-
-      <dl class="placement-details govuk-summary-list">
-        <%= summary_row 'Reason', @cancellation.reason %>
-      </dl>
-    </section>
+    <%= render "schools/placement_requests/cancellation", cancellation: @withdrawn_request.cancellation %>
 
     <%= render partial: 'schools/placement_requests/personal_details', object: @withdrawn_request.gitis_contact %>
     <%= render partial: 'schools/placement_requests/request_details', object: @withdrawn_request %>

--- a/features/schools/placement_requests/show.feature
+++ b/features/schools/placement_requests/show.feature
@@ -59,3 +59,15 @@ Feature: Viewing a placement request
         And I am on the placement request page
         When I click the 'Accept request' button
         Then I should be on the confirm booking page
+
+    Scenario: Viewing a withdrawn request
+        Given there is at least one placement request
+        And the request has been withdrawn
+        When I am on the placement request page
+        Then I should see the withdrawal details
+
+    Scenario: Viewing a rejected request
+        Given there is at least one placement request
+        And the request has been rejected
+        When I am on the placement request page
+        Then I should see the rejection details

--- a/features/schools/withdrawn_requests/show.feature
+++ b/features/schools/withdrawn_requests/show.feature
@@ -22,11 +22,11 @@ Feature: Viewing a withdrawn request
             | Some school        | /schools/dashboard           |
             | Withdrawn requests | /schools/withdrawn_requests  |
             | Request            | None                         |
-    
+
     Scenario: Cancellation details
         Given there is at least one withdrawn request
         When I am viewing the withdrawn request
-        Then I should see a 'Cancellation details' section with the following values:
+        Then I should see the withdrawn details with the following values:
             | Heading      | Value      |
             | Reason       | MyText     |
 

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -250,3 +250,14 @@ Then("I should see the rejection details") do
     expect(page).to have_text @placement_request.school_cancellation.extra_details
   end
 end
+
+Then("I should see the withdrawn details with the following values:") do |table|
+  within "section#cancellation-details" do
+    expect(page).to have_css('h2', text: 'Withdrawal details')
+
+    table.hashes.each do |row|
+      expect(page).to have_css('dt', text: row['Heading'])
+      expect(page).to have_css('dd', text: /#{row['Value']}/i)
+    end
+  end
+end

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -214,3 +214,39 @@ Then("the viewed requests should have no status") do
     expect(page).not_to have_css('.govuk-tag')
   end
 end
+
+Given("the request has been withdrawn") do
+  FactoryBot.create :cancellation,
+    :sent,
+    :cancelled_by_candidate,
+    placement_request: @placement_request
+
+  @placement_request.reload
+end
+
+Given("the request has been rejected") do
+  FactoryBot.create :cancellation,
+    :sent,
+    :cancelled_by_school,
+    placement_request: @placement_request,
+    extra_details: 'Better luck next time'
+
+  @placement_request.reload
+end
+
+Then("I should see the withdrawal details") do
+  expect(page).to have_css 'h1', text: "Matthew Richards has withdrawn their request"
+
+  within '#cancellation-details' do
+    expect(page).to have_text @placement_request.candidate_cancellation.reason
+  end
+end
+
+Then("I should see the rejection details") do
+  expect(page).to have_css 'h1', text: "This request from Matthew Richards has been rejected"
+
+  within '#cancellation-details' do
+    expect(page).to have_text @placement_request.school_cancellation.reason
+    expect(page).to have_text @placement_request.school_cancellation.extra_details
+  end
+end


### PR DESCRIPTION
If the request has been withdrawn/rejected display that information when
viewing the placement request show page.

### JIRA Ticket Number
SE-1727

### Context
placement_request/show wasn't displaying the cancellation details for cancelled requests.

### Changes proposed in this pull request
Display cancellation information on cancelled placement requests.
Add missing bread crumbs on placement_request show

### Guidance to review
Reject and withdraw a placement request. Visit the placement request show page, expect to see the correct details. Visit the withdrawn requests page expect to see the correct details.

Check spelling