### PR TITLE
Upload test failures into CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
 
   # Testing framework
   gem 'rspec-rails', '~> 3.9'
+  gem 'rspec_junit_formatter'
   gem 'factory_bot_rails'
 
   gem 'brakeman', '>= 4.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,6 +333,8 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.65.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -482,6 +484,7 @@ DEPENDENCIES
   rails-controller-testing
   redis (~> 4.1)
   rspec-rails (~> 3.9)
+  rspec_junit_formatter
   rubocop (~> 0.65.0)
   sassc-rails
   selenium-webdriver

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,8 +54,15 @@ jobs:
       until docker-compose ps | grep -m 1 "db-tasks" | grep -m 1 "Exit 0" || [ $WAIT_COUNT -eq 12 ]; do echo "WAIT COUNT $(( WAIT_COUNT++ ))" && sleep 5 ; done
     displayName: bring up postgres, redis and create database (for the web app) and spin up application
 
-  - script: docker-compose run --rm db-tasks rspec
+  - script: docker-compose run --rm db-tasks rspec --format progress --format RspecJunitFormatter --out /ci_build/rspec_results.xml
     displayName: Run the Specs
+
+  - task: PublishTestResults@2
+    displayName: Upload RSpec results
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: rspec_results.xml
+      testRunTitle: RSpec results
 
   - script: docker-compose run --rm -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true db-tasks cucumber --profile=$(CUCUMBER_PROFILE)
     displayName: Run the Cucumber features

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -126,8 +126,14 @@ jobs:
       WAIT_COUNT=0
       until docker-compose ps | grep -m 1 "db-tasks" | grep -m 1 "Exit 0" || [ $WAIT_COUNT -eq 12 ]; do echo "WAIT COUNT $(( WAIT_COUNT++ ))" && sleep 5 ; done
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
-      docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) --no-deps school-experience cucumber $(features)
+      docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) --no-deps school-experience cucumber --format junit --out /ci_build/junit $(features)
     displayName: Run Cucumber Tests
+  - task: PublishTestResults@2
+    displayName: Upload Cucumber results
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'junit/TEST-*.xml'
+      testRunTitle: Cucumber results
 
 - job: PublishArtifacts
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ jobs:
     displayName: Run the Specs
 
   - task: PublishTestResults@2
+    condition: failed()
     displayName: Upload RSpec results
     inputs:
       testResultsFormat: 'JUnit'
@@ -68,6 +69,7 @@ jobs:
     displayName: Run the Cucumber features
 
   - task: PublishTestResults@2
+    condition: failed()
     displayName: Upload Cucumber results
     inputs:
       testResultsFormat: 'JUnit'
@@ -128,7 +130,9 @@ jobs:
       echo SELENIUM_HUB_HOSTNAME=selenium-$(browser) CUC_DRIVER=$(browser) with features... $(features)
       docker-compose -f docker-compose.yml -f docker-compose-$(browser).yml run --rm -e RAILS_ENV=test -e SELENIUM_HUB_HOSTNAME=selenium-$(browser) -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true -e APP_URL -e CUC_DRIVER=$(browser) --no-deps school-experience cucumber --format junit --out /ci_build/junit $(features)
     displayName: Run Cucumber Tests
+
   - task: PublishTestResults@2
+    condition: failed()
     displayName: Upload Cucumber results
     inputs:
       testResultsFormat: 'JUnit'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,8 +64,15 @@ jobs:
       testResultsFiles: rspec_results.xml
       testRunTitle: RSpec results
 
-  - script: docker-compose run --rm -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true db-tasks cucumber --profile=$(CUCUMBER_PROFILE)
+  - script: docker-compose run --rm -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true db-tasks cucumber --profile=$(CUCUMBER_PROFILE) --format junit --out /ci_build/junit
     displayName: Run the Cucumber features
+
+  - task: PublishTestResults@2
+    displayName: Upload Cucumber results
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: 'junit/TEST-*.xml'
+      testRunTitle: Cucumber results
 
   - script: |
       docker tag $(DOCKER_HUB_REPO):$(imageTag) $(DOCKER_HUB_REPO):latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
        - WEB_URL=postgis://postgres:secret@postgres/school_experience
      depends_on:
        - db-tasks
-  
+
    db-tasks:
      image: school-experience:latest
      command: rake db:create db:schema:load
@@ -47,12 +47,14 @@ services:
        - SECRET_KEY_BASE=stubbed
        - SKIP_FORCE_SSL=true
        - WEB_URL=postgis://postgres:secret@postgres/school_experience
+     volumes:
+       - .:/ci_build
      depends_on:
        - postgres
        - redis
 
    postgres:
      image: mdillon/postgis:11-alpine
-     
+
    redis:
      image: redis:5-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
        - WEB_URL=postgis://postgres:secret@postgres/school_experience
      depends_on:
        - db-tasks
+     volumes:
+       - .:/ci_build
 
    delayed-jobs:
      image: school-experience:latest


### PR DESCRIPTION
### JIRA Ticket Number

N/A

### Context

Currently test failures end up just dumped into the logs, leaving the developer trying to wade through the console output. This is a nuisance with RSpec but a real faff with more extensive  cucumber output.

### Changes proposed in this pull request

1. Upload test results from each stage of testing to Azure DevOps. These are then accessible from the DevOps interface

### Guidance to review
1. See the tests tab for the following runs
a) 20191121.9
b) 20191121.13
c) 20191121.17

2. Does the pipeline still run correctly
