### PR TITLE
SE-2002 Stop updating secondary teaching subjects

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -134,6 +134,10 @@ module Bookings
         self.dfe_notesforclassroomexperience = "#{dfe_notesforclassroomexperience}#{log_line}\r\n"
       end
 
+      def attributes_for_update
+        super.except('dfe_PreferredTeachingSubject02@odata.bind')
+      end
+
     private
 
       def set_email_address_2_if_blank


### PR DESCRIPTION
### JIRA Ticket Number

SE-2002

### Context

Currently we attempt to update the users second preferred teaching subject. If that has been updated to 'no subject' though we attempt to set it to blank which Gitis wont accept

### Changes proposed in this pull request

1. As a stop gap, just don't update the second preferred teaching subject.

