### PR TITLE
Invalid subjects

### DIFF
--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -149,7 +149,7 @@ module Bookings
     end
 
     def requested_subject
-      subject || Bookings::Subject.find_by!(name: subject_first_choice)
+      subject || Bookings::Subject.unscoped.find_by!(name: subject_first_choice)
     end
 
     def received_on


### PR DESCRIPTION
### Context

If a placement request is against a subject which is no longer available, than we currently trigger an error.

### Changes proposed in this pull request

1. Allow loading any subject, not just those in the default scope

### Guidance to review

