### PR TITLE
Add unscoped to the Bookings::Subject find

### DIFF
--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -149,7 +149,7 @@ module Bookings
     end
 
     def requested_subject
-      subject || Bookings::Subject.find_by!(name: subject_first_choice)
+      subject || Bookings::Subject.unscoped.find_by!(name: subject_first_choice)
     end
 
     def received_on


### PR DESCRIPTION
### JIRA Ticket Number

SE-2003

### Context

The recent scoping change was causing in-flight placement requests to fail as their subject couldn't be found

### Changes proposed in this pull request

Remove the scoping from `#requested_subjects`

### Guidance to review

Ensure everything still works. This shouldn't cause any further problems because `#requested_subject` is only really used for display purposes