### PR TITLE
SE-2002 Dont assign odata.bind to null

### DIFF
--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -134,10 +134,6 @@ module Bookings
         self.dfe_notesforclassroomexperience = "#{dfe_notesforclassroomexperience}#{log_line}\r\n"
       end
 
-      def attributes_for_update
-        super.except('dfe_PreferredTeachingSubject02@odata.bind')
-      end
-
     private
 
       def set_email_address_2_if_blank

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -66,7 +66,10 @@ module Bookings::Gitis
 
     def attributes_for_update
       attributes.slice(*(changed - update_blacklist)).reject do |k, v|
-        k =~ /@odata\.bind\z/ && v.nil?
+        # Don't attempt to set bind values to NULL - this is invalid syntax
+        # Dissasociating requires deleting the $ref
+        # Which is not currently supported
+        k.ends_with?('@odata.bind') && v.nil?
       end
     end
 

--- a/app/services/bookings/gitis/entity.rb
+++ b/app/services/bookings/gitis/entity.rb
@@ -65,7 +65,9 @@ module Bookings::Gitis
     end
 
     def attributes_for_update
-      attributes.slice(*(changed - update_blacklist))
+      attributes.slice(*(changed - update_blacklist)).reject do |k, v|
+        k =~ /@odata\.bind\z/ && v.nil?
+      end
     end
 
     def attributes_for_create

--- a/spec/services/bookings/gitis/entity_spec.rb
+++ b/spec/services/bookings/gitis/entity_spec.rb
@@ -310,6 +310,18 @@ RSpec.describe Bookings::Gitis::Entity do
             include('testassoc@odata.bind' => e2.entity_id)
         end
       end
+
+      context "and updated to null" do
+        before { subject.testassoc = nil }
+
+        it { is_expected.to have_attributes _testassoc_value: nil }
+        it "is not included in update attributes" do
+          expect(subject.attributes_for_update).not_to \
+            include('testassoc@odata.bind')
+        end
+
+        it "should review this behaviour - ideally we should break the connection instead"
+      end
     end
 
     context 'initializing with existing data' do


### PR DESCRIPTION
### JIRA Ticket Number

SE-2002

### Context

As part of a latent bug we're potentially attempting to assign Preferred Teaching Subjects to null which isn't valid.

### Changes proposed in this pull request

1. Reverted earlier solution of skipping all updates odata.bind's for contacts
2. Just skip the assignment for now if its null

### Guidance to review

1. Code review