### PR TITLE
Move no date warnings up to top of dashboard

### DIFF
--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -1,14 +1,6 @@
 <section class="manage-dates">
   <h2 class="govuk-heading-m">Manage dates</h3>
 
-  <%- if show_no_placement_dates_warning?(@current_school) -%>
-    <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
-  <%- end -%>
-
-  <%- if show_no_availability_info_warning?(@current_school) -%>
-    <%= render partial: 'schools/dashboards/no_availability_info_warning' %>
-  <%- end -%>
-
   <%- if is_fixed_and_has_active_dates?(@current_school) -%>
     <div id="add-remove-and-change-dates" class="subsection">
       <header class="dashboard-medium-priority">

--- a/app/views/schools/dashboards/_no_availability_info_warning.html.erb
+++ b/app/views/schools/dashboards/_no_availability_info_warning.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-warning-text">
+<div class="govuk-warning-text govuk-!-padding-top-7">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>

--- a/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
+++ b/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-warning-text">
+<div class="govuk-warning-text govuk-!-padding-top-7">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>

--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -15,6 +15,15 @@
       <% if @current_school.private_beta? %>
 
         <%= render partial: 'your_school_is_disabled' if @current_school.disabled? %>
+
+        <%- if show_no_placement_dates_warning?(@current_school) -%>
+          <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
+        <%- end -%>
+
+        <%- if show_no_availability_info_warning?(@current_school) -%>
+          <%= render partial: 'schools/dashboards/no_availability_info_warning' %>
+        <%- end -%>
+
         <%= render partial: 'new_requests_and_bookings' %>
         <%= render partial: 'manage_dates' %>
         <%= render partial: 'account_admin' %>


### PR DESCRIPTION
### JIRA Ticket Number

SE-1990

### Context

The no dates/availability warnings were being displayed in the dates section which is half way down the dashboard

### Changes proposed in this pull request

Move the warnings up to the top of the dashboard

### Guidance to review

Ensure it looks sensible

![Screenshot from 2019-11-25 14-42-18](https://user-images.githubusercontent.com/128088/69549859-f4cd6f00-0f91-11ea-8ba0-026c09313569.png)
