### PR TITLE
Fix degree stage explanation display SE-1998

### DIFF
--- a/app/controllers/candidates/registrations/educations_controller.rb
+++ b/app/controllers/candidates/registrations/educations_controller.rb
@@ -35,10 +35,13 @@ module Candidates
     private
 
       def education_params
-        params.require(:candidates_registrations_education).permit \
+        params.require(:candidates_registrations_education).permit(
           :degree_stage,
           :degree_stage_explaination,
           :degree_subject
+        ).tap do |params|
+          params[:degree_stage_explaination] = nil unless params[:degree_stage] == 'Other'
+        end
       end
 
       def attributes_from_session

--- a/app/services/candidates/registrations/application_preview.rb
+++ b/app/services/candidates/registrations/application_preview.rb
@@ -140,7 +140,7 @@ module Candidates
         [
           @education.degree_stage,
           @education.degree_stage_explaination
-        ].map(&:presence).compact.join("\n")
+        ].map(&:presence).compact.join(" - ")
       end
 
       def dbs_check_document

--- a/spec/controllers/candidates/registrations/educations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/educations_controller_spec.rb
@@ -11,7 +11,6 @@ describe Candidates::Registrations::EducationsController, type: :request do
   end
   let!(:school) { create(:bookings_school, urn: 11048) }
 
-
   context '#new' do
     context 'without existing education in session' do
       before do
@@ -128,12 +127,12 @@ describe Candidates::Registrations::EducationsController, type: :request do
       { candidates_registrations_education: education.attributes }
     end
 
-    before do
-      patch '/candidates/schools/11048/registrations/education',
-        params: education_params
-    end
-
     context 'invalid' do
+      before do
+        patch '/candidates/schools/11048/registrations/education',
+          params: education_params
+      end
+
       let :education do
         Candidates::Registrations::Education.new
       end
@@ -150,6 +149,11 @@ describe Candidates::Registrations::EducationsController, type: :request do
     end
 
     context 'valid' do
+      before do
+        patch '/candidates/schools/11048/registrations/education',
+          params: education_params
+      end
+
       let :education do
         FactoryBot.build \
           :education,
@@ -166,6 +170,48 @@ describe Candidates::Registrations::EducationsController, type: :request do
       it 'redirects to the application preview page' do
         expect(response).to redirect_to \
           candidates_school_registrations_application_preview_path
+      end
+    end
+
+    context 'unsetting explanation when changed from other' do
+      let :education do
+        FactoryBot.build \
+          :education,
+          degree_stage: 'Other',
+          degree_stage_explaination: 'On an important quest'
+      end
+
+      before do
+        registration_session.save education
+      end
+
+      let(:degree_stage) { 'Final year' }
+      let(:degree_subject) { 'Art' }
+      let(:params) do
+        {
+          candidates_registrations_education: {
+            degree_stage: degree_stage,
+            degree_subject: degree_subject
+          }
+        }
+      end
+
+      subject do
+        patch '/candidates/schools/11048/registrations/education', params: params
+      end
+
+      specify 'should set degree_stage_explaination to nil' do
+        expect(registration_session.education.degree_stage_explaination).not_to be_nil
+        subject
+        expect(registration_session.education.degree_stage_explaination).to be_nil
+      end
+
+      specify 'should set the other attributes in the normal fashion' do
+        subject
+        registration_session.education.tap do |ed|
+          expect(ed.degree_stage).to eql(degree_stage)
+          expect(ed.degree_subject).to eql(degree_subject)
+        end
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1998

### Context

Started off as adding a missing dash to the degree stage explanation row, this uncovered another bug where users can go back and change their degree stage and the explanation remains in

### Changes proposed in this pull request

Add the dash to degree stage explanation on the check answers screen and unset the degree stage explanation when a option that doesn't need an explanation is picked

### Guidance to review

Ensure it looks sensible
