### PR TITLE
Remove explanation text field for no DBS required SE-1839

### DIFF
--- a/app/controllers/schools/on_boarding/dbs_requirements_controller.rb
+++ b/app/controllers/schools/on_boarding/dbs_requirements_controller.rb
@@ -57,8 +57,7 @@ module Schools
       def dbs_requirement_params
         params.require(:schools_on_boarding_dbs_requirement).permit \
           :requires_check,
-          :dbs_policy_details,
-          :no_dbs_policy_details
+          :dbs_policy_details
       end
     end
   end

--- a/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
@@ -30,9 +30,7 @@
           <%= f.text_area_with_maxwords :dbs_policy_details, maxwords: { count: 50 } %>
         <% end %>
 
-        <%= fieldset.radio_input false do  %>
-          <%= f.text_area_with_maxwords :no_dbs_policy_details, maxwords: { count: 50 } %>
-        <% end %>
+        <%= fieldset.radio_input false %>
       <% end %>
 
       <%= f.submit 'Continue' %>

--- a/features/schools/onboarding/dbs_required_toggling_fees.feature
+++ b/features/schools/onboarding/dbs_required_toggling_fees.feature
@@ -39,7 +39,6 @@ Feature: Dbs required toggling available fees
         | Admin contact                    |                           |
     And I am on the 'edit DBS requirements' page
     And I choose 'No - Candidates will be accompanied at all times' from the 'Do you require candidates to have or get a DBS check?' radio buttons
-    And I enter 'No more details' into the 'Provide any extra details in 50 words or less.' text area
     When I submit the form
     Then I should be on the 'profile' page
 

--- a/features/schools/onboarding/dbs_requirements.feature
+++ b/features/schools/onboarding/dbs_requirements.feature
@@ -20,6 +20,5 @@ Feature: DBS requirements
   Scenario: Completing step chosing no
     Given I am on the 'DBS requirements' page
     And I choose 'No - Candidates will be accompanied at all times' from the 'Do you require candidates to have or get a DBS check?' radio buttons
-    And I enter 'Candidates are always accompanied' into the 'Provide any extra details in 50 words or less.' text area
     When I submit the form
     Then I should be on the 'candidate requirements choice' page

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -15,7 +15,6 @@ Given "I have completed the DBS Requirements step, choosing No" do
   steps %(
     Given I am on the 'DBS requirements' page
     And I choose 'No - Candidates will be accompanied at all times' from the 'Do you require candidates to have or get a DBS check?' radio buttons
-    And I enter 'No more details' into the 'Provide any extra details in 50 words or less.' text area
     When I submit the form
   )
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1839

### Context

The text box that appears when school admins pick 'No' for whether a DBS check is required isn't necessary

### Changes proposed in this pull request

Remove the check box and references to it in the test.

### Guidance to review

Ensure it looks sensible. We should probably think about removing the field at some point too, but we need to make a decision based on the data held.