### PR TITLE
Reminders SE-1953

### DIFF
--- a/app/jobs/bookings/reminder_builder.rb
+++ b/app/jobs/bookings/reminder_builder.rb
@@ -1,0 +1,13 @@
+module Bookings
+  # ReminderBuilder takes a single booking/period, builds a Bookings::Reminder
+  # object and enqueues it (creating a mailer job). This allows a the caller (ie the
+  # schedule in Cron::Reminders) to create large numbers of jobs without hitting
+  # Gitis too hard at once.
+  class ReminderBuilder < ApplicationJob
+    queue_as :default
+
+    def perform(booking, time_until_booking)
+      Bookings::Reminder.new(booking, time_until_booking).enqueue
+    end
+  end
+end

--- a/app/jobs/cron/reminders/next_week.rb
+++ b/app/jobs/cron/reminders/next_week.rb
@@ -1,0 +1,21 @@
+module Cron
+  module Reminders
+    class NextWeek < CronJob
+      self.cron_expression = '35 2 * * *'
+
+      def perform
+        Bookings::Reminder.new(time_until_booking, bookings).enqueue
+      end
+
+      def bookings
+        Bookings::Booking.not_cancelled.one_week_from_now
+      end
+
+      # this string will be used in the email subject, something along the lines
+      # of "Your School Experience placement at {some school} is in {one week}"
+      def time_until_booking
+        "one week"
+      end
+    end
+  end
+end

--- a/app/jobs/cron/reminders/next_week.rb
+++ b/app/jobs/cron/reminders/next_week.rb
@@ -4,7 +4,9 @@ module Cron
       self.cron_expression = '35 2 * * *'
 
       def perform
-        Bookings::Reminder.new(time_until_booking, bookings).enqueue
+        bookings.all? do |booking|
+          Bookings::ReminderBuilder.perform_later(booking, time_until_booking)
+        end
       end
 
       def bookings

--- a/app/jobs/cron/reminders/tomorrow.rb
+++ b/app/jobs/cron/reminders/tomorrow.rb
@@ -1,0 +1,21 @@
+module Cron
+  module Reminders
+    class Tomorrow < CronJob
+      self.cron_expression = '30 2 * * *'
+
+      def perform
+        Bookings::Reminder.new(time_until_booking, bookings).enqueue
+      end
+
+      def bookings
+        Bookings::Booking.not_cancelled.tomorrow
+      end
+
+      # this string will be used in the email subject, something along the lines
+      # of "Your School Experience placement at {some school} is in {one day}"
+      def time_until_booking
+        "one day"
+      end
+    end
+  end
+end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -81,6 +81,10 @@ module Bookings
       previous.accepted
     end
 
+    scope :days_in_the_future, ->(days_away) { where(date: days_away.from_now.to_date) }
+    scope :tomorrow,           -> { days_in_the_future(1.day) }
+    scope :one_week_from_now,  -> { days_in_the_future(7.days) }
+
     def self.from_confirm_booking(confirm_booking)
       new(
         date: confirm_booking.date,

--- a/app/notify/notify_email/candidate_booking_reminder.b3e75ee5-61cf-49c5-a145-c0710c54347d.md
+++ b/app/notify/notify_email/candidate_booking_reminder.b3e75ee5-61cf-49c5-a145-c0710c54347d.md
@@ -1,0 +1,30 @@
+Dear ((candidate_name)),
+
+It's ((time_until_booking)) until your placement at ((school_name)).
+
+* Address: ((school_address))
+* Start date: ((placement_schedule))
+* Start and finish times: ((school_start_time)) to ((school_finish_time))
+* Dress code: ((school_dress_code))
+* Parking: ((school_parking))
+
+# School experience contacts
+
+If you have any questions about your booking:
+
+Email address: ((school_admin_email))
+UK telephone number: ((school_admin_telephone))
+
+On the day of your school experience, you'll need to report to:
+
+Name: ((school_teacher_name))
+Email address: ((school_teacher_email))
+UK telephone number: ((school_teacher_telephone))
+
+You can also contact them if you have any questions.
+
+To cancel your school experience use the following link ((cancellation_url)).
+
+# School experience details
+
+((placement_details))

--- a/app/notify/notify_email/candidate_booking_reminder.rb
+++ b/app/notify/notify_email/candidate_booking_reminder.rb
@@ -55,7 +55,7 @@ class NotifyEmail::CandidateBookingReminder < Notify
     super(to: to)
   end
 
-  def self.from_booking(to, time_until_booking, booking)
+  def self.from_booking(to, time_until_booking, booking, candidates_cancel_url)
     school = booking.bookings_school
     profile = school.profile
 
@@ -89,22 +89,8 @@ class NotifyEmail::CandidateBookingReminder < Notify
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
       placement_details: booking.placement_details,
-      cancellation_url: candidates_cancel_url(booking.token)
+      cancellation_url: candidates_cancel_url
     )
-  end
-
-  # FIXME is there a nicer way of doing this? Being able to
-  # call the helper from .from_booking is definitely a nicety
-  # as the helper isn't available from models or services
-  def self.candidates_cancel_url(token)
-    Rails
-      .application
-      .routes
-      .url_helpers
-      .candidates_cancel_url(
-        token,
-        host: Rails.configuration.x.base_url
-      )
   end
 
   def template_id

--- a/app/notify/notify_email/candidate_booking_reminder.rb
+++ b/app/notify/notify_email/candidate_booking_reminder.rb
@@ -1,0 +1,120 @@
+class NotifyEmail::CandidateBookingReminder < Notify
+  attr_accessor :school_name,
+    :time_until_booking,
+    :candidate_name,
+    :placement_schedule,
+    :school_address,
+    :school_start_time,
+    :school_finish_time,
+    :school_dress_code,
+    :school_parking,
+    :school_admin_email,
+    :school_admin_telephone,
+    :school_teacher_name,
+    :school_teacher_email,
+    :school_teacher_telephone,
+    :placement_details,
+    :cancellation_url
+
+  def initialize(
+    to:,
+    school_name:,
+    time_until_booking:,
+    candidate_name:,
+    placement_schedule:,
+    school_address:,
+    school_start_time:,
+    school_finish_time:,
+    school_dress_code:,
+    school_parking:,
+    school_admin_email:,
+    school_admin_telephone:,
+    school_teacher_name:,
+    school_teacher_email:,
+    school_teacher_telephone:,
+    placement_details:,
+    cancellation_url:
+  )
+    self.school_name = school_name
+    self.time_until_booking = time_until_booking
+    self.candidate_name = candidate_name
+    self.placement_schedule = placement_schedule
+    self.school_address = school_address
+    self.school_start_time = school_start_time
+    self.school_finish_time = school_finish_time
+    self.school_dress_code = school_dress_code
+    self.school_parking = school_parking
+    self.school_admin_email = school_admin_email
+    self.school_admin_telephone = school_admin_telephone
+    self.school_teacher_name = school_teacher_name
+    self.school_teacher_email = school_teacher_email
+    self.school_teacher_telephone = school_teacher_telephone
+    self.placement_details = placement_details
+    self.cancellation_url = cancellation_url
+
+    super(to: to)
+  end
+
+  def self.from_booking(to, time_until_booking, booking, cancellation_url)
+    school = booking.bookings_school
+    profile = school.profile
+
+    new(
+      to: to,
+      school_name: school.name,
+      time_until_booking: time_until_booking,
+      candidate_name: booking.candidate_name,
+      placement_schedule: booking.placement_start_date_with_duration,
+      school_address: [
+        school.address_1,
+        school.address_2,
+        school.address_3,
+        school.town,
+        school.county,
+        school.postcode
+      ].reject(&:blank?).join(', '),
+      school_start_time: profile.start_time,
+      school_finish_time: profile.end_time,
+      school_dress_code: [
+        profile.dress_code,
+        profile.dress_code_other_details,
+      ].reject(&:blank?).join(', '),
+      school_parking: [
+        profile.parking_provided ? 'Yes' : 'No',
+        profile.parking_details
+      ].join(', '),
+      school_admin_email: profile.admin_contact_email,
+      school_admin_telephone: profile.admin_contact_phone,
+      school_teacher_name: booking.contact_name,
+      school_teacher_email: booking.contact_email,
+      school_teacher_telephone: booking.contact_number,
+      placement_details: booking.placement_details,
+      cancellation_url: cancellation_url
+    )
+  end
+
+  def template_id
+    'b3e75ee5-61cf-49c5-a145-c0710c54347d'
+  end
+
+  def personalisation
+    {
+      school_name: school_name,
+      time_until_booking: time_until_booking,
+      candidate_name: candidate_name,
+      placement_schedule: placement_schedule,
+      school_address: school_address,
+      school_start_time: school_start_time,
+      school_finish_time: school_finish_time,
+      school_dress_code: school_dress_code,
+      school_parking: school_parking,
+      school_admin_email: school_admin_email,
+      school_admin_telephone: school_admin_telephone,
+      school_teacher_name: school_teacher_name,
+      school_teacher_email: school_teacher_email,
+      school_teacher_telephone: school_teacher_telephone,
+      placement_details: placement_details,
+      cancellation_url: cancellation_url
+    }
+  end
+end

--- a/app/notify/notify_email/candidate_booking_reminder.rb
+++ b/app/notify/notify_email/candidate_booking_reminder.rb
@@ -55,7 +55,7 @@ class NotifyEmail::CandidateBookingReminder < Notify
     super(to: to)
   end
 
-  def self.from_booking(to, time_until_booking, booking, cancellation_url)
+  def self.from_booking(to, time_until_booking, booking)
     school = booking.bookings_school
     profile = school.profile
 
@@ -89,8 +89,22 @@ class NotifyEmail::CandidateBookingReminder < Notify
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
       placement_details: booking.placement_details,
-      cancellation_url: cancellation_url
+      cancellation_url: candidates_cancel_url(booking.token)
     )
+  end
+
+  # FIXME is there a nicer way of doing this? Being able to
+  # call the helper from .from_booking is definitely a nicety
+  # as the helper isn't available from models or services
+  def self.candidates_cancel_url(token)
+    Rails
+      .application
+      .routes
+      .url_helpers
+      .candidates_cancel_url(
+        token,
+        host: Rails.configuration.x.base_url
+      )
   end
 
   def template_id

--- a/app/services/bookings/reminder.rb
+++ b/app/services/bookings/reminder.rb
@@ -1,0 +1,37 @@
+# Bookings::Reminder is responsible for sending emails to candidates
+# informing them that they have an upcoming school experience
+class Bookings::Reminder
+  include GitisAccess
+
+  def initialize(time_until_booking, bookings)
+    @time_until_booking = time_until_booking
+
+    @bookings = bookings
+    assign_gitis_contacts(@bookings)
+  end
+
+  def enqueue
+    Delayed::Job.transaction do
+      @bookings.each do |booking|
+        NotifyEmail::CandidateBookingReminder.from_booking(
+          booking.candidate_email,
+          @time_until_booking,
+          booking
+        ).despatch_later!
+      end
+    end
+  end
+
+private
+
+  def assign_gitis_contacts(bookings)
+    return bookings if bookings.empty?
+
+    contacts = gitis_crm.find(bookings.map(&:contact_uuid)).index_by(&:id)
+
+    bookings.each do |booking|
+      booking.bookings_placement_request.candidate.gitis_contact = \
+        contacts[booking.contact_uuid]
+    end
+  end
+end

--- a/app/services/bookings/reminder.rb
+++ b/app/services/bookings/reminder.rb
@@ -2,6 +2,7 @@
 # informing them that they have an upcoming school experience
 class Bookings::Reminder
   include GitisAccess
+  include Rails.application.routes.url_helpers
 
   def initialize(time_until_booking, bookings)
     @time_until_booking = time_until_booking
@@ -16,13 +17,18 @@ class Bookings::Reminder
         NotifyEmail::CandidateBookingReminder.from_booking(
           booking.candidate_email,
           @time_until_booking,
-          booking
+          booking,
+          candidates_cancel_url(booking.token)
         ).despatch_later!
       end
     end
   end
 
 private
+
+  def default_url_options
+    { host: Rails.configuration.x.base_url }
+  end
 
   def assign_gitis_contacts(bookings)
     return bookings if bookings.empty?

--- a/spec/jobs/bookings/reminder_builder_spec.rb
+++ b/spec/jobs/bookings/reminder_builder_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe Bookings::ReminderBuilder, type: :job do
+  let(:period) { 'one week' }
+  let(:reminder) { double(Bookings::Reminder, enqueue: true) }
+  let(:booking) { create(:bookings_booking) }
+  before do
+    allow(Bookings::Reminder).to receive(:new).with(booking, period).and_return(reminder)
+  end
+
+  subject { described_class.perform_now(booking, period) }
+
+  context '#perform' do
+    before { subject }
+
+    specify 'should build a new reminder with the correct params' do
+      expect(Bookings::Reminder).to have_received(:new).with(booking, period)
+    end
+
+    specify 'should enqueue the reminder' do
+      expect(reminder).to have_received(:enqueue)
+    end
+  end
+end

--- a/spec/jobs/cron/reminders/next_week_spec.rb
+++ b/spec/jobs/cron/reminders/next_week_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Cron::Reminders::NextWeek, type: :job do
+  specify 'should have a schedule of daily at 02:35' do
+    expect(described_class.cron_expression).to eql('35 2 * * *')
+  end
+
+  describe '#time_until_booking' do
+    specify { expect(subject.time_until_booking).to eql('one week') }
+  end
+
+  describe '#perform' do
+    let(:reminder_instance) { double Bookings::Reminder, enqueue: true }
+
+    before do
+      allow(Bookings::Reminder).to receive(:new).and_return(reminder_instance)
+    end
+
+    subject! { described_class.new.perform }
+
+    specify 'calling perform should call Bookings::Reminder.new.enqueue' do
+      expect(reminder_instance).to have_received(:enqueue)
+    end
+  end
+end

--- a/spec/jobs/cron/reminders/next_week_spec.rb
+++ b/spec/jobs/cron/reminders/next_week_spec.rb
@@ -10,16 +10,15 @@ describe Cron::Reminders::NextWeek, type: :job do
   end
 
   describe '#perform' do
-    let(:reminder_instance) { double Bookings::Reminder, enqueue: true }
-
     before do
-      allow(Bookings::Reminder).to receive(:new).and_return(reminder_instance)
+      allow_any_instance_of(Cron::Reminders::NextWeek).to receive(:bookings).and_return(%w(a b c))
+      allow(Bookings::ReminderBuilder).to receive(:perform_later).and_return(true)
     end
 
     subject! { described_class.new.perform }
 
     specify 'calling perform should call Bookings::Reminder.new.enqueue' do
-      expect(reminder_instance).to have_received(:enqueue)
+      expect(Bookings::ReminderBuilder).to have_received(:perform_later).exactly(3).times
     end
   end
 end

--- a/spec/jobs/cron/reminders/tomorrow_spec.rb
+++ b/spec/jobs/cron/reminders/tomorrow_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Cron::Reminders::Tomorrow, type: :job do
+  specify 'should have a schedule of daily at 02:30' do
+    expect(described_class.cron_expression).to eql('30 2 * * *')
+  end
+
+  describe '#time_until_booking' do
+    specify { expect(subject.time_until_booking).to eql('one day') }
+  end
+
+  describe '#perform' do
+    let(:reminder_instance) { double Bookings::Reminder, enqueue: true }
+
+    before do
+      allow(Bookings::Reminder).to receive(:new).and_return(reminder_instance)
+    end
+
+    subject! { described_class.new.perform }
+
+    specify 'calling perform should call Bookings::Reminder.new.enqueue' do
+      expect(reminder_instance).to have_received(:enqueue)
+    end
+  end
+end

--- a/spec/jobs/cron/reminders/tomorrow_spec.rb
+++ b/spec/jobs/cron/reminders/tomorrow_spec.rb
@@ -10,16 +10,15 @@ describe Cron::Reminders::Tomorrow, type: :job do
   end
 
   describe '#perform' do
-    let(:reminder_instance) { double Bookings::Reminder, enqueue: true }
-
     before do
-      allow(Bookings::Reminder).to receive(:new).and_return(reminder_instance)
+      allow_any_instance_of(Cron::Reminders::Tomorrow).to receive(:bookings).and_return(%w(a b c))
+      allow(Bookings::ReminderBuilder).to receive(:perform_later).and_return(true)
     end
 
     subject! { described_class.new.perform }
 
     specify 'calling perform should call Bookings::Reminder.new.enqueue' do
-      expect(reminder_instance).to have_received(:enqueue)
+      expect(Bookings::ReminderBuilder).to have_received(:perform_later).exactly(3).times
     end
   end
 end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -292,6 +292,37 @@ describe Bookings::Booking do
         end
       end
     end
+
+    describe '.days_in_the_future' do
+      let!(:booking_in_1_days) { create(:bookings_booking, date: Date.tomorrow) }
+      let!(:booking_in_3_days) { create(:bookings_booking, date: 3.days.from_now.to_date) }
+      let!(:booking_in_7_days) { create(:bookings_booking, date: 7.days.from_now.to_date) }
+      let!(:booking_in_8_days) { create(:bookings_booking, date: 8.days.from_now.to_date) }
+
+      specify 'should return bookings the specified number of days away' do
+        expect(described_class.days_in_the_future(1.days)).to include(booking_in_1_days)
+      end
+
+      specify 'should not return other bookings' do
+        expect(described_class.days_in_the_future(1.days)).not_to include(booking_in_3_days)
+        expect(described_class.days_in_the_future(1.days)).not_to include(booking_in_7_days)
+        expect(described_class.days_in_the_future(1.days)).not_to include(booking_in_8_days)
+      end
+
+      describe '.tomorrow' do
+        after { described_class.tomorrow }
+        specify 'should call .days_in_the_future with 1 days' do
+          expect(described_class).to receive(:days_in_the_future).with(1.day)
+        end
+      end
+
+      describe '.one_week_from_now' do
+        after { described_class.one_week_from_now }
+        specify 'should call .days_in_the_future with 7 days' do
+          expect(described_class).to receive(:days_in_the_future).with(7.days)
+        end
+      end
+    end
   end
 
   describe 'Acceptance' do

--- a/spec/notify/notify_email/candidate_booking_reminder_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_reminder_spec.rb
@@ -17,7 +17,7 @@ describe NotifyEmail::CandidateBookingReminder do
     school_teacher_email: "ednak@springfield.co.uk",
     school_teacher_telephone: "01234 234 1245",
     placement_details: "You will shadow a teacher and assist with lesson planning",
-    cancellation_url: 'https://example.com/candiates/cancel/abc-123'
+    cancellation_url: "#{Rails.configuration.x.base_url}/candiates/cancel/abc-123"
 
   describe ".from_booking" do
     before do
@@ -48,9 +48,9 @@ describe NotifyEmail::CandidateBookingReminder do
       allow(booking).to receive(:candidate_name).and_return(candidate_name)
     end
 
-    let!(:cancellation_url) { "https://example.com/candidates/cancel/#{booking.token}" }
+    let!(:cancellation_url) { "#{Rails.configuration.x.base_url}/candidates/cancel/#{booking.token}" }
 
-    subject { described_class.from_booking(to, time_until_booking, booking, cancellation_url) }
+    subject { described_class.from_booking(to, time_until_booking, booking) }
 
     it { is_expected.to be_a(described_class) }
 

--- a/spec/notify/notify_email/candidate_booking_reminder_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_reminder_spec.rb
@@ -1,0 +1,126 @@
+require 'rails_helper'
+
+describe NotifyEmail::CandidateBookingReminder do
+  it_should_behave_like "email template", "b3e75ee5-61cf-49c5-a145-c0710c54347d",
+    time_until_booking: "2 weeks",
+    school_name: "Springfield Elementary",
+    candidate_name: "Kearney Zzyzwicz",
+    placement_schedule: "2022-03-04 for 3 days",
+    school_address: "123 Main Street, Springfield, M2 3JF",
+    school_start_time: "08:40",
+    school_finish_time: "15:30",
+    school_dress_code: "Smart casual, elbow patches",
+    school_parking: "There is a car park on the school grounds",
+    school_admin_email: "sskinner@springfield.co.uk",
+    school_admin_telephone: "01234 123 1234",
+    school_teacher_name: "Edna Krabappel",
+    school_teacher_email: "ednak@springfield.co.uk",
+    school_teacher_telephone: "01234 234 1245",
+    placement_details: "You will shadow a teacher and assist with lesson planning",
+    cancellation_url: 'https://example.com/candiates/cancel/abc-123'
+
+  describe ".from_booking" do
+    before do
+      stub_const(
+        'Notify::API_KEY',
+        ["somekey", SecureRandom.uuid, SecureRandom.uuid].join("-")
+      )
+    end
+
+    specify { expect(described_class).to respond_to(:from_booking) }
+
+    let(:time_until_booking) { "2 weeks" }
+    let!(:school) { create(:bookings_school) }
+    let!(:profile) { create(:bookings_profile, school: school) }
+    let(:to) { "morris.szyslak@moes.net" }
+    let(:candidate_name) { "morris.szyslak" }
+
+    let!(:pr) { create(:bookings_placement_request, school: school) }
+    let!(:booking) do
+      create(
+        :bookings_booking,
+        bookings_school: school,
+        bookings_placement_request: pr
+      )
+    end
+
+    before do
+      allow(booking).to receive(:candidate_name).and_return(candidate_name)
+    end
+
+    let!(:cancellation_url) { "https://example.com/candidates/cancel/#{booking.token}" }
+
+    subject { described_class.from_booking(to, time_until_booking, booking, cancellation_url) }
+
+    it { is_expected.to be_a(described_class) }
+
+    context 'correctly assigning attributes' do
+      specify 'time_until_booking is correctly assigned' do
+        expect(subject.time_until_booking).to eql(time_until_booking)
+      end
+
+      specify 'candidate_name is correctly-assigned' do
+        expect(subject.candidate_name).to eql(candidate_name)
+      end
+
+      specify 'placement_schedule is correctly-assigned' do
+        expect(subject.placement_schedule).to eql(booking.placement_start_date_with_duration)
+      end
+
+      specify 'school_address is correctly-assigned' do
+        expect(subject.school_address).to eql(
+          [school.address_1, school.address_2, school.address_3,
+           school.town, school.county, school.postcode].reject(&:blank?).join(", ")
+        )
+      end
+
+      specify 'school_start_time is correctly-assigned' do
+        expect(subject.school_start_time).to eql(profile.start_time)
+      end
+
+      specify 'school_end_time is correctly-assigned' do
+        expect(subject.school_finish_time).to eql(profile.end_time)
+      end
+
+      specify 'school_dress_code is correctly-assigned' do
+        expect(subject.school_dress_code).to eql(
+          [profile.dress_code, profile.dress_code_other_details].reject(&:blank?).join(", ")
+        )
+      end
+
+      specify 'school_parking is correctly-assigned' do
+        expect(subject.school_parking).to eql(
+          ['No', profile.parking_details].join(', ')
+        )
+      end
+
+      specify 'school_admin_email is correctly-assigned' do
+        expect(subject.school_admin_email).to eql(profile.admin_contact_email)
+      end
+
+      specify 'school_admin_telephone is correctly-assigned' do
+        expect(subject.school_admin_telephone).to eql(profile.admin_contact_phone)
+      end
+
+      specify 'school_teacher_name is correctly-assigned' do
+        expect(subject.school_teacher_name).to eql(booking.contact_name)
+      end
+
+      specify 'school_teacher_email is correctly-assigned' do
+        expect(subject.school_teacher_email).to eql(booking.contact_email)
+      end
+
+      specify 'school_teacher_telephone is correctly-assigned' do
+        expect(subject.school_teacher_telephone).to eql(booking.contact_number)
+      end
+
+      specify 'placement_details is correctly-assigned' do
+        expect(subject.placement_details).to eql(booking.placement_details)
+      end
+
+      specify 'cancellation_url is correctly-assigned' do
+        expect(subject.cancellation_url).to eql(cancellation_url)
+      end
+    end
+  end
+end

--- a/spec/notify/notify_email/candidate_booking_reminder_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_reminder_spec.rb
@@ -50,7 +50,7 @@ describe NotifyEmail::CandidateBookingReminder do
 
     let!(:cancellation_url) { "#{Rails.configuration.x.base_url}/candidates/cancel/#{booking.token}" }
 
-    subject { described_class.from_booking(to, time_until_booking, booking) }
+    subject { described_class.from_booking(to, time_until_booking, booking, cancellation_url) }
 
     it { is_expected.to be_a(described_class) }
 

--- a/spec/services/bookings/reminder_spec.rb
+++ b/spec/services/bookings/reminder_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe Bookings::Reminder do
+  include ActiveJob::TestHelper
+
+  let(:time_until_booking) { '3 weeks' }
+  let(:school) { create(:bookings_school, :onboarded) }
+  let(:bookings) { create_list(:bookings_booking, 3, bookings_school: school, date: 3.weeks.from_now) }
+
+  subject { Bookings::Reminder.new(time_until_booking, bookings) }
+
+  describe '#enqueue' do
+    specify 'should enqueue one job per provided booking' do
+      expect(enqueued_jobs.size).to be_zero
+
+      subject.enqueue
+
+      expect(enqueued_jobs.size).to eql(bookings.size)
+    end
+  end
+end

--- a/spec/services/bookings/reminder_spec.rb
+++ b/spec/services/bookings/reminder_spec.rb
@@ -5,9 +5,9 @@ describe Bookings::Reminder do
 
   let(:time_until_booking) { '3 weeks' }
   let(:school) { create(:bookings_school, :onboarded) }
-  let(:bookings) { create_list(:bookings_booking, 3, bookings_school: school, date: 3.weeks.from_now) }
+  let(:booking) { create(:bookings_booking,  bookings_school: school, date: 3.weeks.from_now) }
 
-  subject { Bookings::Reminder.new(time_until_booking, bookings) }
+  subject { Bookings::Reminder.new(booking, time_until_booking) }
 
   describe '#enqueue' do
     specify 'should enqueue one job per provided booking' do
@@ -15,7 +15,7 @@ describe Bookings::Reminder do
 
       subject.enqueue
 
-      expect(enqueued_jobs.size).to eql(bookings.size)
+      expect(enqueued_jobs.size).to eql(1)
     end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1953

### Context

Currently there's no contact between the service and candidates from the point the booking is accepted until it begins.

### Changes proposed in this pull request

Every morning at 02:30 and 02:35 jobs will run automatically that select all uncancelled bookings that are due one week and one day in the future, and for each of these jobs a reminder email (currently closely matching the confirmation email in terms of content) will be queued.

The queuing is wrapped in a transaction meaning that if it fails for some reason no reminders will be sent rather than some.

### Guidance to review

Does it look sensible? The populating the queue stage _could_ be further refined but in order to run it incrementally and repeatedly we'd need flags or events (`weekly_reminder_sent: true`) and build that into the query. At our quantities that might be over-engineering.