### PR TITLE
Reorganising school profile content

### DIFF
--- a/app/views/candidates/schools/_access_needs_statement.html.erb
+++ b/app/views/candidates/schools/_access_needs_statement.html.erb
@@ -1,5 +1,4 @@
 <section id="access-needs-statement" class="govuk-!-margin-bottom-6">
-  <h2>Disability and access needs details</h2>
   <p>
     <%= presenter.access_needs_description %>
   </p>

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -24,6 +24,11 @@
           <%= format_school_subjects @presenter.school %>
         <% end %>
       </dl>
+
+      <% if @presenter.school.availability_preference_fixed? %>
+        <%= render partial: 'candidates/schools/placement_dates', locals: { primary_dates: @presenter.primary_dates, secondary_dates_grouped_by_date: @presenter.secondary_dates_grouped_by_date } %>
+      <% end %>
+
     </div>
 
     <div>
@@ -42,14 +47,6 @@
     </div>
 
     <div>
-      <h2>About our school</h2>
-
-      <dl class="govuk-summary-list govuk-summary-list--no-border inline">
-        <%= dlist_item 'Age range:', id: 'school-phases' do %>
-          <%= format_phases(@presenter.school) %>
-        <% end %>
-      </dl>
-
       <p>
         <strong>
           For more information about our school:
@@ -87,15 +84,6 @@
       </ul>
     </div>
 
-    <% if @presenter.school.availability_preference_fixed? %>
-      <%= render partial: 'candidates/schools/placement_dates', locals: { primary_dates: @presenter.primary_dates, secondary_dates_grouped_by_date: @presenter.secondary_dates_grouped_by_date } %>
-    <% end %>
-
-    <% if @presenter.supports_access_needs? %>
-      <%= render partial: 'candidates/schools/access_needs_statement.html.erb',
-        locals: { presenter: @presenter } %>
-    <% end %>
-
     <% if include_candidate_request_links %>
       <div class="school-start-request-button__tablet_plus">
         <%= render 'start_request', profile: @presenter %>
@@ -111,6 +99,11 @@
 
   <div class="candidate-profile-sidebar govuk-grid-column-one-third column-top-border">
     <dl class="govuk-summary-list govuk-summary-list--no-border vertical">
+
+      <%= dlist_item 'School phases', id: 'school-phases' do %>
+        <%= format_school_phases(@presenter.school) %>
+      <% end %>
+
       <%= dlist_item 'Address', id: 'school-address' do %>
         <%= format_school_address @presenter.school, tag(:br) %>
       <% end %>
@@ -191,6 +184,14 @@
 
         <%= safe_format @presenter.parking_details %>
       <% end %>
+
+      <% if @presenter.supports_access_needs? %>
+        <%= dlist_item 'Disability and access details', id: 'disability-and-access' do %>
+          <%= render partial: 'candidates/schools/access_needs_statement.html.erb',
+            locals: { presenter: @presenter } %>
+        <% end %>
+      <% end %>
+
 
       <%= dlist_item 'Teacher training offered', id: 'school-teacher-training-info' do %>
         <%= safe_format @presenter.teacher_training_info %>

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -85,7 +85,7 @@
     </div>
 
     <% if include_candidate_request_links %>
-      <div class="school-start-request-button__tablet_plus">
+      <div class="school-start-request-button__tablet_plus govuk-!-margin-top-8">
         <%= render 'start_request', profile: @presenter %>
 
       </div>

--- a/features/candidates/schools/show/full_school_details.feature
+++ b/features/candidates/schools/show/full_school_details.feature
@@ -31,7 +31,7 @@ Feature: School show page (enhanced data)
         Given the phases 'Primary' and 'Secondary' exist
         And the school is a 'Primary' and 'Secondary' school
         When I am on the profile page for the chosen school
-        Then the age range should be 'Primary and Secondary'
+        Then the age range should contain 'Primary' and 'Secondary'
 
     Scenario: Subjects
         Given some subjects exist

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -89,7 +89,8 @@ Feature: School Profile
             | Individual requirements           | Must be applying to or have applied to our, or a partner school's, teacher training course. They must live within 7 miles from the school. Some details |
             | Experience details                | A really good one                                                                                                                                       |
             | School subjects                   | Maths                                                                                                                                                   |
-            | School phases                     | Secondary (11 to 16) and 16 to 18                                                                                                                       |
+            | School phases                     | Secondary (11 to 16)                                                                                                                       |
+            | School phases                     | 16 to 18                                                                                                                       |
             | School Address                    | 22 something                                                                                                                                            |
             | School availability info          | No information supplied                                                                                                                                 |
             | DBS check info                    | Yes\nAlways require DBS check                                                                                                                           |

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -33,6 +33,12 @@ Then("the age range should be {string}") do |string|
   end
 end
 
+Then("the age range should contain {string} and {string}") do |phase1, phase2|
+  within("#school-phases") do
+    [phase1, phase2].all? { |p| expect(page).to have_content(p) }
+  end
+end
+
 Given("some subjects exist") do
   @subjects = FactoryBot.create_list(:bookings_subject, 5)
 end

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -343,7 +343,11 @@ Then "I should see the dress code policy information I entered in the wizard" do
 end
 
 Then "I should see the accessability information I have entered" do
-  within '#access-needs-statement' do
-    expect(page).to have_text "Disability and access needs details We offer facilities and provide an inclusive environment for students, staff and school experience candidates with disability and access needs. We're happy to discuss your disability or access needs before or as part of your school experience request. Access needs policy", normalize_ws: true
+  within('#disability-and-access') do
+    expect(page).to have_css('dt', text: 'Disability and access details')
+
+    within('#access-needs-statement') do
+      expect(page).to have_text "We offer facilities and provide an inclusive environment for students, staff and school experience candidates with disability and access needs. We're happy to discuss your disability or access needs before or as part of your school experience request. Access needs policy", normalize_ws: true
+    end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

N/A

### Context

We had a discussion about the ordering of the school profile and this is a quick (20 minute) shuffle. Not intended to be merged yet but up for discussion when we're all back in the office

### Changes proposed in this pull request

* Move the dates/subjects list _above_ the map
* Move accessibility info to the right hand column
* Move the phases to the top of the right hand column and format as a list

#### Before

![before](https://user-images.githubusercontent.com/128088/70246584-e2142080-176f-11ea-939b-b91663c946f5.png)

#### After

![after](https://user-images.githubusercontent.com/128088/70246571-df193000-176f-11ea-9861-e79ecbcd5521.png)

### Guidance to review

Discuss. Does the profile look better overall? Is the restructuring of the right hand column sensible? Does it feel more balanced? Does the dates/subjects list being above the map always make sense?

