### PR TITLE
Remove all subjects checkbox SE-1996

### DIFF
--- a/app/forms/schools/placement_dates/subject_selection.rb
+++ b/app/forms/schools/placement_dates/subject_selection.rb
@@ -4,19 +4,12 @@ module Schools
       include ActiveModel::Model
       include ActiveModel::Attributes
 
-      attribute :available_for_all_subjects, :boolean
       attr_reader :subject_ids
 
-      validates :subject_ids, presence: true, unless: :available_for_all_subjects
+      validates :subject_ids, presence: true
 
       def self.new_from_date(placement_date)
-        if placement_date.published?
-          new \
-            available_for_all_subjects: !placement_date.subject_specific?,
-            subject_ids: placement_date.subject_ids
-        else
-          new subject_ids: placement_date.subject_ids
-        end
+        new(subject_ids: placement_date.subject_ids)
       end
 
       def subject_ids=(array)

--- a/app/forms/schools/placement_dates/subject_selection.rb
+++ b/app/forms/schools/placement_dates/subject_selection.rb
@@ -19,17 +19,13 @@ module Schools
       def save(placement_date)
         return false unless valid?
 
-        if available_for_all_subjects
-          placement_date.subject_specific = false
-          placement_date.subject_ids = []
-        else
-          placement_date.subject_specific = true
-          placement_date.subject_ids = self.subject_ids
+        placement_date.tap do |pd|
+          pd.subject_specific = true
+          pd.subject_ids = self.subject_ids
+          pd.published_at = DateTime.now
+
+          pd.save!
         end
-
-        placement_date.published_at = DateTime.now
-
-        placement_date.save!
       end
     end
   end

--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -1,4 +1,6 @@
-<% self.page_title = 'Manage attendees' %>
+<% self.page_title = 'Set date options' %>
+
+<%= link_to 'Back', :back, class: 'govuk-back-link' %>
 
 <h1><%= @placement_date.date.to_formatted_s :govuk %> (<%= pluralize @placement_date.duration, 'day' %>)</h1>
 

--- a/app/views/schools/placement_dates/subject_selections/new.html.erb
+++ b/app/views/schools/placement_dates/subject_selections/new.html.erb
@@ -1,5 +1,7 @@
 <% self.page_title = 'Select school experience subjects' %>
 
+<%= link_to 'Back', :back, class: 'govuk-back-link' %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @subject_selection, method: :post, url: schools_placement_date_subject_selection_path(@placement_date) do |f| %>

--- a/app/views/schools/placement_dates/subject_selections/new.html.erb
+++ b/app/views/schools/placement_dates/subject_selections/new.html.erb
@@ -1,21 +1,11 @@
 <% self.page_title = 'Select school experience subjects' %>
 
-<h1>Select school experience subjects</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @subject_selection, method: :post, url: schools_placement_date_subject_selection_path(@placement_date) do |f| %>
       <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
-      <p>
-        Tell us which subjects you offer for this date and select continue
-      </p>
-
-      <%= f.check_box_input :available_for_all_subjects %>
-
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-      <%= f.collection_check_boxes :subject_ids, @placement_date.bookings_school.subjects, :id, :name %>
+      <%= f.collection_check_boxes :subject_ids, @placement_date.bookings_school.subjects, :id, :name, { page_heading: true} %>
       <%= f.submit 'Continue' %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,7 +502,7 @@ en:
         available_for_all_subjects: Select type of experience
 
       schools_placement_dates_subject_selection:
-        subject_ids: Select all that apply.
+        subject_ids: Select school experience subjects
 
       candidates_feedback:
         <<: *feedback_fieldset

--- a/features/schools/placement_dates/secondary_school_configuration.feature
+++ b/features/schools/placement_dates/secondary_school_configuration.feature
@@ -9,8 +9,10 @@ Feature: Configuring a placement date
     And my school is fully-onboarded
     And I have entered a placement date
 
-  Scenario: Page title
+  Scenario: Page contents
     Then the page's main heading should be the date I just entered
+    And I should see a back link
+    And the page title should be 'Set date options'
 
   @javascript
   Scenario: Select no max number of bookings

--- a/features/schools/placement_dates/subject_selection.feature
+++ b/features/schools/placement_dates/subject_selection.feature
@@ -14,19 +14,9 @@ Feature: Selecting subjects for a placement date
     Scenario: Page title
         Then the page's main heading should be 'Select school experience subjects'
 
-    Scenario: Page content
-        Then I should see a list of subjects the school offers
-        And an option to select all subjects
-
     Scenario: Selecting nothing
         When I submit the form
         Then I should see a validation error message
-
-    Scenario: Selecting all subjects
-        Given I check 'All subjects'
-        When I submit the form
-        Then I should be on the 'placement dates' page
-        And my date should be listed
 
     Scenario: Selecting some subjects
         Given I check 'Maths'

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -97,5 +97,5 @@ Then("I should see a notification that {string}") do |string|
 end
 
 Then("I should see a back link") do
-  expect(page).to have_link("Back", href: 'javascript:history.back()')
+  expect(page).to have_link("Back")
 end

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -65,10 +65,6 @@ Then "I should see a list of subjects the school offers" do
   end
 end
 
-Then "an option to select all subjects" do
-  expect(page).to have_field('All subjects', type: 'checkbox')
-end
-
 Then "my date should be listed" do
   date = @school.bookings_placement_dates.last
 

--- a/spec/forms/schools/placement_dates/subject_selection_spec.rb
+++ b/spec/forms/schools/placement_dates/subject_selection_spec.rb
@@ -40,7 +40,6 @@ describe Schools::PlacementDates::SubjectSelection, type: :model do
       end
 
       it 'returns a new subject_selection without attributes set' do
-        expect(subject.available_for_all_subjects).to eq nil
         expect(subject.subject_ids).to be_empty
       end
     end
@@ -66,8 +65,10 @@ describe Schools::PlacementDates::SubjectSelection, type: :model do
 
     context 'invalid' do
       let :attributes do
-        { available_for_all_subjects: nil, subject_ids: nil }
+        { subject_ids: nil }
       end
+
+      it { is_expected.to(be_invalid) }
 
       it 'doesnt update the placement_date' do
         expect(placement_date.published_at).to be nil
@@ -75,36 +76,20 @@ describe Schools::PlacementDates::SubjectSelection, type: :model do
     end
 
     context 'valid' do
-      context 'when available_for_all_subjects' do
-        let :attributes do
-          { available_for_all_subjects: true, subject_ids: [] }
-        end
-
-        it 'updates the placement_date to not be subject_specific' do
-          expect(placement_date).not_to be_subject_specific
-        end
-
-        it 'updates published_at' do
-          expect(placement_date.published_at).to eq stubbed_time
-        end
+      let :subjects do
+        school.subjects.first(2)
       end
 
-      context 'when not available_for_all_subjects' do
-        let :subjects do
-          school.subjects.first(2)
-        end
+      let :attributes do
+        { subject_ids: subjects.map(&:id) }
+      end
 
-        let :attributes do
-          { available_for_all_subjects: false, subject_ids: subjects.map(&:id) }
-        end
+      it 'updates the placement_date subjects to the selected_subjects' do
+        expect(placement_date.subjects).to eq subjects
+      end
 
-        it 'updates the placement_date subjects to the selected_subjects' do
-          expect(placement_date.subjects).to eq subjects
-        end
-
-        it 'updates published_at' do
-          expect(placement_date.published_at).to eq stubbed_time
-        end
+      it 'updates published_at' do
+        expect(placement_date.published_at).to eq stubbed_time
       end
     end
   end

--- a/spec/forms/schools/placement_dates/subject_selection_spec.rb
+++ b/spec/forms/schools/placement_dates/subject_selection_spec.rb
@@ -23,12 +23,10 @@ describe Schools::PlacementDates::SubjectSelection, type: :model do
         create \
           :bookings_placement_date,
           published_at: DateTime.now,
-          bookings_school: school,
-          subject_specific: false
+          bookings_school: school
       end
 
       it 'returns a new subject_selection with attributes set' do
-        expect(subject.available_for_all_subjects).to eq true
         expect(subject.subject_ids).to eq placement_date.subject_ids
       end
     end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1996

### Context

The 'All subjects' box at the top of the subject checkbox list when adding/configuring a placement date was superfluous, it was re-asking the same question as the previous page.

### Changes proposed in this pull request

Remove the 'All subjects' checkbox and the specialised logic that made it work, now it's just a plain collection of check boxes.

![Screenshot from 2019-12-09 12-10-00](https://user-images.githubusercontent.com/128088/70434741-f6606200-1a7c-11ea-9fd3-e0d3add2104e.png)

### Guidance to review

Ensure the change makes sense and functions correctly. Note, I'm going to chat to Nahella regarding adding some hint text above the checkboxes.
