### PR TITLE
Added DfE Signin help page, link from schools home

### DIFF
--- a/app/views/pages/dfe_signin_help.html.erb
+++ b/app/views/pages/dfe_signin_help.html.erb
@@ -1,0 +1,64 @@
+<%= link_to 'Back', :back, class: 'govuk-back-link' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1>DfE Sign-in help</h1>
+
+
+    <p>
+      You need a DfE Sign-in account username and password to manage school
+      experience for an organisation.
+    </p>
+
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+
+        These are not the same as your old School Experience Portal (SEP)
+        login details and do not include your URN.
+      </strong>
+    </div>
+
+    <p>
+      Don't worry if you don't have or don't know your details - all you need to
+      do is contact your organisation's DfE Sign-in approver.
+    </p>
+
+    <p>
+      Your approver can help you:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>
+        set up a new account if you don't already have one
+      </li>
+      <li>
+        sign in to your existing account if you already have one
+      </li>
+      <li>
+        set up your account so you can manage school experience for your schools
+      </li>
+    </ul>
+
+    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-dfe-signin-help">
+      <div class="govuk-accordion__section ">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-3">
+              How do I find my DfE Sign-in approver?
+            </span>
+          </h2>
+        </div>
+        <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+            <p>Your approver will normally be the head or deputy head.<p>
+            <p>If they're not or you're not sure, don't worry. We just need to get some of your details so we can find them.</p>
+            <p>We'll be in touch within 3 to 5 working days.</p>
+            <a class="govuk-button" href="https://docs.google.com/forms/d/e/1FAIpQLSdO3qOE-Kgo8keTou3DDYPVv2YKi225YbCqMUl_sadZNRW2mA/viewform?usp=pp_url">
+              School experience help form
+            </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/pages/dfe_signin_help.html.erb
+++ b/app/views/pages/dfe_signin_help.html.erb
@@ -55,7 +55,7 @@
             <p>If they're not or you're not sure, don't worry. We just need to get some of your details so we can find them.</p>
             <p>We'll be in touch within 3 to 5 working days.</p>
             <a class="govuk-button" href="https://docs.google.com/forms/d/e/1FAIpQLSdO3qOE-Kgo8keTou3DDYPVv2YKi225YbCqMUl_sadZNRW2mA/viewform?usp=pp_url">
-              School experience help form
+              Get help
             </a>
         </div>
       </div>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -9,23 +9,22 @@
 
         <section>
           <p>
-            Use this service if you're a primary or secondary school in England
-            and want to offer school experience to potential teachers.
+            Use this service if you're a school in England and want to offer
+            school experience.
           </p>
 
           <p>
-            You'll see details about candidates who've requested to visit your
-            school so you can decide whether to offer them experience.
+            The service will enable you to advertise your school and allow
+            candidates to request exerience dates. You'll be able to accept
+            or reject each request.
           </p>
 
           <p>
-            The service is currently only open to specific schools. To sign up
-            for the service email us with your URN at
-            <%= mail_to('organise.school-experience@education.gov.uk') %>
+            You need a <strong>DfE Sign-in account</strong> with access to School Experience.
           </p>
 
           <p>
-            You’ll be asked to sign in using DfE Sign-in.
+            If you have any questions read our <%= link_to 'DfE Sign-in help', dfe_signin_help_path %>.
           </p>
         </section>
 
@@ -48,63 +47,6 @@
             school DBS and safeguarding policies.
           </p>
         </section>
-
-        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-dfe-signin-help">
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button" id="i-have-no-dfe-signin-account-heading">
-                  I do not have a DfE Sign-in account
-                </span>
-              </h2>
-            </div>
-
-            <div id="i-have-no-dfe-signin-account-content" class="govuk-accordion__section-content" aria-labelledby="i-have-no-dfe-signin-account-heading">
-              <p class='govuk-body'>
-                You’ll need to ask your organisation’s ‘DfE Sign-in approver’
-                (often your head or deputy head) to create a DfE Sign-in
-                account for you.
-              </p>
-
-              <p>
-                They’ll need your email address but make sure this is one
-                that only you have access to.
-              </p>
-
-              <p>
-                It will only be used for DfE Sign-in purposes and we won’t
-                use it to send you anything to do with the service.
-              </p>
-
-              <p>
-                If you don’t know who's your DfE Sign-in approver email us
-                with your URN at <%= mail_to "organise.school-experience@education.gov.uk" %>.
-              </p>
-            </div>
-          </div>
-
-          <div class="govuk-accordion__section ">
-            <div class="govuk-accordion__section-header">
-              <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button" id="i-have-forgotten-about-my-dfe-signin-status-heading">
-                  I cannot remember if I have a DfE Sign-in account
-                </span>
-              </h2>
-            </div>
-            <div id="i-have-forgotten-about-my-dfe-signin-status-content" class="govuk-accordion__section-content" aria-labelledby="i-have-forgotten-about-my-dfe-signin-status-heading">
-              <p class='govuk-body'>
-                You’ll need to fill in the following online form and ask DfE
-                Sign-in if they can provide you with your DfE Sign-in account
-                details.
-              </p>
-
-              <p>
-                Submit a <%= link_to 'DfE Sign-in support request',
-                  href: "https://help.signin.education.gov.uk/contact/submit?type=create-account" %>
-              </p>
-            </div>
-          </div>
-        </div>
       </div>
 
       <div class="govuk-grid-column-one-third column-top-border">
@@ -113,6 +55,10 @@
           <ul class="govuk-list">
             <li>
               <%= link_to 'Manage school experience: information for schools', 'https://www.gov.uk/government/publications/school-experience-programme-information-for-schools' %>
+            </li>
+            <li>
+              <%= link_to 'DfE Sign-in help', dfe_signin_help_path %>             
+            </li>
           </ul>
         </nav>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   get '/schools_privacy_policy', to: 'pages#schools_privacy_policy'
   get '/service_update', to: 'pages#service_update'
   get '/help_and_support_access_needs', to: 'pages#help_and_support_access_needs'
+  get '/dfe_signin_help', to: 'pages#dfe_signin_help'
 
   get '/auth/callback', to: 'schools/sessions#create'
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-1768

### Context

The help text around DfE Sign-in was clunk and not especially useful (see JIRA ticket)

### Changes proposed in this pull request

Make the text simpler and more informative

### Guidance to review

Ensure the new guidance makes sense

