### PR TITLE
Patch ActiveRecord::RecordInvalid exception to bypass translations

### DIFF
--- a/config/initializers/active_record_invalid_error.rb
+++ b/config/initializers/active_record_invalid_error.rb
@@ -1,0 +1,13 @@
+ActiveRecord::RecordInvalid.class_eval do
+  def initialize(record = nil)
+    if record
+      @record = record
+      errors = @record.errors.to_hash.inspect
+      message = I18n.t(:"#{@record.class.i18n_scope}.errors.messages.record_invalid", errors: errors, default: :"errors.messages.record_invalid")
+    else
+      message = "Record invalid"
+    end
+
+    super(message)
+  end
+end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -57,13 +57,12 @@ describe Bookings::Booking do
         end
 
         context 'error messages' do
-          let(:message) { 'Validation failed: Date must not be in the past' }
-          let(:invalid_pd) { create(:bookings_placement_date, date: 3.weeks.ago) }
+          let(:message) { 'Date must not be in the past' }
+          let(:invalid_pd) { build(:bookings_placement_date, date: 3.weeks.ago).tap(&:valid?) }
+          subject { invalid_pd.errors.full_messages }
 
           specify 'should show a suitable error message' do
-            expect { invalid_pd }.to(
-              raise_error(ActiveRecord::RecordInvalid, message)
-            )
+            is_expected.to include(message)
           end
         end
       end

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -36,13 +36,14 @@ describe Bookings::PlacementDate, type: :model do
         end
 
         context 'error messages' do
-          let(:message) { 'Validation failed: Date must not be in the past' }
-          let(:invalid_pd) { create(:bookings_placement_date, date: 3.weeks.ago) }
+          let(:message) { 'Date must not be in the past' }
+          let(:invalid_pd) { build(:bookings_placement_date, date: 3.weeks.ago) }
+
+          before { invalid_pd.valid? }
+          subject { invalid_pd.errors.full_messages }
 
           specify 'should show a suitable error message' do
-            expect { invalid_pd }.to(
-              raise_error(ActiveRecord::RecordInvalid, message)
-            )
+            is_expected.to include(message)
           end
         end
 


### PR DESCRIPTION
### JIRA Ticket Number

2021

### Context

Currently we are loosing the fieldnames in the RecordInvalid exceptions which
makes it hard to debug the source of the error.

### Changes proposed in this pull request

The exception messages is not surfaced to the user so changed the definition of
RecordInvalid to include a lower level representation of the error messages
with more complete information.

### Guidance to review

1. Behavioural test - do the errors in forms still come out correctly
2. Sanity check - its not the nicest solution but should have very limited scope for problems at this point and does provide us with the information we need.

### Note

Longer term will need to change the form builder to not use the full messages methods, then those can be revert to actually being full messages
