### PR TITLE
SE-2030 Title change on edit placement date

### DIFF
--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -1,14 +1,14 @@
-<%- self.page_title = "Modify placement date" %>
+<%- self.page_title = "Modify placement details" %>
 
 <%
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,
     'Placement dates' => schools_placement_dates_path,
-    'Modify placement date' => nil
+    'Modify placement details' => nil
   }
 %>
 
-<h1>Modify placement date</h1>
+<h1>Modify placement details</h1>
 
 <p>
   These details will be shown to candidates to help them choose school experience

--- a/features/schools/placement_dates/edit.feature
+++ b/features/schools/placement_dates/edit.feature
@@ -9,15 +9,15 @@ Feature: Editing placement dates
 
     Scenario: Page title
         Given I am on the edit page for my placement
-        Then the page title should be 'Modify placement date'
+        Then the page title should be 'Modify placement details'
 
     Scenario: Breadcrumbs
         Given I am on the edit page for my placement
         Then I should see the following breadcrumbs:
-            | Text                  | Link                     |
-            | Some school           | /schools/dashboard       |
-            | Placement dates       | /schools/placement_dates |
-            | Modify placement date | None                     |
+            | Text                     | Link                     |
+            | Some school              | /schools/dashboard       |
+            | Placement dates          | /schools/placement_dates |
+            | Modify placement details | None                     |
 
     Scenario: Placement date form
         Given I am on the edit page for my placement


### PR DESCRIPTION
### JIRA Ticket Number

2030

### Context

The page title is currently misleading - it implies the user can amend the Placements date when in fact they can only amend other details of the Placement Date

### Changes proposed in this pull request

1. Amended the page title

### Guidance to review

1. Sanity check

