### PR TITLE
Fix for ordering bug in array comparison

### DIFF
--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Candidates::SchoolSearch do
     subject { described_class.new(subjects: [@first.id, @third.id]) }
 
     it "will return an array of subjects" do
-      expect(subject.subject_names).to eq([@first.name, @third.name])
+      expect(subject.subject_names).to match_array([@first.name, @third.name])
     end
   end
 
@@ -252,7 +252,7 @@ RSpec.describe Candidates::SchoolSearch do
     subject { described_class.new(phases: [@first.id, @third.id]) }
 
     it "will return an array of phases" do
-      expect(subject.phase_names).to eq([@first.name, @third.name])
+      expect(subject.phase_names).to match_array([@first.name, @third.name])
     end
   end
 end


### PR DESCRIPTION
### Context

Whilst debugging a separate issue I encountered an ordering bug in a different test - its assuming results will appear in a certain order but doing nothing to ensure that is the case.

### Changes proposed in this pull request

1. Stop checking for specific order

### Guidance to review

1. Sanity check
2. Do tests still pass
