### PR TITLE
Use lower URNs for test schools to avoid clash

### DIFF
--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     sequence(:name) { |n| "school #{n}" }
     coordinates { Bookings::School::GEOFACTORY.point(-2.241, 53.481) }
     fee { 0 }
-    sequence(:urn) { |n| 10000 + n }
+    sequence(:urn) { |n| n }
     sequence(:address_1) { |n| "#{n} Something Street" }
     sequence(:postcode) { |n| "M#{n} 2JF" }
     association :school_type, factory: :bookings_school_type


### PR DESCRIPTION
### Context

Currently we now have enough tests that the school factory is automatically generating the magic URN of 11048 used for some tests. This can then potentially result in a clash depending upon ordering.

### Changes proposed in this pull request

1. Don't offset URNs in order to avoid the clash.

### Guidance to review

1. Sanity check
2. Do the tests pass
