### PR TITLE
Use correct URN in RegistrationSession factory for PlacementDate

### DIFF
--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -3,8 +3,12 @@ FactoryBot.define do
     transient do
       current_time { DateTime.current }
       urn { 11048 }
-      placement_date { create(:bookings_placement_date) }
       uuid { 'some-uuid' }
+
+      placement_date do
+        school = Bookings::School.find_by(urn: urn) || create(:bookings_school, urn: urn)
+        create :bookings_placement_date, bookings_school: school
+      end
 
       with do
         %i(

--- a/spec/services/candidates/registrations/registration_session_spec.rb
+++ b/spec/services/candidates/registrations/registration_session_spec.rb
@@ -208,11 +208,7 @@ describe Candidates::Registrations::RegistrationSession do
     end
 
     context 'when registration is complete' do
-      include_context 'Stubbed candidates school'
-
-      subject do
-        FactoryBot.build :registration_session
-      end
+      subject { FactoryBot.build :registration_session }
 
       before do
         subject.flag_as_pending_email_confirmation!

--- a/spec/support/stubbed_candidates_school_context.rb
+++ b/spec/support/stubbed_candidates_school_context.rb
@@ -4,11 +4,12 @@ shared_context 'Stubbed candidates school' do |fixed|
   end
 
   let :school do
-    create :bookings_school, \
-      name: 'Test School',
-      contact_email: 'test@test.com',
-      urn: school_urn,
-      availability_preference_fixed: fixed
+    Bookings::School.find_by(urn: school_urn) ||
+      create(:bookings_school,
+        name: 'Test School',
+        contact_email: 'test@test.com',
+        urn: school_urn,
+        availability_preference_fixed: fixed)
   end
 
   let :allowed_subject_choices do


### PR DESCRIPTION
### Context

Within the specs, the RegistrationSession factory was creating PlacementDates against different
schools than the RegistrationSession was against

### Changes proposed in this pull request

1. Use the supplied URN in the factory
2. In stubbed school context, try to find the school first before blindly creating one with the potentially clashing URN.

### Guidance to review

1. Sanity check
2. Do the tests still pass

