### PR TITLE
SE-2032 Gitis subject sync

### DIFF
--- a/app/models/bookings/subject_sync.rb
+++ b/app/models/bookings/subject_sync.rb
@@ -13,8 +13,8 @@ module Bookings
 
     def synchronise
       uuids = gitis_subjects.map(&:dfe_teachingsubjectlistid)
-      assigned = Bookings::Subject.where(gitis_uuid: uuids).index_by(&:gitis_uuid)
-      unassigned = Bookings::Subject.where(gitis_uuid: nil).index_by do |s|
+      assigned = Bookings::Subject.unscoped.where(gitis_uuid: uuids).index_by(&:gitis_uuid)
+      unassigned = Bookings::Subject.unscoped.where(gitis_uuid: nil).index_by do |s|
         s.name.to_s.strip.downcase
       end
 

--- a/spec/models/bookings/subject_sync_spec.rb
+++ b/spec/models/bookings/subject_sync_spec.rb
@@ -47,9 +47,8 @@ RSpec.describe Bookings::SubjectSync do
     end
 
     context 'for a successful sync' do
-      before { sync.synchronise }
-
       context 'when matched on id' do
+        before { sync.synchronise }
         it "will update name" do
           expect(matched1.reload).to have_attributes(name: gitis_subject_1.dfe_name)
           expect(matched2.reload).to have_attributes(name: gitis_subject_2.dfe_name)
@@ -57,23 +56,35 @@ RSpec.describe Bookings::SubjectSync do
       end
 
       context 'when matched on name' do
+        before { sync.synchronise }
         subject { unmatched.reload }
         it { is_expected.to have_attributes(gitis_uuid: gitis_subject_3.id) }
       end
 
       context "with new subjects" do
+        before { sync.synchronise }
         subject { Bookings::Subject.where(gitis_uuid: gitis_subject_4.id).first }
         it { is_expected.to have_attributes(name: gitis_subject_4.dfe_name) }
         it { is_expected.to have_attributes(hidden: false) }
       end
 
       context "with subjects it cannot match" do
+        before { sync.synchronise }
         subject { nomatch.reload }
         it { is_expected.to have_attributes(name: 'nomatch') }
         it { is_expected.to have_attributes(gitis_uuid: nil) }
       end
 
       context "with blacklisted new subject" do
+        before { sync.synchronise }
+        subject { Bookings::Subject.unscoped.where(gitis_uuid: gitis_subject_5.id).first }
+        it { is_expected.to have_attributes(name: gitis_subject_5.dfe_name) }
+        it { is_expected.to have_attributes(hidden: true) }
+      end
+
+      context "with blacklisted existing subject" do
+        before { Bookings::Subject.create!(name: gitis_subject_5.dfe_name, hidden: true) }
+        before { sync.synchronise }
         subject { Bookings::Subject.unscoped.where(gitis_uuid: gitis_subject_5.id).first }
         it { is_expected.to have_attributes(name: gitis_subject_5.dfe_name) }
         it { is_expected.to have_attributes(hidden: true) }


### PR DESCRIPTION
### JIRA Ticket Number

SE-2032

### Context

Synchronising subjects with Gitis is currently erroring. This is caused by the change to exclude subjects from the default scope. 

### Changes proposed in this pull request

1. Use unscoped for retrieving the list of subjects

### Guidance to review

1. Code review
2. Does the new test pass
3. Observe once it reaches staging
