### PR TITLE
Removed old unneeded verification route

### DIFF
--- a/app/controllers/concerns/candidates/registrations/current_registration.rb
+++ b/app/controllers/concerns/candidates/registrations/current_registration.rb
@@ -30,10 +30,6 @@ module Candidates
       def registration_session_attributes
         if store.has_registration?(current_registration_session_uuid)
           store.retrieve!(current_registration_session_uuid).to_h
-        elsif session.has_key? "schools/#{current_urn}/registrations"
-          # TODO SE-1992 Remove this
-          # Get attributes from legacy session
-          session["schools/#{current_urn}/registrations"]
         else
           # Start a new registration_session
           { 'urn' => current_urn }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -122,8 +122,6 @@ Rails.application.routes.draw do
     resources :school_searches, only: %i{new}
 
     get 'verify/:school_id/:token/:uuid', to: 'registrations/sign_ins#update', as: :registration_verify
-    # TODO SE-1992 Remove this
-    get 'verify/:school_id/:token', to: 'registrations/sign_ins#update'
 
     resources :schools, only: %i{index show} do
       namespace :registrations do

--- a/features/candidates/registrations/verify_your_email.feature
+++ b/features/candidates/registrations/verify_your_email.feature
@@ -12,23 +12,16 @@ Feature: Verify your email
         Then the page's main header should be 'We already have your details'
         And I should see an email was sent to my email address
 
-    # TODO SE-1992 Remove this
-    Scenario: Confirming the Eamil
-        Given I have completed the Personal Information step for my school of choice
-        And I have a valid session token
-        And I follow the legacy verify link in the confirmation email
-        Then I should be on the 'enter your contact details' page for my school of choice
-
     # Disabled these features as they will be flakey when run in parralel
     @wip
-    Scenario: Confirming the Eamil
+    Scenario: Confirming the Email
         Given I have completed the Personal Information step for my school of choice
         And I have a valid session token
         And I follow the verify link in the confirmation email
         Then I should be on the 'enter your contact details' page for my school of choice
 
     @wip
-    Scenario: Confirming the Eamil
+    Scenario: Confirming the Email on a different device
         Given the school offers 'Physics, Mathematics'
         And the school I'm applying to is not flexible on dates
         And there are no registration sessions

--- a/features/step_definitions/candidates/registrations/verify_your_email_steps.rb
+++ b/features/step_definitions/candidates/registrations/verify_your_email_steps.rb
@@ -39,11 +39,6 @@ Given("I follow the verify link in the confirmation email") do
     school: @school, session_token: @session_token, uuid: uuid)
 end
 
-# TODO SE-1992 Remove this
-Given("I follow the legacy verify link in the confirmation email") do
-  visit "/candidates/verify/#{@school.to_param}/#{@session_token.to_param}"
-end
-
 Given "I have chosen a subject specific date" do
   steps %(
     And I am on the 'choose a subject and date' screen for my chosen school


### PR DESCRIPTION
### JIRA Ticket Number

SE-1992

### Context

Previously registrations were held in session. They were then migrated to go straight to Redis, with the session only containing the key for the data in Redis.

Compatibility support for legacy sessions is no longer needed now all sessions will have migrated.

### Changes proposed in this pull request

1. Remove the legacy route
2. Remove the legacy session support

### Guidance to review

1. Code review
2. Do the tests still pass
