### PR TITLE
Allow adding feature flags from FEATURE_FLAGS env var

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,9 +1,11 @@
 class Feature
   include Singleton
 
-  delegate :only_phase, :from_phase, :until_phase, to: :instance
-  delegate :only, :from, :until, to: :instance
-  delegate :active?, to: :instance
+  class << self
+    delegate :only_phase, :from_phase, :until_phase, to: :instance
+    delegate :only, :from, :until, to: :instance
+    delegate :active?, to: :instance
+  end
 
   def only_phase(phase_to_test)
     return false unless Integer(phase_to_test) == current_phase
@@ -37,6 +39,28 @@ class Feature
   alias_method :current=, :current_phase=
 
   def active?(feature_key)
-    Array.wrap(Rails.application.config.x.features).include? feature_key
+    all_features.include? feature_key.to_sym
+  end
+
+private
+
+  def env_features
+    tokenised_env_features.compact.map(&:to_sym)
+  end
+
+  def config_features
+    Array.wrap(Rails.application.config.x.features).compact.map(&:to_sym)
+  end
+
+  def all_features
+    use_env_var? ? config_features + env_features : config_features
+  end
+
+  def use_env_var?
+    Rails.env.test? || Rails.env.servertest?
+  end
+
+  def tokenised_env_features
+    ENV['FEATURE_FLAGS'].to_s.strip.split(%r(\s+))
   end
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -61,6 +61,6 @@ private
   end
 
   def tokenised_env_features
-    ENV['FEATURE_FLAGS'].to_s.strip.split(%r(\s+))
+    ENV['FEATURE_FLAGS'].to_s.strip.split(%r([\s,]+))
   end
 end

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -124,8 +124,9 @@ describe Feature do
   end
 
   describe '#active?' do
+    let(:feature_flags) { 'env1 env2' }
     before do
-      allow(ENV).to receive(:[]).with('FEATURE_FLAGS') { 'env1 env2' }
+      allow(ENV).to receive(:[]).with('FEATURE_FLAGS') { feature_flags }
       allow(Rails.application.config.x).to \
         receive(:features) { %i(config1 config2) }
 
@@ -136,7 +137,7 @@ describe Feature do
 
     shared_examples "test feature sources" do
       context 'with env feature' do
-        let(:feature) { 'env1' }
+        let(:feature) { 'env2' }
         it { is_expected.to be true }
       end
 
@@ -163,6 +164,18 @@ describe Feature do
 
     context 'from class' do
       let(:feature_tester) { described_class }
+      include_examples 'test feature sources'
+    end
+
+    context 'with comma separated env var' do
+      let(:feature_flags) { 'env1,env2' }
+      let(:feature_tester) { described_class.instance }
+      include_examples 'test feature sources'
+    end
+
+    context 'with mixed separator separated env var' do
+      let(:feature_flags) { 'env1, env2 env3' }
+      let(:feature_tester) { described_class.instance }
       include_examples 'test feature sources'
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1955

### Context

Building block for SE-1955

### Changes proposed in this pull request

Allow adding feature flags from environment variables

Format is FEATURE_FLAG='first_flag second_flag'

### Guidance to review

1. Sanity check
2. Does staging still work

