### PR TITLE
SE-2037 Added API health checks endpoint

### DIFF
--- a/app/controllers/healthchecks_controller.rb
+++ b/app/controllers/healthchecks_controller.rb
@@ -1,4 +1,6 @@
 class HealthchecksController < ApplicationController
+  include GitisAccess
+
   http_basic_authenticate_with \
     name: Rails.application.config.x.healthchecks.username,
     password: Rails.application.config.x.healthchecks.password,
@@ -19,5 +21,24 @@ class HealthchecksController < ApplicationController
 
   def deployment
     render plain: ENV.fetch('DEPLOYMENT_ID') { 'not set' }
+  end
+
+  def api_health
+    check_gitis_api
+    check_dfe_signin_api
+
+    render plain: 'healthy'
+  end
+
+private
+
+  def check_gitis_api
+    gitis_crm.fetch(Bookings::Gitis::Country, limit: 1)
+  end
+
+  def check_dfe_signin_api
+    return true unless Schools::DFESignInAPI::Organisations.enabled?
+
+    Schools::DFESignInAPI::Organisations.new(SecureRandom.uuid).urns
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   get '/healthcheck.txt', to: 'healthchecks#show', as: :healthcheck
   get '/deployment.txt', to: 'healthchecks#deployment', as: :deployment
+  get '/apihealth.txt', to: 'healthchecks#api_health', as: :api_health
 
   if Rails.application.config.x.maintenance_mode
     match '*path', to: 'pages#maintenance', via: :all

--- a/spec/controllers/healthchecks_controller_spec.rb
+++ b/spec/controllers/healthchecks_controller_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 describe HealthchecksController, type: :request do
+  let(:username) { Rails.application.config.x.healthchecks.username }
+  let(:password) { Rails.application.config.x.healthchecks.password }
+  let(:encoded) do
+    ActionController::HttpAuthentication::Basic.
+      encode_credentials(username, password)
+  end
+
   describe '#show' do
     context 'with functional redis and postgres' do
       before { get healthcheck_path }
@@ -30,13 +37,6 @@ describe HealthchecksController, type: :request do
 
   describe '#deployment' do
     context "with auth" do
-      let(:username) { Rails.application.config.x.healthchecks.username }
-      let(:password) { Rails.application.config.x.healthchecks.password }
-      let(:encoded) do
-        ActionController::HttpAuthentication::Basic.
-          encode_credentials(username, password)
-      end
-
       context "with DEPLOYMENT_ID set" do
         before do
           allow(ENV).to \
@@ -62,6 +62,49 @@ describe HealthchecksController, type: :request do
     context 'without auth' do
       before { get deployment_path }
       it { expect(response).to have_http_status(:unauthorized) }
+    end
+  end
+
+  describe '#api_health' do
+    include_context "fake gitis"
+    let(:check_api_health) { get api_health_path, headers: { "Authorization" => encoded } }
+
+    before do
+      allow(fake_gitis).to receive(:fetch) { [Bookings::Gitis::Country.new] }
+      allow_any_instance_of(Schools::DFESignInAPI::Client).to \
+        receive(:response).and_return([])
+      allow(Schools::DFESignInAPI::Client).to receive(:enabled?).and_return(true)
+    end
+
+    context 'with all APIs healthy' do
+      before { check_api_health }
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response).to have_attributes body: 'healthy' }
+    end
+
+    context 'with unhealthy Gitis' do
+      before do
+        allow(fake_gitis).to receive(:fetch).and_raise \
+          Bookings::Gitis::API::BadResponseError.new \
+            Struct.new(:status, :headers, :body, :env).new(500, {}, 'timeout')
+      end
+
+      it "will raise an error" do
+        expect { check_api_health }.to \
+          raise_exception Bookings::Gitis::API::BadResponseError
+      end
+    end
+
+    context 'with unhealthy DfE Sign In' do
+      before do
+        allow_any_instance_of(Schools::DFESignInAPI::Client).to \
+          receive(:response).and_raise Faraday::TimeoutError
+      end
+
+      it "will raise an error" do
+        expect { check_api_health }.to raise_exception Faraday::Error
+      end
     end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2037

### Context

At deployment time, we want to check nothing has been changed around API configuration which will interfere with the successful running of the website

### Changes proposed in this pull request

1. Added and API Healthcheck endpoint, protected by deployment env vars for security
2. Note the DFE Sign In API checks are tied to whether the service is enabled, so they'll only run at the point we roll that service out

### Guidance to review

1. Sanity check
2. Do the tests pass

