### PR TITLE
Format experience details field

### DIFF
--- a/app/helpers/text_formatting_helper.rb
+++ b/app/helpers/text_formatting_helper.rb
@@ -5,4 +5,12 @@ module TextFormattingHelper
   def safe_format(content)
     simple_format strip_tags content
   end
+
+  def conditional_format(content)
+    if content.to_s.match? %r{\r?\n}
+      safe_format content
+    else
+      content
+    end
+  end
 end

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -17,7 +17,7 @@
         <% end %>
 
         <%= dlist_item 'Details:', id: 'experience-details' do %>
-          <%= content_or_msg @presenter.experience_details, "No information supplied" %>
+          <%= conditional_format content_or_msg @presenter.experience_details, "No information supplied" %>
         <% end %>
 
         <%= dlist_item 'Subjects:', id: "school-subjects" do %>

--- a/spec/helpers/text_formatting_helper_spec.rb
+++ b/spec/helpers/text_formatting_helper_spec.rb
@@ -14,4 +14,18 @@ describe TextFormattingHelper, type: :helper do
       it { is_expected.to eql "<p>hello world</p>" }
     end
   end
+
+  describe '#conditional_format' do
+    subject { conditional_format content }
+
+    context "with new lines" do
+      let(:content) { "foo\nbar" }
+      it { is_expected.to eql "<p>foo\n<br />bar</p>" }
+    end
+
+    context "without new lines" do
+      let(:content) { "foobar" }
+      it { is_expected.to eql "foobar" }
+    end
+  end
 end


### PR DESCRIPTION
Added conditional_format helper for use in definition lists. Only uses
paragraphs when necessary.

### JIRA Ticket Number

SE-1463

### Context

The experience details field had got missed in the original work to maintain formatting

### Changes proposed in this pull request

1. Maintain the formatting of the experience details
2. Added helper to only apply p tag formatting if text is actually multiline

### Guidance to review

1. Code review
2. Does the output look right