### PR TITLE
Remove 'enter valid date' from date of birth error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -165,8 +165,8 @@ en:
               blank: "Enter your full name"
             date_of_birth:
               blank: "Enter your date of birth"
-              on_or_before: "Enter a valid date of birth. You must be at least 18 years old"
-              on_or_after: "Enter a valid date of birth. You must be younger than 100 years old"
+              on_or_before: "You must be at least 18 years old"
+              on_or_after: "You must be younger than 100 years old"
 
         candidates/registrations/placement_preference:
           <<: *placement_preference_errors

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -106,7 +106,7 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
 
         it 'is invalid' do
           expect(subject.errors[:date_of_birth]).to eq [
-            'Enter a valid date of birth. You must be at least 18 years old'
+            'You must be at least 18 years old'
           ]
         end
       end
@@ -118,7 +118,7 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
 
         it 'is invalid' do
           expect(subject.errors[:date_of_birth]).to eq [
-            'Enter a valid date of birth. You must be younger than 100 years old'
+            'You must be younger than 100 years old'
           ]
         end
       end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1966

### Context

The 'Enter a valid date of birth' part of the error message is unnecessary

### Changes proposed in this pull request

Remove it

### Guidance to review

Sense check