### PR TITLE
Validate length of firstname and lastname

### DIFF
--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -14,8 +14,8 @@ module Candidates
       attribute :date_of_birth, :date
       attribute :read_only, :boolean, default: false
 
-      validates :first_name, presence: true, unless: :read_only
-      validates :last_name, presence: true, unless: :read_only
+      validates :first_name, presence: true, length: { maximum: 50 }, unless: :read_only
+      validates :last_name, presence: true, length: { maximum: 50 }, unless: :read_only
       validates :email, presence: true, length: { maximum: 100 }
       validates :email, email_format: true, if: -> { email.present? }
       validates :date_of_birth, presence: true, unless: :read_only

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,8 +159,10 @@ en:
               too_long: "Email must be 100 characters or fewer"
             first_name:
               blank: 'Enter your first name'
+              too_long: "First name must be 50 characters or fewer"
             last_name:
               blank: 'Enter your last name'
+              too_long: "Last name must be 50 characters or fewer"
             full_name:
               blank: "Enter your full name"
             date_of_birth:

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -18,6 +18,16 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     it { is_expected.to validate_presence_of :last_name }
     it { is_expected.to validate_presence_of :date_of_birth }
 
+    it do
+      is_expected.to validate_length_of(:first_name).is_at_most(50).
+        with_message('First name must be 50 characters or fewer')
+    end
+
+    it do
+      is_expected.to validate_length_of(:last_name).is_at_most(50).
+        with_message('Last name must be 50 characters or fewer')
+    end
+
     let(:too_long_msg) { 'Email must be 100 characters or fewer' }
     it { is_expected.to validate_presence_of :email }
     it { is_expected.to validate_length_of(:email).is_at_most(100).with_message(too_long_msg) }


### PR DESCRIPTION
### JIRA Ticket Number

SE-1977

### Context

Gitis only allows 50 chars for firstname and lastname fields.

### Changes proposed in this pull request

1. Added length validation (max: 50) for firstname on PersonalInformation
2. Added length validation (max: 50) for lastname on PersonalInformation

### Guidance to review

1. Sanity check
