### PR TITLE
Add rejection reason to rejected placements index SE-2039

### DIFF
--- a/app/views/schools/rejected_requests/index.html.erb
+++ b/app/views/schools/rejected_requests/index.html.erb
@@ -48,7 +48,7 @@
                 <%- end -%>
               </td>
               <td class="reason govuk-table__cell">
-                <%= rejected_request.school_cancellation.reason.truncate(80) %>
+                <%= rejected_request.school_cancellation.rejection_description.truncate(80) %>
               </td>
               <td class="govuk-table__cell">
                 <%= link_to "View", schools_rejected_request_path(rejected_request),

--- a/app/views/schools/rejected_requests/show.html.erb
+++ b/app/views/schools/rejected_requests/show.html.erb
@@ -25,8 +25,13 @@
       <h2>Rejection details</h2>
 
       <dl class="govuk-summary-list">
-        <%= summary_row 'Reason', @cancellation.reason %>
+        <%= summary_row 'Reason', @cancellation.rejection_description %>
+
+        <% if @cancellation.extra_details.present? %>
+          <%= summary_row 'Extra details', @cancellation.extra_details %>
+        <% end %>
       </dl>
+
     </section>
 
     <%= render partial: 'schools/placement_requests/personal_details', object: @rejected_request.gitis_contact %>

--- a/features/schools/rejected_requests/index.feature
+++ b/features/schools/rejected_requests/index.feature
@@ -17,12 +17,17 @@ Feature: Viewing rejected requests
         Then I should see the following breadcrumbs:
             | Text               | Link               |
             | Some school        | /schools/dashboard |
-            | Rejected requests | None               |
+            | Rejected requests  | None               |
 
     Scenario: List presence
         Given there are some rejected requests
         When I am on the 'rejected requests' page
         Then I should see the rejected requests listed
+
+    Scenario: Rejection category
+        Given a request has been rejected because of 'date_not_available'
+        When I am on the 'rejected requests' page
+        Then I should see a rejected request with the rejection reason displayed
 
     Scenario: Table headings
         Given there are some rejected requests

--- a/features/schools/rejected_requests/show.feature
+++ b/features/schools/rejected_requests/show.feature
@@ -22,13 +22,18 @@ Feature: Viewing a rejected request
             | Some school        | /schools/dashboard           |
             | Rejected requests  | /schools/rejected_requests  |
             | Request            | None                         |
-    
+
     Scenario: Rejection details
         Given there is at least one rejected request
         When I am viewing the rejected request
         Then I should see a 'Rejection details' section with the following values:
             | Heading      | Value      |
             | Reason       | MyText     |
+
+    Scenario: Rejection category
+        Given a request has been rejected because of 'date_not_available'
+        When I am viewing the rejected request
+        Then I should see a rejected request with the rejection reason displayed in full
 
     Scenario: Personal details
         Given there is at least one rejected request

--- a/features/step_definitions/schools/rejected_requests_steps.rb
+++ b/features/step_definitions/schools/rejected_requests_steps.rb
@@ -72,6 +72,7 @@ end
 
 Given("there is at least one rejected request") do
   step "there is 1 rejected requests"
+  @rejected_request.cancellation.update(rejection_category: :other, reason: 'MyText')
 end
 
 When("I am viewing the rejected request") do
@@ -79,4 +80,19 @@ When("I am viewing the rejected request") do
 
   visit(path)
   expect(page.current_path).to eql(path)
+end
+
+Given("a request has been rejected because of {string}") do |rejection_category|
+  step %(there is 1 rejected requests)
+  @cancellation = @rejected_request.cancellation.tap do |cancellation|
+    cancellation.update(rejection_category: rejection_category)
+  end
+end
+
+Then("I should see a rejected request with the rejection reason displayed") do
+  expect(page).to have_css('td', text: 'We cannot support the date you have requested', count: 1)
+end
+
+Then("I should see a rejected request with the rejection reason displayed in full") do
+  expect(page).to have_css('dd', text: 'We cannot support the date you have requested', count: 1)
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2039

### Context

The new rejection reason hadn't been added to the rejected requests index or show pages

### Changes proposed in this pull request

Add it where required and ensure presence via features

![Screenshot from 2019-12-18 14-46-26](https://user-images.githubusercontent.com/128088/71096029-869d5600-21a5-11ea-8e2b-ec5d41866362.png)


### Guidance to review

Ensure everything makes sense