### PR TITLE
Use earlier selenium-(chrome|firefox) docker release

### DIFF
--- a/docker-compose-chrome.yml
+++ b/docker-compose-chrome.yml
@@ -3,6 +3,6 @@ version: '3.3'
 services:
 
    selenium-chrome:
-     image: selenium/standalone-chrome
+     image: selenium/standalone-chrome:3.141.59-xenon
      volumes:
        - /dev/shm:/dev/shm

--- a/docker-compose-firefox.yml
+++ b/docker-compose-firefox.yml
@@ -1,8 +1,8 @@
 version: '3.3'
-  
+
 services:
 
    selenium-firefox:
-     image: selenium/standalone-firefox
+     image: selenium/standalone-firefox:3.141.59-xenon
      volumes:
        - /dev/shm:/dev/shm


### PR DESCRIPTION
### JIRA Ticket Number

SE-2042

### Context

There seems to be a bug (possible memory issue) in the latest release
of the selenium-chrome and possibly selenium-firefox images. We 
should be using specific versions anyway since it will make it easier to 
isolate problems when we upgrade the version.

### Changes proposed in this pull request

1. Change docker-compose.yml to use a specific version

### Notes

1. 15 successful runs in CI with this branch - previous failure rate was somewhere around 1/3 or 1/4
2. 3 successful runs in CD - previous failure rate was 100%
3. This doesn't resolve the underlying question of why cucumber is failing with new versions of selenium-chrome but that can get investigated off on its own branch.

### Guidance to review

3. Sanity check