### PR TITLE
Enable parallel tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,8 @@ group :development, :test do
   gem 'brakeman', '>= 4.4.0'
 
   gem 'bullet'
+  
+  gem 'parallel_tests'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,8 @@ GEM
       validate_url
       webfinger (>= 1.0.1)
     parallel (1.17.0)
+    parallel_tests (2.30.0)
+      parallel
     parser (2.6.5.0)
       ast (~> 2.4.0)
     pg (1.1.4)
@@ -472,6 +474,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.3)
   notifications-ruby-client
   openid_connect
+  parallel_tests
   pg (>= 0.18, < 2.0)
   pg_search
   phonelib

--- a/config/database.yml
+++ b/config/database.yml
@@ -58,7 +58,7 @@ development:
 test: &test
   <<: *default
   host: <%= ENV.fetch('CUC_DB_HOST') { 'localhost' } %>
-  database: <%= ENV.fetch('CUC_DB_DATABASE') { 'school_experience_candidate_test' } %>
+  database: <%= ENV.fetch('CUC_DB_DATABASE') { "school_experience_candidate_test#{ENV['TEST_ENV_NUMBER']}" } %>
   username: <%= ENV.fetch('CUC_DB_USERNAME') { nil } %>
   password: <%= ENV.fetch('CUC_DB_PASSWORD') { nil } %>
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,7 +50,12 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Use Redis for Session and cache
-  config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
+  config.cache_store = :redis_cache_store, {
+    url: ENV['REDIS_URL'].presence,
+    db: ENV['TEST_ENV_NUMBER'].presence, # Note DB overrides db in URL if both specified
+    namespace: 'test-cache'
+  }
+
   config.session_store :cache_store,
     key: 'schoolex-test-session',
     expire_after: 1.hour # Sets explicit TTL for Session Redis keys

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,6 +1,7 @@
 # Test the Redis connection on boot
 unless ENV['SKIP_REDIS'].present?
   Redis.current = Redis.new(
+    db: (Rails.env.test? ? ENV['TEST_ENV_NUMBER'].presence : nil),
     connect_timeout: 20, # Default is 5s but logic is we're better being slower booting than failing to boot
     tcp_keepalive: 60, # Turn keep alive on, ping after 40 seconds, try twice, 10 seconds apart, before giving up - then fall through to reconnect attemp
     reconnect_attempts: 1 # Allow for connection failure since Azure networking to Redis is showing some unreliability

--- a/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
@@ -54,6 +54,8 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
       end
 
       context 'skipped step' do
+        before { registration_store.send :delete, 'some-uuid' } # ensure key not left lying around
+
         let :registration_session do
           FactoryBot.build :registration_session, with: []
         end


### PR DESCRIPTION
### Context

For Christmas I bring you faster (parallel) test runs - lets make use of those cores!

### Changes proposed in this pull request

1. Added `parallel_tests` gem
2. Change to swap the Redis DB according to the process being run
3. Fixed a latent randomisation bug - with `rspec --seed=3374` one of the tests would fail because it assumed the Redis key wouldn't exist, when actually it might (depending upon ordering of specs)

### Guidance to review

1. `bundle exec rake parallel:create`
2. `bundle exec rake parallel:prepare`
3. `bundle exec rake parallel:spec RAILS_ENV=test`
4. `bundle exec rake parallel:features RAILS_ENV=test`

Behold 12 sec rspec runs and 40 sec cucumber runs !!

