### PR TITLE
SE-2037 Allow healthchecks to bypass canonical redirect

### DIFF
--- a/config/initializers/canonical_redirect.rb
+++ b/config/initializers/canonical_redirect.rb
@@ -16,7 +16,7 @@ if ENV['CANONICAL_DOMAIN'].present? || Rails.env.test? || Rails.env.servertest?
       if: Proc.new { |rack_env|
         ENV['CANONICAL_DOMAIN'].present? &&
           rack_env['HTTP_HOST'] != ENV['CANONICAL_DOMAIN'] &&
-          !rack_env['PATH_INFO'].in?(%w(/healthcheck.txt /deployment.txt))
+          !rack_env['PATH_INFO'].match?(%r(/(healthcheck|deployment|healthchecks\/[a-z]+)\.txt))
       }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   get '/healthcheck.txt', to: 'healthchecks#show', as: :healthcheck
   get '/deployment.txt', to: 'healthchecks#deployment', as: :deployment
-  get '/apihealth.txt', to: 'healthchecks#api_health', as: :api_health
+  get '/healthchecks/api.txt', to: 'healthchecks#api_health', as: :api_health
 
   if Rails.application.config.x.maintenance_mode
     match '*path', to: 'pages#maintenance', via: :all

--- a/spec/requests/canonical_url_redirection_spec.rb
+++ b/spec/requests/canonical_url_redirection_spec.rb
@@ -9,6 +9,11 @@ describe "Redirecting to Canonical Domain", type: :request do
         encode_credentials(username, password)
     end
 
+    before do
+      allow_any_instance_of(HealthchecksController).to \
+        receive(:check_gitis_api).and_return(true)
+    end
+
     specify "will allow direct access to healthcheck.txt" do
       get healthcheck_path
 
@@ -21,6 +26,13 @@ describe "Redirecting to Canonical Domain", type: :request do
 
       expect(response).to have_http_status(200)
       expect(response.body).to match('not set')
+    end
+
+    specify "will allow direct access to all healthcheck paths" do
+      get api_health_path, headers: { "Authorization" => encoded }
+
+      expect(response).to have_http_status(200)
+      expect(response.body).to match('healthy')
     end
   end
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-2037

### Context

We have a working API healthcheck endpoint but this cannot work on the staging slot because of the canonical redirection. More over, this is a potential future 'trap' for other developers who may be hit by the same issue.

### Changes proposed in this pull request

1. Move the healthcheck url to be nested under the '/healthchecks' path
2. Allow any paths under `/healthchecks/` to bypass the canonical redirection
3. Added test to verify generic `/healthchecks/*.txt` can bypass canonical redirection
