### PR TITLE
SE-1922 Dry out booking date rules

### DIFF
--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -5,7 +5,7 @@ class Schools::PlacementDatesController < Schools::BaseController
     @placement_dates = current_school
       .bookings_placement_dates
       .published
-      .future
+      .bookable_date
       .in_date_order
       .eager_load(:bookings_school, :placement_date_subjects, :subjects)
   end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -101,8 +101,8 @@ module Bookings
 
     def self.from_placement_request(placement_request)
       # only populate the date if it's in the future
-      date = if placement_request&.placement_date&.in_future?
-               placement_request.placement_date.date
+      date = if placement_request&.fixed_date_is_bookable?
+               placement_request.fixed_date
              end
 
       new(

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -80,7 +80,7 @@ module Bookings
     end
 
     def bookable?
-      date > Date.today
+      date >= (Date.today + Bookings::Booking::MIN_BOOKING_DELAY)
     end
 
     def has_subjects?

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -79,12 +79,8 @@ module Bookings
       }
     end
 
-    def in_future?
+    def bookable?
       date > Date.today
-    end
-
-    def in_past?
-      date <= Date.today
     end
 
     def has_subjects?

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -52,13 +52,12 @@ module Bookings
       validates :subjects, absence: true, unless: :subject_specific?
     end
 
-    scope :future, -> { where(arel_table[:date].gteq(Time.now)) }
-    scope :past, -> { where(arel_table[:date].lt(Time.now)) }
+    scope :bookable_date, -> { where(arel_table[:date].gteq(Time.now)) }
     scope :in_date_order, -> { order(date: 'asc') }
     scope :active, -> { where(active: true) }
     scope :inactive, -> { where(active: false) }
 
-    scope :available, -> { published.active.future.in_date_order }
+    scope :available, -> { published.active.bookable_date.in_date_order }
     scope :published, -> { where.not published_at: nil }
 
     # 'supporting subjects' are dates belonging to phases where

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -216,7 +216,7 @@ module Bookings
     end
 
     def fixed_date_is_bookable?
-      !!placement_date&.in_future?
+      !!placement_date&.bookable?
     end
 
   private

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -211,6 +211,14 @@ module Bookings
       created_at&.to_date
     end
 
+    def fixed_date
+      placement_date&.date
+    end
+
+    def fixed_date_is_bookable?
+      !!placement_date&.in_future?
+    end
+
   private
 
     def completed?

--- a/app/presenters/candidates/school_presenter.rb
+++ b/app/presenters/candidates/school_presenter.rb
@@ -83,7 +83,8 @@ module Candidates
       school
         .bookings_placement_dates
         .secondary
-        .eager_load(:subjects, placement_date_subjects: :bookings_subject).available
+        .eager_load(:subjects, placement_date_subjects: :bookings_subject)
+        .available
     end
 
     def secondary_dates_grouped_by_date

--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -98,7 +98,7 @@
     </dl>
 
     <div>
-      <% if @placement_request&.placement_date&.in_future? && @last_booking.present?  %>
+      <% if @placement_request.fixed_date_is_bookable? && @last_booking.present? %>
         <%# contact details are present and school has fixed dates, allow for move on to the email preview%>
         <%= button_to 'Continue', schools_placement_request_acceptance_confirm_booking_path, class: 'govuk-button' %>
         <%= govuk_link_to 'Make changes', new_schools_placement_request_acceptance_make_changes_path(@placement_request), secondary: true, data: { module: "govuk-button" } %>

--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -13,7 +13,11 @@
       <div>
 
         <% if @placement_request.school.availability_preference_fixed? %>
-          <%- if @placement_request.placement_date.in_past? %>
+          <%- if @placement_request.placement_date.bookable? %>
+            <h3 class="govuk-heading-m">The candidate requested</h3>
+
+            <p><%= @placement_request.requested_subject.name %> on <%= @placement_request.dates_requested %></p>
+          <%- else -%>
             <div class="govuk-warning-text">
               <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
               <strong class="govuk-warning-text__text">
@@ -23,10 +27,6 @@
                 which has elapsed. Select a new booking date.
               </strong>
             </div>
-          <% else %>
-            <h3 class="govuk-heading-m">The candidate requested</h3>
-
-            <p><%= @placement_request.requested_subject.name %> on <%= @placement_request.dates_requested %></p>
           <% end %>
         <% else %>
           <h3 class="govuk-heading-m">The candidate requested</h3>

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -168,7 +168,7 @@
     <% if @placement_request.open? %>
       <div class="accept-or-reject">
         <div class="govuk-se-button-container">
-          <% if @placement_request.placement_date&.in_future? %>
+          <% if @placement_request.fixed_date_is_bookable? %>
             <%= govuk_link_to "Accept request", new_schools_placement_request_acceptance_confirm_booking_path(@placement_request) %>
           <% else %>
             <%= govuk_link_to "Accept request", new_schools_placement_request_acceptance_make_changes_path(@placement_request) %>

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -75,6 +75,15 @@ FactoryBot.define do
     end
 
     trait :with_a_fixed_date do
+      association \
+        :school,
+        :with_profile,
+        :with_subjects,
+        :with_fixed_availability_preference,
+        factory: :bookings_school,
+        urn: 11048,
+        subject_count: 2
+
       availability { nil }
       association :placement_date, factory: :bookings_placement_date
     end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
     end
 
     trait :with_subjects do
-      after :create do |school, evaluator|
+      after :build do |school, evaluator|
         evaluator.subject_count.times do
           school.subjects << FactoryBot.create(:bookings_subject)
         end

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -136,23 +136,21 @@ describe Bookings::PlacementDate, type: :model do
   describe 'Scopes' do
     let(:future_date) { create(:bookings_placement_date) }
     let(:past_date) { create(:bookings_placement_date, :in_the_past) }
-    context '.past' do
-      it 'should include past dates' do
-        expect(described_class.past).to include(past_date)
-      end
+    let(:today_date) { create(:bookings_placement_date, :in_the_past, date: Date.today) }
 
-      it 'should not include future dates' do
-        expect(described_class.past).not_to include(future_date)
-      end
-    end
+    context '.bookable_date' do
+      subject { described_class.bookable_date }
 
-    context '.future' do
       it 'should include future dates' do
-        expect(described_class.future).to include(future_date)
+        is_expected.to include(future_date)
       end
 
       it 'should not include past dates' do
-        expect(described_class.future).not_to include(past_date)
+        is_expected.not_to include(past_date)
+      end
+
+      it 'should include dates on today' do
+        is_expected.to include(today_date)
       end
     end
 
@@ -198,7 +196,7 @@ describe Bookings::PlacementDate, type: :model do
     context '.available' do
       after { described_class.available }
       specify 'should combine the future, active, published, and in_date_order scopes' do
-        expect(described_class).to receive_message_chain(:published, :active, :future, :in_date_order)
+        expect(described_class).to receive_message_chain(:published, :active, :bookable_date, :in_date_order)
       end
     end
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -851,4 +851,44 @@ describe Bookings::PlacementRequest, type: :model do
       it { is_expected.to eq subject_2 }
     end
   end
+
+  describe '#fixed_date' do
+    subject { pr.fixed_date }
+
+    context 'with fixed date' do
+      let(:pr) { build :placement_request, :with_a_fixed_date }
+      it { is_expected.to eql pr.placement_date.date }
+    end
+
+    context 'with flexible date' do
+      let(:pr) { build :placement_request }
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#fixed_date_is_bookable?' do
+    let(:pr) { build :placement_request, :with_a_fixed_date }
+    let(:date) { pr.placement_date }
+    subject { pr.fixed_date_is_bookable? }
+
+    context 'for today' do
+      before { date.date = Date.today }
+      it { is_expected.to be false }
+    end
+
+    context 'for yesterday' do
+      before { date.date = Date.yesterday }
+      it { is_expected.to be false }
+    end
+
+    context 'for tomorrow' do
+      before { date.date = Date.tomorrow }
+      it { is_expected.to be true }
+    end
+
+    context 'with flexible' do
+      let(:pr) { build(:placement_request) }
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-1922

### Context

The logic around booking dates is duplicated in several places - each replicating logic for whether there is a fixed date, and whether that date is in the future.

### Changes proposed in this pull request

1. Change scope from future to be whether a placement date is bookable
2. Moved logic out of view and into placement_request model
3. Renamed #in_future? test to be #bookable?
4. Use the delay constant on Booking to determine whether a Placement Date is bookable?

