### PR TITLE
SE-1875 Cannot confirm booking for today

### DIFF
--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -52,7 +52,10 @@ module Bookings
       validates :subjects, absence: true, unless: :subject_specific?
     end
 
-    scope :bookable_date, -> { where(arel_table[:date].gteq(Time.now)) }
+    scope :bookable_date, -> do
+      where arel_table[:date].gteq Bookings::Booking::MIN_BOOKING_DELAY.from_now.to_date
+    end
+
     scope :in_date_order, -> { order(date: 'asc') }
     scope :active, -> { where(active: true) }
     scope :inactive, -> { where(active: false) }

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -150,7 +150,7 @@ describe Bookings::PlacementDate, type: :model do
       end
 
       it 'should include dates on today' do
-        is_expected.to include(today_date)
+        is_expected.not_to include(today_date)
       end
     end
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-1875

### Context

Currently dates from today onwards are listed but a school cannot confirm a
booking which is on today, they will need to amend and set a date from
tomorrow onwards.

### Changes proposed in this pull request

Instead just don't show todays Placement Dates to users.

