### PR TITLE
SE-2058 Fix incorrectly showing 'No dates' warning on profile

### DIFF
--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -17,7 +17,7 @@
 
   <%- if secondary_dates_grouped_by_date.any? -%>
 
-    <%- if secondary_dates_grouped_by_date.any? -%>
+    <%- if primary_dates.any? -%>
       <h4 class="govuk-heading-m">Secondary school dates</h4>
     <%- else -%>
       <h4 class="govuk-heading-m">Dates</h4>
@@ -45,11 +45,11 @@
       <%- end -%>
     </dl>
 
-  <%- else -%>
+  <%- end -%>
 
+  <%- if primary_dates.none? and secondary_dates_grouped_by_date.none? -%>
     <div class="govuk-inset-text">
       There are no upcoming dates
     </div>
-
   <%- end -%>
 </div>


### PR DESCRIPTION
### JIRA Ticket Number

SE-2058

### Context

When there were primary dates but no secondary dates then the 'no dates' message
would be incorrectly shown to the candidate on the schools profile.

### Changes proposed in this pull request

1. Changed conditionals to only show the error if neither primary or secondary dates

### Guidance to review

