### PR TITLE
SE-2060 Dont rely on referer in uneditable template for links

### DIFF
--- a/app/views/schools/confirmed_bookings/date/uneditable.html.erb
+++ b/app/views/schools/confirmed_bookings/date/uneditable.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to 'Back', request.referer || schools_booking_path(@booking), class: 'govuk-back-link' %>
+    <%= link_to 'Back', schools_booking_path(@booking), class: 'govuk-back-link' %>
 
     <%= page_heading 'Booking date cannot be edited' %>
 
@@ -9,7 +9,7 @@
     </p>
 
     <p>
-      <%= govuk_link_to 'Return to booking', request.referer || schools_booking_date_path, secondary: true %>
+      <%= govuk_link_to 'Return to booking', schools_booking_path(@booking), secondary: true %>
     </p>
   </div>
 </div>


### PR DESCRIPTION
### JIRA Ticket Number

SE-2060

### Context

Return links on the bookings date 'uneditable' page used referer but if the page was accessed via a PATCH request than referer will generate a GET request to the wrong controller action.

### Changes proposed in this pull request

1. Use explicit links

