### PR TITLE
Gem updates Jan 2020

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'pg_search'
 
 # PostGIS adapter for Active Record
-gem 'activerecord-postgis-adapter'
+gem 'activerecord-postgis-adapter', '~> 5.2' # v6 is incompatible with rails 5.2
 gem 'breasal'
 gem 'geocoder'
 
@@ -70,7 +70,7 @@ gem 'application_insights', github: 'microsoft/ApplicationInsights-Ruby', ref: '
 gem 'addressable'
 gem 'faraday'
 
-gem 'validates_timeliness', '~> 5.0.0.alpha5'
+gem 'validates_timeliness', '>= 5.0.0.beta1'
 gem 'activerecord-import'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -102,7 +102,7 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
+  gem 'web-console', '>= 3.3.0', '~> 3.3'
   gem 'listen', '>= 3.0.5', '< 3.3'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
@@ -124,7 +124,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
 
-  gem 'shoulda-matchers', '~> 4.1'
+  gem 'shoulda-matchers', '~> 4.2'
   gem 'rails-controller-testing'
 
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -119,8 +119,7 @@ group :test do
   gem 'capybara', '>= 2.15'
 
   gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper', platforms: [:mri]
+  gem 'webdrivers'
 
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,8 +68,6 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     attr_required (1.0.1)
@@ -101,9 +99,6 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
@@ -182,7 +177,6 @@ GEM
     httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.3)
     json-jwt (1.11.0)
       activesupport (>= 4.2)
@@ -421,6 +415,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webfinger (1.1.0)
       activesupport
       httpclient (>= 2.4)
@@ -456,7 +454,6 @@ DEPENDENCIES
   canonical-rails
   capybara (>= 2.15)
   capybara-screenshot
-  chromedriver-helper
   cucumber-rails
   database_cleaner
   delayed_cron_job
@@ -503,6 +500,7 @@ DEPENDENCIES
   uk_postcode
   validates_timeliness (~> 5.0.0.alpha5)
   web-console (>= 3.3.0)
+  webdrivers
   webmock
   webpacker
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       activemodel (= 5.2.4.1)
       activesupport (= 5.2.4.1)
       arel (>= 9.0)
-    activerecord-import (1.0.3)
+    activerecord-import (1.0.4)
       activerecord (>= 3.2)
     activerecord-postgis-adapter (5.2.2)
       activerecord (~> 5.1)
@@ -81,13 +81,13 @@ GEM
     brakeman (4.7.2)
     breasal (0.0.1)
     builder (3.2.4)
-    bullet (6.0.2)
+    bullet (6.1.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.0.1)
     canonical-rails (0.2.6)
       rails (>= 4.1, < 6.1)
-    capybara (3.29.0)
+    capybara (3.30.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -154,11 +154,11 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
-    faraday (0.17.1)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     ffi (1.11.3)
-    foreman (0.86.0)
-    geocoder (1.5.2)
+    foreman (0.87.0)
+    geocoder (1.6.0)
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -175,9 +175,9 @@ GEM
       sass (>= 3.2.0)
     hashdiff (1.0.0)
     httpclient (2.8.3)
-    i18n (1.7.0)
+    i18n (1.8.1)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.3)
+    jaro_winkler (1.5.4)
     json-jwt (1.11.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -208,7 +208,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
-    mime-types (3.3)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
     mimemagic (0.3.3)
@@ -219,7 +219,8 @@ GEM
     multi_json (1.14.1)
     multi_test (0.1.2)
     multipart-post (2.1.1)
-    mustermann (1.0.3)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
@@ -235,15 +236,15 @@ GEM
       validate_email
       validate_url
       webfinger (>= 1.0.1)
-    parallel (1.17.0)
+    parallel (1.19.1)
     parallel_tests (2.30.0)
       parallel
-    parser (2.6.5.0)
+    parser (2.7.0.2)
       ast (~> 2.4.0)
-    pg (1.1.4)
-    pg_search (2.3.0)
-      activerecord (>= 4.2)
-      activesupport (>= 4.2)
+    pg (1.2.2)
+    pg_search (2.3.1)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     phonelib (0.6.40)
     powerpack (0.1.2)
     pry (0.12.2)
@@ -255,17 +256,17 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     psych (3.1.0)
-    public_suffix (4.0.1)
+    public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
     rack (2.0.8)
-    rack-oauth2 (1.10.0)
+    rack-oauth2 (1.10.1)
       activesupport
       attr_required
       httpclient
-      json-jwt (>= 1.9.0)
+      json-jwt (>= 1.11.0)
       rack
-    rack-protection (2.0.7)
+    rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
       rack
@@ -304,7 +305,7 @@ GEM
     rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
+    rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.1.3)
     regexp_parser (1.6.0)
@@ -312,12 +313,12 @@ GEM
     rgeo-activerecord (6.2.1)
       activerecord (>= 5.0)
       rgeo (>= 1.0.0)
-    rspec-core (3.9.0)
-      rspec-support (~> 3.9.0)
+    rspec-core (3.9.1)
+      rspec-support (~> 3.9.1)
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.0)
+    rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-rails (3.9.0)
@@ -328,7 +329,7 @@ GEM
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.0)
+    rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.65.0)
@@ -343,6 +344,7 @@ GEM
     rubocop-rspec (1.35.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -361,17 +363,17 @@ GEM
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (3.142.6)
+    selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
-    sentry-raven (2.12.3)
+    sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
-    shoulda-matchers (4.1.2)
+    shoulda-matchers (4.2.0)
       activesupport (>= 4.2.0)
-    sinatra (2.0.7)
+    sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.7)
+      rack-protection (= 2.0.8.1)
       tilt (~> 2.0)
     slack-notifier (2.3.2)
     spring (2.1.0)
@@ -395,20 +397,20 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.10)
     timeliness (0.4.3)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.5)
     unicode-display_width (1.4.1)
-    uniform_notifier (1.12.1)
+    uniform_notifier (1.13.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
     validate_url (1.0.8)
       activemodel (>= 3.0.0)
       public_suffix
-    validates_timeliness (5.0.0.alpha5)
+    validates_timeliness (5.0.0.beta1)
       timeliness (>= 0.3.10, < 1)
     web-console (3.7.0)
       actionview (>= 5.0)
@@ -441,7 +443,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
-  activerecord-postgis-adapter
+  activerecord-postgis-adapter (~> 5.2)
   acts_as_list
   addressable
   application_insights!
@@ -489,7 +491,7 @@ DEPENDENCIES
   sassc-rails
   selenium-webdriver
   sentry-raven
-  shoulda-matchers (~> 4.1)
+  shoulda-matchers (~> 4.2)
   slack-notifier
   spring
   spring-commands-rspec
@@ -498,8 +500,8 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   uk_postcode
-  validates_timeliness (~> 5.0.0.alpha5)
-  web-console (>= 3.3.0)
+  validates_timeliness (>= 5.0.0.beta1)
+  web-console (~> 3.3, >= 3.3.0)
   webdrivers
   webmock
   webpacker


### PR DESCRIPTION
### Context

Keep gems up to date, will help with the upcoming Rails 6 upgrade

### Changes proposed in this pull request

1. Switch to webdrivers gem to stop deprecation warnings
2. Update any outdated Gems which can be updated
