### PR TITLE
SE-2067 Step2 prevent scheduling invalid notify jobs

### DIFF
--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -13,7 +13,7 @@ class Notify
       NotifyJob.perform_later \
         to: address,
         template_id: template_id,
-        personalisation_json: personalisation.to_json
+        personalisation_json: personalisation_json
     end
   end
 
@@ -39,5 +39,9 @@ private
 
     fail InvalidPersonalisationError.new \
       template_id, self.class.to_s, invalid_fields
+  end
+
+  def personalisation_json
+    personalisation.transform_values(&:to_s).to_json
   end
 end

--- a/app/notify/notify.rb
+++ b/app/notify/notify.rb
@@ -1,16 +1,25 @@
 class Notify
   attr_accessor :to
+  attr_reader :invalid_fields
 
   def initialize(to:)
     self.to = Array.wrap(to).uniq
   end
 
   def despatch_later!
+    validate_personalisation!
+
     to.each do |address|
       NotifyJob.perform_later \
         to: address,
         template_id: template_id,
         personalisation_json: personalisation.to_json
+    end
+  end
+
+  class InvalidPersonalisationError < RuntimeError
+    def initialize(template_id, template_name, invalid_fields)
+      super "Template #{template_id}: #{template_name} - #{invalid_fields.inspect}"
     end
   end
 
@@ -22,5 +31,13 @@ private
 
   def personalisation
     fail 'Not implemented'
+  end
+
+  def validate_personalisation!
+    @invalid_fields = personalisation.map { |k, v| v.nil? ? k : nil }.compact
+    return true if invalid_fields.empty?
+
+    fail InvalidPersonalisationError.new \
+      template_id, self.class.to_s, invalid_fields
   end
 end

--- a/app/notify/notify_email/candidate_booking_date_changed.rb
+++ b/app/notify/notify_email/candidate_booking_date_changed.rb
@@ -91,7 +91,7 @@ class NotifyEmail::CandidateBookingDateChanged < Notify
       school_teacher_name: booking.contact_name,
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
-      placement_details: booking.placement_details,
+      placement_details: booking.placement_details.to_s,
       cancellation_url: cancellation_url,
       new_date: booking.date.to_formatted_s(:govuk),
       old_date: old_date

--- a/app/notify/notify_email/candidate_booking_reminder.rb
+++ b/app/notify/notify_email/candidate_booking_reminder.rb
@@ -88,7 +88,7 @@ class NotifyEmail::CandidateBookingReminder < Notify
       school_teacher_name: booking.contact_name,
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
-      placement_details: booking.placement_details,
+      placement_details: booking.placement_details.to_s,
       cancellation_url: candidates_cancel_url
     )
   end

--- a/spec/notify/notify_email/candidate_booking_date_changed_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_date_changed_spec.rb
@@ -108,7 +108,7 @@ describe NotifyEmail::CandidateBookingDateChanged do
       end
 
       specify 'placement_details is correctly-assigned' do
-        expect(subject.placement_details).to eql(booking.placement_details)
+        expect(subject.placement_details).to eql(booking.placement_details.to_s)
       end
 
       specify 'cancellation_url is correctly-assigned' do

--- a/spec/notify/notify_email/candidate_booking_reminder_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_reminder_spec.rb
@@ -115,7 +115,7 @@ describe NotifyEmail::CandidateBookingReminder do
       end
 
       specify 'placement_details is correctly-assigned' do
-        expect(subject.placement_details).to eql(booking.placement_details)
+        expect(subject.placement_details).to eql(booking.placement_details.to_s)
       end
 
       specify 'cancellation_url is correctly-assigned' do

--- a/spec/notify/notify_spec.rb
+++ b/spec/notify/notify_spec.rb
@@ -72,27 +72,40 @@ describe Notify do
       end
     end
 
-    let :notification do
-      StubNotification.new to: recipients, name: 'Test User'
-    end
-
     let :recipients do
       %w(test1@user.com test2@user.com)
     end
 
     describe '#despatch_later!' do
-      before do
-        perform_enqueued_jobs do
-          notification.despatch_later!
+      context 'with valid personalisation' do
+        let :notification do
+          StubNotification.new to: recipients, name: 'Test User'
+        end
+
+        before do
+          perform_enqueued_jobs do
+            notification.despatch_later!
+          end
+        end
+
+        it "should send emails with the correct parameters" do
+          recipients.each do |recipient|
+            expect(NotifyService.instance).to have_received(:send_email).with \
+              email_address: recipient,
+              template_id: notification.send(:template_id),
+              personalisation: notification.send(:personalisation)
+          end
         end
       end
 
-      it "should enqueue a notify job with the correct parameters" do
-        recipients.each do |recipient|
-          expect(NotifyService.instance).to have_received(:send_email).with \
-            email_address: recipient,
-            template_id: notification.send(:template_id),
-            personalisation: notification.send(:personalisation)
+      context 'with invalid personalisation' do
+        let :notification do
+          StubNotification.new to: recipients, name: nil
+        end
+
+        it "should raise an error whilst trying to enqueue" do
+          expect { notification.despatch_later! }.to \
+            raise_exception Notify::InvalidPersonalisationError
         end
       end
     end

--- a/spec/notify/notify_spec.rb
+++ b/spec/notify/notify_spec.rb
@@ -108,6 +108,27 @@ describe Notify do
             raise_exception Notify::InvalidPersonalisationError
         end
       end
+
+      context 'with none string personalisation' do
+        let :notification do
+          StubNotification.new to: recipients, name: 1
+        end
+
+        before do
+          perform_enqueued_jobs do
+            notification.despatch_later!
+          end
+        end
+
+        it "should cast personalisations to string" do
+          recipients.each do |recipient|
+            expect(NotifyService.instance).to have_received(:send_email).with \
+              email_address: recipient,
+              template_id: notification.send(:template_id),
+              personalisation: { name: '1' }
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2067

### Context

We do not validate supplied personalisation when we schedule emails with notify. This means invalid data causes the notify job to fail but this is asynchronous and the user gets no feedback that this has failed.

### Changes proposed in this pull request

1. Change the notify class to reject scheduling email deliveries if the personalisation is invalid
2. Ensure the various emails personalisation does not include nil values



