### PR TITLE
SE-2070 Show duration information for primary dates

### DIFF
--- a/app/views/candidates/schools/_placement_dates.html.erb
+++ b/app/views/candidates/schools/_placement_dates.html.erb
@@ -9,7 +9,10 @@
 
     <ul class="govuk-list">
       <%- primary_dates.each do |primary_date| -%>
-        <li><strong><%= primary_date.date.to_formatted_s(:govuk) %></strong></li>
+        <li>
+          <%= primary_date.date.to_formatted_s(:govuk) %>
+          (<%= pluralize primary_date.duration, 'day' %>)
+        </li>
       <%- end -%>
     </ul>
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-2070

### Context

Currently we don't show the duration of primary dates when candidates are viewing the School's Profile

### Changes proposed in this pull request

1. Show the duration of a primary schools placement dates
