### PR TITLE
Demo

### DIFF
--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -85,7 +85,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
       school_teacher_name: booking.contact_name,
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
-      placement_details: booking.placement_details,
+      placement_details: booking.placement_details.to_s,
       cancellation_url: cancellation_url
     )
   end

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -38,7 +38,8 @@ describe NotifyEmail::CandidateBookingConfirmation do
       create(
         :bookings_booking,
         bookings_school: school,
-        bookings_placement_request: pr
+        bookings_placement_request: pr,
+        placement_details: 'something'
       )
     end
 
@@ -111,6 +112,11 @@ describe NotifyEmail::CandidateBookingConfirmation do
       specify 'cancellation_url is correctly-assigned' do
         expect(subject.cancellation_url).to eql(cancellation_url)
       end
+    end
+
+    context 'with nil placemement_details' do
+      before { booking.placement_details = nil }
+      specify { expect(subject.placement_details).to eql('') }
     end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2067

### Context

We're getting errors from the notify service when sending the candidate booking confirmation email when placement_details is nil

### Changes proposed in this pull request

1. Convert placement details to a string when generating the email



