### PR TITLE
SE-2072 Fix layout on phase2 template

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -147,7 +147,7 @@ module Candidates::SchoolHelper
 
     return nil if items.blank?
 
-    content_tag('ul', class: 'govuk-list') do
+    content_tag('ul', class: 'govuk-list govuk-list--bullet') do
       safe_join(items.map { |req| tag.li(req) })
     end
   end

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -11,9 +11,9 @@
         About our school experience
       </h2>
 
-      <dl class="govuk-summary-list govuk-summary-list--no-border">
+      <dl class="govuk-summary-list govuk-summary-list--no-border inline">
         <%= dlist_item 'Individual requirements:', id: 'individual-requirements' do %>
-          <%= content_or_msg(split_to_list(@presenter.individual_requirements), "No requirements specified") %>
+          <%= content_or_msg split_to_list(@presenter.individual_requirements), "No requirements specified" %>
         <% end %>
 
         <%= dlist_item 'Details:', id: 'experience-details' do %>

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -297,10 +297,10 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
         CONTENT
       end
 
-      subject { Nokogiri.parse(split_to_list(content)) }
+      subject { split_to_list content }
 
       specify 'should create a list with the correct number of entries' do
-        expect(subject.css(%(ul[class='govuk-list'])).css('li').count).to eql(3)
+        is_expected.to have_css('ul.govuk-list--bullet > li', count: 3)
       end
     end
 
@@ -313,10 +313,10 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
         CONTENT
       end
 
-      subject { Nokogiri.parse(split_to_list(content)) }
+      subject { split_to_list content }
 
       specify 'should create a list with the correct number of entries' do
-        expect(subject.css(%(ul[class='govuk-list'])).css('li').count).to eql(2)
+        is_expected.to have_css('ul.govuk-list--bullet > li', count: 2)
       end
     end
   end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2072

### Context

The fields on the school profile are showing as normal definition lists instead of inline ones. Separately the individual requirements are not showing as bullets.

### Changes proposed in this pull request

1. Revert the definition lists to being inline lists
2. The individual requirements are shown as bullets
