### PR TITLE
SE-2063 Always show edit dates link if school is using fixed dates

### DIFF
--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -7,11 +7,6 @@ module Schools::DashboardsHelper
     end
   end
 
-  def is_fixed_and_has_active_dates?(school)
-    school.availability_preference_fixed? &&
-      school.bookings_placement_dates.available.any?
-  end
-
   def numbered_circle(number, aria_label:, id: nil, show_if_zero: false)
     # Does string comparison in case its not a number
     return if number.to_s == '0' && !show_if_zero

--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -1,7 +1,7 @@
 <section class="manage-dates">
   <h2 class="govuk-heading-m">Manage dates</h3>
 
-  <%- if is_fixed_and_has_active_dates?(@current_school) -%>
+  <%- if @current_school.availability_preference_fixed? -%>
     <div id="add-remove-and-change-dates" class="subsection">
       <header class="dashboard-medium-priority">
         <%= link_to "Add, remove and change dates", schools_placement_dates_path %>

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -64,7 +64,10 @@ Feature: The School Dashboard
         Given my school has fully-onboarded
         And it has 'fixed' availability
         When I am on the 'schools dashboard' page
-        Then there should be no 'Add, remove and change dates' link
+        Then I should see the following 'medium-priority' links:
+            | Text                                   | Hint | Path                                  |
+            | Change dates and how they're displayed | None | /schools/availability_preference/edit |
+            | Add, remove and change dates           | None | /schools/placement_dates              |
 
 
     Scenario: Account admin


### PR DESCRIPTION
### JIRA Ticket Number

SE-2063

### Context

Currently the 'edit dates' link on the schools dashboard only shows if the school is using fixed dates and has dates available. Instead this should show, irrespective of whether there are dates available.

### Changes proposed in this pull request

1. Removed helper method for detecting whether to show link 
2. Just use the flag on the school model in the view template
