### PR TITLE
SE-1953 Fix reminders not sending

### DIFF
--- a/app/jobs/cron/reminders/next_week_job.rb
+++ b/app/jobs/cron/reminders/next_week_job.rb
@@ -1,6 +1,6 @@
 module Cron
   module Reminders
-    class NextWeek < CronJob
+    class NextWeekJob < CronJob
       self.cron_expression = '35 2 * * *'
 
       def perform

--- a/app/jobs/cron/reminders/tomorrow_job.rb
+++ b/app/jobs/cron/reminders/tomorrow_job.rb
@@ -1,6 +1,6 @@
 module Cron
   module Reminders
-    class Tomorrow < CronJob
+    class TomorrowJob < CronJob
       self.cron_expression = '30 2 * * *'
 
       # Create one Bookings::ReminderBuilder task _per booking_, each

--- a/app/jobs/cron/sync_subjects_with_gitis_job.rb
+++ b/app/jobs/cron/sync_subjects_with_gitis_job.rb
@@ -1,4 +1,3 @@
-# FIXME needs to inherit from CronJob once its merged
 class Cron::SyncSubjectsWithGitisJob < CronJob
   self.cron_expression = '30 3 * * *'
   delegate :crm, to: Bookings::Gitis::Factory

--- a/spec/jobs/cron/reminders/next_week_job_spec.rb
+++ b/spec/jobs/cron/reminders/next_week_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Cron::Reminders::NextWeek, type: :job do
+describe Cron::Reminders::NextWeekJob, type: :job do
   specify 'should have a schedule of daily at 02:35' do
     expect(described_class.cron_expression).to eql('35 2 * * *')
   end
@@ -11,7 +11,7 @@ describe Cron::Reminders::NextWeek, type: :job do
 
   describe '#perform' do
     before do
-      allow_any_instance_of(Cron::Reminders::NextWeek).to receive(:bookings).and_return(%w(a b c))
+      allow_any_instance_of(described_class).to receive(:bookings).and_return(%w(a b c))
       allow(Bookings::ReminderBuilder).to receive(:perform_later).and_return(true)
     end
 

--- a/spec/jobs/cron/reminders/tomorrow_job_spec.rb
+++ b/spec/jobs/cron/reminders/tomorrow_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Cron::Reminders::Tomorrow, type: :job do
+describe Cron::Reminders::TomorrowJob, type: :job do
   specify 'should have a schedule of daily at 02:30' do
     expect(described_class.cron_expression).to eql('30 2 * * *')
   end
@@ -11,7 +11,7 @@ describe Cron::Reminders::Tomorrow, type: :job do
 
   describe '#perform' do
     before do
-      allow_any_instance_of(Cron::Reminders::Tomorrow).to receive(:bookings).and_return(%w(a b c))
+      allow_any_instance_of(described_class).to receive(:bookings).and_return(%w(a b c))
       allow(Bookings::ReminderBuilder).to receive(:perform_later).and_return(true)
     end
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-1953

### Context

Reminders are not sending - this is caused by the Job classes not being appropriately named so not getting scheduled.

### Changes proposed in this pull request

1. Renaming the reminder Job class


