### PR TITLE
Removed feature_flag for subject specific dates

### DIFF
--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -53,7 +53,7 @@ private
   end
 
   def next_step(placement_date)
-    if Feature.instance.active?(:subject_specific_dates) && placement_date.supports_subjects?
+    if placement_date.supports_subjects?
       redirect_to new_schools_placement_date_configuration_path(placement_date)
     else
       placement_date.update! published_at: DateTime.now

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -35,9 +35,3 @@
 
   <%= form.submit 'Continue' %>
 <%- end -%>
-
-<% unless Feature.instance.active? :subject_specific_dates %>
-<p class="govuk-inset-text">
-  You'll be able to add subject-specific dates soon.
-</p>
-<% end %>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -29,9 +29,3 @@
   <% end %>
   <%= form.submit 'Continue' %>
 <%- end -%>
-
-<% unless Feature.instance.active? :subject_specific_dates %>
-<p class="govuk-inset-text">
-  You'll be able to add subject-specific dates soon.
-</p>
-<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,7 +80,6 @@ Rails.application.configure do
 
   config.x.phase = Integer(ENV.fetch('PHASE') { 10000 })
   config.x.features = %i(
-    subject_specific_dates
     capped_bookings
   )
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -156,7 +156,8 @@ Rails.application.configure do
     config.x.gitis.caching = truthy_strings.include?(ENV['CRM_CACHING'].to_s)
   end
 
-  config.x.features = %i(subject_specific_dates)
+  config.x.features = %i(
+  )
 
   config.sass[:style] = :compressed if config.sass
 

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -14,7 +14,6 @@ Rails.application.configure do
 
   config.x.phase = 10000
   config.x.features = %i(
-    subject_specific_dates
     capped_bookings
   )
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,7 +76,6 @@ Rails.application.configure do
 
   config.x.phase = 10000
   config.x.features = %i(
-    subject_specific_dates
     capped_bookings
   )
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,10 +74,8 @@ Rails.application.routes.draw do
     resource :availability_preference, only: %i(edit update)
     resource :availability_info, only: %i(edit update), controller: 'availability_info'
     resources :placement_dates do
-      if Feature.instance.active? :subject_specific_dates
-        resource :configuration, only: %i(new create), controller: 'placement_dates/configurations'
-        resource :subject_selection, only: %i(new create), controller: 'placement_dates/subject_selections'
-      end
+      resource :configuration, only: %i(new create), controller: 'placement_dates/configurations'
+      resource :subject_selection, only: %i(new create), controller: 'placement_dates/subject_selections'
     end
 
     namespace :errors do


### PR DESCRIPTION
### Context

We've now released the subject_specific date feature and it is not possible to disable it now. 

### Changes proposed in this pull request

1. Remove the feature flag from the code base to simply the code.



