### PR TITLE
Added missing validation translation to placement_date#supports_subjects

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -405,6 +405,8 @@ en:
             date:
               blank: Enter a start date
               on_or_after: Date must be in the future
+            supports_subjects:
+              inclusion: Select the phase for this date
         bookings/booking:
           attributes:
             supports_subjects:


### PR DESCRIPTION
### JIRA Ticket Number

SE-2074

### Context

If a school supports both Primary and Secondary placements, and the School experience phase field (`supports_subjects`) is left blank - the user see's the rails default error message.

### Changes proposed in this pull request

1. Added a translation for this field which is clearer for the user

