### PR TITLE
Revert "SE-1953 Fix reminders not sending"

### DIFF
--- a/app/jobs/cron/reminders/next_week.rb
+++ b/app/jobs/cron/reminders/next_week.rb
@@ -1,6 +1,6 @@
 module Cron
   module Reminders
-    class NextWeekJob < CronJob
+    class NextWeek < CronJob
       self.cron_expression = '35 2 * * *'
 
       def perform

--- a/app/jobs/cron/reminders/tomorrow.rb
+++ b/app/jobs/cron/reminders/tomorrow.rb
@@ -1,6 +1,6 @@
 module Cron
   module Reminders
-    class TomorrowJob < CronJob
+    class Tomorrow < CronJob
       self.cron_expression = '30 2 * * *'
 
       # Create one Bookings::ReminderBuilder task _per booking_, each

--- a/app/jobs/cron/sync_subjects_with_gitis_job.rb
+++ b/app/jobs/cron/sync_subjects_with_gitis_job.rb
@@ -1,3 +1,4 @@
+# FIXME needs to inherit from CronJob once its merged
 class Cron::SyncSubjectsWithGitisJob < CronJob
   self.cron_expression = '30 3 * * *'
   delegate :crm, to: Bookings::Gitis::Factory

--- a/spec/jobs/cron/reminders/next_week_spec.rb
+++ b/spec/jobs/cron/reminders/next_week_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Cron::Reminders::NextWeekJob, type: :job do
+describe Cron::Reminders::NextWeek, type: :job do
   specify 'should have a schedule of daily at 02:35' do
     expect(described_class.cron_expression).to eql('35 2 * * *')
   end
@@ -11,7 +11,7 @@ describe Cron::Reminders::NextWeekJob, type: :job do
 
   describe '#perform' do
     before do
-      allow_any_instance_of(described_class).to receive(:bookings).and_return(%w(a b c))
+      allow_any_instance_of(Cron::Reminders::NextWeek).to receive(:bookings).and_return(%w(a b c))
       allow(Bookings::ReminderBuilder).to receive(:perform_later).and_return(true)
     end
 

--- a/spec/jobs/cron/reminders/tomorrow_spec.rb
+++ b/spec/jobs/cron/reminders/tomorrow_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Cron::Reminders::TomorrowJob, type: :job do
+describe Cron::Reminders::Tomorrow, type: :job do
   specify 'should have a schedule of daily at 02:30' do
     expect(described_class.cron_expression).to eql('30 2 * * *')
   end
@@ -11,7 +11,7 @@ describe Cron::Reminders::TomorrowJob, type: :job do
 
   describe '#perform' do
     before do
-      allow_any_instance_of(described_class).to receive(:bookings).and_return(%w(a b c))
+      allow_any_instance_of(Cron::Reminders::Tomorrow).to receive(:bookings).and_return(%w(a b c))
       allow(Bookings::ReminderBuilder).to receive(:perform_later).and_return(true)
     end
 


### PR DESCRIPTION
Reverts DFE-Digital/schools-experience#1309

This doesn't seem to have resolved the problem so remove from the release to avoid scheduling the job until the problem is fully understood.