### PR TITLE
Fix assumption in view template

### DIFF
--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -12,29 +12,37 @@
       <%= GovukElementsErrorsHelper.error_summary @booking, 'There is a problem', '' %>
       <div>
 
-        <% if @placement_request.school.availability_preference_fixed? %>
-          <%- if @placement_request.placement_date.bookable? %>
-            <h3 class="govuk-heading-m">The candidate requested</h3>
-
-            <p><%= @placement_request.requested_subject.name %> on <%= @placement_request.dates_requested %></p>
-          <%- else -%>
-            <div class="govuk-warning-text">
-              <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-              <strong class="govuk-warning-text__text">
-                <span class="govuk-warning-text__assistive">Warning</span>
-                The candidate requested <%= @placement_request.requested_subject.name %>
-                on <%= @placement_request.dates_requested %>
-                which has elapsed. Select a new booking date.
-              </strong>
-            </div>
-          <% end %>
-        <% else %>
+        <%- if @placement_request.fixed_date_is_bookable? %>
           <h3 class="govuk-heading-m">The candidate requested</h3>
 
-          <p><%= @placement_request.requested_subject.name %></p>
+          <p>
+            <%= @placement_request.requested_subject.name %> on
+            <%= @placement_request.dates_requested %>
+          </p>
+        <%- elsif @placement_request.placement_date -%>
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
 
-          <p class="govuk-inset-text"><%= @placement_request.dates_requested %></p>
-        <% end %>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-warning-text__assistive">Warning</span>
+
+              The candidate requested
+              <%= @placement_request.requested_subject.name %>
+              on <%= @placement_request.dates_requested %>
+              which has elapsed. Select a new booking date.
+            </strong>
+          </div>
+        <%- else -%>
+          <h3 class="govuk-heading-m">The candidate requested</h3>
+
+          <p>
+            <%= @placement_request.requested_subject.name %>
+          </p>
+
+          <p class="govuk-inset-text">
+            <%= @placement_request.dates_requested %>
+          </p>
+        <%- end -%>
 
         <%= f.date_field :date, heading: true %>
         <%= f.collection_select :bookings_subject_id, @subjects, :id, :name, {}, label_options: { class: 'govuk-heading-m' } %>
@@ -52,6 +60,5 @@
 
       <%= f.submit 'Continue' %>
     <% end %>
-
   </div>
 </div>


### PR DESCRIPTION
### JIRA Ticket Number

SE-2076

### Context

The view assumes that because the school is currently using fixed dates, that
the placement request was created with fixed dates.

### Changes proposed in this pull request

1. Reordered the nested if clauses to be a single layer, checking first if a dates is bookable (which always fails for flexible dates), then if it even is a fixed date, and finally showing the flexible dates section.
2. Remove use of whether the school is using fixed dates to determine whether the PlacementRequest was created with fixed/flexible dates.

