### PR TITLE
Leave the test database in a clean state after a Cucumber run

### DIFF
--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -14,6 +14,10 @@ deletion_options = {
 }
 
 DatabaseCleaner.clean_with :truncation, truncation_options
+at_exit do
+  DatabaseCleaner.clean_with :truncation, truncation_options
+end
+
 DatabaseCleaner.strategy = :deletion, deletion_options
 Cucumber::Rails::Database.javascript_strategy = :deletion, deletion_options
 if ENV['DEBUG_DATABASE_CLEANER'].present?


### PR DESCRIPTION
### Context

Previously you couldn't run rspec after cucumber without first creating the
test db and its data.

### Changes proposed in this pull request

1. Run a Database clean with truncation at the end of cucumber



