### PR TITLE
Restructure DfE Sign In api requests to only do check once at sign in

### DIFF
--- a/app/controllers/concerns/dfe_authentication.rb
+++ b/app/controllers/concerns/dfe_authentication.rb
@@ -29,6 +29,8 @@ module DFEAuthentication
         scope: %i(profile organisation)
       )
     end
+
+    helper_method :has_other_schools?
   end
 
 private
@@ -43,5 +45,29 @@ private
       token_endpoint: '/token',
       userinfo_endpoint: '/me'
     )
+  end
+
+  def school_urns(reload = false)
+    session[:urns] = nil if reload
+
+    session[:urns] ||= retrieve_school_urns.freeze # should only be replaced, not changed immutable
+  end
+
+  def retrieve_school_urns
+    Schools::DFESignInAPI::Organisations
+      .new(current_user.sub)
+      .urns
+  end
+
+  def other_school_urns
+    school_urns.without(current_school.urn)
+  end
+
+  # if the DfE Sign-in api client isn't configured assume users
+  # may have other schools
+  def has_other_schools?
+    return true unless Schools::DFESignInAPI::Client.enabled?
+
+    other_school_urns.any?
   end
 end

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -11,7 +11,6 @@ module Schools
     include DFEAuthentication
     before_action :require_auth
     before_action :set_current_school
-    before_action :set_other_urns
     before_action :set_site_header_text
     before_action :ensure_onboarded
 
@@ -32,23 +31,12 @@ module Schools
       @site_header_text = "Manage school experience"
     end
 
-    def set_other_urns
-      @other_urns = (session[:other_urns] || retrieve_other_urns)
-    end
-
     def retrieve_school(urn)
       unless (school = Bookings::School.find_by(urn: urn))
         raise SchoolNotRegistered, "school #{urn} not found" unless school.present?
       end
 
       school
-    end
-
-    def retrieve_other_urns
-      Schools::DFESignInAPI::Organisations
-        .new(current_user.sub)
-        .urns
-        .reject { |urn| urn == @current_school.urn }
     end
 
     def ensure_onboarded

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,14 +78,6 @@ module ApplicationHelper
     safe_join([greeting, logout_link, "or", switch_service].compact, " ")
   end
 
-  # if the DfE Sign-in api client isn't configured assume users
-  # may have other schools
-  def has_other_schools?
-    return true unless Schools::DFESignInAPI::Client.enabled?
-
-    @other_urns.any?
-  end
-
   def current_user_full_name
     return 'Unknown' unless valid_user?(@current_user)
 

--- a/spec/views/schools/dashboards/show.html.erb_spec.rb
+++ b/spec/views/schools/dashboards/show.html.erb_spec.rb
@@ -4,12 +4,13 @@ describe 'schools/dashboards/show.html.erb', type: :view do
   let(:school) { create(:bookings_school) }
   before { assign :current_school, school }
 
-  before do
-    allow(Schools::DFESignInAPI::Client).to receive(:enabled?).and_return(true)
-  end
-
   context 'when the user has other schools' do
-    before { assign :other_urns, [111111] }
+    before do
+      without_partial_double_verification do
+        allow(view).to receive(:has_other_schools?).and_return true
+      end
+    end
+
     subject { render }
 
     specify 'the page should have a change school link that initiates a DfE Sign-in switch' do
@@ -18,7 +19,12 @@ describe 'schools/dashboards/show.html.erb', type: :view do
   end
 
   context 'when the user has no other schools' do
-    before { assign :other_urns, [] }
+    before do
+      without_partial_double_verification do
+        allow(view).to receive(:has_other_schools?).and_return false
+      end
+    end
+
     subject { render }
 
     specify 'the page should have no change school link' do


### PR DESCRIPTION
### JIRA Ticket Number

SE-2094

### Context

Currrently every page in the Schools Dashboard is doing an API request to DFE Sign In to determine whether users organisation list.

### Changes proposed in this pull request

1. Query the organisation list lazily
2. Cache the results in the session - this gets removed when the session expires or the user logs out.
3. Moved the logic from the Base controller to the DfE Authentication module



