### PR TITLE
Don't modify the organisation URNs list

### DIFF
--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -62,11 +62,7 @@ module Schools
         .school
         .urn
 
-      dfe_sign_in_organisations.urns.delete(placement_request_urn)
-    end
-
-    def dfe_sign_in_organisations
-      DFESignInAPI::Organisations.new(current_user.sub)
+      placement_request_urn if other_school_urns.include? placement_request_urn
     end
 
     def assign_gitis_contacts(reqs)


### PR DESCRIPTION
### JIRA Ticket Number

SE-2083

### Context

Currently duplicate API calls are made for the organisation URNs list. 

### Changes proposed in this pull request

1. Removed the separate query of the organisations urn list
2. Avoid changing the list after its retrieved.
 
### Guidance to review

