### PR TITLE
Disable logging updates to Bookings and PlacementRequests to Gitis STEP 1

### DIFF
--- a/app/services/bookings/gitis/event_logger.rb
+++ b/app/services/bookings/gitis/event_logger.rb
@@ -11,9 +11,8 @@ module Bookings
           new(type, subject).entry
         end
 
-        def write_later(contactid, type, subject)
-          Bookings::LogToGitisJob.perform_later \
-            contactid, new(type, subject).entry
+        def write_later(_contactid, _type, _subject)
+          true
         end
       end
 

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -82,8 +82,6 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
     end
 
     before do
-      allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return(true)
-
       post \
         "/candidates/placement_requests/#{placement_request.token}/cancellation/",
         params: cancellation_params
@@ -115,11 +113,6 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
           have_received :despatch_later!
       end
 
-      it 'does not enqueues a log to gitis job' do
-        expect(Bookings::LogToGitisJob).not_to \
-          have_received(:perform_later)
-      end
-
       it 'redirects to the show action' do
         expect(response).to redirect_to \
           candidates_placement_request_cancellation_path(placement_request.token)
@@ -149,11 +142,6 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
 
           it 'does not cancel the placement request' do
             expect(placement_request).not_to be_closed
-          end
-
-          it 'does not enqueues a log to gitis job' do
-            expect(Bookings::LogToGitisJob).not_to \
-              have_received(:perform_later)
           end
 
           it 'rerenders the new template' do
@@ -201,12 +189,6 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
 
           it 'cancels the placement request' do
             expect(placement_request).to be_closed
-          end
-
-          it 'enqueues a log to gitis job' do
-            expect(Bookings::LogToGitisJob).to \
-              have_received(:perform_later).with \
-                placement_request.contact_uuid, /CANCELLED BY CANDIDATE/
           end
 
           it 'redirects to the show action' do

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -74,9 +74,6 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       context 'registration job not already enqueued' do
         shared_examples 'a successful create' do
           before do
-            allow(Bookings::LogToGitisJob).to \
-              receive(:perform_later).and_return(true)
-
             allow(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
               receive(:perform_later).and_return(true)
           end
@@ -126,13 +123,6 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
               have_received(:perform_later).with \
                 fake_gitis_uuid,
                 Bookings::Gitis::PrivacyPolicy.default
-          end
-
-          it 'enqueues a log to gitis job' do
-            expect(Bookings::LogToGitisJob).to \
-              have_received(:perform_later).with \
-                fake_gitis_uuid,
-                %r{#{Date.today.to_formatted_s(:gitis)} REQUEST}
           end
 
           it 'redirects to placement request show' do

--- a/spec/controllers/schools/confirm_attendance_controller_spec.rb
+++ b/spec/controllers/schools/confirm_attendance_controller_spec.rb
@@ -15,8 +15,6 @@ describe Schools::PlacementRequestsController, type: :request do
   end
 
   describe '#update' do
-    before { allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return(true) }
-
     let!(:attended) do
       build(:bookings_booking, :accepted, bookings_school: school, date: 3.days.ago).tap do |bb|
         bb.save(validate: false)
@@ -49,18 +47,6 @@ describe Schools::PlacementRequestsController, type: :request do
 
     specify 'should redirect to the dashboard' do
       expect(subject).to redirect_to(schools_dashboard_path)
-    end
-
-    specify 'should enqueue a gitis update for the attended record' do
-      expect(Bookings::LogToGitisJob).to \
-        have_received(:perform_later).with \
-          attended.contact_uuid, /ATTENDED/
-    end
-
-    specify 'should enqueue a gitis update for the unattended record' do
-      expect(Bookings::LogToGitisJob).to \
-        have_received(:perform_later).with \
-          unattended.contact_uuid, /DID NOT ATTEND/
     end
   end
 end

--- a/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller_spec.rb
@@ -25,8 +25,6 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
 
   context '#create' do
     before do
-      allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return(true)
-
       post schools_booking_cancellation_notification_delivery_path \
         booking
     end
@@ -38,10 +36,6 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
 
       let!(:booking) do
         create(:bookings_booking, bookings_placement_request: placement_request, bookings_school: school)
-      end
-
-      it 'does not enqueue a log to gitis job' do
-        expect(Bookings::LogToGitisJob).not_to have_received(:perform_later)
       end
 
       it 'redirects to the placement_show path' do
@@ -86,12 +80,6 @@ describe Schools::ConfirmedBookings::Cancellations::NotificationDeliveriesContro
 
       it 'updates the placement_request to closed' do
         expect(placement_request.reload).to be_closed
-      end
-
-      it 'enqueues a log to gitis job' do
-        expect(Bookings::LogToGitisJob).to \
-          have_received(:perform_later).with \
-            placement_request.contact_uuid, /CANCELLED BY SCHOOL/
       end
 
       it 'redirects to the show action' do

--- a/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
@@ -35,8 +35,6 @@ describe Schools::PlacementRequests::Acceptance::PreviewConfirmationEmailControl
 
   context '#create' do
     before do
-      allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return(true)
-
       allow(NotifyEmail::CandidateBookingConfirmation).to(
         receive(:from_booking)
           .and_return(double(NotifyEmail::CandidateBookingConfirmation, despatch_later!: true))
@@ -53,11 +51,6 @@ describe Schools::PlacementRequests::Acceptance::PreviewConfirmationEmailControl
 
     specify 'should set the accepted_at time on the booking' do
       expect(booking.reload.accepted_at).not_to be_nil
-    end
-
-    specify 'should enqueue a log to gitis job' do
-      expect(Bookings::LogToGitisJob).to \
-        have_received(:perform_later).with pr.contact_uuid, /ACCEPTED/
     end
 
     specify 'should be redirected to the placement requests index' do

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -24,8 +24,6 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
 
   context '#create' do
     before do
-      allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return(true)
-
       post schools_placement_request_cancellation_notification_delivery_path \
         placement_request
     end
@@ -38,10 +36,6 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
       it 'redirects to the placement_show path' do
         expect(response).to redirect_to \
           schools_placement_requests_path(placement_request)
-      end
-
-      it 'does not enqueue a log to gitis job' do
-        expect(Bookings::LogToGitisJob).not_to have_received(:perform_later)
       end
     end
 
@@ -76,12 +70,6 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
 
       it 'updates the placement_request to closed' do
         expect(placement_request.reload).to be_closed
-      end
-
-      it 'enqueues a log to gitis job' do
-        expect(Bookings::LogToGitisJob).to \
-          have_received(:perform_later).with \
-            placement_request.contact_uuid, /CANCELLED BY SCHOOL/
       end
 
       it 'redirects to the show action' do

--- a/spec/models/schools/attendance_spec.rb
+++ b/spec/models/schools/attendance_spec.rb
@@ -57,22 +57,4 @@ describe Schools::Attendance do
       end
     end
   end
-
-  describe '#update_gitis' do
-    before do
-      allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return('cattlee')
-      subject.save
-      subject.update_gitis
-    end
-
-    specify 'should correctly update bookings with param values' do
-      bookings_params.each do |id, _status|
-        booking = Bookings::Booking.find(id)
-        expect(Bookings::LogToGitisJob).to \
-          have_received(:perform_later).with \
-            booking.contact_uuid,
-            booking.attended ? /ATTENDED/ : /DID NOT ATTEND/
-      end
-    end
-  end
 end

--- a/spec/services/bookings/gitis/event_logger_spec.rb
+++ b/spec/services/bookings/gitis/event_logger_spec.rb
@@ -126,20 +126,4 @@ describe Bookings::Gitis::EventLogger, type: :model do
       expect { subject }.to raise_exception(NoMethodError)
     end
   end
-
-  context 'write_later' do
-    let(:contactid) { SecureRandom.uuid }
-    let(:placement_request) { create(:placement_request) }
-
-    before do
-      allow(Bookings::LogToGitisJob).to receive(:perform_later).and_return(true)
-
-      described_class.write_later contactid, :request, placement_request
-    end
-
-    it "will schedule an update job" do
-      expect(Bookings::LogToGitisJob).to have_received(:perform_later).with \
-        contactid, /REQUEST/
-    end
-  end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2102

### Context

We no longer need to add a log of placement request information to the notes field on the Gitis Contact record.

### Changes proposed in this pull request

1. Step 1: Removed triggers for the ActiveJob responsible for the Gitis updates



