### PR TITLE
SE-2080 Failing updates to attendance records

### DIFF
--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -12,12 +12,14 @@ module Schools
       @updated_attendance = Schools::Attendance.new(bookings: bookings, bookings_params: bookings_params)
 
       if @updated_attendance.save
-        @updated_attendance.update_gitis
         redirect_to schools_dashboard_path
       else
         build_outstanding_attendance
         render 'show'
       end
+
+      # will only update those bookings which were successfully updated
+      @updated_attendance.update_gitis
     end
 
   private

--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -3,22 +3,20 @@ module Schools
   # attended a booking
   class ConfirmAttendanceController < Schools::BaseController
     def show
-      @bookings = unlogged_bookings.eager_load(
-        :bookings_subject,
-        bookings_placement_request: :candidate
-      )
-
-      assign_gitis_contacts(@bookings)
+      @updated_attendance = build_outstanding_attendance
     end
 
     def update
       bookings = unlogged_bookings.where(id: bookings_params.keys). \
         includes(bookings_placement_request: %i(candidate candidate_cancellation school_cancellation))
-      attendance = Schools::Attendance.new(bookings: bookings, bookings_params: bookings_params)
+      @updated_attendance = Schools::Attendance.new(bookings: bookings, bookings_params: bookings_params)
 
-      if attendance.save
-        attendance.update_gitis
+      if @updated_attendance.save
+        @updated_attendance.update_gitis
         redirect_to schools_dashboard_path
+      else
+        build_outstanding_attendance
+        render 'show'
       end
     end
 
@@ -47,6 +45,17 @@ module Schools
           :bookings_school
         )
         .order(date: 'desc')
+    end
+
+    def build_outstanding_attendance
+      @bookings = unlogged_bookings.eager_load(
+        :bookings_subject,
+        bookings_placement_request: :candidate
+      )
+
+      assign_gitis_contacts(@bookings)
+
+      @attendance = Schools::Attendance.new bookings: @bookings, bookings_params: {}
     end
   end
 end

--- a/app/models/schools/attendance.rb
+++ b/app/models/schools/attendance.rb
@@ -2,7 +2,7 @@ module Schools
   class Attendance
     include ActiveModel::Model
 
-    attr_accessor :bookings, :bookings_params
+    attr_accessor :bookings, :bookings_params, :updated_bookings
 
     def initialize(bookings:, bookings_params:)
       self.bookings = bookings
@@ -10,15 +10,27 @@ module Schools
     end
 
     def save
+      @updated_bookings = []
+
       bookings_params.each do |booking_id, attended|
         fetch(booking_id).tap do |booking|
-          booking.update(attended: ActiveModel::Type::Boolean.new.cast(attended))
+          begin
+            booking.update! attended: ActiveModel::Type::Boolean.new.cast(attended)
+            @updated_bookings << booking.id
+          rescue ActiveRecord::RecordInvalid => e
+            errors.add :bookings_params,
+              "Unable to set attendance for #{booking.date.to_formatted_s(:govuk)}"
+
+            update_error e
+          end
         end
       end
+
+      errors.empty?
     end
 
     def update_gitis
-      bookings_params.each do |booking_id, _attended|
+      bookings_params.slice(*updated_bookings).each do |booking_id, _attended|
         fetch(booking_id).tap do |booking|
           Bookings::Gitis::EventLogger.write_later \
             booking.contact_uuid, :attendance, booking
@@ -34,6 +46,11 @@ module Schools
 
     def fetch(id)
       indexed_bookings.fetch(id)
+    end
+
+    def update_error(exception)
+      ExceptionNotifier.notify_exception(exception)
+      Raven.capture_exception(exception)
     end
   end
 end

--- a/app/models/schools/attendance.rb
+++ b/app/models/schools/attendance.rb
@@ -10,11 +10,9 @@ module Schools
     end
 
     def save
-      Bookings::Booking.transaction do
-        bookings_params.each do |booking_id, attended|
-          fetch(booking_id).tap do |booking|
-            booking.update(attended: ActiveModel::Type::Boolean.new.cast(attended))
-          end
+      bookings_params.each do |booking_id, attended|
+        fetch(booking_id).tap do |booking|
+          booking.update(attended: ActiveModel::Type::Boolean.new.cast(attended))
         end
       end
     end

--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -7,6 +7,7 @@
 <%- if @bookings.any? %>
 
   <%= form_with url: schools_confirm_attendance_path, method: 'put' do |f| %>
+    <%= GovukElementsErrorsHelper.error_summary @updated_attendance, 'There is a problem', '' %>
 
     <table class="govuk-table">
       <thead class="govuk-table__head">

--- a/spec/controllers/schools/confirm_attendance_controller_spec.rb
+++ b/spec/controllers/schools/confirm_attendance_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require Rails.root.join("spec", "controllers", "schools", "session_context")
 
-describe Schools::PlacementRequestsController, type: :request do
+describe Schools::ConfirmAttendanceController, type: :request do
   include_context "logged in DfE user"
 
   let(:school) { Bookings::School.find_by(urn: urn) }


### PR DESCRIPTION
### JIRA Ticket Number

SE-2080

### Context

Currently we've had a couple of reports of schools attempting to update Attendance for Bookings but getting it taking no effect.

#### Reviewing the code

1. All updates are wrapped in a transaction so if any update to a booking fails then all updates are rolled back
2. Models are revalidated at point of save - which requires they remain valid even with new validations running against older data.
2. No errors are reported, and if the Attendance#save fails we would get a render error - since #save always returns true this isn't a problem at present

### Changes proposed in this pull request

1. Remove the transaction - a couple of problematic updates shouldn't block all updates
2. Report errors for any bookings which could not be updated
3. Ensure we get exceptions reported for the invalid bookings which should help with identifying the root cause of the invalid bookings.
