### PR TITLE
Downgraded FFI to 1.11.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,9 @@ group :development, :test do
   gem 'bullet'
 
   gem 'parallel_tests'
+  
+  # Held back for now because 1.12.x seems buggy
+  gem 'ffi', '~> 1.11.3'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       railties (>= 4.2.0)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    ffi (1.12.1)
+    ffi (1.11.3)
     foreman (0.87.0)
     geocoder (1.6.1)
     gherkin (5.1.0)
@@ -472,6 +472,7 @@ DEPENDENCIES
   exception_notification
   factory_bot_rails
   faraday
+  ffi (~> 1.11.3)
   foreman
   geocoder
   govuk-lint (= 3.11.0)


### PR DESCRIPTION
### Context

We are getting increasingly frequent failures from CI, the errors appear to originate from FFI.

I'd originally tried upgrading to the latest version of FFI but that doesn't seem to resolve the problem.

### Changes proposed in this pull request

1. Downgrade to the last version we knew to work reliably

