### PR TITLE
Expanded error message for blank DBS requirements field

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,7 +203,7 @@ en:
             requires_check:
               inclusion: 'Select whether you require candidates to have a DBS check'
             dbs_policy_details:
-              blank: 'Provide details'
+              blank: 'Provide details of your DBS check requirements'
             no_dbs_policy_details:
               blank: 'Provide details'
         schools/on_boarding/candidate_requirements_choice:


### PR DESCRIPTION
### JIRA Ticket Number

2022

### Context

The DBS Requirements field only gives a generic error message

### Changes proposed in this pull request

1. Expand the error message to provide more clarity to the user



