### PR TITLE
Changed default page delay in cucumber to be 0 seconds

### DIFF
--- a/features/support/feature_helper.rb
+++ b/features/support/feature_helper.rb
@@ -1,5 +1,5 @@
 def delay_page_load
   if ENV['CUC_DRIVER'].present? || ENV['CUC_PAGE_DELAY'].present?
-    sleep Integer(ENV.fetch('CUC_PAGE_DELAY') { 2 })
+    sleep Integer(ENV.fetch('CUC_PAGE_DELAY') { 0 })
   end
 end


### PR DESCRIPTION
Remove default page delay because it may no longer be required

