### PR TITLE
Don't re-assign OIDC nonces if already assigned

### DIFF
--- a/app/controllers/concerns/dfe_authentication.rb
+++ b/app/controllers/concerns/dfe_authentication.rb
@@ -20,8 +20,8 @@ module DFEAuthentication
 
       client = get_oidc_client
 
-      session[:state] = SecureRandom.uuid # You can specify or pass in your own state here
-      session[:nonce] = SecureRandom.hex(16) # You should store this and validate it on return.
+      session[:state] ||= SecureRandom.uuid # You can specify or pass in your own state here
+      session[:nonce] ||= SecureRandom.hex(16) # You should store this and validate it on return.
       session[:return_url] = request.original_url
       redirect_to client.authorization_uri(
         state: session[:state],


### PR DESCRIPTION
### JIRA Ticket Number

SE-1684

### Context

When we hand across to DfE Sign In, we include a couple of tokens which are
held in session data

Currently we assign these prior to the redirect - this creates a scenario where
multiple pages failing the check will end up in a race assigning the tokens
(eg browser restoring multiple tabs for our dashboard). The last restored tab
assigns the token but if that is not the one the user signs in through then the
token we have in session, does not match that returned by DfE Sign-in

### Changes proposed in this pull request

1. Use existing tokens when they are already assigned



