### PR TITLE
Ensure compiled sassc gem is portable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV RAILS_ENV=production \
     NODE_ENV=production \
     RAILS_SERVE_STATIC_FILES=true \
     RAILS_LOG_TO_STDOUT=true \
-    RACK_TIMEOUT_SERVICE_TIMEOUT=60
+    RACK_TIMEOUT_SERVICE_TIMEOUT=60 \
+    BUNDLE_BUILD__SASSC=--disable-march-tune-native
 
 RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
### Context

We've have been encountering sporadic failures from our CI pipeline, appearing to relate to a compilation error. I think I've tracked this down to an issue in the Sassc gem.

The sassc gem compiles using -march=native which produces a non-portable c lib
of sassc. In a Docker environment, the built image may be run on a different
system than the one it is compiled on - potentially resulting in a segfault.

This looks to be the issue we have been encountering over the last week.

2.2.1 is supposed to fix this but does not actually remove the -march=native
optimisation and I believe continues to exhibit this problem.

### Changes proposed in this pull request

1. Update the docker file to prevent the usage of `-march=native`



