### PR TITLE
SE-2125 Marking invalid attendances

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
@@ -9,7 +9,7 @@ module Schools
 
           @placement_request.fetch_gitis_contact gitis_crm
           @booking = find_or_build_booking(@placement_request)
-          @last_booking = Bookings::Booking.last_accepted_booking_by(@placement_request.school)
+          @last_booking_found = @booking.populate_contact_details
         end
 
         def create
@@ -18,9 +18,8 @@ module Schools
             .find(params[:placement_request_id])
 
           booking = find_or_build_booking(@placement_request)
-          booking.populate_contact_details!
 
-          if booking.save
+          if booking.save(context: :acceptance)
             redirect_to edit_schools_placement_request_acceptance_preview_confirmation_email_path(@placement_request.id)
           else
             @placement_request.fetch_gitis_contact gitis_crm

--- a/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
@@ -20,7 +20,7 @@ module Schools
           @booking = find_or_build_booking(@placement_request)
           @booking.assign_attributes(booking_params)
 
-          if @booking.save
+          if @booking.save(context: :acceptance)
             redirect_to edit_schools_placement_request_acceptance_preview_confirmation_email_path(@placement_request.id)
           else
             @subjects = @current_school.subjects.all

--- a/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
@@ -9,7 +9,7 @@ module Schools
 
           @placement_request.fetch_gitis_contact gitis_crm
           @booking = @placement_request.booking || Bookings::Booking.from_placement_request(@placement_request)
-          @booking.populate_contact_details!
+          @booking.populate_contact_details
 
           @subjects = @current_school.subjects.all
         end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -38,8 +38,10 @@ module Bookings
     validates :attended, inclusion: [nil], if: -> { bookings_placement_request&.cancelled? }
 
     validates :contact_name, presence: true
-    validates :contact_number, presence: true, phone: true
-    validates :contact_email, presence: true, email_format: true
+    validates :contact_number, presence: true
+    validates :contact_number, phone: true, if: -> { contact_number.present? }
+    validates :contact_email, presence: true
+    validates :contact_email, email_format: true, if: -> { contact_email.present? }
 
     validates :candidate_instructions, presence: true, on: :acceptance_email_preview
 

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -123,10 +123,10 @@ module Bookings
 
     # on subsequent placement request acceptances, pre-populate the contact details and
     # candidate instructions to shorten the process
-    def populate_contact_details!
+    def populate_contact_details
       last_booking = Bookings::Booking.last_accepted_booking_by(bookings_school)
 
-      return self unless last_booking.present?
+      return false unless last_booking.present?
 
       assign_attributes(
         contact_name: last_booking.contact_name,
@@ -134,6 +134,8 @@ module Bookings
         contact_number: last_booking.contact_number,
         location: last_booking.location,
       )
+
+      true
     end
 
     def status

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -37,10 +37,10 @@ module Bookings
     validates :duration, presence: true, numericality: { greater_than: 0 }
     validates :attended, inclusion: [nil], if: -> { bookings_placement_request&.cancelled? }
 
-    validates :contact_name, presence: true
-    validates :contact_number, presence: true
+    validates :contact_name, presence: true, on: %i(create acceptance)
+    validates :contact_number, presence: true, on: %i(create acceptance)
     validates :contact_number, phone: true, if: -> { contact_number.present? }
-    validates :contact_email, presence: true
+    validates :contact_email, presence: true, on: %i(create acceptance)
     validates :contact_email, email_format: true, if: -> { contact_email.present? }
 
     validates :candidate_instructions, presence: true, on: :acceptance_email_preview

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -36,6 +36,7 @@ module Bookings
     validates :bookings_school, presence: true
     validates :duration, presence: true, numericality: { greater_than: 0 }
     validates :attended, inclusion: [nil], if: -> { bookings_placement_request&.cancelled? }
+    validates :attended, inclusion: [true, false], on: :attendance
 
     validates :contact_name, presence: true, on: %i(create acceptance)
     validates :contact_number, presence: true, on: %i(create acceptance)

--- a/app/models/schools/attendance.rb
+++ b/app/models/schools/attendance.rb
@@ -15,7 +15,8 @@ module Schools
       bookings_params.each do |booking_id, attended|
         fetch(booking_id).tap do |booking|
           begin
-            booking.update! attended: ActiveModel::Type::Boolean.new.cast(attended)
+            booking.attended = ActiveModel::Type::Boolean.new.cast(attended)
+            booking.save!(context: :attendance)
             @updated_bookings << booking.id
           rescue ActiveRecord::RecordInvalid => e
             errors.add :bookings_params,

--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -55,24 +55,21 @@
 
     <dl class="govuk-summary-list">
 
-      <% if @last_booking.present? %>
+      <% if @last_booking_found %>
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Contact details
           </dt>
           <dd class="govuk-summary-list__value">
             <ul class="govuk-list">
-              <li aria-label="Contact name" >
-                <%= @last_booking.contact_name %>
+              <li aria-label="Contact name">
+                <%= @booking.contact_name %>
               </li>
-              <li aria-label="Contact telephone number" >
-                <%= @last_booking.contact_number %>
+              <li aria-label="Contact telephone number">
+                <%= @booking.contact_number %>
               </li>
-              <li aria-label="Contact email address" >
-                <%= @last_booking.contact_email %>
-              </li>
-              <li aria-label="Location" >
-                <%= @last_booking.location %>
+              <li aria-label="Contact email address">
+                <%= @booking.contact_email %>
               </li>
             </ul>
           </dd>
@@ -98,9 +95,14 @@
     </dl>
 
     <div>
-      <% if @placement_request.fixed_date_is_bookable? && @last_booking.present? %>
+      <% if @placement_request.fixed_date_is_bookable? && @last_booking_found %>
         <%# contact details are present and school has fixed dates, allow for move on to the email preview%>
-        <%= button_to 'Continue', schools_placement_request_acceptance_confirm_booking_path, class: 'govuk-button' %>
+        <%= form_for @booking, url: schools_placement_request_acceptance_make_changes_path, method: 'post' do |f| %>
+          <%= f.hidden_field :contact_name %>
+          <%= f.hidden_field :contact_number %>
+          <%= f.hidden_field :contact_email %>
+          <%= f.submit 'Continue' %>
+        <% end %>
         <%= govuk_link_to 'Make changes', new_schools_placement_request_acceptance_make_changes_path(@placement_request), secondary: true, data: { module: "govuk-button" } %>
       <% else %>
         <%# contact details are missing (this is the first time) or it's a flex booking %>

--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -136,6 +136,6 @@ Then("there should be an {string} button and a {string} link") do |button_text, 
 end
 
 Then("I should be on the {string} page for the placement request") do |string|
-  expect(@placement_request.booking).to be_present
   expect(page.current_path).to eql(path_for(string, placement_request: @placement_request))
+  expect(@placement_request.booking).to be_present
 end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -40,9 +40,12 @@ describe Bookings::Booking do
     it { is_expected.to validate_presence_of(:duration) }
     it { is_expected.to validate_numericality_of(:duration).is_greater_than 0 }
 
-    it { is_expected.to validate_presence_of(:contact_name) }
-    it { is_expected.to validate_presence_of(:contact_number) }
-    it { is_expected.to validate_presence_of(:contact_email) }
+    it { is_expected.to validate_presence_of(:contact_name).on(:create) }
+    it { is_expected.to validate_presence_of(:contact_number).on(:create) }
+    it { is_expected.to validate_presence_of(:contact_email).on(:create) }
+    it { is_expected.to validate_presence_of(:contact_name).on(:acceptance) }
+    it { is_expected.to validate_presence_of(:contact_number).on(:acceptance) }
+    it { is_expected.to validate_presence_of(:contact_email).on(:acceptance) }
     it { is_expected.to validate_email_format_of(:contact_email).with_message('Enter a valid contact email address') }
 
     context '#date' do

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -48,6 +48,10 @@ describe Bookings::Booking do
     it { is_expected.to validate_presence_of(:contact_email).on(:acceptance) }
     it { is_expected.to validate_email_format_of(:contact_email).with_message('Enter a valid contact email address') }
 
+    it { is_expected.to allow_value(true).for(:attended).on(:attendance) }
+    it { is_expected.to allow_value(false).for(:attended).on(:attendance) }
+    it { is_expected.not_to allow_value(nil).for(:attended).on(:attendance) }
+
     context '#date' do
       it { is_expected.to validate_presence_of(:date) }
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-2125

### Context

Historical bookings do not necessarily have a contact name/number/email - these fields were requested but not required.

We now require these fields to be supplied, which means some older bookings are no longer valid under the current rule set.

This is preventing schools from marking attendance on these 'historical' bookings.

### Changes proposed in this pull request

1. Remove duplicate error messages for the contact number/email when left blank
2. Make the required validations only run on the screen they apply to
3. Send all booking confirmations through the MakeChanges controller which can show error information in the scenario a booking is invalid, allowing the user to correct it.
4. Make the attendance validations only run on the Attendance screen.


