### PR TITLE
SE-2127 Candidate instructions getting excluded

### DIFF
--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -13,6 +13,8 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     :school_teacher_email,
     :school_teacher_telephone,
     :placement_details,
+    :candidate_instructions,
+    :subject_name,
     :cancellation_url
 
   def initialize(
@@ -31,6 +33,8 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     school_teacher_email:,
     school_teacher_telephone:,
     placement_details:,
+    candidate_instructions:,
+    subject_name:,
     cancellation_url:
   )
 
@@ -48,6 +52,8 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
     self.school_teacher_email = school_teacher_email
     self.school_teacher_telephone = school_teacher_telephone
     self.placement_details = placement_details
+    self.candidate_instructions = candidate_instructions
+    self.subject_name = subject_name
     self.cancellation_url = cancellation_url
 
     super(to: to)
@@ -85,7 +91,9 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
       school_teacher_name: booking.contact_name,
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
-      placement_details: booking.placement_details.to_s,
+      placement_details: profile.experience_details,
+      candidate_instructions: booking.candidate_instructions,
+      subject_name: booking.bookings_subject.name,
       cancellation_url: cancellation_url
     )
   end
@@ -93,7 +101,7 @@ class NotifyEmail::CandidateBookingConfirmation < Notify
 private
 
   def template_id
-    'feb44a3a-c2f9-47a3-9be2-b8b665912570'
+    'f66aaa08-df33-4be6-95b6-7e1cf8595a2b'
   end
 
   def personalisation
@@ -112,6 +120,8 @@ private
       school_teacher_email: school_teacher_email,
       school_teacher_telephone: school_teacher_telephone,
       placement_details: placement_details,
+      candidate_instructions: candidate_instructions,
+      subject_name: subject_name,
       cancellation_url: cancellation_url
     }
   end

--- a/app/notify/notify_email/candidate_booking_confirmation_v2.f66aaa08-df33-4be6-95b6-7e1cf8595a2b.md
+++ b/app/notify/notify_email/candidate_booking_confirmation_v2.f66aaa08-df33-4be6-95b6-7e1cf8595a2b.md
@@ -1,0 +1,42 @@
+Dear ((candidate_name)),
+
+Here are the main details about your school experience at ((school_name)):
+
+# School details
+
+* School or college: ((school_name))
+* Address: ((school_address))
+* Dress code: ((school_dress_code))
+* Parking: ((school_parking))
+
+# School experience contacts
+
+On the day of your school experience, you'll need to report to:
+
+Name: ((school_teacher_name))
+Email address: ((school_teacher_email))
+UK telephone number: ((school_teacher_telephone))
+
+You can also contact them if you have any questions about your experience.
+
+To cancel your school experience use the following link.
+
+((cancellation_url))
+
+# School experience details
+
+* Start date: ((placement_schedule))
+* Start and finish times: ((school_start_time)) to ((school_finish_time))
+* Subject: ((subject_name))
+* Experience details: ((placement_details))
+
+# Extra instructions for the candidate
+
+((candidate_instructions))
+
+# Help and support
+
+If you have any questions about your booking contact:
+
+Email address: ((school_admin_email))
+UK telephone number: ((school_admin_telephone))

--- a/app/notify/notify_email/candidate_booking_date_changed.rb
+++ b/app/notify/notify_email/candidate_booking_date_changed.rb
@@ -13,6 +13,8 @@ class NotifyEmail::CandidateBookingDateChanged < Notify
     :school_teacher_email,
     :school_teacher_telephone,
     :placement_details,
+    :candidate_instructions,
+    :subject_name,
     :cancellation_url,
     :new_date,
     :old_date
@@ -33,6 +35,8 @@ class NotifyEmail::CandidateBookingDateChanged < Notify
     school_teacher_email:,
     school_teacher_telephone:,
     placement_details:,
+    candidate_instructions:,
+    subject_name:,
     cancellation_url:,
     new_date:,
     old_date:
@@ -52,6 +56,8 @@ class NotifyEmail::CandidateBookingDateChanged < Notify
     self.school_teacher_email = school_teacher_email
     self.school_teacher_telephone = school_teacher_telephone
     self.placement_details = placement_details
+    self.candidate_instructions = candidate_instructions
+    self.subject_name = subject_name
     self.cancellation_url = cancellation_url
     self.new_date = new_date
     self.old_date = old_date
@@ -91,7 +97,9 @@ class NotifyEmail::CandidateBookingDateChanged < Notify
       school_teacher_name: booking.contact_name,
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
-      placement_details: booking.placement_details.to_s,
+      placement_details: profile.experience_details,
+      candidate_instructions: booking.candidate_instructions,
+      subject_name: booking.bookings_subject.name,
       cancellation_url: cancellation_url,
       new_date: booking.date.to_formatted_s(:govuk),
       old_date: old_date
@@ -101,7 +109,7 @@ class NotifyEmail::CandidateBookingDateChanged < Notify
 private
 
   def template_id
-    'b02bb4c7-ae3a-466a-8d2d-5bda3c45ff6a'
+    '3c1fd380-db1c-4efb-8e98-f3a0ef3e2661'
   end
 
   def personalisation
@@ -120,6 +128,8 @@ private
       school_teacher_email: school_teacher_email,
       school_teacher_telephone: school_teacher_telephone,
       placement_details: placement_details,
+      candidate_instructions: candidate_instructions,
+      subject_name: subject_name,
       cancellation_url: cancellation_url,
       new_date: new_date,
       old_date: old_date

--- a/app/notify/notify_email/candidate_booking_date_changed_v2.3c1fd380-db1c-4efb-8e98-f3a0ef3e2661.md
+++ b/app/notify/notify_email/candidate_booking_date_changed_v2.3c1fd380-db1c-4efb-8e98-f3a0ef3e2661.md
@@ -1,0 +1,44 @@
+Dear ((candidate_name)),
+
+^ Your experience date has been changed by the school from ((old_date)) to ((new_date))
+
+Here are the main details about your school experience at ((school_name)):
+
+# School details
+
+* School or college: ((school_name))
+* Address: ((school_address))
+* Dress code: ((school_dress_code))
+* Parking: ((school_parking))
+
+# School experience contacts
+
+On the day of your school experience, you'll need to report to:
+
+Name: ((school_teacher_name))
+Email address: ((school_teacher_email))
+UK telephone number: ((school_teacher_telephone))
+
+You can also contact them if you have any questions about your experience.
+
+To cancel your school experience use the following link.
+
+((cancellation_url))
+
+# School experience details
+
+* Start date: ((placement_schedule))
+* Start and finish times: ((school_start_time)) to ((school_finish_time))
+* Subject: ((subject_name))
+* Experience details: ((placement_details))
+
+# Extra instructions for the candidate
+
+((candidate_instructions))
+
+# Help and support
+
+If you have any questions about your booking contact:
+
+Email address: ((school_admin_email))
+UK telephone number: ((school_admin_telephone))

--- a/app/views/schools/placement_requests/acceptance/email_preview_sections/_school_experience_details.html.erb
+++ b/app/views/schools/placement_requests/acceptance/email_preview_sections/_school_experience_details.html.erb
@@ -2,8 +2,24 @@
   <h3>School experience details</h3>
 
   <ul class="govuk-list govuk-list--bullet">
-    <li class="govuk-list__item">Dates: <%= @placement_request.booking.placement_start_date_with_duration %></li>
-    <li class="govuk-list__item">Subject: <%= @placement_request.booking.bookings_subject.name %></li>
-    <li class="govuk-list__item">Experience details: <%= @placement_request.booking.placement_details %></li>
+    <li class="govuk-list__item">
+      Start date:
+      <%= @placement_request.booking.placement_start_date_with_duration %>
+    </li>
+
+    <li class="govuk-list__item">
+      Start and finish times:
+      <%= @placement_request.school.profile.start_time %> to
+      <%= @placement_request.school.profile.end_time %>
+    </li>
+
+    <li class="govuk-list__item">
+      Subject: <%= @placement_request.booking.bookings_subject.name %>
+    </li>
+
+    <li class="govuk-list__item">
+      Experience details:
+      <%= safe_format @placement_request.school.profile.experience_details %>
+    </li>
   </ul>
 </section>

--- a/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
@@ -6,7 +6,7 @@ describe Schools::ConfirmedBookings::DateController, type: :request do
   include_context "logged in DfE user"
 
   let(:booking) do
-    create(:bookings_booking, bookings_school: @current_user_school)
+    create(:bookings_booking, :accepted, bookings_school: @current_user_school)
   end
 
   let!(:profile) { create(:bookings_profile, school: @current_user_school) }

--- a/spec/factories/bookings/bookings_factory.rb
+++ b/spec/factories/bookings/bookings_factory.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     date { 2.months.from_now }
 
     trait :accepted do
+      candidate_instructions { 'Report to reception on arrival' }
       accepted_at { 5.minutes.ago }
     end
 

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateBookingConfirmation do
-  it_should_behave_like "email template", "feb44a3a-c2f9-47a3-9be2-b8b665912570",
+  it_should_behave_like "email template", "f66aaa08-df33-4be6-95b6-7e1cf8595a2b",
     school_name: "Springfield Elementary",
     candidate_name: "Kearney Zzyzwicz",
     placement_schedule: "2022-03-04 for 3 days",
@@ -16,6 +16,8 @@ describe NotifyEmail::CandidateBookingConfirmation do
     school_teacher_email: "ednak@springfield.co.uk",
     school_teacher_telephone: "01234 234 1245",
     placement_details: "You will shadow a teacher and assist with lesson planning",
+    candidate_instructions: "Report to reception on arrival",
+    subject_name: "Biology",
     cancellation_url: 'https://example.com/candiates/cancel/abc-123'
 
   describe ".from_booking" do
@@ -35,12 +37,7 @@ describe NotifyEmail::CandidateBookingConfirmation do
 
     let!(:pr) { create(:bookings_placement_request, school: school) }
     let!(:booking) do
-      create(
-        :bookings_booking,
-        bookings_school: school,
-        bookings_placement_request: pr,
-        placement_details: 'something'
-      )
+      create :bookings_booking, :accepted, bookings_placement_request: pr
     end
 
     let!(:cancellation_url) { "https://example.com/candidates/cancel/#{booking.token}" }
@@ -106,17 +103,20 @@ describe NotifyEmail::CandidateBookingConfirmation do
       end
 
       specify 'placement_details is correctly-assigned' do
-        expect(subject.placement_details).to eql(booking.placement_details)
+        expect(subject.placement_details).to eql(school.profile.experience_details)
+      end
+
+      specify 'candidate_instructions are correctly-assigned' do
+        expect(subject.candidate_instructions).to eql(booking.candidate_instructions)
+      end
+
+      specify 'subject_name is correctly-assigned' do
+        expect(subject.subject_name).to eql(booking.bookings_subject.name)
       end
 
       specify 'cancellation_url is correctly-assigned' do
         expect(subject.cancellation_url).to eql(cancellation_url)
       end
-    end
-
-    context 'with nil placemement_details' do
-      before { booking.placement_details = nil }
-      specify { expect(subject.placement_details).to eql('') }
     end
   end
 end

--- a/spec/notify/notify_email/candidate_booking_date_changed_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_date_changed_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe NotifyEmail::CandidateBookingDateChanged do
-  it_should_behave_like "email template", "b02bb4c7-ae3a-466a-8d2d-5bda3c45ff6a",
+  it_should_behave_like "email template", "3c1fd380-db1c-4efb-8e98-f3a0ef3e2661",
     school_name: "Springfield Elementary",
     candidate_name: "Kearney Zzyzwicz",
     placement_schedule: "2022-03-04 for 3 days",
@@ -16,7 +16,9 @@ describe NotifyEmail::CandidateBookingDateChanged do
     school_teacher_email: "ednak@springfield.co.uk",
     school_teacher_telephone: "01234 234 1245",
     placement_details: "You will shadow a teacher and assist with lesson planning",
+    candidate_instructions: "Please report to reception on arrival",
     cancellation_url: 'https://example.com/candiates/cancel/abc-123',
+    subject_name: 'Biology',
     old_date: '24 July 2019',
     new_date: '28 July 2019'
 
@@ -38,11 +40,7 @@ describe NotifyEmail::CandidateBookingDateChanged do
 
     let!(:pr) { create(:bookings_placement_request, school: school) }
     let!(:booking) do
-      create(
-        :bookings_booking,
-        bookings_school: school,
-        bookings_placement_request: pr
-      )
+      create :bookings_booking, :accepted, bookings_placement_request: pr
     end
 
     let!(:cancellation_url) { "https://example.com/candidates/cancel/#{booking.token}" }
@@ -108,7 +106,15 @@ describe NotifyEmail::CandidateBookingDateChanged do
       end
 
       specify 'placement_details is correctly-assigned' do
-        expect(subject.placement_details).to eql(booking.placement_details.to_s)
+        expect(subject.placement_details).to eql(profile.experience_details)
+      end
+
+      specify 'candidate_instructions' do
+        expect(subject.candidate_instructions).to eql(booking.candidate_instructions)
+      end
+
+      specify 'subject_name' do
+        expect(subject.subject_name).to eql(booking.bookings_subject.name)
       end
 
       specify 'cancellation_url is correctly-assigned' do


### PR DESCRIPTION
### JIRA Ticket Number

SE-2127

### Context

There are a few issues with the emails which go out to candidates confirming bookings.

1. The emails to candidates do not include the 'candidate experience' information from the schools profile, they instead include the old phase 1 information.
2. The candidate instructions added as part of the Accept a Booking process are never sent to the candidate.
3. The subject is not included in the email
4. The layout of the preview email doesn't accurately reflect the email the candidate receives.

### Changes proposed in this pull request

1. Include Subject, and Candidate Instructions
2. Re-order the layout to reflect the email preview screen
3. Use the profile candidate experience instead of the old Phase 1 info on both the preview screen and on the email screen.



