### PR TITLE
Standardise back links

### DIFF
--- a/app/helpers/link_and_button_helper.rb
+++ b/app/helpers/link_and_button_helper.rb
@@ -9,6 +9,17 @@ module LinkAndButtonHelper
     button_to(*args, link_defaults(classes).deep_merge(options), &block)
   end
 
+  def govuk_back_link(path = :back, text: 'Back', javascript: false, **options)
+    if javascript
+      options[:data] ||= {}
+      options[:data][:controller] = "back-link #{options[:data][:controller]}".strip
+    end
+
+    options[:class] = "govuk-back-link #{options[:class]}".strip
+
+    link_to text, path, **options
+  end
+
 private
 
   def link_defaults(classes)

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -1,5 +1,5 @@
 <% self.page_title = 'Request a school experience date' %>
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-full">

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -1,5 +1,5 @@
 <% self.page_title = "School experience placements #{ describe_current_search @search }" %>
-<%= link_to 'Back', new_candidates_school_search_path(school_new_search_params), class: 'govuk-back-link' %>
+<%= govuk_back_link new_candidates_school_search_path(school_new_search_params) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -1,8 +1,6 @@
 <% self.page_title = @school.name %>
 
-<%= link_to 'Back', :back,
-            class: 'govuk-back-link',
-            data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <h1 class="govuk-heading-l govuk-!-margin-top-4"><%= @school.name %></h1>
 

--- a/app/views/cookie_preferences/edit.html.erb
+++ b/app/views/cookie_preferences/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= link_to 'Back', :back, class: 'govuk-back-link' %>
+    <%= govuk_back_link %>
 
     <%= page_heading 'Edit your cookie settings' %>
 

--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <article class="govuk-grid-column-full">
-    <%= link_to 'Back', :back, class: 'govuk-back-link', data: { controller: 'back-link' } %>
+    <%= govuk_back_link javascript: true %>
 
     <%= page_heading do %>
       Accessibility statement for the school experience service

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= link_to 'Back', :back, class: 'govuk-back-link' %>
+    <%= govuk_back_link %>
 
     <%= page_heading 'Cookies' %>
 

--- a/app/views/pages/dfe_signin_help.html.erb
+++ b/app/views/pages/dfe_signin_help.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'Back', :back, class: 'govuk-back-link' %>
+<%= govuk_back_link %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/help_and_support_access_needs.html.erb
+++ b/app/views/pages/help_and_support_access_needs.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to 'Back', :back, class: 'govuk-back-link' %>
+    <%= govuk_back_link %>
 
     <%= page_heading do %>
       Help and support candidates with disability and access needs

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= link_to 'Back', (request.referer || candidates_root_path), class: 'govuk-back-link' %>
+    <%= govuk_back_link (request.referer || candidates_root_path) %>
 
     <%= page_heading do %>
       Privacy Notice: Get Into Teaching Information Service

--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -1,6 +1,6 @@
 <% self.page_title = 'Privacy policy - Schools' %>
 
- <%= link_to 'Back', :back, class: 'govuk-back-link' %>
+<%= govuk_back_link %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -1,6 +1,6 @@
 <%- self.page_title = "Confirm attendance" -%>
 
-<%= link_to 'Back', schools_dashboard_path, class: 'govuk-back-link' %>
+<%= govuk_back_link schools_dashboard_path %>
 
 <h1>Confirm attendance</h1>
 

--- a/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
@@ -1,5 +1,5 @@
 <%- self.page_title = "Review and send cancellation email to candidate" %>
-<%= link_to 'Back', schools_dashboard_path, class: 'govuk-back-link' %>
+<%= govuk_back_link schools_dashboard_path %>
 
 <%= form_for cancellation, url: schools_booking_cancellation_path do |f| %>
   <div class="govuk-grid-row">

--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-     <%= link_to 'Back', schools_booking_path(@booking), class: 'govuk-back-link' %>
+     <%= govuk_back_link schools_booking_path(@booking) %>
 
      <%= GovukElementsErrorsHelper.error_summary @booking, 'There is a problem', '' %>
 

--- a/app/views/schools/confirmed_bookings/date/uneditable.html.erb
+++ b/app/views/schools/confirmed_bookings/date/uneditable.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= link_to 'Back', schools_booking_path(@booking), class: 'govuk-back-link' %>
+    <%= govuk_back_link schools_booking_path @booking %>
 
     <%= page_heading 'Booking date cannot be edited' %>
 

--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -7,7 +7,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/access_needs_details/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_details/_form.html.erb
@@ -7,7 +7,7 @@
   }
 -%>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for access_needs_detail, url: schools_on_boarding_access_needs_detail_path, method: method do |f| %>

--- a/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
@@ -7,7 +7,7 @@
   }
 -%>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
@@ -7,7 +7,7 @@
   }
 -%>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for access_needs_support, url: schools_on_boarding_access_needs_support_path, method: method do |f| %>

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -7,7 +7,7 @@
   }
 -%>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
@@ -7,7 +7,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -7,7 +7,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -7,7 +7,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
@@ -6,7 +6,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -7,7 +7,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/disability_confidents/_form.html.erb
+++ b/app/views/schools/on_boarding/disability_confidents/_form.html.erb
@@ -7,7 +7,7 @@
   }
 -%>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/experience_outlines/_form.html.erb
+++ b/app/views/schools/on_boarding/experience_outlines/_form.html.erb
@@ -7,7 +7,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -6,7 +6,7 @@
     'Do you charge fees to cover any of the following?' => nil
   }
 %>
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -7,7 +7,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -6,7 +6,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/previews/show.html.erb
+++ b/app/views/schools/on_boarding/previews/show.html.erb
@@ -1,8 +1,6 @@
 <% self.page_title = @school.name %>
 
-<%= link_to 'Back', schools_on_boarding_profile_path,
-            class: 'govuk-back-link',
-            data: {controller: 'back-link'} %>
+<%= govuk_back_link schools_on_boarding_profile_path, javascript: true %>
 
 <h1 class="govuk-heading-l govuk-!-margin-top-4">
   Preview your school experience profile

--- a/app/views/schools/on_boarding/subjects/_form.html.erb
+++ b/app/views/schools/on_boarding/subjects/_form.html.erb
@@ -6,7 +6,7 @@
   }
 %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -1,6 +1,6 @@
 <% self.page_title = 'Set date options' %>
 
-<%= link_to 'Back', schools_placement_dates_path, class: 'govuk-back-link' %>
+<%= govuk_back_link schools_placement_dates_path %>
 
 <h1><%= @placement_date.date.to_formatted_s :govuk %> (<%= pluralize @placement_date.duration, 'day' %>)</h1>
 

--- a/app/views/schools/placement_dates/subject_selections/new.html.erb
+++ b/app/views/schools/placement_dates/subject_selections/new.html.erb
@@ -1,7 +1,6 @@
 <% self.page_title = 'Select school experience subjects' %>
 
-<%= link_to 'Back', new_schools_placement_date_configuration_path, class: 'govuk-back-link' %>
-
+<%= govuk_back_link new_schools_placement_date_configuration_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <%- self.page_title = "Confirm booking" %>
 

--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'Back', :back, class: 'govuk-back-link', data: {controller: 'back-link'} %>
+<%= govuk_back_link javascript: true %>
 
 <%- self.page_title = "Confirm booking" %>
 

--- a/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
+++ b/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
@@ -1,6 +1,6 @@
 <%- self.page_title = "Send details to candidate" %>
 
-<%= link_to "Back", new_schools_placement_request_acceptance_make_changes_path(@placement_request), class: 'govuk-back-link', data: { controller: 'back-link' } %>
+<%= govuk_back_link new_schools_placement_request_acceptance_make_changes_path(@placement_request), javascript: true %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_requests/cancellations/_form.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_form.html.erb
@@ -1,6 +1,6 @@
 <%- self.page_title = "Review and send rejection email to candidate" %>
 
-<%= link_to 'Back', schools_placement_requests_path, class: 'govuk-back-link' %>
+<%= govuk_back_link schools_placement_requests_path %>
 
 <%= form_for cancellation, url: schools_placement_request_cancellation_path do |f| %>
   <div class="govuk-grid-row">

--- a/app/views/schools/placement_requests/index.html.erb
+++ b/app/views/schools/placement_requests/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= link_to 'Back', schools_dashboard_path, class: 'govuk-back-link' %>
+    <%= govuk_back_link schools_dashboard_path %>
 
     <h1>Manage requests</h1>
 
@@ -13,7 +13,7 @@
     <p>
       You'll need to refer to <strong>your own records</strong> for any requests received before this date.
     </p>
-    
+
     <% if @placement_requests.any? %>
       <%= pagination_bar @placement_requests %>
 
@@ -26,7 +26,7 @@
       <p>
         There are no requests.
       </p>
-    <% end %>    
+    <% end %>
 
     <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path, secondary: true %>
   </div>

--- a/app/views/schools/placement_requests/reject/new.html.erb
+++ b/app/views/schools/placement_requests/reject/new.html.erb
@@ -1,6 +1,6 @@
 <%- self.page_title = 'Reject request' -%>
 
-<%= link_to 'Back', schools_dashboard_path, class: 'govuk-back-link' %>
+<%= govuk_back_link schools_dashboard_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -8,7 +8,7 @@
   }
 %>
 
-<%= link_to 'Back', schools_placement_requests_path, class: 'govuk-back-link' %>
+<%= govuk_back_link schools_placement_requests_path %>
 
 <% if @placement_request.candidate_cancellation&.sent? %>
   <h1><%= @gitis_contact.full_name %> has withdrawn their request</h1>

--- a/app/views/shared/failed_gitis_connection.html.erb
+++ b/app/views/shared/failed_gitis_connection.html.erb
@@ -1,6 +1,6 @@
 <%- self.page_title = "Sorry, the information is unavailable" %>
 
-<%= link_to 'Back', :back, class: 'govuk-back-link' %>
+<%= govuk_back_link %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/spec/helpers/link_and_button_helper_spec.rb
+++ b/spec/helpers/link_and_button_helper_spec.rb
@@ -78,4 +78,49 @@ describe LinkAndButtonHelper do
   describe '#govuk_button_to' do
     include_examples 'govuk-styled links and buttons', 'govuk_button_to', 'input'
   end
+
+  describe '#govuk_back_link' do
+    context 'without params' do
+      subject { govuk_back_link }
+      it { is_expected.to have_content 'Back' }
+      it { is_expected.to have_css 'a.govuk-back-link' }
+      it { is_expected.not_to have_css 'a[data-controller]' }
+    end
+
+    context 'with title' do
+      subject { govuk_back_link text: 'Dashboard' }
+      it { is_expected.to have_content 'Dashboard' }
+      it { is_expected.to have_css 'a.govuk-back-link' }
+      it { is_expected.not_to have_css 'a[data-controller]' }
+    end
+
+    context 'with title and js enabled' do
+      subject { govuk_back_link text: 'Dashboard', javascript: true }
+      it { is_expected.to have_content 'Dashboard' }
+      it { is_expected.to have_css 'a.govuk-back-link' }
+      it { is_expected.to have_css 'a[data-controller="back-link"]' }
+    end
+
+    context 'with custom class' do
+      subject { govuk_back_link class: 'some-other' }
+      it { is_expected.to have_content 'Back' }
+      it { is_expected.to have_css 'a.govuk-back-link.some-other' }
+      it { is_expected.not_to have_css 'a[data-controller]' }
+    end
+
+    context 'with javascript and custom data controller' do
+      subject { govuk_back_link javascript: true, data: { controller: 'test' } }
+      it { is_expected.to have_content 'Back' }
+      it { is_expected.to have_css 'a.govuk-back-link' }
+      it { is_expected.to have_css 'a[data-controller="back-link test"]' }
+    end
+
+    context 'with back path', :focus do
+      subject { govuk_back_link '/test' }
+      it { is_expected.to have_content 'Back' }
+      it { is_expected.to have_css 'a.govuk-back-link' }
+      it { is_expected.to have_css 'a[href="/test"]' }
+      it { is_expected.not_to have_css 'a[data-controller="back-link"]' }
+    end
+  end
 end


### PR DESCRIPTION
### Context

Refactor: We have many back links throughout the site - replace these with a standard helper to avoid duplication and allow for consistent future updates.

### Changes proposed in this pull request

1. Add `govuk_back_link` helper
2. Replace numerous back links with the helper to DRY out view code

