### PR TITLE
Dont validate format of contact_email and number when recording Attendance

### DIFF
--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -40,9 +40,9 @@ module Bookings
 
     validates :contact_name, presence: true, on: %i(create acceptance)
     validates :contact_number, presence: true, on: %i(create acceptance)
-    validates :contact_number, phone: true, if: -> { contact_number.present? }
+    validates :contact_number, phone: true, on: %i(create acceptance), if: -> { contact_number.present? }
     validates :contact_email, presence: true, on: %i(create acceptance)
-    validates :contact_email, email_format: true, if: -> { contact_email.present? }
+    validates :contact_email, email_format: true, on: %i(create acceptance), if: -> { contact_email.present? }
 
     validates :candidate_instructions, presence: true, on: :acceptance_email_preview
 

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -46,6 +46,11 @@ describe Bookings::Booking do
     it { is_expected.to validate_presence_of(:contact_name).on(:acceptance) }
     it { is_expected.to validate_presence_of(:contact_number).on(:acceptance) }
     it { is_expected.to validate_presence_of(:contact_email).on(:acceptance) }
+
+    it { is_expected.not_to allow_value('0123').for(:contact_number).on(:create) }
+    it { is_expected.not_to allow_value('0123').for(:contact_number).on(:acceptance) }
+    it { is_expected.to allow_value('0123').for(:contact_number).on(:attendance) }
+
     it { is_expected.to validate_email_format_of(:contact_email).with_message('Enter a valid contact email address') }
 
     it { is_expected.to allow_value(true).for(:attended).on(:attendance) }


### PR DESCRIPTION
### JIRA Ticket Number

SE-2107

### Context

Previously I'd changed the validations to not check for presence of email or phone number when marking Attendance on bookings. Turns out we have some historical bookings with phone numbers present but invalid.

### Changes proposed in this pull request

1. Don't validate the format of phone numbers or emails when marking attendance



