### PR TITLE
Include page title on education form

### DIFF
--- a/app/views/candidates/registrations/educations/_form.html.erb
+++ b/app/views/candidates/registrations/educations/_form.html.erb
@@ -1,6 +1,5 @@
-<h1 class="govuk-heading-l">
-  We need some more details
-</h1>
+<%= page_heading 'We need some more details' %>
+
 <p>
   The following will be used to help schools offer you school experience.
 </p>


### PR DESCRIPTION
### JIRA Ticket Number

SE-2132

### Context

The education details step on the Candidate application process is missing a page title.

### Changes proposed in this pull request

1. Added missing page title



