### PR TITLE
Simplified Dfe Sign-in role check

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -1,4 +1,5 @@
 class Bookings::School < ApplicationRecord
+  self.ignored_columns += %w(dfe_signin_organisation_uuid)
   include FullTextSearch
   include GeographicSearch
 

--- a/app/services/schools/dfe_sign_in_api/roles.rb
+++ b/app/services/schools/dfe_sign_in_api/roles.rb
@@ -3,15 +3,25 @@ module Schools
     class NoOrganisationError < RuntimeError; end
 
     class Roles < Client
-      attr_accessor :user_uuid, :urn
+      attr_accessor :user_uuid, :organisation_uuid
 
-      def initialize(user_uuid, urn)
-        self.user_uuid = user_uuid
-        self.urn       = urn
+      class << self
+        def service_id
+          ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID')
+        end
+
+        def role_id
+          ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID')
+        end
+      end
+
+      def initialize(user_uuid, organisation_uuid)
+        self.user_uuid          = user_uuid
+        self.organisation_uuid  = organisation_uuid
       end
 
       def has_school_experience_role?
-        roles.any? { |role| role['id'] == ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID') }
+        roles.any? { |role| role['id'] == self.class.role_id }
       end
 
     private
@@ -26,35 +36,17 @@ module Schools
         @response.fetch('roles')
       end
 
-      # rather than request the UUID every time, as there's a 1:1 mapping with URN
-      # on the DfE Sign-in end store it with the School
-      def organisation_uuid
-        find_organisation_uuid || retrieve_organisation_uuid
-      end
-
-      def find_organisation_uuid
-        Bookings::School
-          .select(:dfe_signin_organisation_uuid)
-          .find_by(urn: urn)
-          &.dfe_signin_organisation_uuid
-      end
-
-      def retrieve_organisation_uuid
-        Schools::DFESignInAPI::Organisations
-          .new(user_uuid)
-          .id(urn)
-          .tap do |org_uuid|
-            fail NoOrganisationError, "No organisation ID found for user #{user_uuid}" unless org_uuid.present?
-
-            Bookings::School.find_by(urn: urn).update!(dfe_signin_organisation_uuid: org_uuid)
-          end
+      def response
+        super
+      rescue Faraday::ResourceNotFound
+        fail NoOrganisationError, "No organisation ID found for user #{user_uuid}"
       end
 
       def endpoint
         URI::HTTPS.build(
           host: Rails.configuration.x.dfe_sign_in_api_host,
           path: [
-            '/services',     ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID'),
+            '/services',     self.class.service_id,
             'organisations', organisation_uuid,
             'users',         user_uuid
           ].join('/')

--- a/spec/controllers/schools/session_context.rb
+++ b/spec/controllers/schools/session_context.rb
@@ -14,7 +14,7 @@ shared_context "logged in DfE user" do
   let(:dfe_signin_admin_role_id) { '66666666-5555-4444-3333-222222222222' }
 
   let(:dfe_signin_role_data) do
-    { roles: [{ id: '66666666-5555-4444-3333-222222222222' }] }
+    { roles: [{ id: dfe_signin_admin_role_id }] }
   end
 
   before do
@@ -55,7 +55,7 @@ shared_context "logged in DfE user" do
         headers: {}
       )
 
-    stub_request(:get, "https://some-signin-host.signin.education.gov.uk/services/#{dfe_signin_admin_service_id}/organisations/33333333-aaaa-5555-bbbb-777777777777/users/33333333-4444-5555-6666-777777777777")
+    stub_request(:get, "https://some-signin-host.signin.education.gov.uk/services/#{dfe_signin_admin_service_id}/organisations/#{dfe_signin_school_id}/users/#{user_guid}")
       .to_return(
         status: 200,
         body: dfe_signin_role_data.to_json,

--- a/spec/services/schools/dfe_sign_in_api/roles_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/roles_spec.rb
@@ -3,7 +3,7 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::DFESignInAPI::Roles do
   include_context "logged in DfE user"
-  subject { described_class.new(user_guid, dfe_signin_school_urn) }
+  subject { described_class.new(user_guid, dfe_signin_school_id) }
 
   before do
     allow_any_instance_of(Schools::DFESignInAPI::Client).to receive(:enabled?).and_return(true)
@@ -16,43 +16,13 @@ describe Schools::DFESignInAPI::Roles do
 
   context '#has_school_experience_role?' do
     context 'when the role is present' do
-      let!(:school) { create(:bookings_school, urn: dfe_signin_school_urn) }
-
-      subject { described_class.new(user_guid, dfe_signin_school_urn) }
-
       specify 'should return true when the role is present' do
         expect(subject.has_school_experience_role?).to be true
-      end
-
-      specify 'should save the DfE Sign-in organisation UUID' do
-        expect(school.dfe_signin_organisation_uuid).to be nil
-        subject.has_school_experience_role?
-        expect(school.reload.dfe_signin_organisation_uuid).to eql(dfe_signin_school_id)
-      end
-
-      context 'when the DfE Sign-in organisation UUID has been saved' do
-        let!(:school) { create(:bookings_school, urn: dfe_signin_school_urn, dfe_signin_organisation_uuid: dfe_signin_school_id) }
-
-        before { allow(subject).to receive(:retrieve_organisation_uuid).and_return(true) }
-        before { allow(subject).to receive(:find_organisation_uuid).and_return(dfe_signin_school_id) }
-        before { subject.has_school_experience_role? }
-
-        specify 'should find the school to get the organisation uuid' do
-          expect(subject).to have_received(:find_organisation_uuid)
-        end
-
-        specify 'should not need to contact the DfE Sign-in API' do
-          expect(subject).to_not have_received(:retrieve_organisation_uuid)
-        end
       end
     end
 
     context 'when the role is not present' do
-      subject { described_class.new(user_guid, dfe_signin_school_urn) }
-
-      before do
-        allow(subject).to receive(:roles).and_return([])
-      end
+      before { allow(described_class).to receive(:role_id) { SecureRandom.uuid } }
 
       specify 'should return false when the role is absent' do
         expect(subject.has_school_experience_role?).to be false
@@ -60,20 +30,26 @@ describe Schools::DFESignInAPI::Roles do
     end
 
     context 'when the user is not associated with the organisation' do
-      let(:another_urn) { 112233 }
+      let(:org_uuid) { SecureRandom.uuid }
+      before do
+        stub_request(:get, "https://some-signin-host.signin.education.gov.uk/services/#{dfe_signin_admin_service_id}/organisations/#{org_uuid}/users/#{user_guid}")
+          .to_return(
+            status: 404,
+            body: "404 Not Found",
+            headers: {}
+          )
+      end
 
-      subject { described_class.new(user_guid, another_urn) }
+      subject { described_class.new(user_guid, org_uuid) }
 
       specify "should raise an 'no organisation' error" do
+#        expect(subject.has_school_experience_role?).to be false
         expect { subject.has_school_experience_role? }.to raise_error(Schools::DFESignInAPI::NoOrganisationError, /No organisation ID found for user/)
       end
     end
 
     context 'when no result is returned' do
-      before do
-        allow(subject).to receive(:response).and_return(nil)
-      end
-
+      before { allow(subject).to receive(:response).and_return(nil) }
       subject { described_class.new(user_guid, dfe_signin_school_urn) }
 
       specify "should raise an 'invalid response' error" do


### PR DESCRIPTION
### JIRA Ticket Number

SE-2135

### Context

Previously this was doing its own translation (and caching) of the Schools
organisation id. Instead use the organisation id provided by DfE Sign-in and
avoid caching these in the database.

This resolves a bug where if the DfE Sign-in user belonged to organisations
which were not part of the service, than the database could not update the
cached copy of the organisations uuid.

### Changes proposed in this pull request

1. Changed the API check to use an dfe sign-in org uuid instead of urn
2. Remove the URN <-> Org UUID translation code



