### PR TITLE
Fix for legacy service update route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get '/cookies_policy', to: 'pages#cookies_policy'
   get '/schools_privacy_policy', to: 'pages#schools_privacy_policy'
   resources :service_updates, only: %i(index show)
-  get '/service_update', to: 'pages#service_update'
+  get '/service_update', to: 'service_updates#index'
   get '/help_and_support_access_needs', to: 'pages#help_and_support_access_needs'
   get '/dfe_signin_help', to: 'pages#dfe_signin_help'
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-1378

### Context

Service updates feature was added but support for the pre-existing route hadn't been updated even though the existing page had been removed. This resulted in errors when attempting to access the missing page.

### Changes proposed in this pull request

1. Update the legacy route to point to the new ServiceUpdates#index



