### PR TITLE
Always check for presence of date, not only on create

### DIFF
--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -16,8 +16,8 @@ module Bookings
     has_one :school_cancellation, through: :bookings_placement_request
 
     validates :date,
-      presence: true,
-      on: :create
+      presence: true
+
     validates :date,
       if: -> { date_changed? },
       timeliness: {

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -64,12 +64,14 @@ describe Bookings::Booking do
         specify 'should allow future dates' do
           [Date.tomorrow, 3.days.from_now, 3.weeks.from_now, 3.months.from_now].each do |d|
             expect(subject).to allow_value(d).for(:date)
+            expect(subject).to allow_value(d).for(:date).on(:acceptance)
           end
         end
 
         specify 'new placement dates should not allow historic dates' do
-          [Date.yesterday, 3.days.ago, 3.weeks.ago, 3.years.ago].each do |d|
+          [Date.yesterday, 3.days.ago, 3.weeks.ago, 3.years.ago, nil].each do |d|
             expect(subject).not_to allow_value(d).for(:date)
+            expect(subject).not_to allow_value(d).for(:date).on(:acceptance)
           end
         end
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-2138

### Context

Currently we only check for the presence of date on create, which means we try (and fail) to insert a null booking date into the database

This appears to be a hangover from when the date's 'futureness' was part of the same validation as the check for presence.

### Changes proposed in this pull request

1. Make the presence check always run, irrespective of context



