### PR TITLE
Skip verify_authenticity_token for cookie preferences

### DIFF
--- a/app/controllers/cookie_preferences_controller.rb
+++ b/app/controllers/cookie_preferences_controller.rb
@@ -1,5 +1,6 @@
 class CookiePreferencesController < ApplicationController
   REFERER_BLACKLIST = %r{/(cookie_preference|cookies_policy)}.freeze
+  skip_before_action :verify_authenticity_token, only: %i(update)
   before_action :save_refererer
 
   def show


### PR DESCRIPTION
### JIRA Ticket Number

SE-2097

### Context

If the user has left the page open for an extended period of time, then it is
likely the token will expire. If they then return and click 'accept' they will
see an unexpected session expired message.

The update action only sets a cookie on the users web browser so it is safe to
not check the authenticity token, I am disabling it to avoid the user seeing
the error unnecessarily.

### Changes proposed in this pull request

1. Disable the authenticity token check on the cookie preferences controller



