### PR TITLE
SE-2142 Allow de-activating DfE Sign In logins

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,5 +1,25 @@
 class SchoolsController < ApplicationController
   include DFEAuthentication
 
-  def show; end
+  def show
+    @signin_deactivated, @signin_message = parse_env_var
+  end
+
+private
+
+  def parse_env_var
+    if env_var.in? %w(1 true yes)
+      true
+    elsif env_var.in? %w(0 false no)
+      false
+    elsif env_var.present?
+      [true, env_var]
+    else
+      false
+    end
+  end
+
+  def env_var
+    ENV['DFE_SIGNIN_DEACTIVATED'].to_s
+  end
 end

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -28,11 +28,34 @@
           </p>
         </section>
 
-        <%= govuk_link_to schools_dashboard_path,
-          role:'button',
-          class:'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' do %>
-          Start now <%= render 'shared/start_button_chevron' %>
-        <% end %>
+        <%- if @signin_deactivated -%>
+          <div id="dfe-signin-deactivated" class="govuk-inset-text">
+            <p>
+              Sign-ins to this service are currently unavailable.
+            </p>
+
+            <p>
+              <%- if @signin_message -%>
+                <%= @signin_message %>
+              <%- else -%>
+                You will be able to use this service later today.
+              <%- end -%>
+            </p>
+
+            <p>
+              Contact
+              <a href="mailto:organise.school-experience@education.gov.uk">
+                organise.school-experience@education.gov.uk
+              </a> if you need further information.
+            </p>
+          </div>
+        <%- else -%>
+          <%= govuk_link_to schools_dashboard_path,
+            role:'button',
+            class:'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' do %>
+            Start now <%= render 'shared/start_button_chevron' %>
+          <% end %>
+        <%- end -%>
 
         <section>
           <h2 class="govuk-heading-m">Before you start</h2>

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -2,21 +2,68 @@ require 'rails_helper'
 require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe SchoolsController, type: :request do
-  describe 'redirecting logged-in users to the dashboard' do
-    context 'when no user is logged in' do
-      before { get '/schools' }
+  describe '#show' do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('DFE_SIGNIN_DEACTIVATED') { toggle }
+    end
 
-      specify 'should not be redirected anywhere' do
-        expect(response).to render_template :show
+    subject { get '/schools'; response }
+
+    context 'when sign in is enabled' do
+      let(:toggle) { 'false' }
+
+      specify 'should render the correct template' do
+        is_expected.to have_rendered :show
+      end
+
+      specify 'should show login button' do
+        expect(subject.body).to match %r(govuk-button--start)
+      end
+
+      specify 'should not show disabled message' do
+        expect(subject.body).not_to match %r(id="dfe-sigin-deactivated)
       end
     end
-  end
 
-  describe '#show' do
-    before { get '/schools' }
+    context 'when sign in is disabled with default message' do
+      let(:toggle) { '1' }
 
-    specify 'should render the correct template' do
-      expect(response).to render_template :show
+      specify 'should render the correct template' do
+        is_expected.to have_rendered :show
+      end
+
+      specify 'should not show login button' do
+        expect(subject.body).not_to match %r(govuk-button--start)
+      end
+
+      specify 'should show disabled message' do
+        expect(subject.body).to match %r(id="dfe-signin-deactivated)
+      end
+
+      specify 'should show default message' do
+        expect(subject.body).to match %r(use this service later today)
+      end
+    end
+
+    context 'when sign in is disabled with custom message' do
+      let(:toggle) { 'custom message' }
+
+      specify 'should render the correct template' do
+        is_expected.to have_rendered :show
+      end
+
+      specify 'should not show login button' do
+        expect(subject.body).not_to match %r(govuk-button--start)
+      end
+
+      specify 'should show disabled message' do
+        expect(subject.body).to match %r(id="dfe-signin-deactivated)
+      end
+
+      specify 'should show custom message' do
+        expect(subject.body).to match %r(custom message)
+      end
     end
   end
 end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2142

### Context

In the event the DfE Sign-in service is unavailable it is desirable to explain this to our users and not present them with an login button which wont work

### Changes proposed in this pull request

1. Add support for replacing the sign in button with a message explaining the service is disabled, controlled via an environment variable



