### PR TITLE
Fix lint unreliability in CI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,15 @@ Metrics/BlockLength:
 Layout/ArgumentAlignment:
   Enabled: false
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Style/StringLiterals:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,12 @@ Style/TrailingCommaInHashLiteral:
 Rails/FilePath:
   EnforcedStyle: arguments
 
+# Excluded for cancellation because we use the same model for both school
+# and candidate cancellations
+Rails/InverseOf:
+  Exclude:
+    - app/models/bookings/placement_request/cancellation.rb
+
 Rails/RakeEnvironment:
   Exclude:
     - lib/tasks/dev_ssl_generator.rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,26 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
 Metrics/BlockLength:
   Exclude:
     - config/**/*
     - spec/**/*
     - spec_external/**/*
+
+Layout/ArgumentAlignment:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
+Rails/DynamicFindBy:
+  Enabled: false
+
 Rails/FilePath:
   EnforcedStyle: arguments
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,5 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
+Rails/FilePath:
+  EnforcedStyle: arguments

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,3 +26,8 @@ Style/TrailingCommaInHashLiteral:
 
 Rails/FilePath:
   EnforcedStyle: arguments
+
+Rails/RakeEnvironment:
+  Exclude:
+    - lib/tasks/dev_ssl_generator.rake
+    - lib/tasks/cucumber.rake

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,11 +24,22 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
+# Excluded because all our jobs are set to retry by default, we dont want that
+# logic applied to CronJobs so we are inheriting from ApplicationJobs parent to
+# solve this.
+Rails/ApplicationJob:
+  Exclude:
+    - app/jobs/cron_job.rb
+
 Rails/DynamicFindBy:
   Enabled: false
 
 Rails/FilePath:
   EnforcedStyle: arguments
+
+Rails/HttpPositionalArguments:
+  Exclude:
+    - spec/controllers/candidates/dashboard_base_controller_spec.rb
 
 # Excluded for cancellation because we use the same model for both school
 # and candidate cancellations

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,10 @@ Rails/RakeEnvironment:
   Exclude:
     - lib/tasks/dev_ssl_generator.rake
     - lib/tasks/cucumber.rake
+
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - servertest
+    - production

--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 
-  gem 'rubocop-govuk'
+  gem 'rubocop-govuk', require: false
 
   # Debugging
   gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -80,9 +80,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 
-  gem 'rubocop', '~> 0.65.0', require: false
-  # GOV.UK interpretation of rubocop for linting Ruby
-  gem 'govuk-lint', '3.11.0', require: false
+  gem 'rubocop-govuk'
 
   # Debugging
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,10 +163,6 @@ GEM
     gherkin (5.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (3.11.0)
-      rubocop (~> 0.64)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_elements_rails (3.1.3)
       govuk_frontend_toolkit (>= 6.0.2)
       rails (>= 4.1.0)
@@ -247,7 +243,6 @@ GEM
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     phonelib (0.6.42)
-    powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -256,7 +251,6 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    psych (3.1.0)
     public_suffix (4.0.3)
     puma (4.3.3)
       nio4r (~> 2.0)
@@ -315,6 +309,7 @@ GEM
       ffi (~> 1.0)
     redis (4.1.3)
     regexp_parser (1.7.0)
+    rexml (3.2.4)
     rgeo (2.1.1)
     rgeo-activerecord (6.2.1)
       activerecord (>= 5.0)
@@ -338,17 +333,23 @@ GEM
     rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.65.0)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
-      psych (>= 3.1.0)
+      parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
-    rubocop-rspec (1.35.0)
-      rubocop (>= 0.60.0)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (3.1.0)
+      rubocop (= 0.80.1)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
+    rubocop-rails (2.4.2)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    rubocop-rspec (1.38.1)
+      rubocop (>= 0.68.1)
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
@@ -367,8 +368,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -408,7 +407,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     uk_postcode (2.1.5)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.6.1)
     uniform_notifier (1.13.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
@@ -473,7 +472,6 @@ DEPENDENCIES
   faraday
   foreman
   geocoder
-  govuk-lint (= 3.11.0)
   govuk_elements_form_builder!
   kaminari
   listen (>= 3.0.5, < 3.3)
@@ -494,7 +492,7 @@ DEPENDENCIES
   redis (~> 4.1)
   rspec-rails (~> 3.9)
   rspec_junit_formatter
-  rubocop (~> 0.65.0)
+  rubocop-govuk
   sassc-rails
   selenium-webdriver
   sentry-raven

--- a/app/controllers/concerns/dfe_authentication.rb
+++ b/app/controllers/concerns/dfe_authentication.rb
@@ -10,6 +10,7 @@ module DFEAuthentication
       @current_user ||= session[:current_user]
     end
     alias_method :set_current_user, :current_user
+    helper_method :current_user
 
     def user_signed_in?
       current_user.present?

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -21,7 +21,7 @@ module Schools
 
     def current_school
       urn = session[:urn]
-      raise MissingURN, 'urn is missing, unable to match with school' unless urn.present?
+      raise MissingURN, 'urn is missing, unable to match with school' if urn.blank?
 
       @current_school ||= retrieve_school(urn)
     end
@@ -35,7 +35,7 @@ module Schools
 
     def retrieve_school(urn)
       unless (school = Bookings::School.find_by(urn: urn))
-        raise SchoolNotRegistered, "school #{urn} not found" unless school.present?
+        raise SchoolNotRegistered, "school #{urn} not found" if school.blank?
       end
 
       school

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -1,5 +1,5 @@
 class Schools::PlacementDatesController < Schools::BaseController
-  before_action :set_placement_date, only: %w(destroy edit update)
+  before_action :set_placement_date, only: %w(edit update)
 
   def index
     @placement_dates = current_school

--- a/app/controllers/schools/placement_requests/acceptance.rb
+++ b/app/controllers/schools/placement_requests/acceptance.rb
@@ -4,8 +4,7 @@ module Schools
       extend ActiveSupport::Concern
 
       def set_placement_request_and_fetch_gitis_contact
-        @placement_request = @current_school
-          .bookings_placement_requests
+        @placement_request = @current_school.placement_requests \
           .find(params[:placement_request_id])
 
         @placement_request.fetch_gitis_contact gitis_crm

--- a/app/forms/schools/on_boarding/candidate_experience_detail.rb
+++ b/app/forms/schools/on_boarding/candidate_experience_detail.rb
@@ -38,19 +38,19 @@ module Schools
       validates :times_flexible_details, presence: true, if: :times_flexible
 
       def self.compose(
-          business_dress,
-          cover_up_tattoos,
-          remove_piercings,
-          smart_casual,
-          other_dress_requirements,
-          other_dress_requirements_detail,
-          parking_provided,
-          parking_details,
-          nearby_parking_details,
-          start_time,
-          end_time,
-          times_flexible,
-          times_flexible_details
+        business_dress,
+        cover_up_tattoos,
+        remove_piercings,
+        smart_casual,
+        other_dress_requirements,
+        other_dress_requirements_detail,
+        parking_provided,
+        parking_details,
+        nearby_parking_details,
+        start_time,
+        end_time,
+        times_flexible,
+        times_flexible_details
       )
         new \
           business_dress: business_dress,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,10 +20,6 @@ module ApplicationHelper
     content_tag(:h1, title, **options)
   end
 
-  def site_header_text
-    @site_header_text || "Get school experience"
-  end
-
   def breadcrumbs
     content_for(:breadcrumbs)
   end
@@ -62,11 +58,11 @@ module ApplicationHelper
       locals: { key: key, value: value, action: action, id: id }
   end
 
-  def current_user_info_and_logout_link
+  def current_user_info_and_logout_link(user)
     logout_link = link_to("Logout", logout_schools_session_path)
 
-    greeting = if valid_user?(@current_user)
-                 "Welcome #{current_user_full_name}"
+    greeting = if valid_user?(user)
+                 "Welcome #{current_user_full_name user}"
                end
 
     switch_service = link_to("switch service", Rails.configuration.x.oidc_services_list_url)
@@ -74,10 +70,10 @@ module ApplicationHelper
     safe_join([greeting, logout_link, "or", switch_service].compact, " ")
   end
 
-  def current_user_full_name
-    return 'Unknown' unless valid_user?(@current_user)
+  def current_user_full_name(user)
+    return 'Unknown' unless valid_user?(user)
 
-    [@current_user.given_name, @current_user.family_name].join(' ')
+    [user.given_name, user.family_name].join(' ')
   end
 
   def phase_three_release_date

--- a/app/helpers/back_to_top_helper.rb
+++ b/app/helpers/back_to_top_helper.rb
@@ -1,12 +1,18 @@
 module BackToTopHelper
   def back_to_top_link
+    svg_icon = tag.svg \
+      class: 'app-back-to-top__icon',
+      xmlns: 'http://www.w3.org/2000/svg',
+      width: '13',
+      height: '17',
+      viewBox: '0 0 13 17' do
+      tag.path \
+        fill: 'currentColor',
+        d: 'M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z'
+    end
+
     link_to '#', class: 'govuk-link govuk-link--no-visited-state back-to-top' do
-      <<-HTML.squish.html_safe
-      <svg class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
-        <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>
-      </svg>
-      Back to top
-      HTML
+      safe_join [svg_icon, 'Back to top'], ' '
     end
   end
 end

--- a/app/helpers/candidates/maps_helper.rb
+++ b/app/helpers/candidates/maps_helper.rb
@@ -17,7 +17,7 @@ module Candidates::MapsHelper
   end
 
   def static_map_url(latitude, longitude, mapsize:, zoom: 10)
-    return unless ENV['BING_MAPS_KEY'].present?
+    return if ENV['BING_MAPS_KEY'].blank?
 
     location = "#{latitude},#{longitude}"
 
@@ -32,7 +32,7 @@ module Candidates::MapsHelper
   end
 
   def ajax_map(latitude, longitude, mapsize:, title: nil, description: nil, zoom: 10, described_by: nil)
-    return unless ENV['BING_MAPS_KEY'].present?
+    return if ENV['BING_MAPS_KEY'].blank?
 
     map_data = {
       controller: 'map',

--- a/app/helpers/candidates/maps_helper.rb
+++ b/app/helpers/candidates/maps_helper.rb
@@ -6,14 +6,11 @@ module Candidates::MapsHelper
   STATIC_MAP_URL = "#{BING_BASE_URL}/Imagery/Map/Road/{center_point}/{zoom_level}{?params*}".freeze
 
   def include_maps_in_head
-    return if @maps_included
-
-    content_for :head, javascript_include_tag(
-      "https://www.bing.com/api/maps/mapcontrol?callback=mapsLoadedCallback",
-      defer: true, async: true
-    )
-
-    @maps_included = true
+    content_for :head do
+      javascript_include_tag \
+        "https://www.bing.com/api/maps/mapcontrol?callback=mapsLoadedCallback",
+        defer: true, async: true
+    end
   end
 
   def static_map_url(latitude, longitude, mapsize:, zoom: 10)
@@ -31,7 +28,8 @@ module Candidates::MapsHelper
     tmpl.expand(params: params, zoom_level: zoom, center_point: location).to_s
   end
 
-  def ajax_map(latitude, longitude, mapsize:, title: nil, description: nil, zoom: 10, described_by: nil)
+  def ajax_map(latitude, longitude, mapsize:, title: nil, description: nil,
+    zoom: 10, described_by: nil, include_js_in_head: true)
     return if ENV['BING_MAPS_KEY'].blank?
 
     map_data = {
@@ -50,7 +48,7 @@ module Candidates::MapsHelper
       zoom: zoom
     )
 
-    include_maps_in_head
+    include_maps_in_head if include_js_in_head
 
     aria_attributes = {
       'aria-label': "Map showing #{title}"

--- a/app/helpers/candidates/maps_helper.rb
+++ b/app/helpers/candidates/maps_helper.rb
@@ -63,7 +63,6 @@ module Candidates::MapsHelper
     content_tag :div, class: "embedded-map", data: map_data, **aria_attributes do
       content_tag :div, class: 'embedded-map__inner-container',
         data: { target: 'map.container' } do
-
         image_tag static_url, class: "embedded-map__nojs-img", alt: "Map showing #{title}", **aria_attributes
       end
     end

--- a/app/helpers/candidates/results_helper.rb
+++ b/app/helpers/candidates/results_helper.rb
@@ -24,34 +24,6 @@ module Candidates::ResultsHelper
         ].min,
         total: school_search.total_count
       )
-    end.html_safe
-  end
-
-  def expanded_search_radius_header_text
-    if @search.has_coordinates?
-      "0 results found within #{pluralize(params[:distance], 'mile')}"
-    else
-      "0 results found"
-    end
-  end
-
-  def expanded_search_nearby_info_text
-    if @search.results.empty?
-      capture do
-        if @search.has_coordinates?
-          concat(tag.p { 'Not all schools in your area have signed up to use this website.' })
-        end
-
-        concat(tag.p do
-          <<~FIND_OUT_MORE
-            To find out about arranging school experience with schools who are
-            not yet on this website visit #{link_to('Get into teaching', 'https://getintoteaching.education.gov.uk/school-experience/arranging-school-experience-independently')}.
-          FIND_OUT_MORE
-          .html_safe
-        end)
-      end
-    else
-      tag.p { 'However, we did find the following schools nearby:' }.html_safe
     end
   end
 end

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -13,17 +13,18 @@ module Candidates::SchoolHelper
   def format_school_subjects(school)
     filtered_subject_ids = filtered_subject_ids(params[:subjects])
 
-    safe_subjects = school
-      .subjects
-      .ordered_by_name
-      .each
-      .with_object({}) { |subject, hash| hash[subject.name] = subject.id.in?(filtered_subject_ids) }
-      .map { |subject, bold| bold ? tag.strong(ERB::Util.h(subject)) : ERB::Util.h(subject) }
+    subjects = school.subjects.ordered_by_name.map do |subject|
+      if subject.id.in? filtered_subject_ids
+        tag.strong(subject.name)
+      else
+        subject.name
+      end
+    end
 
-    if safe_subjects.empty?
+    if subjects.empty?
       'Not specified'
     else
-      safe_subjects.to_sentence.html_safe
+      to_sentence subjects
     end
   end
 

--- a/app/helpers/link_and_button_helper.rb
+++ b/app/helpers/link_and_button_helper.rb
@@ -30,7 +30,7 @@ private
   end
 
   def link_classes(options)
-    classes = ['govuk-button'].tap do |c|
+    classes = %w(govuk-button).tap do |c|
       c << 'govuk-button--secondary' if options.delete(:secondary)
       c << 'govuk-button--warning'   if options.delete(:warning)
 

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -74,8 +74,8 @@ module Bookings
     scope :upcoming, -> { not_cancelled.accepted.future }
 
     scope :accepted, -> { where.not(accepted_at: nil) }
-    scope :previous, -> { where(arel_table[:date].lteq(Date.today)) }
-    scope :future, -> { where(arel_table[:date].gteq(Date.today)) }
+    scope :previous, -> { where(arel_table[:date].lteq(Time.zone.today)) }
+    scope :future, -> { where(arel_table[:date].gteq(Time.zone.today)) }
     scope :attendance_unlogged, -> { where(attended: nil) }
 
     scope :with_unviewed_candidate_cancellation, -> do
@@ -170,7 +170,7 @@ module Bookings
     end
 
     def in_future?
-      date > Date.today
+      date > Time.zone.today
     end
 
     def cancellable?

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -127,7 +127,7 @@ module Bookings
     def populate_contact_details
       last_booking = Bookings::Booking.last_accepted_booking_by(bookings_school)
 
-      return false unless last_booking.present?
+      return false if last_booking.blank?
 
       assign_attributes(
         contact_name: last_booking.contact_name,

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -14,6 +14,10 @@ class Bookings::Candidate < ApplicationRecord
               dependent: :destroy
 
   has_many :bookings, through: :placement_requests
+  has_many :events,
+    inverse_of: :bookings_candidate,
+    foreign_key: :bookings_candidate_id,
+    dependent: :destroy
 
   validates :gitis_uuid, presence: true, format: { with: Bookings::Gitis::Entity::ID_FORMAT }
   validates :gitis_uuid, uniqueness: { case_sensitive: false }

--- a/app/models/bookings/data/school_manager.rb
+++ b/app/models/bookings/data/school_manager.rb
@@ -21,7 +21,7 @@ module Bookings
         Bookings::School.transaction do
           urns.each do |row|
             Bookings::School.find_by(urn: row['urn']).tap do |bs|
-              fail "no school found with urn #{row['urn']}" unless bs.present?
+              fail "no school found with urn #{row['urn']}" if bs.blank?
 
               puts "Updating #{bs.name}, enabled: #{new_status}"
               if new_status

--- a/app/models/bookings/data/school_mass_importer.rb
+++ b/app/models/bookings/data/school_mass_importer.rb
@@ -32,7 +32,7 @@ module Bookings
 
             school = Bookings::School.find_by(urn: urn)
 
-            next unless school.present?
+            next if school.blank?
 
             assign_phases(school, row['PhaseOfEducation (code)'])
           end
@@ -86,7 +86,7 @@ module Bookings
       end
 
       def cleanup_website(urn, url)
-        return nil unless url.present?
+        return nil if url.blank?
 
         fail "invalid hostname for #{urn}, #{url}" unless url.split(".").size > 1
 
@@ -126,7 +126,7 @@ module Bookings
           urn:                     nilify(edubase_row['URN']),
           name:                    nilify(edubase_row['EstablishmentName']),
           website:                 cleanup_website(edubase_row['URN'], edubase_row['SchoolWebsite']),
-          contact_email:           email_override.present? ? email_override : nil,
+          contact_email:           email_override.presence,
           address_1:               nilify(edubase_row['Street']),
           address_2:               nilify(edubase_row['Locality']),
           address_3:               nilify(edubase_row['Address3']),

--- a/app/models/bookings/data/school_updater.rb
+++ b/app/models/bookings/data/school_updater.rb
@@ -75,9 +75,7 @@ module Bookings
         # Will be converted to:
         # { name: 'Some School' }
         #
-        attributes = ATTRIBUTE_MAPPING.each_with_object({}) do |(k, v), h|
-          h[k] = row[v]
-        end
+        attributes = ATTRIBUTE_MAPPING.transform_values { |v| row[v] }
 
         # In addition to the directly-mappable attributes we also need
         # to assign a school type and convert its coordinates

--- a/app/models/bookings/phase.rb
+++ b/app/models/bookings/phase.rb
@@ -7,7 +7,8 @@ class Bookings::Phase < ApplicationRecord
   has_many :bookings_schools_phases,
     class_name: "Bookings::SchoolsPhase",
     inverse_of: :bookings_phase,
-    foreign_key: :bookings_phase_id
+    foreign_key: :bookings_phase_id,
+    dependent: :destroy
 
   has_many :schools,
     class_name: "Bookings::School",

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -2,6 +2,7 @@ module Bookings
   class PlacementDate < ApplicationRecord
     belongs_to :bookings_school,
       class_name: 'Bookings::School',
+      inverse_of: :bookings_placement_dates,
       foreign_key: 'bookings_school_id'
 
     has_many :placement_requests,

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -83,7 +83,7 @@ module Bookings
     end
 
     def bookable?
-      date >= (Date.today + Bookings::Booking::MIN_BOOKING_DELAY)
+      date >= (Time.zone.today + Bookings::Booking::MIN_BOOKING_DELAY)
     end
 
     def has_subjects?

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -8,7 +8,8 @@ module Bookings
     has_many :placement_requests,
       class_name: 'Bookings::PlacementRequest',
       inverse_of: :placement_date,
-      foreign_key: :bookings_placement_date_id
+      foreign_key: :bookings_placement_date_id,
+      dependent: :restrict_with_exception
 
     has_many :placement_date_subjects,
       class_name: 'Bookings::PlacementDateSubject',

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -19,10 +19,12 @@ module Bookings
 
     belongs_to :school,
       class_name: 'Bookings::School',
+      inverse_of: :placement_requests,
       foreign_key: :bookings_school_id
 
     belongs_to :candidate,
       class_name: 'Bookings::Candidate',
+      inverse_of: :placement_requests,
       foreign_key: :candidate_id,
       optional: true
 
@@ -34,11 +36,13 @@ module Bookings
     belongs_to :placement_date,
       class_name: 'Bookings::PlacementDate',
       foreign_key: :bookings_placement_date_id,
+      inverse_of: :placement_requests,
       optional: true # If this is a placement_request to a school with fixed dates
 
     belongs_to :subject,
       class_name: 'Bookings::Subject',
       foreign_key: :bookings_subject_id,
+      inverse_of: :placement_requests,
       optional: true # If this is a placement_request for a subject_specific_date
 
     has_one :candidate_cancellation,

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -31,7 +31,8 @@ module Bookings
     has_one :booking,
       class_name: 'Bookings::Booking',
       foreign_key: 'bookings_placement_request_id',
-      inverse_of: :bookings_placement_request
+      inverse_of: :bookings_placement_request,
+      dependent: :destroy
 
     belongs_to :placement_date,
       class_name: 'Bookings::PlacementDate',

--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -85,7 +85,7 @@ module Bookings
     end
 
     def subject_from_gitis_uuid(uuid)
-      return nil unless uuid.present?
+      return nil if uuid.blank?
 
       @subjects_from_gitis_uuids ||= begin
         uuids = [

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -76,11 +76,6 @@ class Bookings::School < ApplicationRecord
     inverse_of: :bookings_school,
     dependent: :destroy
 
-  has_many :bookings_placement_requests,
-    class_name: 'Bookings::PlacementRequest',
-    foreign_key: :bookings_school_id,
-    dependent: :destroy
-
   has_many :bookings,
     class_name: 'Bookings::Booking',
     foreign_key: :bookings_school_id,

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -36,7 +36,8 @@ class Bookings::School < ApplicationRecord
   has_many :bookings_schools_subjects,
     class_name: "Bookings::SchoolsSubject",
     inverse_of: :bookings_school,
-    foreign_key: :bookings_school_id
+    foreign_key: :bookings_school_id,
+    dependent: :destroy
 
   has_many :subjects,
     class_name: "Bookings::Subject",
@@ -46,7 +47,8 @@ class Bookings::School < ApplicationRecord
   has_many :bookings_schools_phases,
     class_name: "Bookings::SchoolsPhase",
     inverse_of: :bookings_school,
-    foreign_key: :bookings_school_id
+    foreign_key: :bookings_school_id,
+    dependent: :destroy
 
   has_many :phases,
     class_name: "Bookings::Phase",

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -55,21 +55,25 @@ class Bookings::School < ApplicationRecord
 
   belongs_to :school_type,
     class_name: "Bookings::SchoolType",
+    inverse_of: :schools,
     foreign_key: :bookings_school_type_id
 
   has_one :school_profile,
     class_name: "Schools::SchoolProfile",
+    inverse_of: :bookings_school,
     foreign_key: :bookings_school_id,
     dependent: :destroy
 
   has_one :profile,
     class_name: "Bookings::Profile",
     foreign_key: :school_id,
+    inverse_of: :school,
     dependent: :destroy
 
   has_many :bookings_placement_dates,
     class_name: 'Bookings::PlacementDate',
     foreign_key: :bookings_school_id,
+    inverse_of: :bookings_school,
     dependent: :destroy
 
   has_many :bookings_placement_requests,
@@ -80,15 +84,18 @@ class Bookings::School < ApplicationRecord
   has_many :bookings,
     class_name: 'Bookings::Booking',
     foreign_key: :bookings_school_id,
+    inverse_of: :bookings_school,
     dependent: :destroy
 
   has_many :placement_requests,
     class_name: 'Bookings::PlacementRequest',
     foreign_key: :bookings_school_id,
+    inverse_of: :school,
     dependent: :destroy
 
   has_many :events,
     foreign_key: :bookings_school_id,
+    inverse_of: :bookings_school,
     dependent: :destroy
 
   scope :enabled, -> { where(enabled: true) }

--- a/app/models/bookings/school_sync.rb
+++ b/app/models/bookings/school_sync.rb
@@ -54,7 +54,7 @@ private
 
   def download
     Rails.logger.debug("Downloading latest edubase data")
-    date = Date.today.strftime('%Y%m%d')
+    date = Time.zone.today.strftime('%Y%m%d')
     url = "http://ea-edubase-api-prod.azurewebsites.net/edubase/edubasealldata#{date}.csv"
     File.open(FILE_LOCATION, 'wb') { |f| f.write(Net::HTTP.get(URI.parse(url))) }
   end

--- a/app/models/bookings/school_type.rb
+++ b/app/models/bookings/school_type.rb
@@ -7,5 +7,6 @@ class Bookings::SchoolType < ApplicationRecord
   has_many :schools,
     class_name: "Bookings::School",
     foreign_key: :bookings_school_type_id,
-    inverse_of: :school_type
+    inverse_of: :school_type,
+    dependent: :restrict_with_exception
 end

--- a/app/models/bookings/school_type.rb
+++ b/app/models/bookings/school_type.rb
@@ -6,5 +6,6 @@ class Bookings::SchoolType < ApplicationRecord
 
   has_many :schools,
     class_name: "Bookings::School",
-    foreign_key: :bookings_school_type_id
+    foreign_key: :bookings_school_type_id,
+    inverse_of: :school_type
 end

--- a/app/models/bookings/subject.rb
+++ b/app/models/bookings/subject.rb
@@ -7,7 +7,8 @@ class Bookings::Subject < ApplicationRecord
   has_many :bookings_schools_subjects,
     class_name: "Bookings::SchoolsSubject",
     inverse_of: :bookings_subject,
-    foreign_key: :bookings_subject_id
+    foreign_key: :bookings_subject_id,
+    dependent: :destroy
 
   has_many :schools,
     class_name: "Bookings::School",
@@ -28,7 +29,8 @@ class Bookings::Subject < ApplicationRecord
 
   has_many :placement_requests,
     inverse_of: :subject,
-    foreign_key: :bookings_subject_id
+    foreign_key: :bookings_subject_id,
+    dependent: :restrict_with_exception
 
   default_scope -> { where.not(hidden: true) }
   scope :secondary_subjects, -> { where(secondary_subject: true) }

--- a/app/models/bookings/subject.rb
+++ b/app/models/bookings/subject.rb
@@ -20,6 +20,16 @@ class Bookings::Subject < ApplicationRecord
     foreign_key: :bookings_subject_id,
     dependent: :destroy
 
+  has_many :onboarding_profile_subjects,
+    class_name: 'Schools::OnBoarding::ProfileSubject',
+    inverse_of: :subject,
+    foreign_key: :bookings_subject_id,
+    dependent: :destroy
+
+  has_many :placement_requests,
+    inverse_of: :subject,
+    foreign_key: :bookings_subject_id
+
   default_scope -> { where.not(hidden: true) }
   scope :secondary_subjects, -> { where(secondary_subject: true) }
 

--- a/app/models/candidates/feedback.rb
+++ b/app/models/candidates/feedback.rb
@@ -1,7 +1,7 @@
 class Candidates::Feedback < Feedback
-  enum reason_for_using_service: %i(
-    make_a_school_experience_request
-    withdraw_request_or_cancel_booking
-    something_else
-  )
+  enum reason_for_using_service: {
+    make_a_school_experience_request: 0,
+    withdraw_request_or_cancel_booking: 1,
+    something_else: 2
+  }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,11 +13,13 @@ class Event < ApplicationRecord
   belongs_to :bookings_school,
     class_name: 'Bookings::School',
     foreign_key: :bookings_school_id,
+    inverse_of: :events,
     optional: true
 
   belongs_to :bookings_candidate,
     class_name: 'Bookings::Candidate',
     foreign_key: :bookings_candidate_id,
+    inverse_of: :events,
     optional: true
 
   validates :event_type, inclusion: EVENT_TYPES

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -1,11 +1,11 @@
 class Feedback < ApplicationRecord
-  enum rating: %i(
-    very_satisfied
-    satisfied
-    neither_satisfied_or_dissatisfied
-    dissatisfied
-    very_dissatisfied
-  )
+  enum rating: {
+    very_satisfied: 0,
+    satisfied: 1,
+    neither_satisfied_or_dissatisfied: 2,
+    dissatisfied: 3,
+    very_dissatisfied: 4
+  }
 
   REASON_REQUIRING_EXPLANATION = :something_else
 

--- a/app/models/schools/on_boarding/profile_subject.rb
+++ b/app/models/schools/on_boarding/profile_subject.rb
@@ -1,10 +1,12 @@
 class Schools::OnBoarding::ProfileSubject < ApplicationRecord
   belongs_to :school_profile,
     class_name: 'Schools::SchoolProfile',
+    inverse_of: :profile_subjects,
     foreign_key: :schools_school_profile_id
 
   belongs_to :subject,
     class_name: 'Bookings::Subject',
+    inverse_of: :onboarding_profile_subjects,
     foreign_key: :bookings_subject_id
 
   validates :school_profile, presence: true

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -248,6 +248,7 @@ module Schools
     has_many :profile_subjects,
       class_name: 'Schools::OnBoarding::ProfileSubject',
       foreign_key: :schools_school_profile_id,
+      inverse_of: :school_profile,
       dependent: :destroy
 
     has_many :subjects,
@@ -258,6 +259,7 @@ module Schools
 
     belongs_to :bookings_school,
       class_name: 'Bookings::School',
+      inverse_of: :school_profile,
       foreign_key: 'bookings_school_id'
 
     def available_subjects

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -144,8 +144,9 @@ module Schools
       def teacher_training_links
         if @school_profile.experience_outline.provides_teacher_training
           details = sanitize(@school_profile.experience_outline.teacher_training_details)
-          url = link_to 'Teacher training information', sanitize(@school_profile.experience_outline.teacher_training_url)
-          "Yes - #{details}. #{url}".html_safe
+          link = link_to 'Teacher training information', sanitize(@school_profile.experience_outline.teacher_training_url)
+
+          safe_join ["Yes - #{details}.", link], ' '
         else
           'No'
         end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -126,7 +126,7 @@ module Bookings
       end
 
       def add_school_experience(log_line)
-        unless dfe_notesforclassroomexperience.present?
+        if dfe_notesforclassroomexperience.blank?
           self.dfe_notesforclassroomexperience = EventLogger::NOTES_HEADER + "\r\n\r\n"
         end
 

--- a/app/services/bookings/reminder.rb
+++ b/app/services/bookings/reminder.rb
@@ -27,7 +27,7 @@ private
   end
 
   def assign_gitis_contact(booking)
-    return unless booking.present?
+    return if booking.blank?
 
     booking
       .bookings_placement_request

--- a/app/services/candidates/registrations/behaviours/education.rb
+++ b/app/services/candidates/registrations/behaviours/education.rb
@@ -5,7 +5,7 @@ module Candidates
         extend ActiveSupport::Concern
 
         NO_DEGREE_SUBJECT = 'Not applicable'.freeze
-        OPTIONS_CONFIG = YAML.load_file "#{Rails.root}/config/candidate_form_options.yml"
+        OPTIONS_CONFIG = YAML.load_file Rails.root.join('config', 'candidate_form_options.yml')
         DEGREE_STAGE_REQUIRING_EXPLANATION = 'Other'.freeze
         NOT_APPLYING_FOR_DEGREE = "I don't have a degree and am not studying for one".freeze
 

--- a/app/services/candidates/registrations/behaviours/teaching_preference.rb
+++ b/app/services/candidates/registrations/behaviours/teaching_preference.rb
@@ -4,7 +4,7 @@ module Candidates
       module TeachingPreference
         extend ActiveSupport::Concern
 
-        OPTIONS_CONFIG = YAML.load_file "#{Rails.root}/config/candidate_form_options.yml"
+        OPTIONS_CONFIG = YAML.load_file Rails.root.join('config', 'candidate_form_options.yml')
 
         included do
           validates :teaching_stage, presence: true

--- a/app/services/candidates/registrations/registration_step.rb
+++ b/app/services/candidates/registrations/registration_step.rb
@@ -9,7 +9,7 @@ module Candidates
       attribute :updated_at, :datetime
 
       def school
-        return nil unless urn.present?
+        return nil if urn.blank?
 
         @school ||= Candidates::School.find(urn)
       end

--- a/app/services/candidates/registrations/registration_store.rb
+++ b/app/services/candidates/registrations/registration_store.rb
@@ -19,7 +19,7 @@ module Candidates
       def store!(registration_session)
         key = registration_session.uuid
 
-        unless key.present?
+        if key.blank?
           fail NoKey, "`registration_session#uuid` can't be blank"
         end
 

--- a/app/views/candidates/schools/_expanded_search.html.erb
+++ b/app/views/candidates/schools/_expanded_search.html.erb
@@ -1,0 +1,30 @@
+<li class="expanded-search-radius">
+  <h3 class="govuk-heading-l">
+    0 results found
+
+    <%- if search.has_coordinates? -%>
+      within <%= pluralize(params[:distance], 'mile') %>
+    <%- end -%>
+  </h3>
+
+  <div class="nearby-info">
+    <%- if search.results.any? -%>
+      <p>
+        However, we did find the following schools nearby:
+      </p>
+    <%- else -%>
+      <%- if @search.has_coordinates? -%>
+      <p>
+        Not all schools in your area have signed up to use this website.
+      </p>
+      <%- end -%>
+
+      <p>
+        To find out about arranging school experience with schools who are
+        not yet on this website visit
+        <%= link_to 'Get into teaching',
+          'https://getintoteaching.education.gov.uk/school-experience/arranging-school-experience-independently' %>.
+      </p>
+    <%- end -%>
+  </div>
+</li>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -89,15 +89,7 @@
     <hr />
 
     <ul id="results">
-      <%- if @expanded_search_radius -%>
-      <li class="expanded-search-radius">
-        <h3 class="govuk-heading-l"><%= expanded_search_radius_header_text %></h3>
-
-        <div class="nearby-info">
-          <%= expanded_search_nearby_info_text %>
-        </div>
-      </li>
-      <%- end -%>
+      <%= render 'expanded_search', search: @search if @expanded_search_radius %>
 
       <% @search.results.each_with_index do |school, index| %>
       <li data-school-urn="<%= school.urn %>">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,8 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to site_header_text, root_path, class: 'govuk-header__link govuk-header__link--service-name' %>
+          <%= link_to @site_header_text || 'Get school experience', root_path,
+                class: 'govuk-header__link govuk-header__link--service-name' %>
         </div>
       </div>
     </header>

--- a/app/views/schools/errors/not_registered/show.html.erb
+++ b/app/views/schools/errors/not_registered/show.html.erb
@@ -21,7 +21,7 @@
 
     <% if @current_user.present? %>
       <p>
-        You are currently logged in as <strong><%= current_user_full_name %></strong>.
+        You are currently logged in as <strong><%= current_user_full_name current_user %></strong>.
       </p>
     <% end %>
 

--- a/app/views/shared/application/_phase_banner.html.erb
+++ b/app/views/shared/application/_phase_banner.html.erb
@@ -8,7 +8,7 @@
     </div>
     <%- if @current_user.present? -%>
     <div class="govuk-phase-banner__text auth">
-      <%= current_user_info_and_logout_link %>
+      <%= current_user_info_and_logout_link current_user %>
     </div>
 
     <%- elsif in_schools_namespace? -%>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
   - script: docker run --rm $(DOCKER_HUB_REPO):$(imageTag) brakeman --no-pager
     displayName: Run the Brakeman security scan
 
-  - script: docker run --rm $(DOCKER_HUB_REPO):$(imageTag) govuk-lint-ruby app config lib features spec spec_external
+  - script: docker run --rm $(DOCKER_HUB_REPO):$(imageTag) rubocop app config lib features spec spec_external
     displayName: Run the GovUK Lint check
 
   - task: Docker@2

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.x.notify_client = NotifyFakeClient
 
   # default to true but allow overriding in CI
-  config.force_ssl = !ENV['SKIP_FORCE_SSL'].present?
+  config.force_ssl = ENV['SKIP_FORCE_SSL'].blank?
 
   config.x.phase = 10000
   config.x.features = %i(

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -1,5 +1,5 @@
 require File.expand_path('production.rb', __dir__)
-require File.join(Rails.root, 'spec', 'support', 'notify_fake_client')
+require Rails.root.join('spec', 'support', 'notify_fake_client')
 require Rails.root.join("lib", "servertest", "geocoder")
 require Rails.root.join("lib", "servertest", "dfe_sign_in_api")
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,4 @@
-require File.join(Rails.root, 'spec', 'support', 'notify_fake_client')
+require Rails.root.join('spec', 'support', 'notify_fake_client')
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.

--- a/config/initializers/conversions.rb
+++ b/config/initializers/conversions.rb
@@ -1,1 +1,1 @@
-require File.join(Rails.root, 'lib', 'conversions')
+require Rails.root.join('lib', 'conversions')

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,5 +1,5 @@
 # Test the Redis connection on boot
-unless ENV['SKIP_REDIS'].present?
+if ENV['SKIP_REDIS'].blank?
   Redis.current = Redis.new(
     db: (Rails.env.test? ? ENV['TEST_ENV_NUMBER'].presence : nil),
     connect_timeout: 20, # Default is 5s but logic is we're better being slower booting than failing to boot

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -821,7 +821,7 @@ en:
           one: "Displaying the only %{entry_name}"
           other: "Displaying all %{count} %{entry_name}"
       more_pages:
-        display_entries: "Showing %{first}&ndash;%{last} of %{total} %{entry_name}"
+        display_entries: "Showing %{first}–%{last} of %{total} %{entry_name}"
 
     candidates:
       school_search:

--- a/features/step_definitions/candidates/registrations/application_preview_steps.rb
+++ b/features/step_definitions/candidates/registrations/application_preview_steps.rb
@@ -9,7 +9,7 @@ Given("I have completed the wizard") do
 end
 
 Given("I have completed the wizard for a fixed date school") do
-  @school.update_attributes(availability_preference_fixed: true)
+  @school.update(availability_preference_fixed: true)
   @wanted_bookings_placement_date = @school.bookings_placement_dates.create!(
     date: 2.weeks.from_now, published_at: 1.week.ago, supports_subjects: true
   )
@@ -110,7 +110,7 @@ end
 
 Given("the/my school has fixed dates") do
   @fixed_dates = true
-  @school.update_attributes(availability_preference_fixed: true)
+  @school.update(availability_preference_fixed: true)
   (1..3).each { |i| i.weeks.from_now }.each do |date|
     @school.bookings_placement_dates.create(date: date.weeks.from_now, published_at: 1.week.ago)
     @wanted_bookings_placement_date = @school.bookings_placement_dates.last

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -15,7 +15,7 @@ end
 
 Given("the school profile has description details text:") do |pi|
   @raw_placement_info = pi
-  @profile.update_attributes(description_details: pi)
+  @profile.update(description_details: pi)
   expect(@profile.description_details).to eql(pi)
 end
 
@@ -52,7 +52,7 @@ Then("all of the subjects should be listed") do
 end
 
 Given("the school's website is {string}") do |url|
-  @school.update_attributes(website: url)
+  @school.update(website: url)
   expect(@school.website).to eql(url)
 end
 
@@ -89,7 +89,7 @@ end
 
 Given("the chosen school has the following availability information") do |string|
   @raw_availability_info = string
-  @school.update_attributes(availability_info: string)
+  @school.update(availability_info: string)
   expect(@school.availability_info).to eql(string)
 end
 
@@ -103,7 +103,7 @@ end
 
 Given("the chosen school offers teacher training and has the following info") do |string|
   @teacher_training_info = string
-  @profile.update_attributes(
+  @profile.update(
     teacher_training_info: string,
     teacher_training_url: "https://www.altervista.com/teacher-training"
   )

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -35,7 +35,7 @@ Given("I have provided a point in {string} as my location") do |centre|
   }
 
   point = points[centre]
-  fail "No point found for #{centre}" unless point.present?
+  fail "No point found for #{centre}" if point.blank?
 
   path = candidates_schools_path(latitude: point["latitude"], longitude: point["longitude"], distance: 25)
   visit(path)

--- a/features/step_definitions/common_school_steps.rb
+++ b/features/step_definitions/common_school_steps.rb
@@ -30,7 +30,7 @@ Given "the school is a {string} and {string} school" do |p1, p2|
 end
 
 Given "my chosen school has the URN {int}" do |int|
-  @school.update_attributes(urn: int)
+  @school.update(urn: int)
   expect(@school.urn).to eql(int)
 end
 

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -58,7 +58,7 @@ end
 
 Then("I should see a select box containing degree subjects labelled {string}") do |string|
   @degree_subjects ||= YAML
-    .load_file("#{Rails.root}/config/candidate_form_options.yml")['DEGREE_SUBJECTS']
+    .load_file(Rails.root.join('config', 'candidate_form_options.yml'))['DEGREE_SUBJECTS']
     .sample(10) # we don't need all of them, just pick out 10
   ensure_select_options_exist(get_form_group(page, string), @degree_subjects)
 end

--- a/features/step_definitions/schools/placement_dates/new_steps.rb
+++ b/features/step_definitions/schools/placement_dates/new_steps.rb
@@ -17,7 +17,7 @@ Then("my newly-created placement date should be listed") do
 end
 
 Given("I fill in the {string} date field with an invalid date of 31st September next year") do |label|
-  year = Date.today.year + 1
+  year = 1.year.from_now.year
   step "I fill in the date field '#{label}' with 31-09-#{year}"
 end
 

--- a/features/step_definitions/schools/previous_bookings_steps.rb
+++ b/features/step_definitions/schools/previous_bookings_steps.rb
@@ -13,7 +13,7 @@ Then("I should see the previous bookings listed") do
 end
 
 And("there is/are {int} previous booking/bookings") do |count|
-  now = Date.today
+  now = Time.zone.today
 
   travel_to 1.year.ago do
     unless @school.subjects.where(name: 'Biology').any?

--- a/lib/tasks/assets/symlink_without_hash.rake
+++ b/lib/tasks/assets/symlink_without_hash.rake
@@ -2,10 +2,10 @@ namespace :assets do
   desc "Symlink non digested versions of assets, for use by static error pages"
   task symlink_non_digested: :environment do
     # limit to stylesheets for the time being
-    assets = Dir.glob(Rails.root.join('public/assets/**/*.{css,ico,png}'))
+    assets_path = Rails.root.join('public', 'assets', '**', '*.{css,ico,png}')
 
     regex = /(-{1}[a-z0-9]{32}*\.{1}){1}/
-    assets.each do |file|
+    Dir.glob(assets_path).each do |file|
       next if File.directory?(file) || file !~ regex
 
       source = file.split('/')

--- a/lib/tasks/cron_jobs.rake
+++ b/lib/tasks/cron_jobs.rake
@@ -2,7 +2,7 @@ namespace :db do
   desc 'Schedule all cron jobs'
   task schedule_jobs: :environment do
     glob = Rails.root.join('app', 'jobs', 'cron', '**', '*_job.rb')
-    Dir.glob(glob).each { |f| require f }
+    Dir.glob(glob).sort.each { |f| require f }
     CronJob.subclasses.each(&:schedule)
   end
 end

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -56,7 +56,7 @@ unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gem
     task default: :cucumber
 
     task features: :cucumber do
-      STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
+      warn "*** The 'features' task is deprecated. See rake -T cucumber ***"
     end
 
     # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -4,10 +4,10 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
-
 unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gems:* tasks
 
-  vendored_cucumber_bin = Dir["#{Rails.root}/vendor/{gems,plugins}/cucumber*/bin/cucumber"].first
+  search_path = Rails.root.join('vendor', '{gems,plugins}', 'cucumber*', 'bin', 'cucumber')
+  vendored_cucumber_bin = Dir[search_path].first
   $LOAD_PATH.unshift(File.dirname(vendored_cucumber_bin) + '/../lib') unless vendored_cucumber_bin.nil?
 
   begin

--- a/lib/tasks/notify/check_templates.rake
+++ b/lib/tasks/notify/check_templates.rake
@@ -1,4 +1,4 @@
-require File.join(Rails.root, "lib", "notify", "notify_sync")
+require Rails.root.join("lib", "notify", "notify_sync")
 
 namespace :notify do
   desc "See if local copies of email templates are up to date"

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -132,7 +132,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
             expect(Bookings::LogToGitisJob).to \
               have_received(:perform_later).with \
                 fake_gitis_uuid,
-                %r{#{Date.today.to_formatted_s(:gitis)} REQUEST}
+                %r{#{Time.zone.today.to_formatted_s(:gitis)} REQUEST}
           end
 
           it 'redirects to placement request show' do

--- a/spec/factories/bookings/bookings_factory.rb
+++ b/spec/factories/bookings/bookings_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
 
     association :bookings_placement_request,
       factory: :bookings_placement_request,
-      created_at: Time.new(2019, 2, 8, 15, 37)
+      created_at: Time.new(2019, 2, 8, 15, 37).in_time_zone
 
     bookings_school { bookings_placement_request.school }
     contact_name { 'William MacDougal' }

--- a/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :gitis_registration_session, parent: :registration_session,
     class: Candidates::Registrations::GitisRegistrationSession do
-
     gitis_contact { build(:gitis_contact, :persisted) }
 
     initialize_with do

--- a/spec/factories/candidates/registrations/legacy_registration_session.rb
+++ b/spec/factories/candidates/registrations/legacy_registration_session.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     transient do
       urn { 11048 }
       bookings_placement_date_id { 16 }
-      timestamp { Date.today }
+      timestamp { Time.zone.today }
     end
 
     initialize_with do

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -4,7 +4,7 @@ feature 'Candidate Registrations', type: :feature do
   include_context 'Stubbed candidates school'
 
   let! :today do
-    Date.today
+    Time.zone.today
   end
 
   let! :tomorrow do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 describe ApplicationHelper, type: :helper do
   let(:given_name) { 'Martin' }
   let(:family_name) { 'Prince' }
+  let(:user) do
+    OpenIDConnect::ResponseObject::UserInfo.new \
+      given_name: given_name,
+      family_name: family_name
+  end
 
   context 'Breadcrumbs' do
     let(:args) do
@@ -55,18 +60,8 @@ describe ApplicationHelper, type: :helper do
   end
 
   context '#current_user_info_and_logout_link' do
-    subject { helper.current_user_info_and_logout_link }
+    subject { helper.current_user_info_and_logout_link user }
     context 'when a user is logged in' do
-      before do
-        assign(
-          :current_user,
-          OpenIDConnect::ResponseObject::UserInfo.new(
-            given_name: given_name,
-            family_name: family_name
-          )
-        )
-      end
-
       specify "should contain the person's name and a logout link" do
         expect(subject).to include("#{given_name} #{family_name}")
       end
@@ -78,25 +73,16 @@ describe ApplicationHelper, type: :helper do
   end
 
   describe '#current_user_full_name' do
-    subject { helper.current_user_full_name }
+    subject { helper.current_user_full_name user }
 
     context 'when current_user present' do
-      before do
-        assign(
-          :current_user,
-          OpenIDConnect::ResponseObject::UserInfo.new(
-            given_name: given_name,
-            family_name: family_name
-          )
-        )
-      end
-
       specify 'should return the combined given and family names' do
         expect(subject).to eql("#{given_name} #{family_name}")
       end
     end
 
     context 'when current_user absent' do
+      let(:user) { nil }
       specify "should return 'Unknown'" do
         expect(subject).to eql("Unknown")
       end

--- a/spec/helpers/candidates/results_helper_spec.rb
+++ b/spec/helpers/candidates/results_helper_spec.rb
@@ -29,7 +29,7 @@ describe Candidates::ResultsHelper, type: :helper do
 
     context 'When there are more than one page of results' do
       let!(:schools) { create_list(:bookings_school, 18, coordinates: point_in_manchester) }
-      specify { expect(subject).to eql("Showing 1&ndash;15 of 18 results") }
+      specify { expect(subject).to eql("Showing 1–15 of 18 results") }
     end
   end
 end

--- a/spec/jobs/notify_job_spec.rb
+++ b/spec/jobs/notify_job_spec.rb
@@ -38,7 +38,7 @@ describe NotifyJob, type: :job do
     allow(Raven).to receive :capture_exception
 
     allow(ActiveJob::Base.logger).to receive :info do |&block|
-      personalisation.values.each { |v| expect(block.call).not_to include v }
+      personalisation.each_value { |v| expect(block.call).not_to include v }
       expect(block.call).not_to include email_address
     end
 

--- a/spec/lib/geocoder_autoexpire_cache_spec.rb
+++ b/spec/lib/geocoder_autoexpire_cache_spec.rb
@@ -29,7 +29,7 @@ describe GeocoderAutoexpireCache do
     subject { described_class.new(store, 2.months) }
 
     it 'should set the ttl of new records to be the newly-specified value' do
-      expect(subject.ttl).to be_within(1).of(2.month)
+      expect(subject.ttl).to be_within(1).of(2.months)
     end
   end
 end

--- a/spec/lib/notify/notify_sync_spec.rb
+++ b/spec/lib/notify/notify_sync_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require File.join(Rails.root, "lib", "notify", "notify_sync")
+require Rails.root.join("lib", "notify", "notify_sync")
 
 describe NotifySync do
   before do

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -340,13 +340,13 @@ describe Bookings::Booking do
       let!(:booking_in_8_days) { create(:bookings_booking, date: 8.days.from_now.to_date) }
 
       specify 'should return bookings the specified number of days away' do
-        expect(described_class.days_in_the_future(1.days)).to include(booking_in_1_days)
+        expect(described_class.days_in_the_future(1.day)).to include(booking_in_1_days)
       end
 
       specify 'should not return other bookings' do
-        expect(described_class.days_in_the_future(1.days)).not_to include(booking_in_3_days)
-        expect(described_class.days_in_the_future(1.days)).not_to include(booking_in_7_days)
-        expect(described_class.days_in_the_future(1.days)).not_to include(booking_in_8_days)
+        expect(described_class.days_in_the_future(1.day)).not_to include(booking_in_3_days)
+        expect(described_class.days_in_the_future(1.day)).not_to include(booking_in_7_days)
+        expect(described_class.days_in_the_future(1.day)).not_to include(booking_in_8_days)
       end
 
       describe '.tomorrow' do

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -76,7 +76,7 @@ describe Bookings::Booking do
         end
 
         specify 'new placement dates should not allow today' do
-          expect(subject).not_to allow_value(Date.today).for(:date)
+          expect(subject).not_to allow_value(Time.zone.today).for(:date)
         end
 
         context 'error messages' do
@@ -187,7 +187,7 @@ describe Bookings::Booking do
         [
           FactoryBot.build(:bookings_booking, date: 1.week.ago),
           FactoryBot.build(:bookings_booking, date: Date.yesterday),
-          FactoryBot.build(:bookings_booking, date: Date.today)
+          FactoryBot.build(:bookings_booking, date: Time.zone.today)
         ].each do |booking|
           booking.save(validate: false)
         end
@@ -223,7 +223,7 @@ describe Bookings::Booking do
 
       let!(:future_bookings) do
         [
-          FactoryBot.build(:bookings_booking, date: Date.today),
+          FactoryBot.build(:bookings_booking, date: Time.zone.today),
           FactoryBot.build(:bookings_booking, date: Date.tomorrow),
           FactoryBot.build(:bookings_booking, date: 3.weeks.from_now)
         ].each do |booking|
@@ -368,7 +368,7 @@ describe Bookings::Booking do
   describe '#placement_start_date_with_duration' do
     context 'when the placement request has a flexible date' do
       let! :date do
-        Date.today
+        Time.zone.today
       end
 
       subject { described_class.new date: date }
@@ -381,7 +381,7 @@ describe Bookings::Booking do
 
     context 'when the placement request has a fixed date' do
       let! :date do
-        Date.today
+        Time.zone.today
       end
 
       let(:placement_date) { create(:bookings_placement_date) }

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Bookings::Candidate, type: :model do
     it { is_expected.to have_many :session_tokens }
     it { is_expected.to have_many(:placement_requests).inverse_of :candidate }
     it { is_expected.to have_many :bookings }
+    it { is_expected.to have_many(:events).inverse_of :bookings_candidate }
   end
 
   describe 'scopes' do

--- a/spec/models/bookings/data/school_mass_importer_spec.rb
+++ b/spec/models/bookings/data/school_mass_importer_spec.rb
@@ -10,7 +10,7 @@ describe Bookings::Data::SchoolMassImporter do
   context 'Initialization' do
     let(:edubase_data) do
       CSV.parse(
-        File.read(File.join(Rails.root, 'spec', 'sample_data', 'edubase.csv')).scrub,
+        Rails.root.join('spec', 'sample_data', 'edubase.csv').read.scrub,
         headers: true
       )
     end

--- a/spec/models/bookings/data/school_updater_spec.rb
+++ b/spec/models/bookings/data/school_updater_spec.rb
@@ -8,7 +8,7 @@ describe Bookings::Data::SchoolUpdater do
 
   let(:edubase_data) do
     CSV.parse(
-      File.read(File.join(Rails.root, 'spec', 'sample_data', 'edubase.csv')).scrub,
+      Rails.root.join('spec', 'sample_data', 'edubase.csv').read.scrub,
       headers: true
     )
   end

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -36,7 +36,7 @@ describe Bookings::PlacementDate, type: :model do
         end
 
         specify 'new placement dates should not allow today' do
-          expect(subject).not_to allow_value(Date.today).for(:date)
+          expect(subject).not_to allow_value(Time.zone.today).for(:date)
         end
 
         context 'error messages' do
@@ -86,7 +86,7 @@ describe Bookings::PlacementDate, type: :model do
     end
 
     context '#max_bookings_count' do
-      before { subject.published_at = Date.today }
+      before { subject.published_at = Time.zone.today }
       it do
         is_expected.to \
           validate_numericality_of(:max_bookings_count).is_greater_than(0).allow_nil
@@ -95,7 +95,7 @@ describe Bookings::PlacementDate, type: :model do
 
     context '#subjects' do
       context 'published' do
-        before { subject.published_at = Date.today }
+        before { subject.published_at = Time.zone.today }
 
         context 'when not subject_specific?' do
           before { subject.subject_specific = false }
@@ -136,7 +136,7 @@ describe Bookings::PlacementDate, type: :model do
   describe 'Scopes' do
     let(:future_date) { create(:bookings_placement_date) }
     let(:past_date) { create(:bookings_placement_date, :in_the_past) }
-    let(:today_date) { create(:bookings_placement_date, :in_the_past, date: Date.today) }
+    let(:today_date) { create(:bookings_placement_date, :in_the_past, date: Time.zone.today) }
 
     context '.bookable_date' do
       subject { described_class.bookable_date }

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -790,7 +790,7 @@ describe Bookings::PlacementRequest, type: :model do
     context 'when #viewed_at has not already been set' do
       before { subject.viewed! }
       specify 'should set #viewed_at to now' do
-        expect(subject.viewed_at).to be_within(0.1).of(Time.now)
+        expect(subject.viewed_at).to be_within(0.1).of(Time.zone.now)
       end
     end
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -565,7 +565,7 @@ describe Bookings::PlacementRequest, type: :model do
   end
 
   let! :today do
-    Date.today
+    Time.zone.today
   end
 
   context 'validations for placement preferences' do
@@ -872,7 +872,7 @@ describe Bookings::PlacementRequest, type: :model do
     subject { pr.fixed_date_is_bookable? }
 
     context 'for today' do
-      before { date.date = Date.today }
+      before { date.date = Time.zone.today }
       it { is_expected.to be false }
     end
 

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -166,15 +166,6 @@ describe Bookings::School, type: :model do
 
     specify do
       is_expected.to(
-        have_many(:bookings_placement_requests)
-          .with_foreign_key(:bookings_school_id)
-          .class_name('Bookings::PlacementRequest')
-          .dependent(:destroy)
-      )
-    end
-
-    specify do
-      is_expected.to(
         have_many(:bookings)
           .with_foreign_key(:bookings_school_id)
           .class_name('Bookings::Booking')

--- a/spec/models/bookings/subject_spec.rb
+++ b/spec/models/bookings/subject_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe Bookings::Subject, type: :model do
     specify do
       is_expected.to have_many(:placement_date_subjects).dependent(:destroy)
     end
+
+    specify do
+      is_expected.to have_many(:onboarding_profile_subjects).dependent(:destroy)
+    end
+
+    specify do
+      is_expected.to have_many(:placement_requests)
+        .with_foreign_key(:bookings_subject_id)
+    end
   end
 
   describe "Scopes" do

--- a/spec/models/candidates/session_token_spec.rb
+++ b/spec/models/candidates/session_token_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Candidates::SessionToken, type: :model do
       before { token.expire! }
 
       it("will be expired now") do
-        expect(token.expired_at).to be > 1.minutes.ago
+        expect(token.expired_at).to be > 1.minute.ago
       end
     end
   end

--- a/spec/notify/notify_spec.rb
+++ b/spec/notify/notify_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
-require File.join(Rails.root, 'spec', 'support', 'notify_fake_client')
-require File.join(Rails.root, 'spec', 'support', 'notify_retryable_erroring_client')
+require Rails.root.join('spec', 'support', 'notify_fake_client')
+require Rails.root.join('spec', 'support', 'notify_retryable_erroring_client')
 
 describe Notify do
   include ActiveJob::TestHelper

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,7 +24,9 @@ require 'webmock/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each do |f|
+  require f
+end
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/services/bookings/gitis/event_logger_spec.rb
+++ b/spec/services/bookings/gitis/event_logger_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Bookings::Gitis::EventLogger, type: :model do
   subject { described_class.entry log_type, log_subject }
-  let(:today) { Date.today.to_formatted_s(:gitis) }
+  let(:today) { Time.zone.today.to_formatted_s(:gitis) }
   let(:padded_urn) { sprintf('%-6s', school.urn) }
 
   context 'with a PlacementRequest' do
@@ -43,7 +43,7 @@ describe Bookings::Gitis::EventLogger, type: :model do
 
   context 'with a Cancellation' do
     let(:log_type) { 'cancellation' }
-    let(:today) { Date.today.to_formatted_s(:gitis) }
+    let(:today) { Time.zone.today.to_formatted_s(:gitis) }
 
     context 'by the Candidate of a Request' do
       let(:request) { create(:placement_request, :cancelled) }

--- a/spec/services/bookings/gitis/store/dynamics_spec.rb
+++ b/spec/services/bookings/gitis/store/dynamics_spec.rb
@@ -68,11 +68,11 @@ describe Bookings::Gitis::Store::Dynamics do
 
     context 'for multiple ids' do
       let(:uuids) do
-        [
-          "03ec3075-a9f9-400f-bc43-a7a5cdf68579",
-          "e46fd2c9-ad04-4ebb-bc2a-26f3ad323c56",
-          "2ec079dd-35a2-419a-9d01-48d63c09cdcc"
-        ]
+        %w(
+          03ec3075-a9f9-400f-bc43-a7a5cdf68579
+          e46fd2c9-ad04-4ebb-bc2a-26f3ad323c56
+          2ec079dd-35a2-419a-9d01-48d63c09cdcc
+        )
       end
 
       let(:matches) do

--- a/spec/services/candidates/registrations/placement_preference_spec.rb
+++ b/spec/services/candidates/registrations/placement_preference_spec.rb
@@ -6,7 +6,7 @@ describe Candidates::Registrations::PlacementPreference, type: :model do
   include_context 'Stubbed candidates school'
 
   let! :today do
-    Date.today
+    Time.zone.today
   end
 
   context 'attributes' do

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
-require File.join(Rails.root, 'spec', 'support', 'notify_fake_client')
+require Rails.root.join('spec', 'support', 'notify_fake_client')
 
 shared_examples_for "email template" do |template_id, personalisation|
   let(:to) { "someone@somecompany.org" }

--- a/spec_external/gitis_crm_spec.rb
+++ b/spec_external/gitis_crm_spec.rb
@@ -376,7 +376,7 @@ private
       'dfe_channelcreation' => ENV.fetch('CRM_CHANNEL_CREATION'),
       'dfe_notesforclassroomexperience' => "Written by School Experience",
       'dfe_hasdbscertificate' => true,
-      'dfe_dateofissueofdbscertificate' => Date.today.to_s(:db),
+      'dfe_dateofissueofdbscertificate' => Time.zone.today.to_s(:db),
       'dfe_Country@odata.bind' => "dfe_countries(#{countryid})", # UK
       'dfe_PreferredTeachingSubject01@odata.bind' => "dfe_teachingsubjectlists(#{teaching_subject_guid})",
       'dfe_PreferredTeachingSubject02@odata.bind' => "dfe_teachingsubjectlists(#{teaching_subject_guid})"


### PR DESCRIPTION
### Context

Our linter is significantly out of date. Whilst not ideal this isn't problematic but its incorrect use of Tempfile is - it closes the file too soon, and if GC runs to quickly the yml config file for Rubocop disappears before it can be used.

### Changes proposed in this pull request

1. Switch to the non-deprecated replacement `rubocop-govuk`
2. Bring the codebase into compliance with the new standards
3. Change the pipelines to use the new linter



