### PR TITLE
SE-2139 DfE Sign-in API robustness

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -18,6 +18,8 @@ module Schools
     rescue_from SchoolNotRegistered, with: -> { redirect_to schools_errors_not_registered_path }
     rescue_from Bookings::Gitis::API::BadResponseError, with: :gitis_retrieval_error
     rescue_from Bookings::Gitis::API::ConnectionFailed, with: :gitis_retrieval_error
+    rescue_from Schools::DFESignInAPI::Client::ApiTimeout, with: :signin_api_failure
+    rescue_from Schools::DFESignInAPI::Client::ApiConnectionFailed, with: :signin_api_failure
 
     def current_school
       raise MissingURN, 'urn is missing, unable to match with school' if current_urn.blank?
@@ -71,6 +73,13 @@ module Schools
       else
         redirect_to schools_errors_insufficient_privileges_path
       end
+    end
+
+    def signin_api_failure(exception)
+      ExceptionNotifier.notify_exception(exception)
+      Raven.capture_exception(exception)
+
+      redirect_to schools_errors_auth_failed_path
     end
   end
 end

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -69,6 +69,13 @@ module Schools
     rescue AttrRequired::AttrMissing => e
       Rails.logger.error("Login failed #{e.backtrace}")
       raise AuthFailedError
+
+    # Timed out querying OIDC callback, show auth failed to let the user retry
+    rescue HTTPClient::TimeoutError => e
+      ExceptionNotifier.notify_exception(e)
+      Raven.capture_exception(e)
+
+      raise AuthFailedError
     end
 
   private

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -74,7 +74,7 @@ module Schools
   private
 
     def check_role!(user_uuid, organisation_uuid)
-      return true unless Schools::DFESignInAPI::Client.role_check_enabled?
+      return true unless Schools::DFESignInAPI::Roles.enabled?
       return true if Schools::ChangeSchool.allow_school_change_in_app? && organisation_uuid.nil?
 
       unless Schools::DFESignInAPI::Roles.new(user_uuid, organisation_uuid).has_school_experience_role?

--- a/app/services/schools/dfe_sign_in_api/client.rb
+++ b/app/services/schools/dfe_sign_in_api/client.rb
@@ -22,6 +22,9 @@ module Schools
       delegate :enabled?, to: :class
 
       class ApiDisabled < RuntimeError; end
+      class ApiError < RuntimeError; end
+      class ApiTimeout < ApiError; end
+      class ApiConnectionFailed < ApiError; end
 
     private
 
@@ -34,6 +37,10 @@ module Schools
         end
 
         JSON.parse(resp.body)
+      rescue Faraday::TimeoutError => e
+        raise ApiTimeout.new(e)
+      rescue Faraday::ConnectionFailed => e
+        raise ApiConnectionFailed.new(e)
       end
 
       def faraday

--- a/app/services/schools/dfe_sign_in_api/client.rb
+++ b/app/services/schools/dfe_sign_in_api/client.rb
@@ -21,16 +21,6 @@ module Schools
       end
       delegate :enabled?, to: :class
 
-      def self.role_check_enabled?
-        enabled? &&
-          Rails.application.config.x.dfe_sign_in_api_role_check_enabled &&
-          [
-            ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID', nil),
-            ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID', nil)
-          ].all?(&:present?)
-      end
-      delegate :role_check_enabled?, to: :class
-
       class ApiDisabled < RuntimeError; end
 
     private

--- a/app/services/schools/dfe_sign_in_api/client.rb
+++ b/app/services/schools/dfe_sign_in_api/client.rb
@@ -31,10 +31,12 @@ module Schools
       end
       delegate :role_check_enabled?, to: :class
 
+      class ApiDisabled < RuntimeError; end
+
     private
 
       def response
-        return [] unless enabled?
+        raise ApiDisabled unless enabled?
 
         resp = faraday.get(endpoint) do |req|
           req.headers['Authorization'] = "bearer #{token}"

--- a/app/services/schools/dfe_sign_in_api/roles.rb
+++ b/app/services/schools/dfe_sign_in_api/roles.rb
@@ -5,11 +5,17 @@ module Schools
 
       class << self
         def service_id
-          ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID')
+          ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID').presence ||
+            raise(MissingConfigVariable)
         end
 
         def role_id
-          ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID')
+          ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID').presence ||
+            raise(MissingConfigVariable)
+        end
+
+        def enabled?
+          super && Rails.application.config.x.dfe_sign_in_api_role_check_enabled
         end
       end
 
@@ -24,6 +30,7 @@ module Schools
         false
       end
 
+      class MissingConfigVariable < RuntimeError; end
       class NoOrganisationError < RuntimeError; end
 
     private

--- a/spec/controllers/schools/change_schools_controller_spec.rb
+++ b/spec/controllers/schools/change_schools_controller_spec.rb
@@ -3,7 +3,8 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::ChangeSchoolsController, type: :request do
   include_context "logged in DfE user"
-  let(:enable_signin_api) { true }
+  include_context "stub role check api"
+
   let(:enable_school_change) { true }
   let(:old_school) { @current_user_school }
   let(:new_school) { create(:bookings_school) }
@@ -63,7 +64,6 @@ describe Schools::ChangeSchoolsController, type: :request do
     end
 
     context 'when internal changing is disabled' do
-      let(:enable_signin_api) { false }
       let(:enable_school_change) { false }
       let(:params) { { schools_change_school: { urn: new_school.urn } } }
       let(:change_school_page) { get '/schools/change' }

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -149,11 +149,9 @@ describe Schools::SessionsController, type: :request do
 
     describe 'role checking' do
       include_context 'oidc callback'
-      before do
-        allow(Schools::DFESignInAPI::Client).to receive(:enabled?).and_return(true)
-        allow(Schools::DFESignInAPI::Client).to receive(:role_check_enabled?).and_return(true)
-        allow_any_instance_of(Schools::DFESignInAPI::Roles).to receive(:has_school_experience_role?).and_return(false)
-      end
+      include_context 'stub role check api'
+
+      let(:signin_role_check_response) { false }
 
       subject! { get callback }
 

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -74,30 +74,33 @@ describe Schools::SessionsController, type: :request do
     context 'when the user is not yet signed in' do
       include_context 'oidc callback'
 
-      subject! { get callback }
+      context 'when successful' do
+        subject! { get callback }
 
-      specify 'should redirect to the return url' do
-        expect(response.body).to redirect_to(return_url)
+        specify 'should redirect to the return url' do
+          expect(response.body).to redirect_to(return_url)
+        end
+
+        specify 'should save the URN in the session' do
+          expect(session[:urn]).to eql(urn)
+        end
+
+        specify 'should save the school name in the session' do
+          expect(session[:school_name]).to eql(school_name)
+        end
+
+        specify 'should save the current user in the session' do
+          expect(session[:current_user]).to be_a(OpenIDConnect::ResponseObject::UserInfo)
+        end
       end
 
-      specify 'should save the URN in the session' do
-        expect(session[:urn]).to eql(urn)
-      end
-
-      specify 'should save the school name in the session' do
-        expect(session[:school_name]).to eql(school_name)
-      end
-
-      specify 'should save the current user in the session' do
-        expect(session[:current_user]).to be_a(OpenIDConnect::ResponseObject::UserInfo)
-      end
-
-      context 'errors' do
+      context 'when there are errors' do
         context 'Errors returned by DfE Sign-in' do
           let(:error) { 'baderror' }
           let(:callback) { "/auth/callback?error=#{error}" }
+          before { allow(Rails.logger).to receive(:error).and_call_original }
 
-          after { get callback }
+          subject! { get callback }
 
           specify 'should raise an AuthFailed error' do
             expect(response.status).to eql 302
@@ -105,7 +108,7 @@ describe Schools::SessionsController, type: :request do
           end
 
           specify 'should write a message to the log' do
-            expect(Rails.logger).to receive(:error).with(/DfE Sign-in error response/)
+            expect(Rails.logger).to have_received(:error).with(/DfE Sign-in error response/)
           end
         end
 
@@ -117,10 +120,12 @@ describe Schools::SessionsController, type: :request do
           }.each do |bad_state, description|
             context description do
               let(:callback) { "/auth/callback?code=#{code}&state=#{bad_state}&session_state=#{session_state}" }
-              after { get callback }
+              before { allow(Rails.logger).to receive(:error).and_call_original }
+
+              subject! { get callback }
 
               specify 'should raise StateMismatchError' do
-                expect(Rails.logger).to receive(:error).with(/doesn't match session state/)
+                expect(Rails.logger).to have_received(:error).with(/doesn't match session state/)
               end
 
               specify 'should redirect to an error page' do
@@ -133,11 +138,35 @@ describe Schools::SessionsController, type: :request do
 
         context 'AuthFailedError' do
           let(:code) { nil }
-          after { get callback }
+          before { allow(Rails.logger).to receive(:error).and_call_original }
+
+          subject! { get callback }
 
           specify 'should raise AuthFailedError' do
-            expect(Rails.logger).to receive(:error).with(/Login failed/)
+            expect(Rails.logger).to have_received(:error).with(/Login failed/)
           end
+
+          specify 'should redirect to an error page' do
+            expect(response.status).to eql 302
+            expect(response.redirect_url).to end_with('schools/errors/auth_failed')
+          end
+        end
+
+        context 'when the OIDC endpoint times out' do
+          before do
+            stub_request(:get, "https://#{Rails.configuration.x.oidc_host}/me")
+              .with(
+                headers: {
+                  'Accept'        => '*/*',
+                  'Authorization' => "Bearer #{access_token}",
+                  'Date'          => /.*/,
+                  'User-Agent'    => /OpenIDConnect::AccessToken/
+                }
+              )
+              .to_timeout
+          end
+
+          subject! { get callback }
 
           specify 'should redirect to an error page' do
             expect(response.status).to eql 302
@@ -183,7 +212,7 @@ describe Schools::SessionsController, type: :request do
       end
     end
 
-    context 'when the session has timed out' do
+    context 'when the session has expired' do
       let(:message) { 'sessionexpired' }
       let(:expired_auth_callback_path) { "/auth/callback?error=#{message}" }
 

--- a/spec/services/schools/dfe_sign_in_api/client_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/client_spec.rb
@@ -35,52 +35,6 @@ describe Schools::DFESignInAPI::Client do
     end
   end
 
-  describe '.role_check_enabled?' do
-    context 'when the client is disabled' do
-      before { allow(subject).to receive(:enabled?).and_return(false) }
-      before { allow(ENV).to receive(:fetch).and_return(true) }
-
-      specify 'should be disabled' do
-        expect(subject).not_to be_role_check_enabled
-      end
-    end
-
-    context 'when the client is enabled' do
-      subject { described_class }
-      before { allow(subject).to receive(:enabled?).and_return(true) }
-      before { allow(Rails.application.config.x).to receive(:dfe_sign_in_api_role_check_enabled).and_return(true) }
-
-
-      context 'when role check is disabled' do
-        context 'when the DfE Sign-in role and service environment variables are absent' do
-          before { allow(ENV).to receive(:fetch).and_return(nil) }
-
-          specify 'should be disabled' do
-            expect(subject).not_to be_role_check_enabled
-          end
-        end
-      end
-
-      context 'when role check is enabled' do
-        context 'when the DfE Sign-in role and service environment variables are absent' do
-          before { allow(ENV).to receive(:fetch).and_return(nil) }
-
-          specify 'should be disabled' do
-            expect(subject).not_to be_role_check_enabled
-          end
-        end
-
-        context 'when the DfE Sign-in role and service environment variables are present' do
-          before { allow(ENV).to receive(:fetch).and_return('yes') }
-
-          specify 'should be enabled' do
-            expect(subject).to be_role_check_enabled
-          end
-        end
-      end
-    end
-  end
-
   describe 'error handling' do
     let(:testdata) { { hello: 'world' } }
     let(:apihost) { "https://some-test-api-host.signin.education.gov.uk" }

--- a/spec/services/schools/dfe_sign_in_api/client_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/client_spec.rb
@@ -107,7 +107,9 @@ describe Schools::DFESignInAPI::Client do
         end
 
         it 'will raise an error' do
-          expect { subject }.to raise_exception Faraday::ConnectionFailed
+          expect { subject }.to raise_exception \
+            described_class::ApiConnectionFailed
+              # confusing but the timeout helper doesnt actually trigger a faraday timeout error
         end
       end
     end

--- a/spec/services/schools/dfe_sign_in_api/client_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/client_spec.rb
@@ -80,4 +80,82 @@ describe Schools::DFESignInAPI::Client do
       end
     end
   end
+
+  describe 'error handling' do
+    let(:testdata) { { hello: 'world' } }
+    let(:apihost) { "https://some-test-api-host.signin.education.gov.uk" }
+
+    before do
+      allow(ENV).to receive(:fetch).and_return('123')
+
+      allow(Schools::DFESignInAPI::Client).to \
+        receive(:enabled?).and_return true
+    end
+
+    class TestAPI < Schools::DFESignInAPI::Client
+      def data; response; end
+
+    private
+
+      def endpoint
+        URI::HTTPS.build \
+          host: "some-test-api-host.signin.education.gov.uk",
+          path: '/testapi'
+      end
+    end
+
+    subject { TestAPI.new.data }
+
+    {
+      400 => Faraday::ClientError,
+      404 => Faraday::ResourceNotFound,
+      405 => Faraday::ClientError,
+      500 => Faraday::ServerError,
+      502 => Faraday::ServerError,
+      503 => Faraday::ServerError
+    }.each do |code, error|
+      context code.to_s do
+        before do
+          stub_request(:get, "#{apihost}/testapi")
+            .to_return(
+              status: code,
+              body: testdata.to_json,
+              headers: {}
+            )
+        end
+
+        specify "should raise a #{error} error" do
+          expect { subject }.to raise_error(error)
+        end
+      end
+    end
+
+    context 'timeouts' do
+      context 'first timeout' do
+        before do
+          stub_request(:get, "#{apihost}/testapi")
+            .to_timeout.then
+            .to_return(
+              status: :success,
+              body: testdata.to_json,
+              headers: {}
+            )
+        end
+
+        it { is_expected.to eql('hello' => 'world') }
+      end
+
+      context 'second timeout' do
+        before do
+          stub_request(:get, "#{apihost}/testapi")
+            .to_timeout.then
+            .to_timeout
+        end
+
+        it 'will raise an error' do
+          expect { subject }.to raise_exception Faraday::ConnectionFailed
+        end
+      end
+    end
+  end
 end

--- a/spec/services/schools/dfe_sign_in_api/organisations_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/organisations_spec.rb
@@ -47,33 +47,8 @@ describe Schools::DFESignInAPI::Organisations do
     end
   end
 
-  # FIXME this is generic behaviour, move to client_spec.rb
   describe 'error_handling' do
     subject { Schools::DFESignInAPI::Organisations.new(user_guid) }
-
-    {
-      400 => Faraday::ClientError,
-      404 => Faraday::ResourceNotFound,
-      405 => Faraday::ClientError,
-      500 => Faraday::ServerError,
-      502 => Faraday::ServerError,
-      503 => Faraday::ServerError
-    }.each do |code, error|
-      context code.to_s do
-        before do
-          stub_request(:get, "https://some-signin-host.signin.education.gov.uk/users/#{user_guid}/organisations")
-            .to_return(
-              status: code,
-              body: dfe_signin_school_data.to_json,
-              headers: {}
-            )
-        end
-
-        specify "should raise a #{error} error" do
-          expect { subject.urns }.to raise_error(error)
-        end
-      end
-    end
 
     describe 'when an invalid response is returned' do
       before do

--- a/spec/support/sign_in_api.rb
+++ b/spec/support/sign_in_api.rb
@@ -1,0 +1,23 @@
+shared_context "enable signin api" do
+  let(:enable_signin_api) { true }
+  before do
+    allow(Schools::DFESignInAPI::Client).to \
+      receive(:enabled?) { enable_signin_api }
+  end
+end
+
+shared_context "stub role check api" do
+  include_context "enable signin api"
+
+  let(:role_check_class) { Schools::DFESignInAPI::Roles }
+
+  let(:enable_signin_role_check_api) { true }
+  let(:signin_role_check_response) { true }
+
+  before do
+    allow(role_check_class).to receive(:enabled?) { enable_signin_role_check_api }
+
+    allow_any_instance_of(role_check_class).to \
+      receive(:has_school_experience_role?) { signin_role_check_response }
+  end
+end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2139

### Context

If calls to the DfE Sign-in API fail, we should initially retry in-case of network flakiness then fail but fail gracefully with an error message giving the user an opportunity to retry the login process.

### Changes proposed in this pull request

1. Add automatic retry on all API calls
2. Add a shorter timeout in case the connection has just hung
3. Raise custom exceptions when calls fail
4. Show the Auth Failed screen allowing the user to retry
5. Minor refactor of `enabled?` logic to make different API call classes responsible for whether they are enabled



