### PR TITLE
Changed redirection path

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -69,7 +69,7 @@ module Schools
       if Schools::ChangeSchool.allow_school_change_in_app?
         redirect_to schools_change_path
       else
-        redirect_to schools_errors_no_school_path
+        redirect_to schools_errors_insufficient_privileges_path
       end
     end
   end

--- a/spec/controllers/schools/dashboards_controller_spec.rb
+++ b/spec/controllers/schools/dashboards_controller_spec.rb
@@ -81,7 +81,8 @@ describe Schools::DashboardsController, type: :request do
         let(:allow_school_change) { false }
 
         specify 'should redirect to school not registered error page' do
-          expect(subject).to redirect_to(schools_errors_no_school_path)
+          expect(subject).to \
+            redirect_to(schools_errors_insufficient_privileges_path)
         end
       end
 


### PR DESCRIPTION
### JIRA Ticket Number

SE-2116

### Context

Prior behaviour cast the blank school urn #to_i, which resulting in a 0. This
meant the user saw the 'School not registered' error instead of the No school
error which appears to be a stub screen.

### Changes proposed in this pull request

1. Instead redirect the user to the insufficient privileges screen which has more
useful information on it for resolving the users issues.



