### PR TITLE
SE-2139 Removed support for invalid config

### DIFF
--- a/app/services/schools/dfe_sign_in_api/roles.rb
+++ b/app/services/schools/dfe_sign_in_api/roles.rb
@@ -13,10 +13,6 @@ module Schools
           ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID').presence ||
             raise(MissingConfigVariable)
         end
-
-        def enabled?
-          super && Rails.application.config.x.dfe_sign_in_api_role_check_enabled
-        end
       end
 
       def initialize(user_uuid, organisation_uuid)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,7 +98,6 @@ Rails.application.configure do
   truthy_strings = %w(true 1 yes)
 
   config.x.dfe_sign_in_api_enabled = ENV['DFE_SIGNIN_API_ENABLED']&.in?(truthy_strings)
-  config.x.dfe_sign_in_api_role_check_enabled = ENV['DFE_SIGNIN_API_ROLE_CHECK_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_api_school_change_enabled = ENV['DFE_SIGNIN_API_SCHOOL_CHANGE_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_request_organisation_url = ENV['DFE_SIGNIN_REQUEST_ORGANISATION_URL'].presence
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -140,7 +140,6 @@ Rails.application.configure do
   truthy_strings = %w(true 1 yes)
 
   config.x.dfe_sign_in_api_enabled = ENV['DFE_SIGNIN_API_ENABLED']&.in?(truthy_strings)
-  config.x.dfe_sign_in_api_role_check_enabled = ENV['DFE_SIGNIN_API_ROLE_CHECK_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_api_school_change_enabled = ENV['DFE_SIGNIN_API_SCHOOL_CHANGE_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_request_organisation_url = ENV['DFE_SIGNIN_REQUEST_ORGANISATION_URL'].presence
 

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -26,7 +26,6 @@ Rails.application.configure do
   config.x.oidc_services_list_url = 'https://some-oidc.provider.com/my-services'
   config.x.dfe_sign_in_api_host = 'pp-api.signin.education.gov.uk'
   config.x.dfe_sign_in_api_enabled = false
-  config.x.dfe_sign_in_api_role_check_enabled = false
   config.x.dfe_sign_in_api_school_change_enabled = false
 
   config.x.gitis.fake_crm = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -89,7 +89,6 @@ Rails.application.configure do
   config.x.dfe_sign_in_admin_service_id = '66666666-5555-aaaa-bbbb-cccccccccccc'
   config.x.dfe_sign_in_admin_role_id = '66666666-5555-4444-3333-222222222222'
   config.x.dfe_sign_in_api_enabled = false
-  config.x.dfe_sign_in_api_role_check_enabled = false
   config.x.dfe_sign_in_api_school_change_enabled = false
 
   config.x.gitis.fake_crm = true

--- a/spec/services/schools/dfe_sign_in_api/roles_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/roles_spec.rb
@@ -6,52 +6,6 @@ describe Schools::DFESignInAPI::Roles do
   before { allow(described_class).to receive(:enabled?) { true } }
   subject { described_class.new(user_guid, dfe_signin_school_id) }
 
-  describe '.enabled?' do
-    before do
-      allow(Schools::DFESignInAPI::Roles).to \
-        receive(:enabled?).and_call_original
-    end
-
-    subject { Schools::DFESignInAPI::Roles.enabled? }
-
-    context 'when the client is disabled' do
-      before do
-        allow(Schools::DFESignInAPI::Client).to receive(:enabled?) { false }
-        allow(ENV).to receive(:fetch).and_return(true)
-      end
-
-      specify 'should be disabled' do
-        is_expected.to be false
-      end
-    end
-
-    context 'when the client is enabled' do
-      before { allow(Schools::DFESignInAPI::Client).to receive(:enabled?) { true } }
-
-      context 'when role check is disabled' do
-        before do
-          allow(Rails.application.config.x).to \
-            receive(:dfe_sign_in_api_role_check_enabled).and_return false
-        end
-
-        specify 'should be disabled' do
-          expect(subject).to be false
-        end
-      end
-
-      context 'when role check is enabled' do
-        before do
-          allow(Rails.application.config.x).to \
-            receive(:dfe_sign_in_api_role_check_enabled).and_return true
-        end
-
-        specify 'should be enabled' do
-          expect(subject).to be true
-        end
-      end
-    end
-  end
-
   specify 'should respond to #has_school_experience_role?' do
     expect(subject).to respond_to(:has_school_experience_role?)
   end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2139

### Context

The recent change to use RoleCheckedOrganisations means we always use role
checks if the API is enabled. A subsequent change to make the Roles#enabled?
return false if the config is disabled breaks the API usage so removing the
option to toggle just this specific API.

The actual issue is Roles#enabled? will now trigger a ApiDisabled error in the
attempt to call response in parent DFESignInAPI::Client class.

### Changes proposed in this pull request

1. Remove support for disabling the Roles API separate from the main usage of DfE Sign-in API, its either all on or off.



