### PR TITLE
Added missing write! method in Gitis cache implementation

### DIFF
--- a/app/services/bookings/gitis/store/write_only_cache.rb
+++ b/app/services/bookings/gitis/store/write_only_cache.rb
@@ -27,6 +27,12 @@ module Bookings
           end
         end
 
+        def write!(entity)
+          store.write!(entity).tap do
+            cache.delete cache_key_for_entity entity
+          end
+        end
+
       private
 
         def entities_to_cache(entities)

--- a/spec/services/bookings/gitis/store/write_only_cache_spec.rb
+++ b/spec/services/bookings/gitis/store/write_only_cache_spec.rb
@@ -20,6 +20,7 @@ describe Bookings::Gitis::Store::WriteOnlyCache do
     it { is_expected.to respond_to :find }
     it { is_expected.to respond_to :fetch }
     it { is_expected.to respond_to :write }
+    it { is_expected.to respond_to :write! }
   end
 
   describe '#cache_key_for_entity' do


### PR DESCRIPTION
### Context

The cache implementation of a Gitis store doesn't implement the `write!` method which was implemented in a parallel PR

### Changes proposed in this pull request

1. Add a write! implementation



