### PR TITLE
Always show change school if request approval enabled

### DIFF
--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -6,7 +6,7 @@
 
     <article id="dashboard">
 
-      <% if has_other_schools? %>
+      <% if has_other_schools? || (Schools::ChangeSchool.allow_school_change_in_app? && Schools::ChangeSchool.request_approval_url) %>
         <section id="change-school">
           <%= link_to "Change school", new_schools_switch_path %>
         </section>


### PR DESCRIPTION
If the user belongs to only one school, the Change school screen is still useful because it sign posts the user to where they can apply for access to another school