### PR TITLE
Added Rake task to download all Gitis metadata

### DIFF
--- a/lib/tasks/gitis/metadata.rake
+++ b/lib/tasks/gitis/metadata.rake
@@ -1,0 +1,19 @@
+namespace :gitis do
+  desc "Retrieve the $metadata xml content from the configured Gitis source - outputs to STDOUT"
+  task metadata: :environment do
+    api = Bookings::Gitis::Factory.crm.send(:store).send(:api)
+    token = api.access_token
+    conn = api.send(:connection)
+
+    response = conn.get do |c|
+      c.url '$metadata'
+      c.headers = {
+        'Authorization' => "Bearer #{token}",
+        'OData-MaxVersion' => '4.0',
+        'OData-Version' => '4.0'
+      }
+    end
+
+    puts response.body
+  end
+end


### PR DESCRIPTION
### Context

Some times I need to download the metadata file when updating our CRM integration code. This script maybe more broadly useful so adding to codebase as a rake task

### Changes proposed in this pull request

1. Add simple rake task to download the metadata (schema) from Gitis



