### PR TITLE
SE-2144 Support for CRM merged records

### DIFF
--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -17,7 +17,7 @@ module Candidates
           placement_request_params
 
         if @cancellation.save(context: :candidate_cancellation)
-          @placement_request.fetch_gitis_contact gitis_crm
+          assign_gitis_contact @placement_request
 
           notify_school @cancellation
           notify_candidate @cancellation

--- a/app/controllers/concerns/gitis_access.rb
+++ b/app/controllers/concerns/gitis_access.rb
@@ -13,12 +13,14 @@ module GitisAccess
   def assign_gitis_contacts(models)
     return models if models.empty?
 
-    contact_uuids = models.map(&:contact_uuid)
-    contacts = gitis_crm.find(contact_uuids).index_by(&:contactid)
+    Bookings::Gitis::ContactFetcher \
+      .new(gitis_crm)
+      .assign_to_models(models)
+  end
 
-    models.each do |model|
-      model.gitis_contact = contacts[model.contact_uuid] ||
-        Bookings::Gitis::MissingContact.new(model.contact_uuid)
-    end
+  def assign_gitis_contact(candidate)
+    Bookings::Gitis::ContactFetcher \
+      .new(gitis_crm)
+      .assign_to_model(candidate)
   end
 end

--- a/app/controllers/concerns/gitis_authentication.rb
+++ b/app/controllers/concerns/gitis_authentication.rb
@@ -48,7 +48,7 @@ protected
     raise UnconfirmedCandidate unless candidate.confirmed?
 
     self.current_contact = candidate.gitis_contact ||
-      candidate.fetch_gitis_contact(gitis_crm)
+      assign_gitis_contact(candidate).gitis_contact
 
     @current_candidate = candidate
   end

--- a/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations/notification_deliveries_controller.rb
@@ -6,12 +6,12 @@ module Schools
 
         def show
           @cancellation = @placement_request.school_cancellation
-          @placement_request.fetch_gitis_contact gitis_crm
+          assign_gitis_contact @placement_request
         end
 
         def create
           @cancellation = @placement_request.school_cancellation
-          @placement_request.fetch_gitis_contact gitis_crm
+          assign_gitis_contact @placement_request
 
           if @cancellation.sent!
             notify_candidate @cancellation

--- a/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/cancellations_controller.rb
@@ -6,17 +6,17 @@ module Schools
 
       def show
         @cancellation = @placement_request.school_cancellation
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
       end
 
       def new
         @cancellation = @placement_request.build_school_cancellation
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
       end
 
       def edit
         @cancellation = @placement_request.school_cancellation
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
       end
 
       def create
@@ -27,7 +27,7 @@ module Schools
           redirect_to schools_booking_cancellation_path \
             @booking
         else
-          @placement_request.fetch_gitis_contact gitis_crm
+          assign_gitis_contact @placement_request
           render :new
         end
       end
@@ -41,7 +41,7 @@ module Schools
           redirect_to schools_booking_cancellation_path \
             @booking
         else
-          @placement_request.fetch_gitis_contact gitis_crm
+          assign_gitis_contact @placement_request
           render :edit
         end
       end

--- a/app/controllers/schools/confirmed_bookings/date_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/date_controller.rb
@@ -50,9 +50,7 @@ module Schools
           .eager_load(bookings_placement_request: :candidate)
           .find(params[:booking_id])
 
-        @booking
-          .bookings_placement_request
-          .fetch_gitis_contact(gitis_crm)
+        assign_gitis_contact @booking
       end
 
       def check_editable

--- a/app/controllers/schools/confirmed_bookings_controller.rb
+++ b/app/controllers/schools/confirmed_bookings_controller.rb
@@ -17,7 +17,7 @@ module Schools
         .eager_load(:bookings_subject, :bookings_placement_request)
         .find(params[:id])
 
-      @booking.bookings_placement_request.fetch_gitis_contact gitis_crm
+      assign_gitis_contact @booking
 
       if @booking.candidate_cancellation
         @booking.candidate_cancellation.viewed!

--- a/app/controllers/schools/placement_requests/acceptance.rb
+++ b/app/controllers/schools/placement_requests/acceptance.rb
@@ -7,7 +7,7 @@ module Schools
         @placement_request = @current_school.placement_requests \
           .find(params[:placement_request_id])
 
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
       end
 
       def find_or_build_booking(placement_request)

--- a/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/confirm_booking_controller.rb
@@ -7,7 +7,6 @@ module Schools
         def new
           set_placement_request_and_fetch_gitis_contact
 
-          @placement_request.fetch_gitis_contact gitis_crm
           @booking = find_or_build_booking(@placement_request)
           @last_booking_found = @booking.populate_contact_details
         end

--- a/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
@@ -7,7 +7,6 @@ module Schools
         def new
           set_placement_request_and_fetch_gitis_contact
 
-          @placement_request.fetch_gitis_contact gitis_crm
           @booking = @placement_request.booking || Bookings::Booking.from_placement_request(@placement_request)
           @booking.populate_contact_details
 

--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -30,7 +30,7 @@ module Schools
         end
 
         def fetch_gitis_contact_for_placement_request
-          @placement_request.fetch_gitis_contact gitis_crm
+          assign_gitis_contact @placement_request
         end
 
         def ensure_placement_request_is_open

--- a/app/controllers/schools/placement_requests/cancellations_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations_controller.rb
@@ -6,19 +6,19 @@ module Schools
 
       def show
         @cancellation = @placement_request.school_cancellation
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
       end
 
       def new
         @cancellation = @placement_request.build_school_cancellation
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
       end
 
       def create
         @cancellation = @placement_request.build_school_cancellation \
           cancellation_params
 
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
 
         if @cancellation.save(context: :rejection)
           redirect_to schools_placement_request_cancellation_path \
@@ -30,7 +30,7 @@ module Schools
 
       def edit
         @cancellation = @placement_request.school_cancellation
-        @placement_request.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @placement_request
       end
 
       def update
@@ -41,7 +41,7 @@ module Schools
           redirect_to schools_placement_request_cancellation_path \
             @placement_request
         else
-          @placement_request.fetch_gitis_contact gitis_crm
+          assign_gitis_contact @placement_request
           render :edit
         end
       end

--- a/app/controllers/schools/placement_requests/past_attendance_controller.rb
+++ b/app/controllers/schools/placement_requests/past_attendance_controller.rb
@@ -5,7 +5,7 @@ module Schools
         @placement_request = load_placement_request
 
         @candidate = @placement_request.candidate
-        @candidate.fetch_gitis_contact gitis_crm
+        assign_gitis_contact @candidate
 
         @attendance = load_attendance_records(@candidate.id, school_urns).to_a
       end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -19,7 +19,7 @@ module Schools
     def show
       @placement_request = placement_request
 
-      @gitis_contact = placement_request.fetch_gitis_contact(gitis_crm)
+      @gitis_contact = assign_gitis_contact(placement_request).gitis_contact
 
       @placement_request.viewed!
 

--- a/app/controllers/schools/previous_bookings_controller.rb
+++ b/app/controllers/schools/previous_bookings_controller.rb
@@ -13,7 +13,7 @@ module Schools
     def show
       @booking = scope.find(params[:id])
 
-      @booking.fetch_gitis_contact gitis_crm
+      assign_gitis_contact @booking
     end
 
   private

--- a/app/controllers/schools/rejected_requests_controller.rb
+++ b/app/controllers/schools/rejected_requests_controller.rb
@@ -11,7 +11,7 @@ module Schools
 
     def show
       @rejected_request = scope.find(params[:id])
-      @rejected_request.fetch_gitis_contact gitis_crm
+      assign_gitis_contact @rejected_request
 
       @cancellation = @rejected_request.school_cancellation
     end

--- a/app/controllers/schools/withdrawn_requests_controller.rb
+++ b/app/controllers/schools/withdrawn_requests_controller.rb
@@ -10,7 +10,7 @@ module Schools
 
     def show
       @withdrawn_request = scope.find(params[:id])
-      @withdrawn_request.fetch_gitis_contact gitis_crm
+      assign_gitis_contact @withdrawn_request
 
       @cancellation = @withdrawn_request.candidate_cancellation
       @cancellation.viewed!

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -62,7 +62,6 @@ module Bookings
       :received_on,
       :gitis_contact,
       :gitis_contact=,
-      :fetch_gitis_contact,
       :contact_uuid,
       :candidate_email,
       :candidate_name,

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -66,6 +66,7 @@ module Bookings
       :contact_uuid,
       :candidate_email,
       :candidate_name,
+      :candidate,
       :cancelled?,
       :cancellation,
       to: :bookings_placement_request

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -96,12 +96,4 @@ class Bookings::Candidate < ApplicationRecord
 
     self
   end
-
-  def fetch_gitis_contact(crm)
-    raise NoGitisUuid unless gitis_uuid?
-
-    self.gitis_contact = crm.find(gitis_uuid)
-  end
-
-  class NoGitisUuid < RuntimeError; end
 end

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -25,6 +25,8 @@ class Bookings::Candidate < ApplicationRecord
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :unconfirmed, -> { where(confirmed_at: nil) }
 
+  alias_attribute :contact_uuid, :gitis_uuid
+
   delegate :full_name, :email, to: :gitis_contact
 
   class << self

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -98,4 +98,24 @@ class Bookings::Candidate < ApplicationRecord
 
     self
   end
+
+  def assign_gitis_contact(contact)
+    self.gitis_contact = contact
+
+    if gitis_uuid != contact.contactid
+      # using update column to avoid accidentally persisting any other
+      # changed state on the candidate
+
+      # This is to handle when a Gitis record gets merged - we request one
+      # contactid but the ContactFetcher returns a different contactid
+
+      if persisted?
+        update_column :gitis_uuid, contact.contactid
+      else
+        self.gitis_uuid = contact.contactid
+      end
+    end
+
+    gitis_contact
+  end
 end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -118,7 +118,7 @@ module Bookings
 
     default_scope { where.not(candidate_id: nil) }
 
-    delegate :gitis_contact, :gitis_contact=, :fetch_gitis_contact, to: :candidate
+    delegate :gitis_contact, :gitis_contact=, to: :candidate
 
     def self.create_from_registration_session!(registration_session, analytics_tracking_uuid = nil)
       self.new(

--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -33,6 +33,7 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
   delegate \
     :candidate_email,
     :candidate_name,
+    :candidate,
     :contact_uuid,
     :gitis_contact,
     :gitis_contact=,

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -3,6 +3,10 @@ module Bookings
     class Contact
       include Entity
 
+      # statecode field values
+      READWRITE = 0
+      READONLY = 1
+
       def self.channel_creation
         Rails.application.config.x.gitis.channel_creation
       end
@@ -20,10 +24,13 @@ module Bookings
       entity_attributes :dfe_notesforclassroomexperience
       entity_attributes :mobilephone, except: :update
       entity_attribute  :dfe_channelcreation, except: :update, default: channel_creation
+      entity_attribute  :statecode, except: %i(create update), default: READWRITE
+      entity_attribute  :merged, except: %i(create update), default: false
 
       entity_association :dfe_Country, Country, default: Country.default
       entity_association :dfe_PreferredTeachingSubject01, TeachingSubject
       entity_association :dfe_PreferredTeachingSubject02, TeachingSubject
+      entity_association :masterid, Contact
 
       entity_collection :dfe_contact_dfe_candidateprivacypolicy_Candidate, CandidatePrivacyPolicy
 
@@ -122,6 +129,14 @@ module Bookings
 
         self.dfe_notesforclassroomexperience = "#{dfe_notesforclassroomexperience}#{log_line}\r\n"
       end
+
+      def been_merged?
+        raise InconsistentState unless merged == _masterid_value.present?
+
+        merged
+      end
+
+      class InconsistentState < RuntimeError; end
 
     private
 

--- a/app/services/bookings/gitis/contact_fetcher.rb
+++ b/app/services/bookings/gitis/contact_fetcher.rb
@@ -1,7 +1,7 @@
 module Bookings
   module Gitis
     class ContactFetcher
-      MAX_NESTING = 5 # max depth we will try to unwind to
+      MAX_NESTING = 5 # max depth we will follow the chain of merged contacts to
       attr_reader :crm
 
       def initialize(crm)
@@ -12,15 +12,25 @@ module Bookings
         return {} if models.empty?
 
         contact_uuids = models.map(&:contact_uuid)
-        crm.find(contact_uuids).index_by(&:contactid)
+        fetch_multiple_master_contacts(contact_uuids)
       end
 
       def assign_to_models(models)
         contacts = fetch_for_models(models)
 
         models.each do |model|
-          model.gitis_contact = contacts[model.contact_uuid] ||
-            Bookings::Gitis::MissingContact.new(model.contact_uuid)
+          candidate = model.is_a?(Bookings::Candidate) ? model : model.candidate
+
+          if contacts.has_key? candidate.gitis_uuid
+            candidate.gitis_contact = contacts[candidate.gitis_uuid]
+
+            if candidate.gitis_uuid != candidate.gitis_contact.contactid
+              candidate.update_column :gitis_uuid, candidate.gitis_contact.contactid
+            end
+          else
+            candidate.gitis_contact = \
+              Bookings::Gitis::MissingContact.new(model.contact_uuid)
+          end
         end
       end
 
@@ -29,7 +39,7 @@ module Bookings
 
         raise NoGitisUuid unless candidate.gitis_uuid?
 
-        candidate.gitis_contact = single_unmerged_contact(candidate.gitis_uuid)
+        candidate.gitis_contact = fetch_single_master_contact(candidate.gitis_uuid)
 
         if candidate.gitis_uuid != candidate.gitis_contact.contactid
           candidate.update_column :gitis_uuid, candidate.gitis_contact.contactid
@@ -42,16 +52,46 @@ module Bookings
 
     private
 
-      def single_unmerged_contact(contactid)
+      def fetch_single_master_contact(contactid)
         contact = nil
 
-        1.upto(MAX_NESTING) do |i|
+        1.upto(MAX_NESTING) do
           contact = crm.find contactid
           break unless contact.been_merged?
+
           contactid = contact._masterid_value
         end
 
         contact
+      end
+
+      def fetch_multiple_master_contacts(contactids)
+        contacts = nil
+        parentids = contactids.dup
+
+        1.upto(MAX_NESTING) do
+          fetched = crm.find(parentids).index_by(&:contactid)
+
+          if contacts.nil?
+            contacts = fetched
+          else
+            contacts.transform_values! do |contact|
+              if contact.been_merged?
+                fetched[contact._masterid_value]
+              else
+                contact
+              end
+            end
+          end
+
+          if contacts.values.any?(&:been_merged?)
+            parentids = contacts.values.select(&:been_merged?).map(&:_masterid_value)
+          else
+            return contacts
+          end
+        end
+
+        contacts
       end
     end
   end

--- a/app/services/bookings/gitis/contact_fetcher.rb
+++ b/app/services/bookings/gitis/contact_fetcher.rb
@@ -1,0 +1,38 @@
+module Bookings
+  module Gitis
+    class ContactFetcher
+      attr_reader :crm
+
+      def initialize(crm)
+        @crm = crm
+      end
+
+      def fetch_for_models(models)
+        return {} if models.empty?
+
+        contact_uuids = models.map(&:contact_uuid)
+        crm.find(contact_uuids).index_by(&:contactid)
+      end
+
+      def assign_to_models(models)
+        contacts = fetch_for_models(models)
+
+        models.each do |model|
+          model.gitis_contact = contacts[model.contact_uuid] ||
+            Bookings::Gitis::MissingContact.new(model.contact_uuid)
+        end
+      end
+
+      def assign_to_model(model)
+        candidate = model.is_a?(Bookings::Candidate) ? model : model.candidate
+
+        raise NoGitisUuid unless candidate.gitis_uuid?
+
+        candidate.gitis_contact = crm.find(candidate.gitis_uuid)
+        model
+      end
+
+      class NoGitisUuid < RuntimeError; end
+    end
+  end
+end

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -16,7 +16,7 @@ module Bookings
 
       def find_by_email(address)
         contacts = store.fetch Contact,
-          filter: filter_pairs(emailaddress2: address, emailaddress1: address),
+          filter: email_filter(address),
           limit: 1
 
         if contacts.any?
@@ -28,7 +28,7 @@ module Bookings
 
       # Will return nil of it cannot match a Contact on final implementation
       def find_contact_for_signin(email:, firstname:, lastname:, date_of_birth:)
-        filter = filter_pairs(emailaddress2: email, emailaddress1: email)
+        filter = email_filter(email)
         contacts = fetch(Contact, filter: filter, limit: 30, order: 'createdon desc')
 
         matcher = ContactFuzzyMatcher.new(firstname, lastname, date_of_birth)
@@ -47,14 +47,10 @@ module Bookings
 
     private
 
-      def filter_pairs(filter_data, join_with = 'or')
-        parts = filter_data.map do |key, values|
-          Array.wrap(values).map do |value|
-            "#{key} eq '#{value}'"
-          end
-        end
-
-        parts.join(" #{join_with} ")
+      def email_filter(email_address)
+        FilterBuilder \
+          .new(:emailaddress2, email_address)
+          .or(:emailaddress1, email_address)
       end
 
       def crmlog(msg)

--- a/app/services/bookings/gitis/crm.rb
+++ b/app/services/bookings/gitis/crm.rb
@@ -15,7 +15,7 @@ module Bookings
       end
 
       def find_by_email(address)
-        contacts = store.fetch Contact,
+        contacts = fetch Contact,
           filter: email_filter(address),
           limit: 1
 
@@ -28,8 +28,10 @@ module Bookings
 
       # Will return nil of it cannot match a Contact on final implementation
       def find_contact_for_signin(email:, firstname:, lastname:, date_of_birth:)
-        filter = email_filter(email)
-        contacts = fetch(Contact, filter: filter, limit: 30, order: 'createdon desc')
+        contacts = fetch Contact,
+          filter: master_record_filter.and(email_filter(email)),
+          limit: 30,
+          order: 'createdon desc'
 
         matcher = ContactFuzzyMatcher.new(firstname, lastname, date_of_birth)
         matcher.find(contacts).tap do |match|
@@ -51,6 +53,13 @@ module Bookings
         FilterBuilder \
           .new(:emailaddress2, email_address)
           .or(:emailaddress1, email_address)
+      end
+
+      def master_record_filter
+        FilterBuilder \
+          .new(:_masterid_value, nil) # reference to master record if merged
+          .and(:merged, false) # whether merged, duplicates presence of masterid
+          .and(:statecode, 0) # 0 = read/write, 1 = read only
       end
 
       def crmlog(msg)

--- a/app/services/bookings/gitis/event_logger.rb
+++ b/app/services/bookings/gitis/event_logger.rb
@@ -4,7 +4,7 @@ module Bookings
       attr_reader :type, :subject
 
       NOTES_HEADER = "RECORDED   ACTION                 EXP DATE   URN    NAME".freeze
-      LOG_LINE = "%10<recorded>s %-22<action>s %8<date>s %-6<urn>s %.25<name>s".freeze
+      LOG_LINE = "%10<recorded>s %-22<action>s %10<date>s %-6<urn>s %.25<name>s".freeze
 
       class << self
         def entry(type, subject)

--- a/app/services/bookings/gitis/fake_crm.rb
+++ b/app/services/bookings/gitis/fake_crm.rb
@@ -1,18 +1,37 @@
 module Bookings::Gitis
   class FakeCrm < CRM
+    NAMESPACE = 'fake-gitis'.freeze
+    VERSION = 'v1'.freeze
+    TTL = 3.minutes.freeze
+
     def initialize
-      @store = Store::Fake.new
+      @store = fake_write_only_cache_store
     end
 
     def find_contact_for_signin(email:, firstname:, lastname:, date_of_birth:)
       return nil if email =~ /unknown/
 
-      Contact.new(store.send(:fake_contact_data)).tap do |contact|
+      Contact.new(fake_contact_data).tap do |contact|
         contact.email = email
         contact.firstname = firstname
         contact.lastname = lastname
         contact.date_of_birth = date_of_birth
       end
+    end
+
+    def fake_store
+      @fake_store ||= Store::Fake.new
+    end
+
+    def fake_contact_data
+      fake_store.send :fake_contact_data
+    end
+
+  private
+
+    def fake_write_only_cache_store
+      Bookings::Gitis::Store::WriteOnlyCache.new fake_store, Rails.cache,
+        namespace: NAMESPACE, ttl: TTL, version: VERSION
     end
   end
 end

--- a/app/services/bookings/gitis/filter_builder.rb
+++ b/app/services/bookings/gitis/filter_builder.rb
@@ -1,0 +1,44 @@
+module Bookings
+  module Gitis
+    class FilterBuilder
+      def initialize(*args)
+        @constraint = serialize(*args)
+      end
+
+      def and(*args)
+        @constraint = "#{self} and #{serialize(*args)}"
+        self
+      end
+
+      def or(*args)
+        @constraint = "#{self} or #{serialize(*args)}"
+        self
+      end
+
+      def to_s
+        @constraint
+      end
+
+    private
+
+      def serialize(attribute_or_filter, value = nil, operator = 'eq')
+        if attribute_or_filter.is_a? FilterBuilder
+          "(#{attribute_or_filter})"
+        else
+          "#{attribute_or_filter} #{operator} #{serialize_value value}"
+        end
+      end
+
+      def serialize_value(value)
+        case value
+        when String
+          "'#{value}'"
+        when nil
+          'null'
+        else
+          value.to_s
+        end
+      end
+    end
+  end
+end

--- a/features/step_definitions/schools/confirm_attendance_steps.rb
+++ b/features/step_definitions/schools/confirm_attendance_steps.rb
@@ -14,11 +14,10 @@ end
 
 Then("the correct data should be present in each row") do
   gitis = Bookings::Gitis::Factory.crm
+  contact = gitis.find(@first_booking.contact_uuid)
 
   within("table > tbody > tr[data-booking-id='#{@first_booking.id}']") do
-    expect(page).to have_content(
-      @first_booking.bookings_placement_request.fetch_gitis_contact(gitis).full_name
-    )
+    expect(page).to have_content(contact.full_name)
     expect(page).to have_content(@first_booking.date.strftime('%d %B %Y'))
     expect(page).to have_content(@first_booking.bookings_subject.name)
   end

--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -27,8 +27,8 @@ end
 
 Then("the subheading should be {string} followed by the candidate's name") do |subheading|
   gitis = Bookings::Gitis::Factory.crm
-  candidate_name = @placement_request.fetch_gitis_contact(gitis).full_name
-  expect(page).to have_css('h3', text: "#{subheading} #{candidate_name}.")
+  contact = gitis.find(@placement_request.contact_uuid)
+  expect(page).to have_css('h3', text: "#{subheading} #{contact.full_name}.")
 end
 
 Then("there should be a list containing school and placement request data") do

--- a/lib/apimock/gitis_crm.rb
+++ b/lib/apimock/gitis_crm.rb
@@ -79,7 +79,10 @@ module Apimock
           .merge(contactdata.stringify_keys)
       end
 
-      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=30&$filter=emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'&$select=#{contact_attributes}&$orderby=createdon desc").
+      email_filter = "emailaddress2 eq '#{email}' or emailaddress1 eq '#{email}'"
+      master_record_filter = "_masterid_value eq null and merged eq false and statecode eq 0"
+
+      stub_request(:get, "#{service_url}#{endpoint}/contacts?$top=30&$filter=#{master_record_filter} and (#{email_filter})&$select=#{contact_attributes}&$orderby=createdon desc").
         with(headers: get_headers).
         to_return(
           status: 200,

--- a/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
@@ -115,9 +115,8 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
         include_context 'fake gitis'
 
         let(:candidate) { create(:candidate, :confirmed) }
-        let(:contact_attributes) do
-          candidate.fetch_gitis_contact(fake_gitis).attributes
-        end
+        let(:contact) { fake_gitis.find candidate.gitis_uuid }
+        let(:contact_attributes) { contact.attributes }
 
         before do
           allow_any_instance_of(ActionDispatch::Request::Session).to \

--- a/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
@@ -93,9 +93,7 @@ describe Schools::ConfirmedBookings::DateController, type: :request do
       end
 
       before do
-        booking
-          .bookings_placement_request
-          .fetch_gitis_contact(fake_gitis)
+        booking.gitis_contact = fake_gitis.find(booking.contact_uuid)
       end
 
       before { subject }

--- a/spec/factories/bookings/gitis/contact_factory.rb
+++ b/spec/factories/bookings/gitis/contact_factory.rb
@@ -19,6 +19,15 @@ FactoryBot.define do
     trait :persisted do
       after(:build, &:clear_changes_information)
       contactid { SecureRandom.uuid }
+      _masterid_value { nil }
+      merged { false }
+      statecode { Bookings::Gitis::Contact::READWRITE }
+    end
+
+    trait :merged do
+      _masterid_value { SecureRandom.uuid }
+      merged { true }
+      statecode { Bookings::Gitis::Contact::READONLY }
     end
   end
 end

--- a/spec/features/candidates/registrations_spec.rb
+++ b/spec/features/candidates/registrations_spec.rb
@@ -59,7 +59,7 @@ feature 'Candidate Registrations', type: :feature do
       include_context 'fake gitis with known uuid'
 
       let(:token) { create(:candidate_session_token) }
-      let(:fake_data) { fake_gitis.store.send(:fake_contact_data) }
+      let(:fake_data) { fake_gitis.fake_contact_data }
       let(:email_address) { fake_data['emailaddress2'] }
       let(:name) { fake_data['firstname'] + ' ' + fake_data['lastname'] }
       let(:date_of_birth) { Date.parse fake_data['birthdate'] }
@@ -86,7 +86,7 @@ feature 'Candidate Registrations', type: :feature do
     context 'for known Candidate not signed in' do
       include_context 'fake gitis with known uuid'
 
-      let(:fake_data) { fake_gitis.store.send(:fake_contact_data) }
+      let(:fake_data) { fake_gitis.fake_contact_data }
       let(:email_address) { fake_data['emailaddress2'] }
       let(:name) { fake_data['firstname'] + ' ' + fake_data['lastname'] }
       let(:date_of_birth) { Date.parse fake_data['birthdate'] }
@@ -115,7 +115,7 @@ feature 'Candidate Registrations', type: :feature do
       include_context 'fake gitis with known uuid'
 
       # Contact gets default email address after reload via token lookup
-      let(:fake_data) { fake_gitis.store.send(:fake_contact_data) }
+      let(:fake_data) { fake_gitis.fake_contact_data }
       let(:email_address) { fake_data['emailaddress2'] }
       let(:name) { fake_data['firstname'] + ' ' + fake_data['lastname'] }
       let(:date_of_birth) { Date.parse fake_data['birthdate'] }

--- a/spec/jobs/candidates/registrations/accept_privacy_policy_job_spec.rb
+++ b/spec/jobs/candidates/registrations/accept_privacy_policy_job_spec.rb
@@ -36,7 +36,7 @@ describe Candidates::Registrations::AcceptPrivacyPolicyJob, type: :job do
 
     context 'on success' do
       before do
-        allow(fake_gitis.store).to receive(:create_entity).and_return(SecureRandom.uuid)
+        allow(fake_gitis.fake_store).to receive(:create_entity).and_return(SecureRandom.uuid)
 
         freeze_time
 
@@ -45,7 +45,7 @@ describe Candidates::Registrations::AcceptPrivacyPolicyJob, type: :job do
       end
 
       it "creates a CandidatePrivacyPolicy entity" do
-        expect(fake_gitis.store).to have_received(:create_entity).with \
+        expect(fake_gitis.fake_store).to have_received(:create_entity).with \
           'dfe_candidateprivacypolicies', hash_including(
             'dfe_meanofconsent' => Bookings::Gitis::PrivacyPolicy.consent,
             'dfe_timeofconsent' => Time.now.utc.iso8601,

--- a/spec/jobs/gitis_job_spec.rb
+++ b/spec/jobs/gitis_job_spec.rb
@@ -5,7 +5,7 @@ describe GitisJob do
     subject { described_class.new.send(:gitis) }
     it do
       is_expected.to have_attributes \
-        store: kind_of(Bookings::Gitis::Store::Fake)
+        fake_store: kind_of(Bookings::Gitis::Store::Fake)
     end
   end
 end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Bookings::Candidate, type: :model do
       let(:contact) { candidate.gitis_contact }
 
       before do
-        expect(fake_gitis.store).to receive(:update_entity).and_return(contact.entity_id)
+        expect(fake_gitis.fake_store).to receive(:update_entity).and_return(contact.entity_id)
       end
 
       subject do
@@ -189,7 +189,7 @@ RSpec.describe Bookings::Candidate, type: :model do
       let(:contact) { build(:gitis_contact, :persisted) }
 
       before do
-        expect(fake_gitis.store).to receive(:update_entity).and_return(contact.entity_id)
+        expect(fake_gitis.fake_store).to receive(:update_entity).and_return(contact.entity_id)
       end
 
       subject do
@@ -217,7 +217,7 @@ RSpec.describe Bookings::Candidate, type: :model do
       let(:contact_id) { SecureRandom.uuid }
 
       before do
-        expect(fake_gitis.store).to receive(:create_entity) do |entity_id, _data|
+        expect(fake_gitis.fake_store).to receive(:create_entity) do |entity_id, _data|
           "#{entity_id}(#{contact_id})"
         end
       end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -315,19 +315,6 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
   end
 
-  describe '#fetch_gitis_contact' do
-    include_context 'fake gitis'
-    subject { FactoryBot.create :candidate }
-
-    it "will assign contact" do
-      expect(subject.fetch_gitis_contact(fake_gitis)).to \
-        be_kind_of(Bookings::Gitis::Contact)
-
-      expect(subject.gitis_contact).to be_kind_of(Bookings::Gitis::Contact)
-      expect(subject.contact).to be_kind_of(Bookings::Gitis::Contact)
-    end
-  end
-
   describe "contact accessor attributes" do
     subject { build :candidate, :with_gitis_contact }
     it "will be delegated to gitis contact" do

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe Bookings::Candidate, type: :model do
     it { is_expected.to have_db_index(:gitis_uuid).unique }
   end
 
+  describe 'attributes' do
+    it { is_expected.to respond_to :contact_uuid }
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of :gitis_uuid }
 

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -267,6 +267,15 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
   end
 
+  describe '#assign_gitis_contact' do
+    let(:contact) { build(:gitis_contact, :persisted) }
+    let(:candidate) { create(:candidate) }
+    before { candidate.assign_gitis_contact contact }
+    subject { candidate.reload }
+
+    it { is_expected.to have_attributes gitis_uuid: contact.contactid }
+  end
+
   describe '#generate_session_token!' do
     let(:candidate) { create(:candidate) }
 

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -805,18 +805,6 @@ describe Bookings::PlacementRequest, type: :model do
     end
   end
 
-  describe '#fetch_gitis_contact' do
-    include_context 'fake gitis'
-    subject { FactoryBot.create :placement_request }
-
-    it "will assign contact" do
-      expect(subject.fetch_gitis_contact(fake_gitis)).to \
-        be_kind_of(Bookings::Gitis::Contact)
-
-      expect(subject.gitis_contact).to be_kind_of(Bookings::Gitis::Contact)
-    end
-  end
-
   describe '#requested_on' do
     subject { create :placement_request }
     it { is_expected.to have_attributes(requested_on: subject.created_at.to_date) }

--- a/spec/models/bookings/subject_sync_spec.rb
+++ b/spec/models/bookings/subject_sync_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Bookings::SubjectSync do
     end
 
     before do
-      expect(fake_gitis.store).to receive(:fetch).
+      expect(fake_gitis.fake_store).to receive(:fetch).
         with(
           Bookings::Gitis::TeachingSubject,
           limit: described_class::LIMIT

--- a/spec/services/bookings/gitis/accept_privacy_policy_spec.rb
+++ b/spec/services/bookings/gitis/accept_privacy_policy_spec.rb
@@ -55,7 +55,7 @@ describe Bookings::Gitis::AcceptPrivacyPolicy do
   describe '#accept!' do
     context 'without existing acceptance' do
       before do
-        allow(fake_gitis.store).to \
+        allow(fake_gitis.fake_store).to \
           receive(:create_entity).
           and_return("#{cpp_entity_path}(#{candidate_pp_id})")
 
@@ -65,7 +65,7 @@ describe Bookings::Gitis::AcceptPrivacyPolicy do
       subject! { described_class.new(fake_gitis, contact.id, policy_id).accept! }
 
       it "will write to gitis" do
-        expect(fake_gitis.store).to have_received(:create_entity).with \
+        expect(fake_gitis.fake_store).to have_received(:create_entity).with \
           cpp_entity_path,
           'dfe_name' => /school experience/,
           'dfe_consentreceivedby' => consent_id,
@@ -99,7 +99,7 @@ describe Bookings::Gitis::AcceptPrivacyPolicy do
           with(contact.id, includes: :dfe_contact_dfe_candidateprivacypolicy_Candidate).
           and_return(contact)
 
-        allow(fake_gitis.store).to receive(:create_entity).and_call_original
+        allow(fake_gitis.fake_store).to receive(:create_entity).and_call_original
 
         freeze_time
       end
@@ -111,7 +111,7 @@ describe Bookings::Gitis::AcceptPrivacyPolicy do
       end
 
       it "will write to gitis" do
-        expect(fake_gitis.store).not_to have_received(:create_entity)
+        expect(fake_gitis.fake_store).not_to have_received(:create_entity)
       end
     end
   end

--- a/spec/services/bookings/gitis/contact_fetcher_spec.rb
+++ b/spec/services/bookings/gitis/contact_fetcher_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe Bookings::Gitis::ContactFetcher do
+  include_context "fake gitis"
+
+  let(:fetcher) { described_class.new fake_gitis }
+  let(:school) { create :bookings_school }
+  let(:requests) { create_list :bookings_placement_request, 2, school: school }
+  let(:reloaded_requests) { Bookings::PlacementRequest.find requests.map(&:id) }
+
+  describe 'fetching contacts' do
+    subject { fetcher.fetch_for_models reloaded_requests }
+
+    it "should return hash with contactids as keys" do
+      expect(subject.keys).to eql \
+        requests.map(&:candidate).map(&:gitis_uuid)
+    end
+
+    it "should return contacts as hash values" do
+      expect(subject.values.map(&:contactid)).to eql \
+        requests.map(&:candidate).map(&:gitis_uuid)
+    end
+  end
+
+  describe 'assigning contacts' do
+    subject { fetcher.assign_to_models reloaded_requests }
+
+    it "should assign expected models" do
+      expect(subject.map(&:gitis_contact).map(&:contactid)).to eql \
+        requests.map(&:candidate).map(&:gitis_uuid)
+    end
+  end
+
+  describe 'assign_to_model' do
+    subject { fetcher.assign_to_model reloaded_requests[0] }
+
+    it "should assign expected models" do
+      expect(subject.gitis_contact.contactid).to eql \
+        requests[0].candidate.gitis_uuid
+    end
+  end
+end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -449,4 +449,91 @@ describe Bookings::Gitis::Contact, type: :model do
       end
     end
   end
+
+  describe 'duplicate handling data' do
+    let(:masterid) { SecureRandom.uuid }
+
+    context 'on initialization' do
+      subject { build :gitis_contact, :merged, _masterid_value: masterid }
+
+      it { is_expected.to respond_to :statecode }
+      it { is_expected.to respond_to :_masterid_value }
+      it { is_expected.to respond_to :masterid }
+      it { is_expected.to respond_to :merged }
+
+      it { is_expected.to have_attributes statecode: described_class::READONLY }
+      it { is_expected.to have_attributes _masterid_value: masterid }
+      it { is_expected.to have_attributes merged: true }
+    end
+
+    context 'create with duplicate fields' do
+      context 'for normal contact' do
+        let(:newcontact) { build :gitis_contact }
+        subject { newcontact.attributes_for_create }
+
+        it { is_expected.to include 'firstname' }
+        it { is_expected.not_to include 'statecode' }
+        it { is_expected.not_to include 'merged' }
+        it { is_expected.not_to include '_masterid_value' }
+      end
+
+      context 'for merged contact' do
+        let(:newcontact) { build :gitis_contact, :merged }
+        subject { newcontact.attributes_for_create }
+
+        it { is_expected.to include 'firstname' }
+        it { is_expected.not_to include 'statecode' }
+        it { is_expected.not_to include 'merged' }
+        it { is_expected.not_to include '_masterid_value' }
+      end
+    end
+
+    context 'update with duplicate fields' do
+      let(:uuid) { SecureRandom.uuid }
+
+      context 'for normal contact' do
+        let(:newcontact) { build :gitis_contact, contactid: uuid }
+        subject { newcontact.attributes_for_create }
+
+        it { is_expected.to include 'firstname' }
+        it { is_expected.not_to include 'statecode' }
+        it { is_expected.not_to include 'merged' }
+        it { is_expected.not_to include '_masterid_value' }
+      end
+
+      context 'for merged contact' do
+        let(:newcontact) { build :gitis_contact, :merged, contactid: uuid }
+        subject { newcontact.attributes_for_create }
+
+        it { is_expected.to include 'firstname' }
+        it { is_expected.not_to include 'statecode' }
+        it { is_expected.not_to include 'merged' }
+        it { is_expected.not_to include '_masterid_value' }
+      end
+    end
+
+    context 'been_merged' do
+      subject { contact.been_merged? }
+
+      context 'correct merged' do
+        let(:contact) { build(:gitis_contact, :merged) }
+        it { is_expected.to be true }
+      end
+
+      context 'correct unmerged' do
+        let(:contact) { build(:gitis_contact, :persisted) }
+        it { is_expected.to be false }
+      end
+
+      context 'merged without master' do
+        let(:contact) { build(:gitis_contact, :merged, _masterid_value: nil) }
+        it { expect { subject }.to raise_exception described_class::InconsistentState }
+      end
+
+      context 'master but not merged' do
+        let(:contact) { build(:gitis_contact, :merged, merged: false) }
+        it { expect { subject }.to raise_exception described_class::InconsistentState }
+      end
+    end
+  end
 end

--- a/spec/services/bookings/gitis/crm_spec.rb
+++ b/spec/services/bookings/gitis/crm_spec.rb
@@ -107,6 +107,8 @@ describe Bookings::Gitis::CRM, type: :model do
 
     context 'with multiple matches' do
       before do
+        allow(gitis).to receive(:master_record_filter).and_call_original
+
         gitis_stub.stub_contact_signin_request(email,
           firstuuid => signin_attrs.merge('emailaddress1' => 'foo@bar.com', 'emailaddress2' => email),
           seconduuid => signin_attrs.merge('firstname' => 'Joe', 'lastname' => 'Bloggs'))
@@ -114,6 +116,12 @@ describe Bookings::Gitis::CRM, type: :model do
 
       it "will return the first contact record" do
         is_expected.to have_attributes(id: firstuuid)
+      end
+
+      it "will only fetch active records" do
+        subject
+
+        expect(gitis).to have_received(:master_record_filter)
       end
     end
 

--- a/spec/services/bookings/gitis/event_logger_spec.rb
+++ b/spec/services/bookings/gitis/event_logger_spec.rb
@@ -13,7 +13,7 @@ describe Bookings::Gitis::EventLogger, type: :model do
     context 'with flexible dates' do
       it "will generate an entry" do
         is_expected.to eql \
-          "#{today} REQUEST                         #{padded_urn} #{school.name}"
+          "#{today} REQUEST                           #{padded_urn} #{school.name}"
       end
     end
 
@@ -52,7 +52,7 @@ describe Bookings::Gitis::EventLogger, type: :model do
 
       it "will record cancellation by Candidate" do
         is_expected.to eql \
-          "#{today} CANCELLED BY CANDIDATE          #{padded_urn} #{school.name}"
+          "#{today} CANCELLED BY CANDIDATE            #{padded_urn} #{school.name}"
       end
     end
 
@@ -63,7 +63,7 @@ describe Bookings::Gitis::EventLogger, type: :model do
 
       it "will record cancellation by School" do
         is_expected.to eql \
-          "#{today} CANCELLED BY SCHOOL             #{padded_urn} #{school.name}"
+          "#{today} CANCELLED BY SCHOOL               #{padded_urn} #{school.name}"
       end
     end
 

--- a/spec/services/bookings/gitis/factory_spec.rb
+++ b/spec/services/bookings/gitis/factory_spec.rb
@@ -55,7 +55,8 @@ describe Bookings::Gitis::Factory do
       end
 
       it { is_expected.to be_kind_of Bookings::Gitis::FakeCrm }
-      it { is_expected.to have_attributes store: kind_of(Bookings::Gitis::Store::Fake) }
+      it { is_expected.to have_attributes store: kind_of(Bookings::Gitis::Store::WriteOnlyCache) }
+      it { expect(subject.store).to have_attributes store: kind_of(Bookings::Gitis::Store::Fake) }
     end
 
     context 'with caching enabled' do

--- a/spec/services/bookings/gitis/filter_builder_spec.rb
+++ b/spec/services/bookings/gitis/filter_builder_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+describe Bookings::Gitis::FilterBuilder, type: :model do
+  let(:filter) { described_class.new 'fname', 'tester' }
+  subject { filter.to_s }
+
+  describe '.new' do
+    it { is_expected.to eq "fname eq 'tester'" }
+  end
+
+  describe 'custom operator' do
+    let(:filter) { described_class.new 'fname', 'tester', :ne }
+    it { is_expected.to eq "fname ne 'tester'" }
+  end
+
+  describe 'serializing values' do
+    context 'with a string' do
+      let(:filter) { described_class.new 'fname', 'tester' }
+      it { is_expected.to eq "fname eq 'tester'" }
+    end
+
+    context 'with a true' do
+      let(:filter) { described_class.new 'accepted_tandc', true }
+      it { is_expected.to eq "accepted_tandc eq true" }
+    end
+
+    context 'with a false' do
+      let(:filter) { described_class.new 'accepted_tandc', false }
+      it { is_expected.to eq "accepted_tandc eq false" }
+    end
+
+    context 'with a nil' do
+      let(:filter) { described_class.new 'parentid', nil }
+      it { is_expected.to eq "parentid eq null" }
+    end
+
+    context 'with an integer' do
+      let(:filter) { described_class.new 'age', 0 }
+      it { is_expected.to eq "age eq 0" }
+    end
+
+    context 'with a a float' do
+      let(:filter) { described_class.new 'height', 1.8 }
+      it { is_expected.to eq "height eq 1.8" }
+    end
+  end
+
+  describe 'chaining' do
+    describe 'and' do
+      subject { filter.and('lname', 'smith').to_s }
+      it { is_expected.to eq "fname eq 'tester' and lname eq 'smith'" }
+    end
+
+    describe 'and with another filter' do
+      subject { filter.and('lname', 'smith', :ne).to_s }
+      it { is_expected.to eq "fname eq 'tester' and lname ne 'smith'" }
+    end
+
+    describe 'or' do
+      subject { filter.or('lname', 'smith').to_s }
+      it { is_expected.to eq "fname eq 'tester' or lname eq 'smith'" }
+    end
+
+    describe 'or with another filter' do
+      subject { filter.or('lname', 'smith', :ne).to_s }
+      it { is_expected.to eq "fname eq 'tester' or lname ne 'smith'" }
+    end
+
+    describe 'complex chain' do
+      subject { filter.and('lname', 'smith').or('age', 90, :gte).to_s }
+      it do
+        is_expected.to eq \
+          "fname eq 'tester' and lname eq 'smith' or age gte 90"
+      end
+    end
+  end
+
+  describe 'nesting' do
+    let(:age) { described_class.new 'age', 90, :gte }
+    let(:nested) { described_class.new filter }
+
+    subject { nested.to_s }
+    it { is_expected.to eq "(fname eq 'tester')" }
+
+    describe 'chained nesting' do
+      subject { filter.and('lname', 'smith').or(age).to_s }
+      it do
+        is_expected.to eq \
+          "fname eq 'tester' and lname eq 'smith' or (age gte 90)"
+      end
+    end
+
+    describe 'combining nesting' do
+      let(:nested) { described_class.new filter.and('lname', 'smith') }
+      subject { nested.or(age).to_s }
+      it do
+        is_expected.to eq \
+          "(fname eq 'tester' and lname eq 'smith') or (age gte 90)"
+      end
+    end
+  end
+end

--- a/spec/services/bookings/gitis/store/dynamics_spec.rb
+++ b/spec/services/bookings/gitis/store/dynamics_spec.rb
@@ -9,6 +9,10 @@ describe Bookings::Gitis::Store::Dynamics do
 
   subject { dynamics }
 
+  describe 'the Caches api' do
+    it_behaves_like 'an implementation of a Gitis store'
+  end
+
   describe '.initialize' do
     it "will succeed with api object" do
       expect(described_class.new(token)).to \

--- a/spec/services/bookings/gitis/store/read_write_cache_spec.rb
+++ b/spec/services/bookings/gitis/store/read_write_cache_spec.rb
@@ -14,11 +14,9 @@ describe Bookings::Gitis::Store::ReadWriteCache do
   let(:uuid) { SecureRandom.uuid }
   let(:entity) { Person.new(personid: uuid, fullname: 'Test Person') }
 
-  describe 'an implementation of Store api' do
+  describe 'the Caches api' do
     subject { store }
-    it { is_expected.to respond_to :find }
-    it { is_expected.to respond_to :fetch }
-    it { is_expected.to respond_to :write }
+    it_behaves_like 'an implementation of a Gitis store'
   end
 
   describe '#cache_key_for_uuid' do

--- a/spec/services/bookings/gitis/store/write_only_cache_spec.rb
+++ b/spec/services/bookings/gitis/store/write_only_cache_spec.rb
@@ -15,12 +15,9 @@ describe Bookings::Gitis::Store::WriteOnlyCache do
   let(:uuid) { SecureRandom.uuid }
   let(:entity) { Person.new(personid: uuid, fullname: 'Test Person') }
 
-  describe 'an implementation of Store api' do
+  describe 'the Caches api' do
     subject { store }
-    it { is_expected.to respond_to :find }
-    it { is_expected.to respond_to :fetch }
-    it { is_expected.to respond_to :write }
-    it { is_expected.to respond_to :write! }
+    it_behaves_like 'an implementation of a Gitis store'
   end
 
   describe '#cache_key_for_entity' do

--- a/spec/support/fake_gitis.rb
+++ b/spec/support/fake_gitis.rb
@@ -9,6 +9,6 @@ shared_context "fake gitis with known uuid" do
   let(:fake_gitis_uuid) { SecureRandom.uuid }
 
   before do
-    allow(fake_gitis.store).to receive(:fake_contact_id).and_return(fake_gitis_uuid)
+    allow(fake_gitis.fake_store).to receive(:fake_contact_id).and_return(fake_gitis_uuid)
   end
 end

--- a/spec/support/gitis_store_shared_examples.rb
+++ b/spec/support/gitis_store_shared_examples.rb
@@ -1,0 +1,6 @@
+shared_examples 'an implementation of a Gitis store' do
+  it { is_expected.to respond_to :find }
+  it { is_expected.to respond_to :fetch }
+  it { is_expected.to respond_to :write }
+  it { is_expected.to respond_to :write! }
+end


### PR DESCRIPTION
### JIRA Ticket Number

SE-2144

### Context

Gitis is gaining the ability to merge records, this means that we may request a contact but the contact returned may be read only, and no longer the canonical contact point for a candidate.

This may mean the information on the contact is out of date, and may cause problems if we attempt to update the record's information.

### Changes proposed in this pull request

1. Filter out merged or read only records when searching for Candidates as part of the Candidate journey.
2. Refactored contact lookup into a separate ContactFetcher class
3. DRYed out assigning contacts using the new ContactFetcher
4. Added support for 'unwinding' the chain of merged records when looking up a contact - reading Contact A may instead return Contact B if they are merged.
5. Update the candidate's gitis_uuid when assigning a contact if the assigned contacts id does not match


