### PR TITLE
Use feature flags to control role check

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -57,7 +57,7 @@ private
   end
 
   def use_env_var?
-    Rails.env.test? || Rails.env.servertest?
+    !Rails.env.test? && !Rails.env.servertest?
   end
 
   def tokenised_env_features

--- a/app/services/schools/dfe_sign_in_api/client.rb
+++ b/app/services/schools/dfe_sign_in_api/client.rb
@@ -13,8 +13,7 @@ module Schools
       delegate :enabled?, to: :class
 
       def self.role_check_enabled?
-        enabled? &&
-          Rails.application.config.x.dfe_sign_in_api_role_check_enabled &&
+        enabled? && Feature.active?(:rolecheck) &&
           [
             ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID', nil),
             ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_ROLE_ID', nil)

--- a/spec/services/schools/dfe_sign_in_api/client_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/client_spec.rb
@@ -36,6 +36,8 @@ describe Schools::DFESignInAPI::Client do
   end
 
   describe '.role_check_enabled?' do
+    before { allow(Feature).to receive(:active?).with(:rolecheck) { true } }
+
     context 'when the client is disabled' do
       before { allow(subject).to receive(:enabled?).and_return(false) }
       before { allow(ENV).to receive(:fetch).and_return(true) }
@@ -50,8 +52,9 @@ describe Schools::DFESignInAPI::Client do
       before { allow(subject).to receive(:enabled?).and_return(true) }
       before { allow(Rails.application.config.x).to receive(:dfe_sign_in_api_role_check_enabled).and_return(true) }
 
-
       context 'when role check is disabled' do
+        before { allow(Feature).to receive(:active?).with(:rolecheck) { false } }
+
         context 'when the DfE Sign-in role and service environment variables are absent' do
           before { allow(ENV).to receive(:fetch).and_return(nil) }
 


### PR DESCRIPTION
### Context

We need to enable the role check again

### Changes proposed in this pull request

1. Fixed use of env vars to control feature flags
2. Use `rolecheck` feature flag to enable role check

