### PR TITLE
Removed script thats been moved to the devops repo

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,21 +157,3 @@ jobs:
       testResultsFormat: 'JUnit'
       testResultsFiles: 'junit/TEST-*.xml'
       testRunTitle: Cucumber results
-
-- job: PublishArtifacts
-  dependsOn:
-  - FunctionalTesting
-
-  steps:
-
-  - task: CopyFiles@2
-    inputs:
-      contents: 'script/image_tags_and_ipaddress.sh'
-      targetFolder: $(Build.ArtifactStagingDirectory)
-    displayName: 'Copy image tags and ip address script to staging area'
-
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: $(Build.ArtifactStagingDirectory)/script/image_tags_and_ipaddress.sh
-      artifactName: 'image-tags-ip-script'
-    displayName: 'Publish image tags and ip address script'

--- a/script/image_tags_and_ipaddress.sh
+++ b/script/image_tags_and_ipaddress.sh
@@ -1,9 +1,0 @@
-if [ $BUILD_SOURCEBRANCHNAME == 'master' ]; then
-  echo "##vso[task.setvariable variable=schoolExperienceImageTag]v${BUILD_BUILDID}"
-  echo "##vso[task.setvariable variable=schoolExperienceImageTagStable]v${BUILD_BUILDID}-stable"
-else
-  echo "##vso[task.setvariable variable=schoolExperienceImageTag]v${BUILD_BUILDID}-${BUILD_SOURCEBRANCHNAME}"
-  echo "##vso[task.setvariable variable=schoolExperienceImageTagStable]v${BUILD_BUILDID}-${BUILD_SOURCEBRANCHNAME}-stable"
-fi
-
-echo "##vso[task.setvariable variable=agentIpAddress]$(curl -s https://api.ipify.org)"


### PR DESCRIPTION
### JIRA Ticket Number

SE-2108

### Context

Fixing warnings during deployment. We were copying a script out of the repo via the artifact publishing into the CD pipeline. Part of this process was loosing the execute permissions on the script.

### Changes proposed in this pull request

1. Removed unused script - it is now included in the devops repo
2. Removed publishing of the script from `azure-pipelines.yml`



