### PR TITLE
Force use of at least JSON 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ ruby File.read(".ruby-version").chomp
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.2.1'
 
+gem 'json', '>= 2.3.0' # Fix for CVE-2020-10663
+
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    json (2.3.0)
     json-jwt (1.11.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -487,6 +488,7 @@ DEPENDENCIES
   foreman
   geocoder
   govuk_elements_form_builder!
+  json (>= 2.3.0)
   kaminari
   listen (>= 3.0.5)
   notifications-ruby-client


### PR DESCRIPTION
Fixes CVE-2020-10663

Ruby 2.6.5 bundles v2.1

