### PR TITLE
Fixed loading custom Notify clients

### DIFF
--- a/app/notify/notify_service.rb
+++ b/app/notify/notify_service.rb
@@ -6,7 +6,9 @@ class NotifyService
   attr_accessor :notification_class
 
   def initialize
-    self.notification_class = Rails.application.config.x.notify_client.presence || Notifications::Client
+    self.notification_class =
+      Rails.application.config.x.notify_client.presence&.constantize ||
+      Notifications::Client
   end
 
   def send_email(email_address:, template_id:, personalisation:)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -118,8 +118,8 @@ Rails.application.configure do
   config.x.dfe_sign_in_api_school_change_enabled = ENV['DFE_SIGNIN_API_SCHOOL_CHANGE_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_request_organisation_url = ENV['DFE_SIGNIN_REQUEST_ORGANISATION_URL'].presence
 
-  if ENV['NOTIFY_CLIENT'] && ENV['NOTIFY_CLIENT'] != ''
-    Rails.application.config.x.notify_client = ENV['NOTIFY_CLIENT'].constantize
+  if ENV['NOTIFY_CLIENT'].present?
+    Rails.application.config.x.notify_client = ENV['NOTIFY_CLIENT']
   end
 
   config.x.gitis.fake_crm = truthy_strings.include?(String(ENV.fetch('FAKE_CRM') { true }))

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   # Override production environment settings here
 
   # Don't actually attempt to delivery emails in Staging environment
-  config.x.notify_client = NotifyFakeClient
+  config.x.notify_client = 'NotifyFakeClient'
 
   # default to true but allow overriding in CI
   config.force_ssl = ENV['SKIP_FORCE_SSL'].blank?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -166,7 +166,7 @@ Rails.application.configure do
   Rails.application.routes.default_url_options = { protocol: 'https' }
 
   # Don't actually attempt to delivery emails during tests
-  config.x.notify_client = NotifyFakeClient
+  config.x.notify_client = 'NotifyFakeClient'
 
   config.x.default_phase = 4
   config.x.phase = 10_000


### PR DESCRIPTION
### Context

Loading alternative notify clients without eager loading (ie RAILS_ENV=development) was broken in the Rails 6.1 upgrade. I think this is because the `app` folder is no longer in the autoloading path, or autoloading is no longer enabled, at configuration.

### Changes proposed in this pull request

1. Changed to hold a string of the notify client class in the config value and constantize on instantiation of the NotifyService singleton.
