### PR TITLE
PlacementRequest#status should ignore partially completed bookings

### DIFF
--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -162,9 +162,9 @@ module Bookings
     end
 
     def status
-      return 'Candidate cancellation' if booking && candidate_cancellation&.sent?
-      return 'School cancellation'    if booking && school_cancellation&.sent?
-      return 'Booked'                 if booking
+      return 'Candidate cancellation' if booking&.accepted? && candidate_cancellation&.sent?
+      return 'School cancellation'    if booking&.accepted? && school_cancellation&.sent?
+      return 'Booked'                 if booking&.accepted?
       return 'Withdrawn'              if candidate_cancellation&.sent?
       return 'Rejected'               if school_cancellation&.sent?
       return 'Viewed'                 if viewed?

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -58,10 +58,23 @@ FactoryBot.define do
       end
     end
 
+    trait :with_incomplete_booking do
+      after :create do |placement_request|
+        FactoryBot.create \
+          :bookings_booking,
+          :with_existing_subject,
+          bookings_school: placement_request.school,
+          bookings_subject: placement_request.school.subjects.first,
+          bookings_placement_request: placement_request,
+          bookings_placement_request_id: placement_request.id
+      end
+    end
+
     trait :booked do
       after :create do |placement_request|
         FactoryBot.create \
           :bookings_booking,
+          :accepted,
           :with_existing_subject,
           bookings_school: placement_request.school,
           bookings_subject: placement_request.school.subjects.first,

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -739,6 +739,12 @@ describe Bookings::PlacementRequest, type: :model do
       it { is_expected.to eq 'Viewed' }
     end
 
+    context 'with incomplete booking' do
+      subject { create(:placement_request, :with_incomplete_booking).status }
+
+      it { is_expected.to eq 'New' }
+    end
+
     context 'when booked' do
       subject { create(:placement_request, :booked).status }
 


### PR DESCRIPTION
### Context

Discovered as part of the CSV work - if a booking is only partially completed than any screen relying on PlacementRequest#status will show as booked when its not.

I think this hasn't been noticed because, prior to now, this method is only used on screens for 'completed' bookings.

### Changes proposed in this pull request

1. Check a booking is completed before marking it as booked



