### PR TITLE
Turn off candidate alert notification

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ protected
   helper_method :cookie_preferences
 
   def show_candidate_alert_notification?
-    true
+    false
   end
   helper_method :show_candidate_alert_notification?
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/k8W6moMq

### Context

We don't need to be showing the candidate alert notification anymore

### Changes proposed in this pull request

1. Disable the candidate notifications


