### PR TITLE
Switch to sentry-ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,9 @@ gem 'slack-notifier'
 gem 'kaminari'
 
 gem 'phonelib'
-gem 'sentry-raven'
+gem 'sentry-rails'
+gem 'sentry-ruby'
+gem 'sentry-delayed_job'
 
 gem 'rack-rewrite'
 gem 'rack-timeout'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,8 +449,18 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.1)
-    sentry-raven (3.1.1)
+    sentry-delayed_job (4.3.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-rails (4.3.0)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
+      concurrent-ruby
+      faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     sinatra (2.1.0)
@@ -587,7 +597,9 @@ DEPENDENCIES
   rubocop-govuk
   sassc-rails
   selenium-webdriver
-  sentry-raven
+  sentry-delayed_job
+  sentry-rails
+  sentry-ruby
   shoulda-matchers (~> 4.5)
   slack-notifier
   spring

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ protected
 
   def session_expired(exception)
     ExceptionNotifier.notify_exception(exception)
-    Raven.capture_exception(exception)
+    Sentry.capture_exception(exception)
 
     render 'shared/session_expired'
   end

--- a/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
@@ -19,7 +19,7 @@ module Candidates
           uuid: current_registration.uuid
         })
 
-        Raven.capture_exception(e)
+        Sentry.capture_exception(e)
 
         render 'shared/session_expired'
       end

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -62,7 +62,7 @@ module Schools
     def gitis_retrieval_error(exception)
       if Rails.env.production? || Rails.env.staging?
         ExceptionNotifier.notify_exception exception
-        Raven.capture_exception exception
+        Sentry.capture_exception exception
       end
 
       render 'shared/failed_gitis_connection', status: :service_unavailable
@@ -73,7 +73,7 @@ module Schools
         redirect_to schools_change_path
       else
         ExceptionNotifier.notify_exception exception
-        Raven.capture_exception exception
+        Sentry.capture_exception exception
 
         redirect_to schools_errors_insufficient_privileges_path
       end

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -138,14 +138,14 @@ module Schools
 
     def authentication_failure(exception)
       ExceptionNotifier.notify_exception(exception)
-      Raven.capture_exception(exception)
+      Sentry.capture_exception(exception)
 
       redirect_to schools_errors_auth_failed_path
     end
 
     def insufficient_privileges_failure(exception)
       ExceptionNotifier.notify_exception(exception)
-      Raven.capture_exception(exception)
+      Sentry.capture_exception(exception)
 
       redirect_to schools_errors_insufficient_privileges_path
     end
@@ -158,7 +158,7 @@ module Schools
 
     def no_organisation_failure(exception)
       ExceptionNotifier.notify_exception(exception)
-      Raven.capture_exception(exception)
+      Sentry.capture_exception(exception)
 
       redirect_to schools_errors_insufficient_privileges_path
     end

--- a/app/jobs/notify_job.rb
+++ b/app/jobs/notify_job.rb
@@ -23,6 +23,6 @@ private
 
   def alert_monitoring(exception)
     ExceptionNotifier.notify_exception exception
-    Raven.capture_exception exception
+    Sentry.capture_exception exception
   end
 end

--- a/app/models/schools/attendance.rb
+++ b/app/models/schools/attendance.rb
@@ -49,7 +49,7 @@ module Schools
 
     def update_error(exception)
       ExceptionNotifier.notify_exception(exception)
-      Raven.capture_exception(exception)
+      Sentry.capture_exception(exception)
     end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -136,7 +136,7 @@ Rails.application.configure do
                                             }
                                           )
 
-                                          Raven.capture_exception(exception)
+                                          Sentry.capture_exception(exception)
                                         end
                        }
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,3 @@
-Raven.configure do |config|
+Sentry.init do |config|
   config.excluded_exceptions -= ['ActionController::InvalidAuthenticityToken']
 end

--- a/spec/jobs/notify_job_spec.rb
+++ b/spec/jobs/notify_job_spec.rb
@@ -35,7 +35,7 @@ describe NotifyJob, type: :job do
     allow(NotifyService.instance).to receive(:notification_class) { notify_class }
     allow(described_class.queue_adapter).to receive :enqueue_at
     allow(ExceptionNotifier).to receive :notify_exception
-    allow(Raven).to receive :capture_exception
+    allow(Sentry).to receive :capture_exception
 
     allow(ActiveJob::Base.logger).to receive :info do |&block|
       personalisation.each_value { |v| expect(block.call).not_to include v }
@@ -62,7 +62,7 @@ describe NotifyJob, type: :job do
         end
 
         it 'alerts monitoring' do
-          expect(Raven).to have_received(:capture_exception).exactly(4).times
+          expect(Sentry).to have_received(:capture_exception).exactly(4).times
           expect(ExceptionNotifier).to \
             have_received(:notify_exception).exactly(4).times
         end


### PR DESCRIPTION
### Trello card

https://trello.com/c/r0Z1xkv3

### Context

The sentry-raven gem is outdated and looks to have a bug in reporting delayed job errors in the last release.

### Changes proposed in this pull request

1. Switch to the Sentry Ruby error reporter, including both `sentry-rails` and `sentry-delayed_jobs` plugins



