### PR TITLE
Drop ExceptionNotifier

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,12 @@ Metrics/BlockLength:
 Layout/ArgumentAlignment:
   Enabled: false
 
+# We have specific keywords we need to receive but not use in the error handler
+# for Redis connections
+Lint/UnusedBlockArgument:
+  Exclude:
+    - config/environments/*
+
 Style/HashEachMethods:
   Enabled: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,9 +48,6 @@ gem 'delayed_job_web'
 
 gem "redis", "~> 4.2"
 
-gem 'exception_notification'
-gem 'slack-notifier'
-
 gem 'kaminari'
 
 gem 'phonelib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,9 +180,6 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
-    exception_notification (4.4.3)
-      actionmailer (>= 4.0, < 7)
-      activesupport (>= 4.0, < 7)
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -468,7 +465,6 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    slack-notifier (2.3.2)
     spoon (0.0.6)
       ffi
     spring (2.1.1)
@@ -567,7 +563,6 @@ DEPENDENCIES
   delayed_job_active_record
   delayed_job_web
   dotenv-rails
-  exception_notification
   factory_bot_rails
   faraday
   foreman
@@ -601,7 +596,6 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   shoulda-matchers (~> 4.5)
-  slack-notifier
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,6 @@ protected
   end
 
   def session_expired(exception)
-    ExceptionNotifier.notify_exception(exception)
     Sentry.capture_exception(exception)
 
     render 'shared/session_expired'

--- a/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/resend_confirmation_emails_controller.rb
@@ -14,11 +14,6 @@ module Candidates
           render 'shared/session_expired'
         end
       rescue RegistrationStore::SessionNotFound => e
-        ExceptionNotifier.notify_exception(e, data: {
-          action: 'ResendConfirmationEmailsController#create',
-          uuid: current_registration.uuid
-        })
-
         Sentry.capture_exception(e)
 
         render 'shared/session_expired'

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -61,7 +61,6 @@ module Schools
 
     def gitis_retrieval_error(exception)
       if Rails.env.production? || Rails.env.staging?
-        ExceptionNotifier.notify_exception exception
         Sentry.capture_exception exception
       end
 
@@ -72,7 +71,6 @@ module Schools
       if Schools::ChangeSchool.allow_school_change_in_app?
         redirect_to schools_change_path
       else
-        ExceptionNotifier.notify_exception exception
         Sentry.capture_exception exception
 
         redirect_to schools_errors_insufficient_privileges_path

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -137,14 +137,12 @@ module Schools
     end
 
     def authentication_failure(exception)
-      ExceptionNotifier.notify_exception(exception)
       Sentry.capture_exception(exception)
 
       redirect_to schools_errors_auth_failed_path
     end
 
     def insufficient_privileges_failure(exception)
-      ExceptionNotifier.notify_exception(exception)
       Sentry.capture_exception(exception)
 
       redirect_to schools_errors_insufficient_privileges_path
@@ -157,7 +155,6 @@ module Schools
     end
 
     def no_organisation_failure(exception)
-      ExceptionNotifier.notify_exception(exception)
       Sentry.capture_exception(exception)
 
       redirect_to schools_errors_insufficient_privileges_path

--- a/app/jobs/notify_job.rb
+++ b/app/jobs/notify_job.rb
@@ -22,7 +22,6 @@ private
   end
 
   def alert_monitoring(exception)
-    ExceptionNotifier.notify_exception exception
     Sentry.capture_exception exception
   end
 end

--- a/app/models/schools/attendance.rb
+++ b/app/models/schools/attendance.rb
@@ -48,7 +48,6 @@ module Schools
     end
 
     def update_error(exception)
-      ExceptionNotifier.notify_exception(exception)
       Sentry.capture_exception(exception)
     end
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,7 +128,7 @@ Rails.application.configure do
                          url: ENV['REDIS_CACHE_URL'].presence || ENV['REDIS_URL'].presence,
                          reconnect_attempts: 1,
                          tcp_keepalive: 60,
-                         error_handler: lambda do |_method:, returning:, exception:|
+                         error_handler: lambda do |method:, returning:, exception:|
                                           Sentry.capture_exception(exception)
                                         end
                        }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -129,13 +129,6 @@ Rails.application.configure do
                          reconnect_attempts: 1,
                          tcp_keepalive: 60,
                          error_handler: lambda do |_method:, returning:, exception:|
-                                          ExceptionNotifier.notify_exception(
-                                            exception,
-                                            data: {
-                                              returning: returning.inspect
-                                            }
-                                          )
-
                                           Sentry.capture_exception(exception)
                                         end
                        }

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,7 +1,4 @@
-require 'delayed_notification_plugin'
-
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_run_time = 5.minutes
 Delayed::Worker.sleep_delay = 15
 Delayed::Worker.max_attempts = 1
-Delayed::Worker.plugins << DelayedNotificationPlugin

--- a/lib/delayed_notification_plugin.rb
+++ b/lib/delayed_notification_plugin.rb
@@ -1,8 +1,0 @@
-class DelayedNotificationPlugin < Delayed::Plugin
-  callbacks do |lifecycle|
-    lifecycle.before(:failure) do |_worker, job, *_args, &_block|
-      ExceptionNotifier.notify_exception(job.error,
-        data: job.attributes.except('last_error'))
-    end
-  end
-end

--- a/spec/controllers/candidates/registrations/resend_confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/resend_confirmation_emails_controller_spec.rb
@@ -62,7 +62,7 @@ describe Candidates::Registrations::ResendConfirmationEmailsController, type: :r
 
     context 'session not found' do
       before do
-        allow(ExceptionNotifier).to receive :notify_exception
+        allow(Sentry).to receive :capture_exception
 
         Candidates::Registrations::RegistrationStore.instance.store! \
           registration_session
@@ -74,14 +74,9 @@ describe Candidates::Registrations::ResendConfirmationEmailsController, type: :r
           registration_session.school
       end
 
-      it 'notifys exception monitoring' do
-        expect(ExceptionNotifier).to have_received(:notify_exception).with(
-          Candidates::Registrations::RegistrationStore::SessionNotFound,
-          data: {
-            action: 'ResendConfirmationEmailsController#create',
-            uuid: registration_session.uuid
-          }
-        )
+      it 'notifies exception monitoring' do
+        expect(Sentry).to have_received(:capture_exception).with \
+          kind_of(Candidates::Registrations::RegistrationStore::SessionNotFound)
       end
 
       it 'renders the shared/session_expired?' do

--- a/spec/jobs/notify_job_spec.rb
+++ b/spec/jobs/notify_job_spec.rb
@@ -34,7 +34,6 @@ describe NotifyJob, type: :job do
 
     allow(NotifyService.instance).to receive(:notification_class) { notify_class }
     allow(described_class.queue_adapter).to receive :enqueue_at
-    allow(ExceptionNotifier).to receive :notify_exception
     allow(Sentry).to receive :capture_exception
 
     allow(ActiveJob::Base.logger).to receive :info do |&block|
@@ -63,8 +62,6 @@ describe NotifyJob, type: :job do
 
         it 'alerts monitoring' do
           expect(Sentry).to have_received(:capture_exception).exactly(4).times
-          expect(ExceptionNotifier).to \
-            have_received(:notify_exception).exactly(4).times
         end
       end
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/r0Z1xkv3

### Context

Now we've got Sentry publishing to Slack we no longer need exception notifier to do the same.

### Changes proposed in this pull request

1. Remove use of ExceptionNotifier



