### PR TITLE
Use cached builds on master as a stopgap fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,11 +33,11 @@ jobs:
       docker pull $(DOCKER_HUB_REPO):$(buildCacheTag) || true
       docker build -f Dockerfile --cache-from=$(DOCKER_HUB_REPO):$(buildCacheTag) -t $(DOCKER_HUB_REPO):$(imageTag) .
     displayName: Build Docker Image using Cache
-    condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+    # condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
 
-  - script: docker build -f Dockerfile -t $(DOCKER_HUB_REPO):$(imageTag) .
-    displayName: Build Docker Image without Cache
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  # - script: docker build -f Dockerfile -t $(DOCKER_HUB_REPO):$(imageTag) .
+  #   displayName: Build Docker Image without Cache
+  #   condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
 
   - script: docker run --rm $(DOCKER_HUB_REPO):$(imageTag) brakeman --no-pager
     displayName: Run the Brakeman security scan


### PR DESCRIPTION
### Context

Our builds are broken whilst the mimemagic gems are yanked.

### Changes proposed in this pull request

1. Use cached builds on `master` until this is resolved



