### PR TITLE
Include logout button on insufficient priviledges page

### DIFF
--- a/app/views/schools/errors/insufficient_privileges/show.html.erb
+++ b/app/views/schools/errors/insufficient_privileges/show.html.erb
@@ -7,7 +7,7 @@
     <section>
       <h1 class="govuk-heading-l">Request school experience access</h1>
 
-      <p>You do not currently have permission to to manage school experience.</p>
+      <p>You do not currently have permission to manage school experience.</p>
 
       <div>
         <h2 class="govuk-heading-m">
@@ -15,8 +15,8 @@
         </h2>
 
         <p>
-          You can request access to another organisation from your
-          ‘DfE Sign-in approver’ via DfE Sign-in.
+          You can request access to another school or organisation via DfE
+          Sign-in.
         </p>
 
         <ul class="govuk-list govuk-list--bullet">
@@ -28,7 +28,7 @@
 
           <li>
             Clicking 'Confirm' will send your access request to the
-            organisations approver.
+            organisation's approver.
           </li>
         </ul>
 
@@ -41,9 +41,9 @@
         </h2>
 
         <p>
-          You'll need to ask your organisation's ‘DfE Sign-in approver' (often
-          your head or deputy head) and within your DfE Sign-in account they’ll
-          need to:
+          You will need to ask your organisation's ‘DfE Sign-in approver' (this
+          maybe your head or deputy head) and within your DfE Sign-in account
+          they will need to:
         </p>
 
         <ul class="govuk-list govuk-list--bullet">
@@ -51,7 +51,7 @@
           <li>set you up with the ‘School Experience Administrator’ role</li>
         </ul>
 
-        <p>If you do not know who’s your ‘DfE Sign-in approver’ either:</p>
+        <p>If you do not know who your ‘DfE Sign-in approver’ is either:</p>
 
         <ul class="govuk-list govuk-list--bullet">
           <li>email us with your URN at <%= mail_to('organise.school-experience@education.gov.uk') %></li>
@@ -60,10 +60,10 @@
       </div>
 
       <div>
-        <h2>Or if you wish to sign in as a different user</h2>
+        <h2>If you wish to sign in as a different user</h2>
 
         <p>
-          If you have more then one account, you can sign out and then sign
+          If you have more than one account, you can sign out and then sign
           back in with a different account.
         </p>
 

--- a/app/views/schools/errors/insufficient_privileges/show.html.erb
+++ b/app/views/schools/errors/insufficient_privileges/show.html.erb
@@ -35,9 +35,9 @@
         <%= govuk_link_to 'Request organisation access', @organisation_access_url %>
       </div>
 
-      <div>
+      <div class="govuk-!-margin-bottom-8">
         <h2>
-          Contact your school’s ‘DfE Sign-in approver’
+          Or you can contact your school’s ‘DfE Sign-in approver’
         </h2>
 
         <p>
@@ -57,6 +57,17 @@
           <li>email us with your URN at <%= mail_to('organise.school-experience@education.gov.uk') %></li>
           <li>submit a <%= link_to('DfE Sign-in support request', 'https://help.signin.education.gov.uk/contact/submit?type=create-account') %></li>
         </ul>
+      </div>
+
+      <div>
+        <h2>Or if you wish to sign in as a different user</h2>
+
+        <p>
+          If you have more then one account, you can sign out and then sign
+          back in with a different account.
+        </p>
+
+        <%= govuk_link_to "Sign out", logout_schools_session_path, class: "govuk-button--secondary" %>
       </div>
     </section>
   </div>

--- a/spec/views/schools/errors/insufficient_privileges/show.html.erb_spec.rb
+++ b/spec/views/schools/errors/insufficient_privileges/show.html.erb_spec.rb
@@ -9,5 +9,7 @@ describe 'schools/errors/insufficient_privileges/show.html.erb' do
     it { is_expected.to have_css "h1", text: "Request school experience access" }
     it { is_expected.to have_css "h2", text: "Request access to an organisation" }
     it { is_expected.to have_link "Request organisation access" }
+    it { is_expected.to have_css "h2", text: "sign in as a different user" }
+    it { is_expected.to have_link "Sign out", href: logout_schools_session_path }
   end
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/zOe6LLEu

### Context

Users who logout with the wrong DFE Sign-in account currently cannot sign back out again.

### Changes proposed in this pull request

1. Show a logout button on the insufficient priviledges page

