### PR TITLE
Removed no longer needed dependency on shared-mime-info library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ EXPOSE 3000
 ENTRYPOINT ["bundle", "exec"]
 CMD ["rails", "server" ]
 
-RUN apk add --no-cache build-base git tzdata shared-mime-info libxml2 \
-			libxml2-dev postgresql-libs postgresql-dev nodejs yarn
+RUN apk add --no-cache build-base git tzdata libxml2 libxml2-dev \
+			postgresql-libs postgresql-dev nodejs yarn
 
 # install NPM packages removign artifacts
 COPY package.json yarn.lock ./


### PR DESCRIPTION
### Context

We've upgraded to Rails 6.1.3.1 which no longer depends upon mimemagic

### Changes proposed in this pull request

1. Removed installation of `shared-mime-info` package



