### PR TITLE
Integrate with GiT API for sign up process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,5 +124,6 @@ group :test do
 
   gem 'webmock'
   gem 'capybara-screenshot'
+  gem 'flipper-active_support_cache_store'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 5356ed841675f8872a345ff8ee8f4e3ee8ccb72d
+  revision: 24118c17e132e11fbb638e397fc54b9bf85df522
   specs:
-    get_into_teaching_api_client (1.1.16)
+    get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.30)
+    get_into_teaching_api_client_faraday (0.1.31)
       activesupport
       faraday
       faraday-encoding
@@ -202,15 +202,19 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.3.0)
+    faraday (1.4.1)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
     faraday-encoding (0.0.5)
       faraday
+    faraday-excon (1.1.0)
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     faraday_middleware-circuit_breaker (0.4.1)
@@ -221,6 +225,9 @@ GEM
     ffi (1.15.0-x64-mingw32)
     ffi (1.15.0-x86-mingw32)
     flipper (0.21.0)
+    flipper-active_support_cache_store (0.21.0)
+      activesupport (>= 5.0, < 7)
+      flipper (~> 0.21.0)
     flipper-redis (0.21.0)
       flipper (~> 0.21.0)
       redis (>= 2.2, < 5)
@@ -590,6 +597,7 @@ DEPENDENCIES
   factory_bot_rails
   faraday
   flipper
+  flipper-active_support_cache_store
   flipper-redis
   flipper-ui
   foreman

--- a/app/controllers/candidates/registrations/personal_informations_controller.rb
+++ b/app/controllers/candidates/registrations/personal_informations_controller.rb
@@ -18,14 +18,7 @@ module Candidates
         if candidate_signed_in?
           redirect_to new_candidates_school_registrations_contact_information_path
         else
-          token = @personal_information.create_signin_token(gitis_crm)
-
-          if token
-            verification_email(token).despatch_later!
-            redirect_to candidates_school_registrations_sign_in_path
-          else
-            redirect_to new_candidates_school_registrations_contact_information_path
-          end
+          Flipper.enabled?(:git_api) ? api_matchback : direct_matchback
         end
       end
 
@@ -47,6 +40,27 @@ module Candidates
       end
 
     private
+
+      def api_matchback
+        success = @personal_information.issue_verification_code
+
+        if success
+          redirect_to candidates_school_registrations_sign_in_path
+        else
+          redirect_to new_candidates_school_registrations_contact_information_path
+        end
+      end
+
+      def direct_matchback
+        token = @personal_information.create_signin_token(gitis_crm)
+
+        if token
+          verification_email(token).despatch_later!
+          redirect_to candidates_school_registrations_sign_in_path
+        else
+          redirect_to new_candidates_school_registrations_contact_information_path
+        end
+      end
 
       def personal_information_params
         if candidate_signed_in?

--- a/app/controllers/candidates/registrations/placement_requests_controller.rb
+++ b/app/controllers/candidates/registrations/placement_requests_controller.rb
@@ -20,7 +20,9 @@ module Candidates
             registration_session,
             cookies[:analytics_tracking_uuid]
 
-          unless Bookings::Gitis::PrivacyPolicy.default.nil?
+          api_contact = current_contact.is_a?(GetIntoTeachingApiClient::SchoolsExperienceSignUp)
+
+          unless Bookings::Gitis::PrivacyPolicy.default.nil? || api_contact
             AcceptPrivacyPolicyJob.perform_later \
               current_candidate.gitis_uuid,
               Bookings::Gitis::PrivacyPolicy.default

--- a/app/controllers/candidates/registrations/sign_ins_controller.rb
+++ b/app/controllers/candidates/registrations/sign_ins_controller.rb
@@ -4,44 +4,84 @@ module Candidates
       include SignInEmails
 
       skip_before_action :ensure_step_permitted!, only: :update
+      before_action :check_api_feature_enabled, only: %i[show update create]
 
       def show
-        @email_address = current_registration.personal_information.email
-        @resend_link = candidates_school_registrations_sign_in_path
+        set_sign_in_details
+        @verification_code = Candidates::VerificationCode.new
       end
 
       def create
         @personal_information = current_registration.personal_information
 
-        token = @personal_information.create_signin_token(gitis_crm)
-        verification_email(token).despatch_later!
+        if @git_api_enabled
+          @personal_information.issue_verification_code
+        else
+          token = @personal_information.create_signin_token(gitis_crm)
+          verification_email(token).despatch_later!
+        end
 
         redirect_to candidates_school_registrations_sign_in_path
       end
 
       def update
+        @git_api_enabled ? api_verify : direct_verify
+      end
+
+    private
+
+      def api_verify
+        @verification_code = Candidates::VerificationCode.new(verification_code_params)
+        candidate_data = @verification_code.exchange(current_registration.personal_information)
+
+        if candidate_data
+          self.current_candidate = Bookings::Candidate.find_or_create_from_gitis_contact!(candidate_data).tap do |c|
+            c.update(confirmed_at: Time.zone.now)
+          end
+          update_registration_data
+          redirect_to new_candidates_school_registrations_contact_information_path
+        else
+          set_sign_in_details
+          render :show
+        end
+      end
+
+      def direct_verify
         candidate = Candidates::Session.signin!(params[:token])
 
         self.current_registration_session_uuid = params[:uuid]
 
         if candidate
           self.current_candidate = candidate
-
-          # Update the registration data in redis with the candidate
-          # information from gitis.
-          personal_information = PersonalInformation.new attributes_from_session
-          persist personal_information
-
+          update_registration_data
           redirect_to new_candidates_school_registrations_contact_information_path
         elsif attributes_from_session.any?
           @resend_link = candidates_school_registrations_sign_in_path
         end
       end
 
-    private
+      def update_registration_data
+        # Update the registration data in redis with the candidate
+        # information from gitis.
+        personal_information = PersonalInformation.new attributes_from_session
+        persist personal_information
+      end
+
+      def set_sign_in_details
+        @email_address = current_registration.personal_information.email
+        @resend_link = candidates_school_registrations_sign_in_path
+      end
+
+      def check_api_feature_enabled
+        @git_api_enabled = Flipper.enabled?(:git_api)
+      end
 
       def attributes_from_session
         current_registration.personal_information_attributes
+      end
+
+      def verification_code_params
+        params.require(:candidates_verification_code).permit(:code)
       end
     end
   end

--- a/app/controllers/concerns/gitis_authentication.rb
+++ b/app/controllers/concerns/gitis_authentication.rb
@@ -15,21 +15,34 @@ protected
   def current_contact
     return nil unless session[:gitis_contact]
 
-    @current_contact ||= Bookings::Gitis::Contact.new(session[:gitis_contact])
+    @current_contact ||=
+      if Flipper.enabled?(:git_api)
+        GetIntoTeachingApiClient::SchoolsExperienceSignUp.new(session[:gitis_contact])
+      else
+        Bookings::Gitis::Contact.new(session[:gitis_contact])
+      end
   end
 
   def current_contact=(contact)
-    raise InvalidContact unless contact.is_a?(Bookings::Gitis::Contact)
+    valid_classes = [GetIntoTeachingApiClient::SchoolsExperienceSignUp, Bookings::Gitis::Contact]
+    raise InvalidContact unless valid_classes.any? { |klass| contact.is_a?(klass) }
 
-    if current_contact && current_contact.contactid != contact.contactid
-      Rails.logger.warn \
-        "Signed in Candidate overwritten - #{current_contact.contactid} to #{contact.contactid}"
+    current_id = current_contact.try(:contactid) || current_contact.try(:candidate_id)
+    new_id = contact.try(:contactid) || contact.try(:candidate_id)
+    candidate_changed = current_contact && current_id != new_id
 
+    if candidate_changed
+      Rails.logger.warn "Signed in Candidate overwritten - #{current_id} to #{new_id}"
       delete_registration_sessions!
     end
 
     contact.tap do |c|
-      session[:gitis_contact] = c.attributes
+      session[:gitis_contact] =
+        if c.is_a?(GetIntoTeachingApiClient::SchoolsExperienceSignUp)
+          c.to_hash
+        else
+          c.attributes
+        end
     end
   end
 

--- a/app/controllers/concerns/gitis_authentication.rb
+++ b/app/controllers/concerns/gitis_authentication.rb
@@ -27,12 +27,8 @@ protected
     valid_classes = [GetIntoTeachingApiClient::SchoolsExperienceSignUp, Bookings::Gitis::Contact]
     raise InvalidContact unless valid_classes.any? { |klass| contact.is_a?(klass) }
 
-    current_id = current_contact.try(:contactid) || current_contact.try(:candidate_id)
-    new_id = contact.try(:contactid) || contact.try(:candidate_id)
-    candidate_changed = current_contact && current_id != new_id
-
-    if candidate_changed
-      Rails.logger.warn "Signed in Candidate overwritten - #{current_id} to #{new_id}"
+    if current_contact && current_contact.candidate_id != contact.candidate_id
+      Rails.logger.warn "Signed in Candidate overwritten - #{current_contact.candidate_id} to #{contact.candidate_id}"
       delete_registration_sessions!
     end
 

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -31,15 +31,13 @@ class Bookings::Candidate < ApplicationRecord
 
   class << self
     def find_or_create_from_gitis_contact!(contact)
-      id = contact.try(:id) || contact.try(:candidate_id)
-      find_or_create_by!(gitis_uuid: id).tap do |c|
+      find_or_create_by!(gitis_uuid: contact.candidate_id).tap do |c|
         c.gitis_contact = contact
       end
     end
 
     def find_by_gitis_contact(contact)
-      id = contact.try(:id) || contact.try(:candidate_id)
-      candidate = find_by(gitis_uuid: id)
+      candidate = find_by(gitis_uuid: contact.candidate_id)
       return nil unless candidate
 
       candidate.tap do |c|
@@ -48,8 +46,7 @@ class Bookings::Candidate < ApplicationRecord
     end
 
     def find_by_gitis_contact!(contact)
-      id = contact.try(:id) || contact.try(:candidate_id)
-      find_by!(gitis_uuid: id).tap do |c|
+      find_by!(gitis_uuid: contact.candidate_id).tap do |c|
         c.gitis_contact = contact
       end
     end
@@ -82,8 +79,7 @@ class Bookings::Candidate < ApplicationRecord
         crm.write! contact
       end
 
-      id = contact.try(:id) || contact.try(:candidate_id)
-      create!(gitis_uuid: id, confirmed_at: Time.zone.now, created_in_gitis: true).tap do |candidate|
+      create!(gitis_uuid: contact.candidate_id, confirmed_at: Time.zone.now, created_in_gitis: true).tap do |candidate|
         candidate.gitis_contact = contact
       end
     end

--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -8,9 +8,57 @@ module Bookings
     def initialize(registration_session, gitis_contact)
       @registration_session = registration_session
       @gitis_contact = gitis_contact
+      @is_api_contact = gitis_contact.is_a?(GetIntoTeachingApiClient::SchoolsExperienceSignUp)
     end
 
     def registration_to_contact
+      if @is_api_contact
+        api_registration_to_contact
+      else
+        direct_registration_to_contact
+      end
+    end
+
+    def contact_to_contact_information
+      if @is_api_contact
+        api_contact_to_contact_information
+      else
+        direct_contact_to_contact_information
+      end
+    end
+
+    def contact_to_personal_information
+      {
+        'first_name' => gitis_contact.first_name,
+        'last_name' => gitis_contact.last_name,
+        'email' => gitis_contact.email&.strip,
+        'date_of_birth' => gitis_contact.date_of_birth
+      }
+    end
+
+    def contact_to_background_check
+      if @is_api_contact
+        {
+          'has_dbs_check' => gitis_contact.has_dbs_certificate
+        }
+      else
+        {
+          'has_dbs_check' => gitis_contact.has_dbs_check
+        }
+      end
+    end
+
+    def contact_to_teaching_preference
+      if @is_api_contact
+        api_contact_to_teaching_preference
+      else
+        direct_contact_to_teaching_preference
+      end
+    end
+
+  private
+
+    def direct_registration_to_contact
       gitis_contact.first_name = personal_information.first_name
       gitis_contact.last_name = personal_information.last_name
       gitis_contact.email = personal_information.email
@@ -31,7 +79,67 @@ module Bookings
       gitis_contact
     end
 
-    def contact_to_contact_information
+    def api_registration_to_contact
+      gitis_contact.first_name = personal_information.first_name
+      gitis_contact.last_name = personal_information.last_name
+      gitis_contact.email ||= personal_information.email
+      gitis_contact.secondary_email = personal_information.email
+      gitis_contact.date_of_birth = personal_information.date_of_birth
+
+      gitis_contact.secondary_telephone = contact_information.phone
+      gitis_contact.telephone ||= contact_information.phone
+      gitis_contact.address_telephone ||= contact_information.phone
+      gitis_contact.address_line1 = contact_information.building
+      gitis_contact.address_line2 = contact_information.street
+      gitis_contact.address_line3 = ""
+      gitis_contact.address_city = contact_information.town_or_city
+      gitis_contact.address_state_or_province = contact_information.county
+      gitis_contact.address_postcode = contact_information.postcode
+
+      if background_check.has_dbs_check != gitis_contact.has_dbs_certificate
+        gitis_contact.dbs_certificate_issued_at = nil
+      end
+
+      gitis_contact.has_dbs_certificate = background_check.has_dbs_check
+
+      gitis_contact.preferred_teaching_subject_id = api_subject_id_from_gitis_value(teaching_preference.subject_first_choice)
+      gitis_contact.secondary_preferred_teaching_subject_id = api_subject_id_from_gitis_value(teaching_preference.subject_second_choice)
+
+      gitis_contact.accepted_policy_id = latest_privacy_policy.id
+
+      gitis_contact
+    end
+
+    def api_contact_to_teaching_preference
+      {
+        'subject_first_choice' =>
+          api_subject_from_gitis_uuid(gitis_contact.preferred_teaching_subject_id),
+        'subject_second_choice' =>
+          api_subject_from_gitis_uuid(gitis_contact.secondary_preferred_teaching_subject_id)
+      }
+    end
+
+    def direct_contact_to_teaching_preference
+      {
+        'subject_first_choice' =>
+          direct_subject_from_gitis_uuid(gitis_contact._dfe_preferredteachingsubject01_value),
+        'subject_second_choice' =>
+          direct_subject_from_gitis_uuid(gitis_contact._dfe_preferredteachingsubject02_value)
+      }
+    end
+
+    def api_contact_to_contact_information
+      {
+        'phone' => gitis_contact.secondary_telephone.presence || gitis_contact.telephone.presence || gitis_contact.mobile_telephone,
+        'building' => gitis_contact.address_line1,
+        'street' => [gitis_contact.address_line1, gitis_contact.address_line2].map(&:presence).compact.join(', '),
+        'town_or_city' => gitis_contact.address_city,
+        'county' => gitis_contact.address_state_or_province,
+        'postcode' => gitis_contact.address_postcode
+      }
+    end
+
+    def direct_contact_to_contact_information
       {
         'phone' => gitis_contact.phone,
         'building' => gitis_contact.building,
@@ -42,31 +150,12 @@ module Bookings
       }
     end
 
-    def contact_to_personal_information
-      {
-        'first_name' => gitis_contact.first_name,
-        'last_name' => gitis_contact.last_name,
-        'email' => gitis_contact.email&.strip,
-        'date_of_birth' => gitis_contact.date_of_birth
-      }
+    def latest_privacy_policy
+      @latest_privacy_policy ||= begin
+        api = GetIntoTeachingApiClient::PrivacyPoliciesApi.new
+        api.get_latest_privacy_policy
+      end
     end
-
-    def contact_to_background_check
-      {
-        'has_dbs_check' => gitis_contact.has_dbs_check
-      }
-    end
-
-    def contact_to_teaching_preference
-      {
-        'subject_first_choice' =>
-          subject_from_gitis_uuid(gitis_contact._dfe_preferredteachingsubject01_value),
-        'subject_second_choice' =>
-          subject_from_gitis_uuid(gitis_contact._dfe_preferredteachingsubject02_value)
-      }
-    end
-
-  private
 
     def find_teaching_subjects
       @find_teaching_subjects ||= begin
@@ -84,7 +173,7 @@ module Bookings
       end
     end
 
-    def subject_from_gitis_uuid(uuid)
+    def direct_subject_from_gitis_uuid(uuid)
       return nil if uuid.blank?
 
       @subjects_from_gitis_uuids ||= begin
@@ -97,6 +186,25 @@ module Bookings
       end
 
       @subjects_from_gitis_uuids[uuid]&.name
+    end
+
+    def api_subject_id_from_gitis_value(value)
+      return nil if value.blank?
+
+      teaching_subjects.find { |s| s.value == value }&.id
+    end
+
+    def api_subject_from_gitis_uuid(uuid)
+      return nil if uuid.blank?
+
+      teaching_subjects.find { |s| s.id == uuid }&.value
+    end
+
+    def teaching_subjects
+      @teaching_subjects ||= begin
+        api = GetIntoTeachingApiClient::LookupItemsApi.new
+        api.get_teaching_subjects
+      end
     end
   end
 end

--- a/app/models/candidates/verification_code.rb
+++ b/app/models/candidates/verification_code.rb
@@ -1,0 +1,31 @@
+class Candidates::VerificationCode
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Validations::Callbacks
+
+  attribute :code
+
+  validates :code, length: { is: 6 }, format: { with: /\A[0-9]*\z/ }
+
+  before_validation if: :code do
+    self.code = code.to_s.strip
+  end
+
+  def exchange(personal_information)
+    return false unless valid?
+
+    identity_data = {
+      firstName: personal_information.first_name,
+      lastName: personal_information.last_name,
+      email: personal_information.email,
+      dateOfBirth: personal_information.date_of_birth,
+    }
+
+    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(identity_data)
+    api = GetIntoTeachingApiClient::SchoolsExperienceApi.new
+    api.exchange_access_token_for_schools_experience_sign_up(code, request)
+  rescue GetIntoTeachingApiClient::ApiError
+    errors.add(:code, :invalid)
+    nil
+  end
+end

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -40,6 +40,7 @@ module Bookings
       alias_attribute :town_or_city, :address1_city
       alias_attribute :county, :address1_stateorprovince
       alias_attribute :postcode, :address1_postalcode
+      alias_attribute :candidate_id, :contactid
 
       validates :email, presence: true, format: /\A.+@.+\..+\z/
       validates :'dfe_Country@odata.bind', presence: true, format: BIND_FORMAT, allow_nil: true

--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -32,6 +32,14 @@ module Candidates
         [first_name, last_name].map(&:presence).join(' ')
       end
 
+      def issue_verification_code
+        request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(matchback_attributes)
+        GetIntoTeachingApiClient::CandidatesApi.new.create_candidate_access_token(request)
+        true
+      rescue GetIntoTeachingApiClient::ApiError
+        false
+      end
+
       def create_signin_token(gitis_crm)
         build_candidate_session(gitis_crm).create_signin_token
       end
@@ -65,6 +73,15 @@ module Candidates
       end
 
     private
+
+      def matchback_attributes
+        {
+          email: email,
+          firstName: first_name,
+          lastName: last_name,
+          dateOfBirth: date_of_birth,
+        }
+      end
 
       def build_candidate_session(gitis_crm)
         Candidates::Session.new(

--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -25,7 +25,7 @@
     <h2>Verify your details</h2>
 
     <p>
-      You now need to <strong>select the link</strong> we've sent to
+      You now need to <strong><%= @git_api_enabled ? "enter the verification code" : "select the link" %></strong> we've sent to
       the following email address:
     </p>
 
@@ -33,9 +33,19 @@
       <li><%= @email_address %></li>
     </ul>
 
-    <p>
-      <strong>The link will expire within 1 hour.</strong>
-    </p>
+    <% if @git_api_enabled %>
+      <%= form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>
+        <%= f.text_field :code %>
+        <%= f.submit "Submit" %>
+      <% end %>
+      <p>
+        <strong>The code will expire within 15 minutes.</strong>
+      </p>
+    <% else %>
+      <p>
+        <strong>The link will expire within 1 hour.</strong>
+      </p>
+    <% end %>
 
     <p>
       If you cannot find the message in your inbox:
@@ -50,6 +60,6 @@
       link to resend it:
     </p>
 
-    <%= govuk_button_to 'Resend link', @resend_link, secondary: true %>
+    <%= govuk_button_to @git_api_enabled ? "Resend verification code" : "Resend link", @resend_link, secondary: true %>
   </div>
 </div>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,4 +1,18 @@
-require 'flipper/adapters/redis'
+if Rails.env.test?
+  require 'active_support/cache'
+  require 'flipper/adapters/active_support_cache_store'
+
+  Flipper.configure do |config|
+    config.adapter do
+      Flipper::Adapters::ActiveSupportCacheStore.new(
+        Flipper::Adapters::Memory.new,
+        ActiveSupport::Cache::MemoryStore.new,
+      )
+    end
+  end
+else
+  require 'flipper/adapters/redis'
+end
 
 Rails.application.configure do
   config.flipper.memoize = false

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -224,6 +224,12 @@ en:
             date_of_birth:
               blank: Enter your date of birth
 
+        candidates/verification_code:
+          attributes:
+            code:
+              invalid: Please enter the latest verification code sent to your email address
+              wrong_length: The verification code should be 6 digits
+
         cookie_preference:
           attributes:
             analytics:
@@ -714,6 +720,8 @@ en:
         firstname: First name
         lastname: Last name
         email: Email address
+      candidates_verification_code:
+        code: Verification code
       cookie_preference:
         analytics:
           true: "On"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,6 +149,7 @@ Rails.application.routes.draw do
     resources :school_searches, only: %i[new]
 
     get 'verify/:school_id/:token/:uuid', to: 'registrations/sign_ins#update', as: :registration_verify
+    put 'verify/:school_id', to: 'registrations/sign_ins#update', as: :registration_verify_code
 
     resources :schools, only: %i[index show] do
       namespace :registrations do

--- a/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
@@ -166,6 +166,8 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
         end
 
         context 'valid and known to gitis' do
+          include_context "api candidate matched back"
+
           let :personal_information do
             FactoryBot.build :personal_information
           end
@@ -173,9 +175,6 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
           let(:token) { create(:candidate_session_token) }
 
           before do
-            allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
-              receive(:create_candidate_access_token)
-
             post \
               '/candidates/schools/10020/registrations/personal_information',
               params: personal_information_params
@@ -188,15 +187,13 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
         end
 
         context 'valid but not known to gitis' do
+          include_context "api candidate not matched back"
+
           let :personal_information do
             FactoryBot.build :personal_information, email: 'unknown@mctest.com'
           end
 
           before do
-            allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
-              receive(:create_candidate_access_token)
-                .and_raise(GetIntoTeachingApiClient::ApiError)
-
             post \
               '/candidates/schools/10020/registrations/personal_information',
               params: personal_information_params

--- a/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
@@ -157,6 +157,57 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
             '/candidates/schools/10020/registrations/contact_information/new'
         end
       end
+
+      context "when the git_api feature is enabled" do
+        around do |example|
+          Flipper.enable(:git_api)
+          example.run
+          Flipper.disable(:git_api)
+        end
+
+        context 'valid and known to gitis' do
+          let :personal_information do
+            FactoryBot.build :personal_information
+          end
+
+          let(:token) { create(:candidate_session_token) }
+
+          before do
+            allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+              receive(:create_candidate_access_token)
+
+            post \
+              '/candidates/schools/10020/registrations/personal_information',
+              params: personal_information_params
+          end
+
+          it 'redirects to the next step' do
+            expect(response).to redirect_to \
+              '/candidates/schools/10020/registrations/sign_in'
+          end
+        end
+
+        context 'valid but not known to gitis' do
+          let :personal_information do
+            FactoryBot.build :personal_information, email: 'unknown@mctest.com'
+          end
+
+          before do
+            allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+              receive(:create_candidate_access_token)
+                .and_raise(GetIntoTeachingApiClient::ApiError)
+
+            post \
+              '/candidates/schools/10020/registrations/personal_information',
+              params: personal_information_params
+          end
+
+          it 'redirects to the contact information step' do
+            expect(response).to redirect_to \
+              '/candidates/schools/10020/registrations/contact_information/new'
+          end
+        end
+      end
     end
   end
 

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -72,6 +72,9 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       end
 
       context 'registration job not already enqueued' do
+        include_context "api latest privacy policy"
+        include_context "api teaching subjects"
+
         shared_examples 'a successful create' do
           before do
             allow(Bookings::LogToGitisJob).to \
@@ -79,12 +82,6 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
 
             allow(Candidates::Registrations::AcceptPrivacyPolicyJob).to \
               receive(:perform_later).and_return(true)
-
-            allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
-              receive(:get_teaching_subjects) { [] }
-
-            allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-              receive(:get_latest_privacy_policy) { build(:api_privacy_policy) }
 
             allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
               receive(:sign_up_schools_experience_candidate) do |_, sign_up|

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -116,6 +116,121 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
         expect(token.candidate.reload).to be_confirmed
       end
     end
+
+    context "when the git_api feature is enabled" do
+      include_context "Stubbed current_registration"
+
+      let(:code) { "123456" }
+      let(:params) { { candidates_verification_code: { code: code } } }
+      let(:request) do
+        GetIntoTeachingApiClient::ExistingCandidateRequest.new({
+          firstName: personal_info.first_name,
+          lastName: personal_info.last_name,
+          email: personal_info.email,
+          dateOfBirth: personal_info.date_of_birth,
+        })
+      end
+      let(:sign_up) { build(:api_schools_experience_sign_up) }
+      let(:perform_request) { put candidates_registration_verify_code_path(school_id), params: params }
+
+      around do |example|
+        Flipper.enable(:git_api)
+        example.run
+        Flipper.disable(:git_api)
+      end
+
+      context "with a valid code" do
+        before do
+          expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:exchange_access_token_for_schools_experience_sign_up).with(code, request) { sign_up }
+
+          perform_request
+        end
+
+        it "will redirect_to ContactInformation step" do
+          expect(response).to \
+            redirect_to new_candidates_school_registrations_contact_information_path(school_id)
+        end
+
+        it "will create a confirmed candidate" do
+          candidate = Bookings::Candidate.find_by(gitis_uuid: sign_up.candidate_id)
+          expect(candidate).to be_confirmed
+        end
+      end
+
+      context "with an invalid code" do
+        before do
+          expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:exchange_access_token_for_schools_experience_sign_up)
+            .and_raise(GetIntoTeachingApiClient::ApiError)
+
+          perform_request
+        end
+
+        it "will show error screen" do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("Please enter the latest verification code sent to your email address")
+        end
+      end
+
+      context "when already signed in" do
+        include_context "candidate signin"
+
+        before do
+          expect_any_instance_of(described_class).to \
+            receive(:delete_registration_sessions!)
+
+          expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:exchange_access_token_for_schools_experience_sign_up).with(code, request) { sign_up }
+        end
+
+        it "will redirect_to ContactInformation step" do
+          perform_request
+
+          expect(response).to \
+            redirect_to new_candidates_school_registrations_contact_information_path(school_id)
+        end
+      end
+
+      context "when the Candidate already exists" do
+        include_context "candidate signin"
+
+        let(:sign_up) { build(:api_schools_experience_sign_up, candidate_id: gitis_contact_attrs[:contactid]) }
+
+        before do
+          expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:exchange_access_token_for_schools_experience_sign_up).with(code, request) { sign_up }
+        end
+
+        it "will not create another Candidate and redirect_to ConfirmationInformation step" do
+          expect { perform_request }.not_to(change { Bookings::Candidate.count })
+
+          expect(response).to \
+            redirect_to new_candidates_school_registrations_contact_information_path(school_id)
+        end
+      end
+
+      context "with valid token but invalid Gitis data" do
+        let(:sign_up) { build(:api_schools_experience_sign_up, date_of_birth: nil) }
+
+        before do
+          expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:exchange_access_token_for_schools_experience_sign_up).with(code, request) { sign_up }
+
+          perform_request
+        end
+
+        it "will redirect_to ContactInformation step" do
+          expect(response).to \
+            redirect_to new_candidates_school_registrations_contact_information_path(school_id)
+        end
+
+        it "will have confirmed candidate" do
+          candidate = Bookings::Candidate.find_by(gitis_uuid: sign_up.candidate_id)
+          expect(candidate).to be_confirmed
+        end
+      end
+    end
   end
 
   describe 'POST #create' do
@@ -126,22 +241,25 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
     let!(:candidate) { create(:candidate, gitis_uuid: fake_gitis_uuid) }
     let(:token) { create(:candidate_session_token, candidate: candidate) }
 
-    before do
+    let(:perform_request) do
       perform_enqueued_jobs do
         post candidates_school_registrations_sign_in_path(school_id)
       end
     end
 
     it "will redirect to the show page" do
+      perform_request
       expect(response).to \
         redirect_to candidates_school_registrations_sign_in_path(school_id)
     end
 
     it "will have created new token" do
+      perform_request
       expect(token.candidate.reload.session_tokens.count).to eql(2)
     end
 
     it "sends a verification email" do
+      perform_request
       expect(NotifyFakeClient.deliveries.length).to eql(1)
 
       delivery = NotifyFakeClient.deliveries.first
@@ -150,6 +268,24 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
 
       expect(delivery[:personalisation][:verification_link]).to \
         match(%r{/candidates/verify/[0-9]+/[^/]{24}/#{registration_session.uuid}\z})
+    end
+
+    context "when the git_api feature is enabled" do
+      around do |example|
+        Flipper.enable(:git_api)
+        example.run
+        Flipper.disable(:git_api)
+      end
+
+      it "will issue a verification code and redirect to the show page" do
+        expect_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token)
+
+        perform_request
+
+        expect(response).to \
+          redirect_to candidates_school_registrations_sign_in_path(school_id)
+      end
     end
   end
 end

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -1,0 +1,34 @@
+FactoryBot.define do
+  factory :api_schools_experience_sign_up, class: GetIntoTeachingApiClient::SchoolsExperienceSignUp do
+    candidate_id { SecureRandom.uuid }
+    first_name { "First" }
+    last_name { "Last" }
+    email { "email@address.com" }
+    secondary_email { "email2@address.com" }
+    date_of_birth { Date.new(1987, 3, 12) }
+    telephone { "111111111" }
+    secondary_telephone { "222222222" }
+    address_telephone { "333333333" }
+    mobile_telephone { "444444444" }
+    address_line1 { "3 Main Street" }
+    address_line2 { "Botchergate" }
+    address_line3 { "" }
+    address_city { "Carlisle" }
+    address_state_or_province { "Cumbria" }
+    address_postcode { "TE7 1NG" }
+    has_dbs_certificate { true }
+    preferred_teaching_subject_id { SecureRandom.uuid }
+    secondary_preferred_teaching_subject_id { SecureRandom.uuid }
+    accepted_policy_id { SecureRandom.uuid }
+  end
+
+  factory :api_lookup_item, class: GetIntoTeachingApiClient::LookupItem do
+    id { SecureRandom.uuid }
+    value { "value-#{sequence(:value)}" }
+  end
+
+  factory :api_privacy_policy, class: GetIntoTeachingApiClient::PrivacyPolicy do
+    id { SecureRandom.uuid }
+    text { "policy text" }
+  end
+end

--- a/spec/factories/bookings/candidates_factory.rb
+++ b/spec/factories/bookings/candidates_factory.rb
@@ -10,5 +10,10 @@ FactoryBot.define do
       gitis_contact { build(:gitis_contact, :persisted) }
       gitis_uuid { gitis_contact.id }
     end
+
+    trait :with_api_contact do
+      gitis_contact { build(:api_schools_experience_sign_up) }
+      gitis_uuid { gitis_contact.candidate_id }
+    end
   end
 end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -232,6 +232,9 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
 
     context "when the git_api feature is enabled" do
+      include_context "api latest privacy policy"
+      include_context "api teaching subjects"
+
       around do |example|
         Flipper.enable(:git_api)
         example.run
@@ -239,10 +242,6 @@ RSpec.describe Bookings::Candidate, type: :model do
       end
 
       before do
-        allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
-          receive(:get_teaching_subjects) { [] }
-        allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-          receive(:get_latest_privacy_policy) { build(:api_privacy_policy) }
         allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
           receive(:sign_up_schools_experience_candidate) do |_, sign_up|
             sign_up.candidate_id = SecureRandom.uuid
@@ -372,16 +371,11 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
 
     context "when the contact is an instance of GetIntoTeachingApi::SchoolsExperienceSignUp" do
-      let(:candidate) { build(:candidate, :with_api_contact) }
+      include_context "api latest privacy policy"
+      include_context "api teaching subjects"
+      include_context "api sign up"
 
-      before do
-        allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
-          receive(:get_teaching_subjects) { [] }
-        allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-          receive(:get_latest_privacy_policy) { build(:api_privacy_policy) }
-        allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
-          receive(:sign_up_schools_experience_candidate)
-      end
+      let(:candidate) { build(:candidate, :with_api_contact) }
 
       it { is_expected.to be_kind_of Bookings::Candidate }
       it { is_expected.to have_attributes(gitis_uuid: subject.gitis_contact.candidate_id) }

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -42,21 +42,19 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to have_attributes(_dfe_preferredteachingsubject02_value: teachingsubjectid2) }
 
     context "when contact is an instance of GetIntoTeachingApiClient::SchoolsExperienceSignUp" do
+      include_context "api latest privacy policy"
+      include_context "api teaching subjects"
+
       let(:contact) { GetIntoTeachingApiClient::SchoolsExperienceSignUp.new }
-      let(:policy) { build(:api_privacy_policy) }
-
-      before do
-        teaching_subjects = [
-          build(:api_lookup_item, id: teachingsubjectid,
-                                  value: registration.teaching_preference.subject_first_choice),
-          build(:api_lookup_item, id: teachingsubjectid2,
-                                  value: registration.teaching_preference.subject_second_choice),
+      let(:teaching_subjects) do
+        [
+          build(:api_lookup_item,
+            id: teachingsubjectid,
+            value: registration.teaching_preference.subject_first_choice),
+          build(:api_lookup_item,
+             id: teachingsubjectid2,
+             value: registration.teaching_preference.subject_second_choice),
         ]
-        allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
-          receive(:get_teaching_subjects) { teaching_subjects }
-
-        allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-          receive(:get_latest_privacy_policy) { policy }
       end
 
       it { is_expected.to have_attributes(first_name: registration.personal_information.first_name) }
@@ -76,7 +74,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
       it { is_expected.to have_attributes(has_dbs_certificate: registration.background_check.has_dbs_check) }
       it { is_expected.to have_attributes(preferred_teaching_subject_id: teachingsubjectid) }
       it { is_expected.to have_attributes(secondary_preferred_teaching_subject_id: teachingsubjectid2) }
-      it { is_expected.to have_attributes(accepted_policy_id: policy.id) }
+      it { is_expected.to have_attributes(accepted_policy_id: latest_policy.id) }
 
       context "when has_dbs_certificate is changing" do
         let(:contact) do
@@ -205,6 +203,8 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to include('subject_second_choice' => english.name) }
 
     context "when contact is an instance of GetIntoTeachingApiClient::SchoolsExperienceSignUp" do
+      include_context "api teaching subjects"
+
       let(:contact) do
         build(
           :api_schools_experience_sign_up,
@@ -212,14 +212,11 @@ RSpec.describe Bookings::RegistrationContactMapper do
           secondary_preferred_teaching_subject_id: english.gitis_uuid,
         )
       end
-
-      before do
-        teaching_subjects = [
+      let(:teaching_subjects) do
+        [
           build(:api_lookup_item, id: maths.gitis_uuid, value: maths.name),
           build(:api_lookup_item, id: english.gitis_uuid, value: english.name),
         ]
-        allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
-          receive(:get_teaching_subjects) { teaching_subjects }
       end
 
       it { is_expected.to include('subject_first_choice' => maths.name) }

--- a/spec/models/candidates/verification_code_spec.rb
+++ b/spec/models/candidates/verification_code_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe Candidates::VerificationCode do
+  it { is_expected.to respond_to :code }
+
+  describe "code" do
+    it { is_expected.to allow_value("000000").for :code }
+    it { is_expected.to allow_value(" 123456").for :code }
+    it { is_expected.not_to allow_value("abc123").for :code }
+    it { is_expected.not_to allow_value("1234567").for :code }
+    it { is_expected.not_to allow_value("12345").for :code }
+  end
+
+  describe "#exchange" do
+    let(:personal_information) { build(:personal_information) }
+    let(:instance) { described_class.new(code: code) }
+
+    subject(:exchange) { instance.exchange(personal_information) }
+
+    context "when the code is invalid" do
+      let(:code) { "123" }
+
+      it { is_expected.to be_falsy }
+
+      it "does not call the API" do
+        expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).not_to \
+          receive(:exchange_access_token_for_schools_experience_sign_up)
+      end
+    end
+
+    context "when the code is valid" do
+      let(:code) { "123456" }
+      let(:response) { build(:api_schools_experience_sign_up) }
+      let(:request) do
+        GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+          firstName: personal_information.first_name,
+          lastName: personal_information.last_name,
+          email: personal_information.email,
+          dateOfBirth: personal_information.date_of_birth
+        )
+      end
+
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+          receive(:exchange_access_token_for_schools_experience_sign_up)
+            .with(code, request) { response }
+      end
+
+      it { is_expected.to eq(response) }
+
+      context "when the code is incorrect" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:exchange_access_token_for_schools_experience_sign_up)
+              .with(code, request).and_raise(GetIntoTeachingApiClient::ApiError.new)
+        end
+
+        it { is_expected.to be_nil }
+
+        it "adds an error to the model" do
+          exchange
+          expect(instance.errors).to be_added(:code, :invalid)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/candidates/verification_code_spec.rb
+++ b/spec/models/candidates/verification_code_spec.rb
@@ -12,10 +12,10 @@ describe Candidates::VerificationCode do
   end
 
   describe "#exchange" do
-    let(:personal_information) { build(:personal_information) }
+    let(:personal_info) { build(:personal_information) }
     let(:instance) { described_class.new(code: code) }
 
-    subject(:exchange) { instance.exchange(personal_information) }
+    subject(:exchange) { instance.exchange(personal_info) }
 
     context "when the code is invalid" do
       let(:code) { "123" }
@@ -29,31 +29,12 @@ describe Candidates::VerificationCode do
     end
 
     context "when the code is valid" do
-      let(:code) { "123456" }
-      let(:response) { build(:api_schools_experience_sign_up) }
-      let(:request) do
-        GetIntoTeachingApiClient::ExistingCandidateRequest.new(
-          firstName: personal_information.first_name,
-          lastName: personal_information.last_name,
-          email: personal_information.email,
-          dateOfBirth: personal_information.date_of_birth
-        )
-      end
+      include_context "api correct verification code"
 
-      before do
-        allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
-          receive(:exchange_access_token_for_schools_experience_sign_up)
-            .with(code, request) { response }
-      end
-
-      it { is_expected.to eq(response) }
+      it { is_expected.to eq(sign_up) }
 
       context "when the code is incorrect" do
-        before do
-          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
-            receive(:exchange_access_token_for_schools_experience_sign_up)
-              .with(code, request).and_raise(GetIntoTeachingApiClient::ApiError.new)
-        end
+        include_context "api incorrect verification code"
 
         it { is_expected.to be_nil }
 

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -31,6 +31,7 @@ describe Bookings::Gitis::Contact, type: :model do
 
       it "will assign id" do
         expect(@contact.id).to eq "d778d663-a022-4c4b-9962-e469ee179f4a"
+        expect(@contact.candidate_id).to eq @contact.id
       end
 
       it "will assign entity_id" do

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -42,6 +42,37 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     end
   end
 
+  describe "#issue_verification_code" do
+    let(:pinfo) { build(:personal_information) }
+    let(:request) do
+      GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+        email: pinfo.email,
+        firstName: pinfo.first_name,
+        lastName: pinfo.last_name,
+        dateOfBirth: pinfo.date_of_birth
+      )
+    end
+
+    subject { pinfo.issue_verification_code }
+
+    before do
+      allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+        receive(:create_candidate_access_token).with(request)
+    end
+
+    it { is_expected.to be_truthy }
+
+    context "when the user cannot be matched back" do
+      before do
+        allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+          receive(:create_candidate_access_token)
+            .with(request).and_raise(GetIntoTeachingApiClient::ApiError)
+      end
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
   context '#full_name' do
     context 'when first_name last_name attributes are set' do
       subject { described_class.new first_name: 'Testy', last_name: 'McTest' }

--- a/spec/support/candidate_signin.rb
+++ b/spec/support/candidate_signin.rb
@@ -1,7 +1,7 @@
 shared_context 'candidate signin' do
   let(:gitis_contact_attrs) { attributes_for(:gitis_contact, :persisted) }
   let(:gitis_contact) { build(:gitis_contact, gitis_contact_attrs) }
-  let(:current_candidate) { build(:candidate, gitis_uuid: gitis_contact.id) }
+  let(:current_candidate) { create(:candidate, gitis_uuid: gitis_contact.id) }
 
   before do
     allow_any_instance_of(described_class).to \

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -1,0 +1,67 @@
+shared_context "api candidate matched back" do
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token)
+  end
+end
+
+shared_context "api candidate not matched back" do
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \
+      receive(:create_candidate_access_token)
+        .and_raise(GetIntoTeachingApiClient::ApiError)
+  end
+end
+
+shared_context "api incorrect verification code" do
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+      receive(:exchange_access_token_for_schools_experience_sign_up)
+      .and_raise(GetIntoTeachingApiClient::ApiError)
+  end
+end
+
+shared_context "api correct verification code" do
+  let(:code) { "123456" }
+  let(:request) do
+    GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+      firstName: personal_info.first_name,
+      lastName: personal_info.last_name,
+      email: personal_info.email,
+      dateOfBirth: personal_info.date_of_birth
+    )
+  end
+  let(:sign_up) { build(:api_schools_experience_sign_up) }
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+      receive(:exchange_access_token_for_schools_experience_sign_up)
+      .with(code, request) { sign_up }
+  end
+end
+
+shared_context "api latest privacy policy" do
+  let(:latest_policy) { build(:api_privacy_policy) }
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
+      receive(:get_latest_privacy_policy) { latest_policy }
+  end
+end
+
+shared_context "api teaching subjects" do
+  let(:teaching_subjects) { [] }
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
+      receive(:get_teaching_subjects) { teaching_subjects }
+  end
+end
+
+shared_context "api sign up" do
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+      receive(:sign_up_schools_experience_candidate)
+        .with(an_instance_of(GetIntoTeachingApiClient::SchoolsExperienceSignUp))
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-65](https://trello.com/c/gYVyBCMH/65-spike-matchback-for-gse)

### Context

We want to migrate the application so that it calls out to the Get into Teaching API instead of interfacing with the Dynamics365 instance directly (reducing complexity in the application and making the integration consistent with our other services).

The PR is large, but should be reviewable by-commit -- arguably the commits could each be an individual PR, however this grouping is the minimum set of changes for a successful end-to-end sign up via the API.

### Changes proposed in this pull request

- Run Flipper against memory store in test env

We use the same Redis instance for our unit tests as development, which causes the features to be enabled in test that are enabled in dev.

Instead, we want to by default have all features off in test - we achieve this by setting Flipper to use an in-memory cache store for the test environment.

- Update registration mapper to support API model

When we start pulling candidates back from the API instead of Dynamics directly they will be an instance of
`SchoolsExperienceSignUp` and have slight different attribute names to the `Bookings::Gitis::Contact` that we are replacing.

Some of the domain logic in the existing `Bookings::Gitis::Contact` has been moved to the mapper model for now; this is to avoid adding _another_ intermediary model that abstracts the `SchoolsExperienceSignUp`. Going forward I think I can push much of this behaviour into the API.

Defaults the accepted privacy policy for the mapped contact - currently this is a separate operation at the controller-level,
but with the API the model encapsulates the accepted policy as well.

- Update Candidate model to support API integration

The `Bookings::Candidate` model contains various methods to find and update candidate records based on the associated
`gitis_contact`. Until now, the `gitis_contact` has always been `Bookings::Gitis::Candidate`, however, going forward the API
will be specifying a `contact` that is an instance of `GetIntoTeachingApiClient::SchoolsExperienceSignUp`.

For the most part we just need to ensure we call `candidate_id` if the object doesn't respond to `id` (the API model uses the
`candidate_id` attribute name). 

This `Bookings::Candidate` class is also responsible for mapping a registration to a contact instance and persisting it to the
CRM. In this case, we check for the `git_api` feature flag and call the API when enabled. It is fine if the state is such that
`contact` is an instance of `Bookings::Gitis::Candidate` and we are now sending it to the API as the support is
backwards-compatible with this model type as well (the mapper doesn't work of the feature flag so should adapt to the input
given).

- Add VerificationCode model

We need to model a verification code so that we can display a form to the user asking them to input a code that we can then
exchange for an existing `GetIntoTeachingApiClient::SchoolsExperienceSignUp`.

As per the existing controller action, the `exchange` method will take `personal_information` (containing the matchback attributes) and call out to the API.

- Support issuing verification codes

When the personal information of a candidate is constructed in the controller we currently create a session and generate a
token that is emailed to the user. 

Instead, we need to be able to call the API with the personal information of the user in order to issue a verification code.
If the API throws any kind of error we treat it as not possible to matchback the candidate and return `false`. If the candidate
was successfully matched back and emailed with a verification code we return `true`; this will enable us to serve the correct
subsequent view in the controller. 

- Issue verification code via API

When the `git_api` feature is enabled we want to bypass the current session creation and associated magic link
generation/delivery to instead call the API to generate and email a verification code.

The flow remains the same, in that if the candidate is successfully matched back we will still take them to the sign in
path (we will need to update this to support entering the verification code).

- Don't run privacy policy job for API contacts

If the `current_contact` is an instance of `GetIntoTeachingApiClient::SchoolsExperienceSignUp` then it will
have the latest privacy policy set on the model as part of the mapping process. We no longer need to queue a job to accept the privacy policy separately.

- Support API sign in/re-send verification code

Update the `SignInsController` to support calling out to the API in order to exchange a verification code for candidate information. The `SessionToken` is bypassed as we only support sign in from the same device used to generate the verification code. Updated to also issue a verification code via the API when the feature flag is enabled.

The `GitisAuthentication` concern has been updated to support both `Bookings::Gitis::Contact` and
`GetIntoTeachingApiClient::SchoolsExperienceSignUp`.

- DRY up tests using shared_context

Move repetetive expectations around the API interactions to `shared_context` so that they can be reused.

### Guidance to review

All of these changes are disabled by default; to enable in development you need to toggle the `git_api` feature switch at `/flipper`.

The main differences are:

- When a match back is successful the candidate is emailed a verification code by the API that they then have to enter into an input field (as opposed to sending out a magic link, which happens currently).
- The candidate is no longer able to start signing up on one device and continue on another, as the API verification process does not support this.
- The `Candidates::Session` and `Candidates::SessionToken` are bypassed as we can now just rely on the HTTP session (because the user is not able to switch device).

<img width="1348" alt="Screenshot 2021-05-21 at 11 16 42" src="https://user-images.githubusercontent.com/29867726/119122075-0926e680-ba26-11eb-8efb-bb41f911d5de.png">
