### PR TITLE
Integrate classroom experience requests to the GiT API

### DIFF
--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -74,6 +74,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       context 'registration job not already enqueued' do
         include_context "api latest privacy policy"
         include_context "api teaching subjects"
+        include_context "api add classroom experience note"
 
         shared_examples 'a successful create' do
           before do

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -65,3 +65,11 @@ shared_context "api sign up" do
         .with(an_instance_of(GetIntoTeachingApiClient::SchoolsExperienceSignUp))
   end
 end
+
+shared_context "api add classroom experience note" do
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+      receive(:add_classroom_experience_note)
+        .with(anything, an_instance_of(GetIntoTeachingApiClient::ClassroomExperienceNote))
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

When the candidate performs certain actions within the SE app it updates their `contact` record with log lines to record whats happening. We want to send these updates via the API instead of to Dynamics directly as part of the work to integrate with the GiT API.

### Changes proposed in this pull request

- Bump api client version

Update to remove client-side validation on ClassroomExperienceNote that was using an incorrect regex.

- Update EventLogger to write via API

Instead of constructing the log line in the app this is now deferred to the API, which accepts POST request containing a
`GetIntoTeachingApiClient::ClassroomExperienceNote`.

The class is a little misleading in that `write_later` will not queue the request to the API, however the operation should be much faster as the request returns immediately and is queued on the API-side now. When we pull out the legacy code we can rename this method so its clear that the request happens in-band.

### Guidance to review

The `EventLogger` class isn't ideal at the moment as its serving two fairly different purposes, in that when the `git_api` flag is off it will enqueue another job to send the log line to the CRM and when the `git_api` flag is on its calling the API directly. The interface to this class can be cleaned up as part of removing the legacy code; I don't think its worth extracting the shared logic to make it cleaner in the interim.
