### PR TITLE
Update healthcheck to run CRM check via API

### DIFF
--- a/spec/controllers/healthchecks_controller_spec.rb
+++ b/spec/controllers/healthchecks_controller_spec.rb
@@ -87,6 +87,26 @@ describe HealthchecksController, type: :request do
       it { expect(response.body).to include_json(api: false) }
       it { expect(response).to have_http_status(:error) }
     end
+
+    context "when the git_api feature is enabled" do
+      around do |example|
+        Flipper.enable(:git_api)
+        example.run
+        Flipper.disable(:git_api)
+      end
+
+      context "with unhealthy API" do
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::OperationsApi).to \
+            receive(:health_check).and_raise(GetIntoTeachingApiClient::ApiError)
+
+          get healthcheck_path
+        end
+
+        it { expect(response.body).to include_json(api: false) }
+        it { expect(response).to have_http_status(:error) }
+      end
+    end
   end
 
   describe '#deployment' do


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

The healthcheck tests connectivity to the CRM; instead of doing this directly we can call the API which, in turn, will test connectivity to the CRM.

Unlike the other services (which can function when the API is in a 'degraded' state) Schools Experience requires the CRM to be online in order to accept any new sign ups, so we check for this service explicitly in the health check response.

### Changes proposed in this pull request

- Update healthcheck to run CRM check via API

### Guidance to review

