### PR TITLE
Integrate reminder feature with GiT API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 24118c17e132e11fbb638e397fc54b9bf85df522
+  revision: 1cbc4f76690aa57cfed7833106fe48b28721bd64
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.31)
+    get_into_teaching_api_client_faraday (0.1.34)
       activesupport
       faraday
       faraday-encoding
@@ -202,12 +202,16 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-encoding (0.0.5)
       faraday
     faraday-excon (1.1.0)
@@ -220,7 +224,7 @@ GEM
     faraday_middleware-circuit_breaker (0.4.1)
       faraday (>= 0.9, < 2.0)
       stoplight (~> 2.1)
-    ffi (1.15.0)
+    ffi (1.15.1)
     flipper (0.21.0)
     flipper-active_support_cache_store (0.21.0)
       activesupport (>= 5.0, < 7)

--- a/app/services/bookings/reminder.rb
+++ b/app/services/bookings/reminder.rb
@@ -29,8 +29,16 @@ private
   def assign_gitis_contact(booking)
     return if booking.blank?
 
+    gitis_contact =
+      if Flipper.enabled?(:git_api)
+        api = GetIntoTeachingApiClient::SchoolsExperienceApi.new
+        api.get_schools_experience_sign_up(booking.contact_uuid)
+      else
+        gitis_crm.find(booking.contact_uuid)
+      end
+
     booking
       .bookings_placement_request
-      .candidate.gitis_contact = gitis_crm.find(booking.contact_uuid)
+      .candidate.gitis_contact = gitis_contact
   end
 end

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :api_schools_experience_sign_up, class: GetIntoTeachingApiClient::SchoolsExperienceSignUp do
     candidate_id { SecureRandom.uuid }
+    full_name { "First Last" }
     first_name { "First" }
     last_name { "Last" }
     email { "email@address.com" }

--- a/spec/services/bookings/reminder_spec.rb
+++ b/spec/services/bookings/reminder_spec.rb
@@ -17,5 +17,22 @@ describe Bookings::Reminder do
 
       expect(enqueued_jobs.size).to eql(1)
     end
+
+    context "when the git_api feature is enabled" do
+      around do |example|
+        Flipper.enable(:git_api)
+        example.run
+        Flipper.disable(:git_api)
+      end
+
+      it "delivers one job per provided booking" do
+        sign_up = build(:api_schools_experience_sign_up)
+
+        expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+          receive(:get_schools_experience_sign_up).with(booking.contact_uuid) { sign_up }
+
+        expect { subject.deliver }.to change { enqueued_jobs.size }.by(1)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

When sending reminders the app calls out to retrieve a contact record by its guid; this is now available in the API and so the reminder feature can be updated with `git_api` feature flag support.

### Changes proposed in this pull request

- Bump API client to include full_name attribute

The API was updated to return the candidate's full name, which exists on the current `Bookings::Gitis::Contact` however wasn't present on `GetIntoTeachingApiClient::SchoolsExperienceSignUp`. Adding it means we don't have to update a number of references to `full_name` with a helper.

- Integrate reminder functionality with API

### Guidance to review

