### PR TITLE
Update RejectedRequestsController to interface with GiT API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 24118c17e132e11fbb638e397fc54b9bf85df522
+  revision: 1cbc4f76690aa57cfed7833106fe48b28721bd64
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.31)
+    get_into_teaching_api_client_faraday (0.1.34)
       activesupport
       faraday
       faraday-encoding
@@ -202,12 +202,16 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
-    faraday (1.4.1)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
     faraday-encoding (0.0.5)
       faraday
     faraday-excon (1.1.0)
@@ -220,7 +224,7 @@ GEM
     faraday_middleware-circuit_breaker (0.4.1)
       faraday (>= 0.9, < 2.0)
       stoplight (~> 2.1)
-    ffi (1.15.0)
+    ffi (1.15.1)
     flipper (0.21.0)
     flipper-active_support_cache_store (0.21.0)
       activesupport (>= 5.0, < 7)

--- a/app/controllers/schools/rejected_requests_controller.rb
+++ b/app/controllers/schools/rejected_requests_controller.rb
@@ -25,7 +25,15 @@ module Schools
     def assign_gitis_contacts(requests)
       return requests if requests.empty?
 
-      contacts = gitis_crm.find(requests.map(&:contact_uuid)).index_by(&:id)
+      contact_ids = requests.map(&:contact_uuid)
+
+      contacts =
+        if Flipper.enabled?(:git_api)
+          api = GetIntoTeachingApiClient::SchoolsExperienceApi.new
+          api.get_schools_experience_sign_ups(contact_ids).index_by(&:candidate_id)
+        else
+          gitis_crm.find(contact_ids).index_by(&:id)
+        end
 
       requests.each do |req|
         req.candidate.gitis_contact = contacts[req.contact_uuid]

--- a/spec/controllers/schools/rejected_requests_controller_spec.rb
+++ b/spec/controllers/schools/rejected_requests_controller_spec.rb
@@ -22,6 +22,31 @@ describe Schools::RejectedRequestsController, type: :request do
     it { expect(response).to render_template('index') }
   end
 
+  context "when the git_api feature is enabled" do
+    around do |example|
+      Flipper.enable(:git_api)
+      example.run
+      Flipper.disable(:git_api)
+    end
+
+    describe "#index" do
+      before do
+        requests = create_list(:placement_request, 2, :cancelled_by_school, school: school)
+        ids = requests.map(&:contact_uuid)
+        sign_ups = ids.map { |id| build(:api_schools_experience_sign_up, candidate_id: id) }
+
+        allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+          receive(:get_schools_experience_sign_ups)
+            .with(a_collection_containing_exactly(*ids)) { sign_ups }
+
+        get schools_rejected_requests_path
+      end
+
+      it { expect(response).to have_http_status(:success) }
+      it { expect(response).to render_template('index') }
+    end
+  end
+
   describe '#show' do
     let(:rejected) { create :placement_request, :cancelled_by_school, school: school }
     before { get schools_rejected_request_path(rejected) }


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

Instead of calling the Dynamics instance directly to retrieve candidate information by a collection of ids we can now go to the GiT API when the `git_api` flag is enabled.

### Changes proposed in this pull request

- Update RejectedRequestsController to interface with GiT API

### Guidance to review

