### PR TITLE
Support calling the API in the ContactFetcher class

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: 1cbc4f76690aa57cfed7833106fe48b28721bd64
+  revision: ad8dc73640e3b34247eeea34cfaf9a0976df88a8
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.34)
+    get_into_teaching_api_client_faraday (0.1.36)
       activesupport
       faraday
       faraday-encoding

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -124,7 +124,7 @@ class Bookings::Candidate < ApplicationRecord
   def assign_gitis_contact(contact)
     self.gitis_contact = contact
 
-    if gitis_uuid != contact.contactid
+    if gitis_uuid != contact.candidate_id
       # using update column to avoid accidentally persisting any other
       # changed state on the candidate
 

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -134,12 +134,6 @@ module Bookings
         self.dfe_notesforclassroomexperience = "#{dfe_notesforclassroomexperience}#{log_line}\r\n"
       end
 
-      def been_merged?
-        raise InconsistentState unless merged == _masterid_value.present?
-
-        merged
-      end
-
       class InconsistentState < RuntimeError; end
 
     private

--- a/app/services/bookings/gitis/contact.rb
+++ b/app/services/bookings/gitis/contact.rb
@@ -40,7 +40,10 @@ module Bookings
       alias_attribute :town_or_city, :address1_city
       alias_attribute :county, :address1_stateorprovince
       alias_attribute :postcode, :address1_postalcode
+
+      # Aliases to achieve parity with GetIntoTeachingApiClient::SchoolsExperienceSignUp
       alias_attribute :candidate_id, :contactid
+      alias_attribute :master_id, :_masterid_value
 
       validates :email, presence: true, format: /\A.+@.+\..+\z/
       validates :'dfe_Country@odata.bind', presence: true, format: BIND_FORMAT, allow_nil: true

--- a/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/personal_informations_controller_spec.rb
@@ -159,11 +159,7 @@ describe Candidates::Registrations::PersonalInformationsController, type: :reque
       end
 
       context "when the git_api feature is enabled" do
-        around do |example|
-          Flipper.enable(:git_api)
-          example.run
-          Flipper.disable(:git_api)
-        end
+        include_context "enable git_api feature"
 
         context 'valid and known to gitis' do
           include_context "api candidate matched back"

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -139,11 +139,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
           end
 
           context "when the git_api feature is enabled" do
-            around do |example|
-              Flipper.enable(:git_api)
-              example.run
-              Flipper.disable(:git_api)
-            end
+            include_context "enable git_api feature"
 
             it "does not enqueue an accept privacy policy job" do
               expect(Candidates::Registrations::AcceptPrivacyPolicyJob).not_to \

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -118,17 +118,12 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
     end
 
     context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
       include_context "Stubbed current_registration"
       include_context "api correct verification code"
 
       let(:params) { { candidates_verification_code: { code: code } } }
       let(:perform_request) { put candidates_registration_verify_code_path(school_id), params: params }
-
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
 
       context "with a valid code" do
         before { perform_request }
@@ -240,13 +235,8 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
     end
 
     context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
       include_context "api candidate matched back"
-
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
 
       it "will issue a verification code and redirect to the show page" do
         perform_request

--- a/spec/controllers/healthchecks_controller_spec.rb
+++ b/spec/controllers/healthchecks_controller_spec.rb
@@ -89,11 +89,7 @@ describe HealthchecksController, type: :request do
     end
 
     context "when the git_api feature is enabled" do
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
+      include_context "enable git_api feature"
 
       context "with unhealthy API" do
         before do

--- a/spec/controllers/schools/rejected_requests_controller_spec.rb
+++ b/spec/controllers/schools/rejected_requests_controller_spec.rb
@@ -30,15 +30,11 @@ describe Schools::RejectedRequestsController, type: :request do
     end
 
     describe "#index" do
+      include_context "api sign ups for requests"
+
+      let(:requests) { create_list(:placement_request, 2, :cancelled_by_school, school: school) }
+
       before do
-        requests = create_list(:placement_request, 2, :cancelled_by_school, school: school)
-        ids = requests.map(&:contact_uuid)
-        sign_ups = ids.map { |id| build(:api_schools_experience_sign_up, candidate_id: id) }
-
-        allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
-          receive(:get_schools_experience_sign_ups)
-            .with(a_collection_containing_exactly(*ids)) { sign_ups }
-
         get schools_rejected_requests_path
       end
 

--- a/spec/controllers/schools/rejected_requests_controller_spec.rb
+++ b/spec/controllers/schools/rejected_requests_controller_spec.rb
@@ -23,11 +23,7 @@ describe Schools::RejectedRequestsController, type: :request do
   end
 
   context "when the git_api feature is enabled" do
-    around do |example|
-      Flipper.enable(:git_api)
-      example.run
-      Flipper.disable(:git_api)
-    end
+    include_context "enable git_api feature"
 
     describe "#index" do
       include_context "api sign ups for requests"

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :api_schools_experience_sign_up, class: GetIntoTeachingApiClient::SchoolsExperienceSignUp do
     candidate_id { SecureRandom.uuid }
+    master_id { nil }
+    merged { false }
     full_name { "First Last" }
     first_name { "First" }
     last_name { "Last" }
@@ -21,6 +23,11 @@ FactoryBot.define do
     preferred_teaching_subject_id { SecureRandom.uuid }
     secondary_preferred_teaching_subject_id { SecureRandom.uuid }
     accepted_policy_id { SecureRandom.uuid }
+
+    trait :merged do
+      master_id { SecureRandom.uuid }
+      merged { true }
+    end
   end
 
   factory :api_lookup_item, class: GetIntoTeachingApiClient::LookupItem do

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -232,14 +232,9 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
 
     context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
       include_context "api latest privacy policy"
       include_context "api teaching subjects"
-
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
 
       before do
         allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -48,11 +48,7 @@ RSpec.describe Healthcheck do
     end
 
     context "when the git_api feature is enabled" do
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
+      include_context "enable git_api feature"
 
       context "with a working connection" do
         before do

--- a/spec/services/bookings/gitis/contact_fetcher_spec.rb
+++ b/spec/services/bookings/gitis/contact_fetcher_spec.rb
@@ -48,11 +48,7 @@ describe Bookings::Gitis::ContactFetcher do
     end
 
     context "when the git_api feature is enabled" do
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
+      include_context "enable git_api feature"
 
       it "returns a hash with contactids as keys" do
         expect(subject.keys).to eql \
@@ -75,11 +71,7 @@ describe Bookings::Gitis::ContactFetcher do
     end
 
     context "when the git_api feature is enabled" do
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
+      include_context "enable git_api feature"
 
       it "assigns expected models" do
         expect(subject.map(&:gitis_contact).map(&:candidate_id)).to eql \
@@ -97,11 +89,7 @@ describe Bookings::Gitis::ContactFetcher do
     end
 
     context "when the git_api feature is enabled" do
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
+      include_context "enable git_api feature"
 
       it "assigns expected models" do
         expect(subject.gitis_contact.candidate_id).to eql \
@@ -210,11 +198,7 @@ describe Bookings::Gitis::ContactFetcher do
   end
 
   context "when the git_api feature is enabled" do
-    around do |example|
-      Flipper.enable(:git_api)
-      example.run
-      Flipper.disable(:git_api)
-    end
+    include_context "enable git_api feature"
 
     describe 'merged records' do
       let(:first) { build :api_schools_experience_sign_up }

--- a/spec/services/bookings/gitis/contact_fetcher_spec.rb
+++ b/spec/services/bookings/gitis/contact_fetcher_spec.rb
@@ -2,11 +2,37 @@ require 'rails_helper'
 
 describe Bookings::Gitis::ContactFetcher do
   include_context "fake gitis"
+  include_context "api sign ups for requests"
+  include_context "api sign up for first request"
 
   let(:fetcher) { described_class.new fake_gitis }
   let(:school) { create :bookings_school }
   let(:requests) { create_list :bookings_placement_request, 2, school: school }
   let(:reloaded_requests) { Bookings::PlacementRequest.find requests.map(&:id) }
+
+  context 'been_merged?' do
+    subject { fetcher.been_merged?(contact) }
+
+    context 'correct merged' do
+      let(:contact) { build(:gitis_contact, :merged) }
+      it { is_expected.to be true }
+    end
+
+    context 'correct unmerged' do
+      let(:contact) { build(:gitis_contact, :persisted) }
+      it { is_expected.to be false }
+    end
+
+    context 'merged without master' do
+      let(:contact) { build(:gitis_contact, :merged, _masterid_value: nil) }
+      it { expect { subject }.to raise_exception Bookings::Gitis::Contact::InconsistentState }
+    end
+
+    context 'master but not merged' do
+      let(:contact) { build(:gitis_contact, :merged, merged: false) }
+      it { expect { subject }.to raise_exception Bookings::Gitis::Contact::InconsistentState }
+    end
+  end
 
   describe 'fetching contacts' do
     subject { fetcher.fetch_for_models reloaded_requests }
@@ -20,6 +46,24 @@ describe Bookings::Gitis::ContactFetcher do
       expect(subject.values.map(&:contactid)).to eql \
         requests.map(&:candidate).map(&:gitis_uuid)
     end
+
+    context "when the git_api feature is enabled" do
+      around do |example|
+        Flipper.enable(:git_api)
+        example.run
+        Flipper.disable(:git_api)
+      end
+
+      it "returns a hash with contactids as keys" do
+        expect(subject.keys).to eql \
+          requests.map(&:candidate).map(&:gitis_uuid)
+      end
+
+      it "returns contacts as hash values" do
+        expect(subject.values.map(&:candidate_id)).to eql \
+          requests.map(&:candidate).map(&:gitis_uuid)
+      end
+    end
   end
 
   describe 'assigning contacts' do
@@ -29,6 +73,19 @@ describe Bookings::Gitis::ContactFetcher do
       expect(subject.map(&:gitis_contact).map(&:contactid)).to eql \
         requests.map(&:candidate).map(&:gitis_uuid)
     end
+
+    context "when the git_api feature is enabled" do
+      around do |example|
+        Flipper.enable(:git_api)
+        example.run
+        Flipper.disable(:git_api)
+      end
+
+      it "assigns expected models" do
+        expect(subject.map(&:gitis_contact).map(&:candidate_id)).to eql \
+          requests.map(&:candidate).map(&:gitis_uuid)
+      end
+    end
   end
 
   describe 'assign_to_model' do
@@ -37,6 +94,19 @@ describe Bookings::Gitis::ContactFetcher do
     it "should assign expected models" do
       expect(subject.gitis_contact.contactid).to eql \
         requests[0].candidate.gitis_uuid
+    end
+
+    context "when the git_api feature is enabled" do
+      around do |example|
+        Flipper.enable(:git_api)
+        example.run
+        Flipper.disable(:git_api)
+      end
+
+      it "assigns expected models" do
+        expect(subject.gitis_contact.candidate_id).to eql \
+          requests[0].candidate.gitis_uuid
+      end
     end
   end
 
@@ -134,6 +204,121 @@ describe Bookings::Gitis::ContactFetcher do
 
         it "will return expected contacts" do
           expect(subject.map(&:gitis_contact)).to eq [first, second]
+        end
+      end
+    end
+  end
+
+  context "when the git_api feature is enabled" do
+    around do |example|
+      Flipper.enable(:git_api)
+      example.run
+      Flipper.disable(:git_api)
+    end
+
+    describe 'merged records' do
+      let(:first) { build :api_schools_experience_sign_up }
+      let(:second) { build :api_schools_experience_sign_up }
+      let(:merged) do
+        build :api_schools_experience_sign_up, :merged, master_id: first.candidate_id
+      end
+      let(:chained) do
+        build :api_schools_experience_sign_up, :merged, master_id: merged.candidate_id, first_name: 'chained'
+      end
+
+      context 'for single record' do
+        let(:candidate) { create :candidate, gitis_uuid: merged.candidate_id }
+        subject { fetcher.assign_to_model candidate }
+
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_up).with(first.candidate_id) { first }
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_up).with(second.candidate_id) { second }
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_up).with(merged.candidate_id) { merged }
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_up).with(chained.candidate_id) { chained }
+        end
+
+        it 'should locate the master contact record' do
+          is_expected.to have_attributes gitis_contact: first
+        end
+        it 'should not update the gitis UUID to match the master contact record' do
+          is_expected.to have_attributes gitis_uuid: merged.candidate_id
+        end
+        it { is_expected.to have_attributes changes: {} }
+
+        context 'with chained records' do
+          let(:candidate) { create :candidate, gitis_uuid: chained.candidate_id }
+
+          it 'should locate the master contact record' do
+            is_expected.to have_attributes gitis_contact: first
+          end
+          it 'should not update the gitis UUID to match the master contact record' do
+            is_expected.to have_attributes gitis_uuid: chained.candidate_id
+          end
+          it { is_expected.to have_attributes changes: {} }
+        end
+
+        context 'with max chained records' do
+          let(:fourth) { build :api_schools_experience_sign_up, :merged, master_id: chained.candidate_id }
+          let(:fifth) { build :api_schools_experience_sign_up, :merged, master_id: fourth.candidate_id }
+          let(:sixth) { build :api_schools_experience_sign_up, :merged, master_id: fifth.candidate_id }
+
+          before do
+            allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+              receive(:get_schools_experience_sign_up).with(fourth.candidate_id) { fourth }
+            allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+              receive(:get_schools_experience_sign_up).with(fifth.candidate_id) { fifth }
+            allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+              receive(:get_schools_experience_sign_up).with(sixth.candidate_id) { sixth }
+          end
+
+          let(:candidate) { create :candidate, gitis_uuid: sixth.candidate_id }
+
+          it 'should locate the master contact record' do
+            is_expected.to have_attributes gitis_contact: merged
+          end
+          it 'should not update the gitis UUID to match the master contact record' do
+            is_expected.to have_attributes gitis_uuid: sixth.candidate_id
+          end
+          it { is_expected.to have_attributes changes: {} }
+        end
+      end
+
+      context 'with multiple records' do
+        let(:candidate) { create :candidate, gitis_uuid: chained.candidate_id }
+        let(:second_candidate) { create :candidate, gitis_uuid: second.candidate_id }
+
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_ups)
+              .with([chained.candidate_id, second.candidate_id]) { [chained, second] }
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_ups).with([merged.candidate_id]) { [merged] }
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_ups).with([first.candidate_id]) { [first] }
+        end
+
+        context 'retrieving multiple records' do
+          subject { fetcher.fetch_for_models [candidate, second_candidate] }
+
+          it { is_expected.to include chained.candidate_id => first }
+          it { is_expected.to include second.candidate_id => second }
+        end
+
+        context 'assigning multiple records' do
+          subject { fetcher.assign_to_models [candidate, second_candidate] }
+
+          it "will update contact ids" do
+            expect(subject.map(&:reload).map(&:gitis_uuid)).to \
+              eq [chained.candidate_id, second.candidate_id]
+          end
+
+          it "will return expected contacts" do
+            expect(subject.map(&:gitis_contact)).to eq [first, second]
+          end
         end
       end
     end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -514,29 +514,5 @@ describe Bookings::Gitis::Contact, type: :model do
         it { is_expected.not_to include '_masterid_value' }
       end
     end
-
-    context 'been_merged' do
-      subject { contact.been_merged? }
-
-      context 'correct merged' do
-        let(:contact) { build(:gitis_contact, :merged) }
-        it { is_expected.to be true }
-      end
-
-      context 'correct unmerged' do
-        let(:contact) { build(:gitis_contact, :persisted) }
-        it { is_expected.to be false }
-      end
-
-      context 'merged without master' do
-        let(:contact) { build(:gitis_contact, :merged, _masterid_value: nil) }
-        it { expect { subject }.to raise_exception described_class::InconsistentState }
-      end
-
-      context 'master but not merged' do
-        let(:contact) { build(:gitis_contact, :merged, merged: false) }
-        it { expect { subject }.to raise_exception described_class::InconsistentState }
-      end
-    end
   end
 end

--- a/spec/services/bookings/gitis/contact_spec.rb
+++ b/spec/services/bookings/gitis/contact_spec.rb
@@ -460,10 +460,12 @@ describe Bookings::Gitis::Contact, type: :model do
       it { is_expected.to respond_to :statecode }
       it { is_expected.to respond_to :_masterid_value }
       it { is_expected.to respond_to :masterid }
+      it { is_expected.to respond_to :master_id }
       it { is_expected.to respond_to :merged }
 
       it { is_expected.to have_attributes statecode: described_class::READONLY }
       it { is_expected.to have_attributes _masterid_value: masterid }
+      it { is_expected.to have_attributes master_id: masterid }
       it { is_expected.to have_attributes merged: true }
     end
 

--- a/spec/services/bookings/reminder_spec.rb
+++ b/spec/services/bookings/reminder_spec.rb
@@ -19,11 +19,7 @@ describe Bookings::Reminder do
     end
 
     context "when the git_api feature is enabled" do
-      around do |example|
-        Flipper.enable(:git_api)
-        example.run
-        Flipper.disable(:git_api)
-      end
+      include_context "enable git_api feature"
 
       it "delivers one job per provided booking" do
         sign_up = build(:api_schools_experience_sign_up)

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -1,3 +1,11 @@
+shared_context "enable git_api feature" do
+  around do |example|
+    Flipper.enable(:git_api)
+    example.run
+    Flipper.disable(:git_api)
+  end
+end
+
 shared_context "api candidate matched back" do
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::CandidatesApi).to \

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -73,3 +73,24 @@ shared_context "api add classroom experience note" do
         .with(anything, an_instance_of(GetIntoTeachingApiClient::ClassroomExperienceNote))
   end
 end
+
+shared_context "api sign ups for requests" do
+  before do
+    ids = requests.map(&:contact_uuid)
+    sign_ups = ids.map { |id| build(:api_schools_experience_sign_up, candidate_id: id) }
+
+    allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+      receive(:get_schools_experience_sign_ups)
+        .with(a_collection_containing_exactly(*ids)) { sign_ups }
+  end
+end
+
+shared_context "api sign up for first request" do
+  before do
+    id = requests.first.contact_uuid
+
+    allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+      receive(:get_schools_experience_sign_up)
+        .with(id) { build(:api_schools_experience_sign_up, candidate_id: id) }
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

The `ContactFetcher` contains complex logic to traverse `contact` records in the CRM in order to obtain the 'master' record. This needs to work against the API instead of Dynamics directly. Once the API migration is finished it would make sense to push this logic into the API to simplify it.

### Changes proposed in this pull request

- Bump API client to add master_id support

- Add master_id field to Contact

This makes the `Contact` model consistent with the `SchoolsExperienceSignUp` so that we can use them interchangeably in the `ContactFetcher`.

- Update ContactFetcher to work against API

The SE app has fairly complex code around getting back to the 'master' contact record in the CRM (a contact has a 'master' when the record has been de-duped and merged with another record).

Update to call the API instead of Dynamics directly.

Extract the `been_merged?` logic out of the `Candidate` model and into the `ContactFetcher` - it was better placed in the `Candidate` model, but doing this allows us to modify the logic so it also works with a `SchoolsExperienceSignUp` model.

The `ContactFetcher` tests have been duplicated and ran against the app when the `git_api` flag is enabled.

- Move git_api feature toggle into shared_context

DRY up the git_api specs a bit by moving the toggle into a shared context.

### Guidance to review

