### PR TITLE
Handle API/Faraday errors

### DIFF
--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -18,6 +18,8 @@ module Schools
     rescue_from SchoolNotRegistered, with: -> { redirect_to schools_errors_not_registered_path }
     rescue_from Bookings::Gitis::API::BadResponseError, with: :gitis_retrieval_error
     rescue_from Bookings::Gitis::API::ConnectionFailed, with: :gitis_retrieval_error
+    rescue_from Faraday::ConnectionFailed, with: :gitis_retrieval_error
+    rescue_from GetIntoTeachingApiClient::ApiError, with: :gitis_retrieval_error
 
     def current_school
       if current_urn.blank?

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -69,6 +69,26 @@ describe Schools::PlacementRequestsController, type: :request do
       end
     end
 
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+
+      context "with a timeout response from the API" do
+        before do
+          ids = placement_requests.map(&:contact_uuid)
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_ups)
+              .with(a_collection_containing_exactly(*ids))
+              .and_raise(Faraday::ConnectionFailed.new("failed"))
+          get "/schools/placement_requests"
+        end
+
+        it "renders the Gitis connection error page" do
+          expect(response).to have_http_status(:service_unavailable)
+          expect(response).to render_template('shared/failed_gitis_connection')
+        end
+      end
+    end
+
     context 'with missing contacts from Gitis' do
       include_context 'fake gitis'
 
@@ -81,6 +101,26 @@ describe Schools::PlacementRequestsController, type: :request do
         expect(response).to have_http_status(:success)
         expect(response).to render_template('index')
         expect(response.body).to match(/Unavailable/)
+      end
+    end
+
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+
+      context "with a missing contact from API" do
+        before do
+          ids = placement_requests.map(&:contact_uuid)
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_ups)
+              .with(a_collection_containing_exactly(*ids)) { [] }
+          get "/schools/placement_requests"
+        end
+
+        it "renders the Gitis connection error page" do
+          expect(response).to have_http_status(:success)
+          expect(response).to render_template('index')
+          expect(response.body).to match(/Unavailable/)
+        end
       end
     end
   end
@@ -198,6 +238,52 @@ describe Schools::PlacementRequestsController, type: :request do
       it "renders the Gitis connection error page" do
         expect(response).to have_http_status(:service_unavailable)
         expect(response).to render_template('shared/failed_gitis_connection')
+      end
+    end
+
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+
+      context 'with a timeout response from Gitis' do
+        let :placement_request do
+          FactoryBot.create :placement_request, school: school
+        end
+
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_up)
+              .with(placement_request.candidate.gitis_uuid)
+              .and_raise(Faraday::ConnectionFailed.new("timeout"))
+
+          get "/schools/placement_requests/#{placement_request.id}"
+        end
+
+        it "renders the Gitis connection error page" do
+          expect(response).to have_http_status(:service_unavailable)
+          expect(response).to render_template('shared/failed_gitis_connection')
+        end
+      end
+
+      context 'with a 404 response from Gitis' do
+        include_context 'stubbed out Gitis'
+
+        let :placement_request do
+          FactoryBot.create :placement_request, school: school
+        end
+
+        before do
+          allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+            receive(:get_schools_experience_sign_up)
+              .with(placement_request.candidate.gitis_uuid)
+              .and_raise(GetIntoTeachingApiClient::ApiError.new(code: 404))
+
+          get "/schools/placement_requests/#{placement_request.id}"
+        end
+
+        it "renders the Gitis connection error page" do
+          expect(response).to have_http_status(:service_unavailable)
+          expect(response).to render_template('shared/failed_gitis_connection')
+        end
       end
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

Rescue from Faraday connection errors and any ApiError to display the standard service unavailable page. This should mimic the behaviour of the direct integration error-handling.

### Changes proposed in this pull request

- Handle API/Faraday errors

### Guidance to review

