### PR TITLE
Test CSV exporter retrieving contacts via API

### DIFF
--- a/spec/models/schools/csv_export_row_spec.rb
+++ b/spec/models/schools/csv_export_row_spec.rb
@@ -1,6 +1,119 @@
 require "rails_helper"
 
 RSpec.describe Schools::CsvExportRow do
+  context "when the git_api feature is enabled" do
+    include_context "enable git_api feature"
+
+    describe "#row" do
+      subject { Hash[Schools::CsvExport::HEADER.zip(row)] }
+
+      let(:contact) { build :api_schools_experience_sign_up }
+
+      let(:row) do
+        pr.gitis_contact = contact
+        described_class.new(pr).row
+      end
+
+      context "a placement request without a booking" do
+        context "for a fixed date school" do
+          let(:pr) { create :placement_request, :with_a_fixed_date }
+
+          it { is_expected.to include "Id" => pr.id }
+          it { is_expected.to include "Name" => contact.full_name }
+          it { is_expected.to include "Email" => contact.email }
+          it { is_expected.to include "Date" => pr.placement_date.date.to_formatted_s(:govuk) }
+          it { is_expected.to include "Duration" => pr.placement_date.duration }
+          it { is_expected.to include "Subject" => pr.subject_first_choice }
+          it { is_expected.to include "Status" => "New" }
+          it { is_expected.to include "Attendance" => nil }
+
+          context "which has been cancelled by the school" do
+            let(:pr) { create :placement_request, :cancelled_by_school, :with_a_fixed_date }
+
+            it { is_expected.to include "Status" => "Rejected" }
+          end
+
+          context "which has been cancelled by the candidate" do
+            let(:pr) { create :placement_request, :cancelled, :with_a_fixed_date }
+
+            it { is_expected.to include "Status" => "Withdrawn" }
+          end
+        end
+
+        context "for a flexible date school" do
+          let(:pr) { create :placement_request }
+
+          it { is_expected.to include "Id" => pr.id }
+          it { is_expected.to include "Name" => contact.full_name }
+          it { is_expected.to include "Email" => contact.email }
+          it { is_expected.to include "Date" => nil }
+          it { is_expected.to include "Duration" => nil }
+          it { is_expected.to include "Subject" => pr.subject_first_choice }
+          it { is_expected.to include "Status" => "New" }
+          it { is_expected.to include "Attendance" => nil }
+        end
+      end
+
+      context "with a placement request with future a booking" do
+        let(:pr) { create(:bookings_booking, :accepted).bookings_placement_request }
+
+        it { is_expected.to include "Id" => pr.id }
+        it { is_expected.to include "Name" => contact.full_name }
+        it { is_expected.to include "Email" => contact.email }
+        it { is_expected.to include "Date" => pr.booking.date.to_formatted_s(:govuk) }
+        it { is_expected.to include "Duration" => pr.booking.duration }
+        it { is_expected.to include "Subject" => pr.booking.bookings_subject.name }
+        it { is_expected.to include "Status" => "Booked" }
+        it { is_expected.to include "Attendance" => nil }
+
+        context "which has been cancelled by the school" do
+          let(:pr) do
+            create(:bookings_booking, :accepted, :cancelled_by_school)
+              .bookings_placement_request
+          end
+
+          it { is_expected.to include "Status" => "School cancellation" }
+        end
+
+        context "which has been cancelled by the candidate" do
+          let(:pr) do
+            create(:bookings_booking, :accepted, :cancelled_by_candidate)
+              .bookings_placement_request
+          end
+
+          it { is_expected.to include "Status" => "Candidate cancellation" }
+        end
+      end
+
+      context "with a placement request with a booking which has passed" do
+        subject { row[Schools::CsvExport.column("Attendance")] }
+
+        let(:pr) do
+          create(:bookings_booking, :accepted, attended: attended)
+            .bookings_placement_request
+        end
+
+        context "with no attendance information" do
+          let(:attended) { nil }
+
+          it { is_expected.to be_nil }
+        end
+
+        context "with an attendance" do
+          let(:attended) { true }
+
+          it { is_expected.to eql "Attended" }
+        end
+
+        context "with a did not attend" do
+          let(:attended) { false }
+
+          it { is_expected.to eql "Did not attend" }
+        end
+      end
+    end
+  end
+
   describe "#row" do
     subject { Hash[Schools::CsvExport::HEADER.zip(row)] }
 

--- a/spec/models/schools/csv_export_spec.rb
+++ b/spec/models/schools/csv_export_spec.rb
@@ -67,4 +67,53 @@ RSpec.describe Schools::CsvExport do
       end
     end
   end
+
+  context "when the git_api feature is enabled" do
+    include_context "enable git_api feature"
+
+    describe "#export" do
+      subject { parsed_csv }
+
+      let(:school) { create :bookings_school }
+      let(:generated_csv) { described_class.new(school).export }
+      let(:parsed_csv) { CSV.new(generated_csv).read }
+
+      describe "header rows" do
+        subject { parsed_csv[0] }
+
+        it "should contain a header row" do
+          is_expected.to eql \
+            %w[Id Name Email Date Duration Subject Status Attendance]
+        end
+      end
+
+      describe "data rows" do
+        include_context "api sign ups for requests"
+
+        subject { parsed_csv.slice(1...).map(&:first).map(&:to_i) }
+
+        let(:first) { create(:bookings_booking).bookings_placement_request }
+        let(:school) { first.school }
+        let(:second) { create :bookings_placement_request, school: school }
+        let!(:historical) do
+          create :bookings_placement_request, school: school, created_at: 1.year.ago
+        end
+        let(:requests) { [first, second] }
+
+        it "should contain placement requests from this academic year" do
+          is_expected.to eql [first.id, second.id]
+        end
+
+        it "should not contain placement requests from earlier academic years" do
+          is_expected.not_to include historical.id
+        end
+
+        context "crm data" do
+          subject { parsed_csv.slice(1...).map(&:second) }
+
+          it { is_expected.to eql sign_ups.map(&:full_name) }
+        end
+      end
+    end
+  end
 end

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -83,10 +83,12 @@ shared_context "api add classroom experience note" do
 end
 
 shared_context "api sign ups for requests" do
-  before do
-    ids = requests.map(&:contact_uuid)
-    sign_ups = ids.map { |id| build(:api_schools_experience_sign_up, candidate_id: id) }
+  let(:ids) { requests.map(&:contact_uuid) }
+  let(:sign_ups) do
+    ids.map { |id| build(:api_schools_experience_sign_up, candidate_id: id) }
+  end
 
+  before do
     allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
       receive(:get_schools_experience_sign_ups)
         .with(a_collection_containing_exactly(*ids)) { sign_ups }


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

The CSV exporter uses the `ContactFetcher` to retrieve contacts associated with placement requests prior to exporting them. Now that the `ContactFetcher` has been updated to support retrieving contacts via the API, it makes sense to test the exporter functionality as well when the `git_api` feature is enabled. 

As the legacy code will be removed eventually I opted to duplicate the test cases instead of extracting them to keep it DRY.

### Changes proposed in this pull request

- Test CSV exporter retrieving contacts via API

### Guidance to review

