### PR TITLE
Raise unexpected direct calls to the CRM when `git_api` feature is enabled

### DIFF
--- a/app/services/bookings/gitis/store/dynamics.rb
+++ b/app/services/bookings/gitis/store/dynamics.rb
@@ -9,6 +9,10 @@ module Bookings
         end
 
         def find(entity_type, id_or_ids, **options)
+          if Flipper.enabled?(:git_api)
+            Sentry.capture_message("Call to Dynamics#find with git_api enabled!")
+          end
+
           params = parse_find_options(**options)
 
           if !id_or_ids.is_a?(Array)
@@ -23,6 +27,10 @@ module Bookings
         end
 
         def fetch(entity_type, filter: nil, limit: 10, order: nil)
+          if Flipper.enabled?(:git_api)
+            Sentry.capture_message("Call to Dynamics#fetch with git_api enabled!")
+          end
+
           params = {
             '$select' => entity_type.attributes_to_select,
             '$top' => limit
@@ -39,6 +47,10 @@ module Bookings
         end
 
         def write(entity)
+          if Flipper.enabled?(:git_api)
+            Sentry.capture_message("Call to Dynamics#write with git_api enabled!")
+          end
+
           raise ArgumentError, "entity must include Entity" unless entity.class < Entity
           return false unless entity.valid?
 

--- a/spec/services/bookings/gitis/store/dynamics_spec.rb
+++ b/spec/services/bookings/gitis/store/dynamics_spec.rb
@@ -25,6 +25,19 @@ describe Bookings::Gitis::Store::Dynamics do
   end
 
   describe '#find' do
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+
+      it "logs the usage to Sentry" do
+        allow(dynamics.api).to receive(:get) { {} }
+
+        expect(Sentry).to receive(:capture_message)
+          .with("Call to Dynamics#find with git_api enabled!")
+
+        dynamics.find(TestEntity, SecureRandom.uuid)
+      end
+    end
+
     context 'for single id' do
       let(:uuid) { SecureRandom.uuid }
 
@@ -184,6 +197,19 @@ describe Bookings::Gitis::Store::Dynamics do
     let(:t3) { { 'testentityid' => SecureRandom.uuid, 'firstname' => 'C', 'lastname' => '3' } }
     let(:response) { [TestEntity.new(t1), TestEntity.new(t2), TestEntity.new(t3)] }
 
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+
+      it "logs the usage to Sentry" do
+        allow(dynamics.api).to receive(:get) { { 'value' => [] } }
+
+        expect(Sentry).to receive(:capture_message)
+          .with("Call to Dynamics#fetch with git_api enabled!")
+
+        dynamics.fetch(TestEntity)
+      end
+    end
+
     context 'without entity' do
       it "will raise an error" do
         expect { subject.fetch }.to raise_exception(ArgumentError)
@@ -247,6 +273,21 @@ describe Bookings::Gitis::Store::Dynamics do
   describe '#write' do
     let(:uuid) { SecureRandom.uuid }
     subject { dynamics.write entity }
+
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+
+      let(:entity) { TestEntity.new }
+
+      it "logs the usage to Sentry" do
+        allow_any_instance_of(TestEntity).to receive(:valid?) { false }
+
+        expect(Sentry).to receive(:capture_message)
+          .with("Call to Dynamics#write with git_api enabled!")
+
+        subject
+      end
+    end
 
     context 'for invalid entity' do
       let(:entity) { TestEntity.new('firstname' => 'testuser') }


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

If the `git_api` feature is enabled all requests should be going via the `GetIntoTeachingApiClient`. To ensure this is the case, the existing `Dynamics` module that handles reading/writing to the CRM currently will raise a message to Sentry if its ever called when the `git_api` feature is on.

### Changes proposed in this pull request

- Raise a message to Sentry on unexpected direct call to CRM

### Guidance to review

