### PR TITLE
Bump API client version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: ad8dc73640e3b34247eeea34cfaf9a0976df88a8
+  revision: 4ebbe65c3d5c089300c95a1079f1839dcdbe75f5
   specs:
     get_into_teaching_api_client (1.1.17)
       addressable (~> 2.3, >= 2.3.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.36)
+    get_into_teaching_api_client_faraday (0.1.37)
       activesupport
       faraday
       faraday-encoding


### PR DESCRIPTION
Changes the `school_urn` type to `integer` instead of `string` on the `ClassroomExperienceNote` model.