### PR TITLE
Update SubjectSyncJob to support `git_api` feature

### DIFF
--- a/app/services/bookings/gitis/teaching_subject.rb
+++ b/app/services/bookings/gitis/teaching_subject.rb
@@ -6,5 +6,9 @@ module Bookings::Gitis
 
     entity_id_attribute :dfe_teachingsubjectlistid
     entity_attribute :dfe_name
+
+    # Aliases to achieve parity with GetIntoTeachingApiClient::LookupItem
+    alias_attribute :id, :dfe_teachingsubjectlistid
+    alias_attribute :value, :dfe_name
   end
 end

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -39,4 +39,9 @@ FactoryBot.define do
     id { SecureRandom.uuid }
     text { "policy text" }
   end
+
+  factory :api_teaching_subject, class: GetIntoTeachingApiClient::LookupItem do
+    id { SecureRandom.uuid }
+    sequence(:value) { |i| "Gitis Subject #{i}" }
+  end
 end

--- a/spec/models/bookings/subject_sync_spec.rb
+++ b/spec/models/bookings/subject_sync_spec.rb
@@ -17,6 +17,97 @@ RSpec.describe Bookings::SubjectSync do
     end
   end
 
+  context "when the git_api feature is enabled" do
+    include_context "enable git_api feature"
+
+    describe "#synchronise" do
+      let(:sync) { described_class.new(fake_gitis) }
+
+      let(:gitis_subject_1) { build(:api_teaching_subject) }
+      let(:gitis_subject_2) { build(:api_teaching_subject) }
+      let(:gitis_subject_3) { build(:api_teaching_subject, value: 'match') }
+      let(:gitis_subject_4) { build(:api_teaching_subject) }
+      let(:gitis_subject_5) { build(:api_teaching_subject, value: described_class::BLACKLIST.first) }
+
+      let!(:matched1) { create(:bookings_subject, gitis_uuid: gitis_subject_1.id) }
+      let!(:matched2) { create(:bookings_subject, gitis_uuid: gitis_subject_2.id) }
+      let!(:unmatched) { create(:bookings_subject, name: 'Match') }
+      let!(:nomatch) { create(:bookings_subject, name: 'nomatch') }
+      let(:response) do
+        [
+          gitis_subject_1,
+          gitis_subject_2,
+          gitis_subject_3,
+          gitis_subject_4,
+          gitis_subject_5
+        ]
+      end
+
+      before do
+        expect_any_instance_of(GetIntoTeachingApiClient::LookupItemsApi).to \
+          receive(:get_teaching_subjects) { response }
+      end
+
+      context 'for a successful sync' do
+        context 'when matched on id' do
+          before { sync.synchronise }
+          it "will update name" do
+            expect(matched1.reload).to have_attributes(name: gitis_subject_1.value)
+            expect(matched2.reload).to have_attributes(name: gitis_subject_2.value)
+          end
+        end
+
+        context 'when matched on name' do
+          before { sync.synchronise }
+          subject { unmatched.reload }
+          it { is_expected.to have_attributes(gitis_uuid: gitis_subject_3.id) }
+        end
+
+        context "with new subjects" do
+          before { sync.synchronise }
+          subject { Bookings::Subject.where(gitis_uuid: gitis_subject_4.id).first }
+          it { is_expected.to have_attributes(name: gitis_subject_4.value) }
+          it { is_expected.to have_attributes(hidden: false) }
+        end
+
+        context "with subjects it cannot match" do
+          before { sync.synchronise }
+          subject { nomatch.reload }
+          it { is_expected.to have_attributes(name: 'nomatch') }
+          it { is_expected.to have_attributes(gitis_uuid: nil) }
+        end
+
+        context "with blacklisted new subject" do
+          before { sync.synchronise }
+          subject { Bookings::Subject.unscoped.where(gitis_uuid: gitis_subject_5.id).first }
+          it { is_expected.to have_attributes(name: gitis_subject_5.value) }
+          it { is_expected.to have_attributes(hidden: true) }
+        end
+
+        context "with blacklisted existing subject" do
+          before { Bookings::Subject.create!(name: gitis_subject_5.value, hidden: true) }
+          before { sync.synchronise }
+          subject { Bookings::Subject.unscoped.where(gitis_uuid: gitis_subject_5.id).first }
+          it { is_expected.to have_attributes(name: gitis_subject_5.value) }
+          it { is_expected.to have_attributes(hidden: true) }
+        end
+      end
+
+      context 'with more than can be handled in a single batch' do
+        let(:response) do
+          (1..(described_class::LIMIT + 1)).map do
+            build(:gitis_subject)
+          end
+        end
+
+        it "will raise an exception" do
+          expect { sync.synchronise }.to \
+            raise_exception(Bookings::SubjectSync::TooManySubjects)
+        end
+      end
+    end
+  end
+
   describe "#synchronise" do
     let(:sync) { described_class.new(fake_gitis) }
 

--- a/spec/services/bookings/gitis/teaching_subject_spec.rb
+++ b/spec/services/bookings/gitis/teaching_subject_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Bookings::Gitis::TeachingSubject, type: :model do
   describe 'attributes' do
     it { is_expected.to respond_to :dfe_name }
     it { is_expected.to respond_to :dfe_teachingsubjectlistid }
+    it { is_expected.to respond_to :id }
+    it { is_expected.to respond_to :value }
   end
 
   describe '.new' do
@@ -27,7 +29,9 @@ RSpec.describe Bookings::Gitis::TeachingSubject, type: :model do
     end
 
     it { is_expected.to have_attributes(dfe_teachingsubjectlistid: uuid) }
+    it { is_expected.to have_attributes(id: uuid) }
     it { is_expected.to have_attributes(dfe_name: 'Test Subject') }
+    it { is_expected.to have_attributes(value: 'Test Subject') }
     it { is_expected.to have_attributes(changed_attributes: {}) }
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

When the `git_api` feature is enabled we want to sync via the GiT API and not directly.

Add attribute aliases to `TeachingSubject` to achieve parity with `LookupItem` models so that they can be used interchangeably in the sync job.

Update sync job to call out to the API when the `git_api` feature is enabled.

### Changes proposed in this pull request

- Update SubjectSyncJob to support git_api feature

### Guidance to review

The tests for the sync job have been duplicated for when the `git_api` feature is enabled - the legacy tests will later be removed.
