### PR TITLE
Replace view calls to Booking model with helpers

### DIFF
--- a/app/helpers/gitis_contact_helper.rb
+++ b/app/helpers/gitis_contact_helper.rb
@@ -1,0 +1,21 @@
+module GitisContactHelper
+  def gitis_contact_display_phone(contact)
+    return contact.phone if contact.is_a?(Bookings::Gitis::Contact)
+
+    contact.secondary_telephone.presence ||
+      contact.telephone.presence || contact.mobile_telephone
+  end
+
+  def gitis_contact_display_address(contact)
+    return contact.address if contact.is_a?(Bookings::Gitis::Contact)
+
+    [
+      contact.address_line1,
+      contact.address_line2.presence,
+      contact.address_line3.presence,
+      contact.address_city,
+      contact.address_state_or_province,
+      contact.address_postcode,
+    ].compact.join(", ")
+  end
+end

--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -24,7 +24,7 @@
           <section id="booking-details">
             <dl class="govuk-summary-list">
               <%= summary_row 'Subject', @booking.bookings_subject.name %>
-              <%= summary_row 'UK telephone number', @booking.gitis_contact.phone %>
+              <%= summary_row 'UK telephone number', gitis_contact_display_phone(@booking.gitis_contact) %>
               <%= summary_row 'Email address', @booking.gitis_contact.email %>
               <%= summary_row 'Request received', @booking.received_on.to_formatted_s(:govuk) %>
             </dl>

--- a/app/views/schools/placement_requests/_personal_details.html.erb
+++ b/app/views/schools/placement_requests/_personal_details.html.erb
@@ -2,8 +2,8 @@
   <h2>Personal details</h2>
 
   <dl class="govuk-summary-list">
-    <%= summary_row 'Address', personal_details.address %>
-    <%= summary_row 'UK telephone number', personal_details.phone %>
+    <%= summary_row 'Address', gitis_contact_display_address(personal_details) %>
+    <%= summary_row 'UK telephone number', gitis_contact_display_phone(personal_details) %>
     <%= summary_row 'Email address', personal_details.email %>
   </dl>
 </section>

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -33,7 +33,7 @@
           Address
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @gitis_contact.address %>
+          <%= gitis_contact_display_address(@gitis_contact) %>
         </dd>
       </div>
 
@@ -42,7 +42,7 @@
           UK telephone number
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= @gitis_contact.phone %>
+          <%= gitis_contact_display_phone(@gitis_contact) %>
         </dd>
       </div>
 

--- a/spec/helpers/gitis_contact_helper_spec.rb
+++ b/spec/helpers/gitis_contact_helper_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe GitisContactHelper, type: :helper do
+  describe "#gitis_contact_display_phone" do
+    context "with a Gitis::Booking::Contact" do
+      it "returns contact.phone" do
+        contact = build(:gitis_contact)
+        expect(helper.gitis_contact_display_phone(contact)).to eq(contact.phone)
+      end
+    end
+
+    context "with a GetIntoTeachingApiClient::SchoolsExperienceSignUp" do
+      it "returns first non-nil of secondary_telephone, telephone then mobile_telephone" do
+        contact = build(:api_schools_experience_sign_up, telephone: nil, secondary_telephone: nil)
+        expect(helper.gitis_contact_display_phone(contact)).to eq(contact.mobile_telephone)
+
+        contact.telephone = "11111111"
+        expect(helper.gitis_contact_display_phone(contact)).to eq(contact.telephone)
+
+        contact.secondary_telephone = "22222222"
+        expect(helper.gitis_contact_display_phone(contact)).to eq(contact.secondary_telephone)
+      end
+    end
+  end
+
+  describe "#gitis_contact_display_address" do
+    context "with a Gitis::Booking::Contact" do
+      it "returns contact.address" do
+        contact = build(:gitis_contact)
+        expect(helper.gitis_contact_display_address(contact)).to eq(contact.address)
+      end
+    end
+
+    context "with a GetIntoTeachingApiClient::SchoolsExperienceSignUp" do
+      it "returns the formatted address" do
+        contact = build(:api_schools_experience_sign_up)
+        address = helper.gitis_contact_display_address(contact)
+        expect(address).to eq(
+          "3 Main Street, Botchergate, Carlisle, Cumbria, TE7 1NG"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

As we are removing `Bookings::Gitis::Contact` we need to decouple the view references to any attributes that are not present on `SchoolsExperienceSignUp`.

Replace direct calls to a `gitis_contact` with helper methods that can operate over both models.

### Changes proposed in this pull request

- Replace view calls to Booking model with helpers

### Guidance to review

