### PR TITLE
Support candidate sign up via the API

### DIFF
--- a/app/controllers/candidates/registrations/sign_ins_controller.rb
+++ b/app/controllers/candidates/registrations/sign_ins_controller.rb
@@ -8,7 +8,12 @@ module Candidates
 
       def show
         set_sign_in_details
-        @verification_code = Candidates::VerificationCode.new
+        @verification_code = Candidates::VerificationCode.new({
+          email: current_registration.personal_information.email,
+          firstname: current_registration.personal_information.first_name,
+          lastname: current_registration.personal_information.last_name,
+          date_of_birth: current_registration.personal_information.date_of_birth,
+        })
       end
 
       def create
@@ -32,7 +37,7 @@ module Candidates
 
       def api_verify
         @verification_code = Candidates::VerificationCode.new(verification_code_params)
-        candidate_data = @verification_code.exchange(current_registration.personal_information)
+        candidate_data = @verification_code.exchange
 
         if candidate_data
           self.current_candidate = Bookings::Candidate.find_or_create_from_gitis_contact!(candidate_data).tap do |c|
@@ -81,7 +86,7 @@ module Candidates
       end
 
       def verification_code_params
-        params.require(:candidates_verification_code).permit(:code)
+        params.require(:candidates_verification_code).permit(:code, :email, :firstname, :lastname, :date_of_birth)
       end
     end
   end

--- a/app/controllers/candidates/sessions_controller.rb
+++ b/app/controllers/candidates/sessions_controller.rb
@@ -1,24 +1,51 @@
 class Candidates::SessionsController < ApplicationController
   include GitisAuthentication
 
+  before_action :check_api_feature_enabled, only: %i[update create]
+
   def new
     @candidates_session = Candidates::Session.new(gitis_crm)
   end
 
   def create
-    @candidates_session = Candidates::Session.new(gitis_crm, session_params)
+    @candidates_session = Candidates::Session.new(gitis_crm, retrieve_params)
+    @verification_code = Candidates::VerificationCode.new(retrieve_params)
 
     if @candidates_session.valid?
-      token = @candidates_session.create_signin_token
-      return unless token
+      if @git_api_enabled
+        @verification_code.issue_verification_code
+      else
+        token = @candidates_session.create_signin_token
+        return unless token
 
-      deliver_signin_link(@candidates_session.email, token)
+        deliver_signin_link(@candidates_session.email, token)
+      end
     else
       render 'new'
     end
   end
 
   def update
+    @git_api_enabled ? api_verify : direct_verify
+  end
+
+private
+
+  def api_verify
+    @verification_code = Candidates::VerificationCode.new(retrieve_params)
+    candidate_data = @verification_code.exchange
+
+    if candidate_data
+      self.current_candidate = Bookings::Candidate.find_or_create_from_gitis_contact!(candidate_data).tap do |c|
+        c.update(confirmed_at: Time.zone.now)
+      end
+      redirect_to candidates_dashboard_path
+    else
+      render :create
+    end
+  end
+
+  def direct_verify
     candidate = Candidates::Session.signin!(params[:authtoken])
 
     if candidate
@@ -27,7 +54,21 @@ class Candidates::SessionsController < ApplicationController
     end
   end
 
-private
+  def check_api_feature_enabled
+    @git_api_enabled = Flipper.enabled?(:git_api)
+  end
+
+  def retrieve_params
+    if params.key?(:candidates_session)
+      session_params
+    else
+      verification_code_params
+    end
+  end
+
+  def verification_code_params
+    params.require(:candidates_verification_code).permit(:code, :email, :firstname, :lastname, :date_of_birth)
+  end
 
   def session_params
     params.require(:candidates_session).permit(:email, :firstname, :lastname, :date_of_birth)

--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -35,7 +35,13 @@
 
     <% if @git_api_enabled %>
       <%= form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :firstname %>
+        <%= f.hidden_field :lastname %>
+        <%= f.hidden_field :date_of_birth %>
+
         <%= f.text_field :code %>
+
         <%= f.submit "Submit" %>
       <% end %>
       <p>

--- a/app/views/candidates/sessions/create.html.erb
+++ b/app/views/candidates/sessions/create.html.erb
@@ -6,14 +6,33 @@
       Verify your school experience sign in
     </h1>
 
+    <% if @git_api_enabled %>
+    <p>
+      You now need to <strong>enter the verification code</strong> we've sent to the following email address:
+    </p>
+    <% else %>
     <p>
       Click the link in the email we’ve sent to the following email address to
       sign in to you school experience dashboard.
     </p>
+    <% end %>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li><%= @candidates_session.email %></li>
+      <li><%= @git_api_enabled ? @verification_code.email : @candidates_session.email %></li>
     </ul>
+
+    <% if @git_api_enabled %>
+      <%= form_for @verification_code, url: candidates_signin_code_path, method: :put do |f| %>
+        <%= f.hidden_field :firstname %>
+        <%= f.hidden_field :lastname %>
+        <%= f.hidden_field :email %>
+        <%= f.hidden_field :date_of_birth %>
+
+        <%= f.text_field :code %>
+
+        <%= f.submit "Submit" %>
+      <% end %>
+    <% end %>
 
     <p>
       If you can’t find the message in your inbox:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,6 +181,7 @@ Rails.application.routes.draw do
       get 'signin', to: 'sessions#new'
       post 'signin', to: 'sessions#create'
       get 'signin/:authtoken', to: 'sessions#update', as: 'signin_confirmation'
+      put 'signin', to: 'sessions#update', as: :signin_code
 
       resource :dashboard, only: :show
     end

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -122,7 +122,17 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
       include_context "Stubbed current_registration"
       include_context "api correct verification code"
 
-      let(:params) { { candidates_verification_code: { code: code } } }
+      let(:params) do
+        {
+          candidates_verification_code: {
+            code: code,
+            firstname: "Testy",
+            lastname: "McTest",
+            email: "testy@mctest.com",
+            date_of_birth: "1980-01-01",
+          }
+        }
+      end
       let(:perform_request) { put candidates_registration_verify_code_path(school_id), params: params }
 
       context "with a valid code" do

--- a/spec/controllers/candidates/sessions_controller_spec.rb
+++ b/spec/controllers/candidates/sessions_controller_spec.rb
@@ -83,6 +83,48 @@ RSpec.describe Candidates::SessionsController, type: :request do
         expect(NotifyFakeClient.deliveries.length).to eql(0)
       end
     end
+
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+
+      context "for known user" do
+        include_context "api candidate matched back"
+
+        let(:candidate) { create(:candidate) }
+
+        before do
+          post candidates_signin_path, params: { candidates_session: valid_creds }
+        end
+
+        it "returns http success" do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to match('Verify your school experience sign in')
+        end
+      end
+
+      context "for unknown user" do
+        include_context "api candidate not matched back"
+
+        before do
+          post candidates_signin_path, params: { candidates_session: valid_creds }
+        end
+
+        it "returns http success" do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to match('Verify your school experience sign in')
+        end
+      end
+
+      context 'with missing details' do
+        let(:invalid_creds) { { candidates_session: { email: 'invalid' } } }
+        before { post candidates_signin_path, params: invalid_creds }
+
+        it "returns http success" do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to match('Get school experience sign in')
+        end
+      end
+    end
   end
 
   describe "GET #update" do
@@ -103,6 +145,51 @@ RSpec.describe Candidates::SessionsController, type: :request do
       it "returns http success" do
         expect(response).to have_http_status(:success)
         expect(response.body).to include("link has expired")
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    context "when the git_api feature is enabled" do
+      include_context "enable git_api feature"
+      include_context "api correct verification code"
+
+      let(:personal_info) { build(:personal_information) }
+      let(:params) do
+        {
+          candidates_verification_code: {
+            code: code,
+            firstname: personal_info.first_name,
+            lastname: personal_info.last_name,
+            email: personal_info.email,
+            date_of_birth: "2000-01-01",
+          }
+        }
+      end
+      let(:perform_request) { put candidates_signin_code_path, params: params }
+
+      context "with a valid code" do
+        before { perform_request }
+
+        it "redirects to dashboard" do
+          expect(response).to redirect_to(candidates_dashboard_path)
+        end
+
+        it "will create a confirmed candidate" do
+          candidate = Bookings::Candidate.find_by(gitis_uuid: sign_up.candidate_id)
+          expect(candidate).to be_confirmed
+        end
+      end
+
+      context "with an invalid code" do
+        include_context "api incorrect verification code"
+
+        before { perform_request }
+
+        it "will show error screen" do
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include("Please enter the latest verification code sent to your email address")
+        end
       end
     end
   end


### PR DESCRIPTION
### Trello card

[Trello-75](https://trello.com/c/LbxTrqnz/75-integrate-schools-experience-to-the-git-api)

### Context

We perform matchback against the API in two scenarios; registering for experience (which we already have migrated) and as a 'candidate sign in' function. This appears to be behind a feature flag/under development, but we should support it via the API for completeness/so we can remove more of the legacy code later.

### Changes proposed in this pull request

- Update VerificationCode model to support exchange/issue

It turns out we have multiple ways a candidate can matchback; off personal information via a registration or as part of a candidate 'sign in'.

As the candidate sign in doesn't persist the matchback data to a session (which does happen in the registration matchback) we need the `VerificationCode` model to support the matchback attributes so that we can render them in the verification code form (hidden from the user) and submit the data back to the app.

- Support candidate sign in via the API

Updates the `SessionsController` so it behaves similarly to the `SignInsController` and can support the `git_api` feature being enabled.

The modelling here is a bit messy, with `Candidates::Session` and `Candidates::VerificationCode` being similar but slightly different. Its also complicated by the session attribute being `firstname` and not `first_name` so we have to manually map to/from models attributes a bit.

Once the legacy code has been removed this can definitely be cleaned up further, but short of a large refactoring this is the best I can do just now to support both CRM integration methods.

### Guidance to review

