### PR TITLE
Remove duplicate fields in the update school profile page

### DIFF
--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -17,8 +17,6 @@
     <dl class="govuk-summary-list">
       <%= summary_row 'Full name', @profile.school_name %>
       <%= summary_row 'Address', @profile.school_address %>
-      <%= summary_row 'UK telephone number', @profile.admin_contact_phone %>
-      <%= summary_row 'Email address', @profile.school_email %>
     </dl>
 
     <h2 class="govuk-heading-m">School experience details</h2>


### PR DESCRIPTION
### Trello card
https://trello.com/c/4Ozq9AQQ

### Context
When a school administrator is editing a schools profile and they view the 'Check your answers' page - they see the contact details shown both at the top of the page (uneditable) and lower down, where they are editable. This is confusing for the user because they think it needs changing twice.

### Changes proposed in this pull request
Remove the duplicate uneditable contact details from the top of the page.
 
### Guidance to review
| Before | After |
| - | - |
| <img width="1005" alt="before" src="https://user-images.githubusercontent.com/951947/119972057-a8f5ee80-bfa9-11eb-96d5-ad4a41aa9ac1.png"> | <img width="987" alt="after" src="https://user-images.githubusercontent.com/951947/119972068-ad220c00-bfa9-11eb-9f47-744ae3dbfc7b.png"> |


