### PR TITLE
Update copy on enter verification code page

### DIFF
--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -2,14 +2,19 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1>
-      We already have your details
-    </h1>
-
+    <% if @git_api_enabled %>
+    <h1>You’re already registered with us</h1>
     <p>
+      The details you have entered match our records.
+      You could have given them to us when you:
+    </p>
+    <% else %>
+    <h1>We already have your details</h1>
+      <p>
       We have your details on record as you previously provided
       them to us when you:
     </p>
+    <% end %>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>attended one of our teaching events</li>
@@ -22,12 +27,16 @@
       </li>
     </ul>
 
-    <h2>Verify your details</h2>
+    <h2>Verify your details to continue</h2>
 
+    <% if @git_api_enabled %>
+    <p>We’ve emailed a verification code to:</p>
+    <% else %>
     <p>
-      You now need to <strong><%= @git_api_enabled ? "enter the verification code" : "select the link" %></strong> we've sent to
-      the following email address:
+      You now need to <strong>select the link</strong>
+      we've sent to the following email address:
     </p>
+    <% end %>
 
     <ul class="govuk-list govuk-list--bullet">
       <li><%= @email_address %></li>
@@ -45,7 +54,7 @@
         <%= f.submit "Submit" %>
       <% end %>
       <p>
-        <strong>The code will expire within 15 minutes.</strong>
+        <strong>The verification code will expire in 15 minutes</strong>
       </p>
     <% else %>
       <p>
@@ -53,6 +62,9 @@
       </p>
     <% end %>
 
+    <% if @git_api_enabled %>
+    <p>Check your spam or junk folder if you cannot find the email.</p>
+    <% else %>
     <p>
       If you cannot find the message in your inbox:
     </p>
@@ -60,11 +72,16 @@
     <ul class="govuk-list govuk-list--bullet">
       <li>check your spam and any other mailbox folders</li>
     </ul>
+    <% end %>
 
+    <% if @git_api_enabled %>
+    <p>If you have not had an email from us, we can resend your verification code:</p>
+    <% else %>
     <p>
       If you cannot find or have not received the email use the following
       link to resend it:
     </p>
+    <% end %>
 
     <%= govuk_button_to @git_api_enabled ? "Resend verification code" : "Resend link", @resend_link, secondary: true %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -721,7 +721,7 @@ en:
         lastname: Last name
         email: Email address
       candidates_verification_code:
-        code: Verification code
+        code: Enter your verification code here
       cookie_preference:
         analytics:
           true: "On"

--- a/spec/features/candidates/api_registrations_spec.rb
+++ b/spec/features/candidates/api_registrations_spec.rb
@@ -165,7 +165,7 @@ feature 'Candidate Registrations (via the API)', type: :feature do
   end
 
   def complete_sign_in_step
-    fill_in "Verification code", with: code
+    fill_in "Enter your verification code here", with: code
     click_button "Submit"
   end
 


### PR DESCRIPTION
Updates the copy on the 'enter your verification code' page, retaining the existing copy when the `git_api` feautre is not enabled.

| Feature Enabled      | Feature Disabled |
| ----------- | ----------- |
| <img width="1349" alt="Screenshot 2021-06-01 at 11 04 30" src="https://user-images.githubusercontent.com/29867726/120305845-259a0d00-c2c9-11eb-8c1d-f26eb4088268.png">     |  <img width="1349" alt="Screenshot 2021-06-01 at 11 04 45" src="https://user-images.githubusercontent.com/29867726/120305872-2d59b180-c2c9-11eb-8110-ee8b12c9b80a.png">       |


