### PR TITLE
Add DDoS protection

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 # Add public environment variables here for the Production environment
 
+FAIL2BAN=5

--- a/Gemfile
+++ b/Gemfile
@@ -37,8 +37,8 @@ gem 'govuk_elements_form_builder', github: 'DFE-Digital/govuk_elements_form_buil
 gem 'notifications-ruby-client'
 
 gem 'acts_as_list'
-gem 'delayed_job_active_record'
 gem 'delayed_cron_job'
+gem 'delayed_job_active_record'
 gem 'delayed_job_web'
 
 gem "redis", "~> 4.2"
@@ -46,22 +46,22 @@ gem "redis", "~> 4.2"
 gem 'kaminari'
 
 gem 'phonelib'
+gem 'sentry-delayed_job'
 gem 'sentry-rails'
 gem 'sentry-ruby'
-gem 'sentry-delayed_job'
 
 gem 'rack-rewrite'
 gem 'rack-timeout'
 
+gem 'application_insights', github: 'microsoft/ApplicationInsights-Ruby', ref: 'a7429200'
 gem 'openid_connect'
 gem 'uk_postcode'
-gem 'application_insights', github: 'microsoft/ApplicationInsights-Ruby', ref: 'a7429200'
 
 gem 'addressable'
 gem 'faraday'
 
-gem 'validates_timeliness', '>= 5.0.0.beta1'
 gem 'activerecord-import'
+gem 'validates_timeliness', '>= 5.0.0.beta1'
 
 gem 'flipper'
 gem 'flipper-redis'
@@ -69,23 +69,23 @@ gem 'flipper-ui'
 gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
 
   gem 'rubocop-govuk', require: false
 
   # Debugging
-  gem 'pry-rails'
   gem 'pry-byebug'
+  gem 'pry-rails'
 
   # Testing framework
-  gem 'rspec-rails', '~> 5.0'
-  gem 'rspec_junit_formatter'
-  gem 'rspec-sonarqube-formatter'
   gem 'factory_bot_rails'
+  gem 'rspec_junit_formatter'
+  gem 'rspec-rails', '~> 5.0'
+  gem 'rspec-sonarqube-formatter'
 
   gem 'brakeman', '>= 4.4.0'
 
@@ -96,13 +96,13 @@ end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'web-console'
   gem 'listen', '>= 3.0.5'
+  gem 'web-console'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'spring-commands-rspec'
+  gem 'spring-watcher-listen', '~> 2.0.0'
 
   # Manage multiple processes i.e. web server and webpack
   gem 'foreman'
@@ -119,12 +119,11 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
 
-  gem 'shoulda-matchers', '~> 4.5'
   gem 'rails-controller-testing'
   gem "rspec-json_expectations", "~> 2.2"
+  gem 'shoulda-matchers', '~> 4.5'
 
-  gem 'webmock'
   gem 'capybara-screenshot'
   gem 'flipper-active_support_cache_store'
+  gem 'webmock'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ gem 'flipper-redis'
 gem 'flipper-ui'
 gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 
+# Ignore cloudfront IPs when getting customer IP address
+gem 'actionpack-cloudfront'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem 'sentry-delayed_job'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 
+gem 'rack-attack'
 gem 'rack-rewrite'
 gem 'rack-timeout'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-attack (6.5.0)
+      rack (>= 1.0, < 3)
     rack-oauth2 (1.16.0)
       activesupport
       attr_required
@@ -602,6 +604,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.3)
+  rack-attack
   rack-rewrite
   rack-timeout
   rails (~> 6.1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,9 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionpack-cloudfront (1.1.0)
+      actionpack (>= 4.2)
+      railties (>= 4.2)
     actiontext (6.1.3.2)
       actionpack (= 6.1.3.2)
       activerecord (= 6.1.3.2)
@@ -564,6 +567,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  actionpack-cloudfront
   activerecord-import
   activerecord-postgis-adapter (~> 7.1)
   acts_as_list

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -17,6 +17,14 @@ class ErrorsController < ApplicationController
     end
   end
 
+  def too_many_requests
+    respond_to do |format|
+      format.html { render status: :too_many_requests }
+      format.json { render json: { error: "Internal server error" }, status: :too_many_requests }
+      format.all { render status: :too_many_requests, body: nil }
+    end
+  end
+
   def unprocessable_entity
     respond_to do |format|
       format.html { render status: :unprocessable_entity }

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,10 @@
+<main class="govuk-main-wrapper" id="main-content" role="main">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-xl">Too many requests</h1>
+
+      <p class="govuk-body">You have tried to access a page too often in a short space of time.</p>
+      <p class="govuk-body">You can <a href="/">browse the homepage</a> or go <%= link_to("back", :back) %> and try to access the page again in 1 minute.</p>
+    </div>
+  </div>
+</main>

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -4,7 +4,7 @@
       <h1 class="govuk-heading-xl">Too many requests</h1>
 
       <p class="govuk-body">You have tried to access a page too often in a short space of time.</p>
-      <p class="govuk-body">You can <a href="/">browse the homepage</a> or go <%= link_to("back", :back) %> and try to access the page again in 1 minute.</p>
+      <p class="govuk-body">You can <a href="/">browse the homepage</a> or try to access the page again in 1 minute.</p>
     </div>
   </div>
 </main>

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path('../spring', __FILE__)
+  load File.expand_path('spring', __dir__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module SchoolExperience
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
-    config.exceptions_app = self.routes
+    config.exceptions_app = routes
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,8 @@ module SchoolExperience
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    config.exceptions_app = self.routes
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/exclude_cloudfront_ips.rb
+++ b/config/initializers/exclude_cloudfront_ips.rb
@@ -1,0 +1,6 @@
+# Don't load in dev or test environments
+# Mirrors behaviour of actionpack-cloudfront
+unless Rails.env.development? || Rails.env.test?
+  require "cloud_front_ip_filter"
+  CloudFrontIpFilter.configure!
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -48,7 +48,7 @@ module Rack
   end
 
   # Redirect to custom response for throttled requests
-  Rack::Attack.throttled_response = lambda do |env|
-    [301, {"Location" => '/429'}, []]
+  Rack::Attack.throttled_response = lambda do |_env|
+    [301, { "Location" => '/429' }, []]
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,54 @@
+module Rack
+  class Attack
+    FAIL2BAN_LIST = %w[
+      /etc/passwd
+      wp-admin
+      wp-login
+      wp-includes
+      .php
+    ].freeze
+
+    FAIL2BAN_REGEX = Regexp.union(FAIL2BAN_LIST).freeze
+
+    unless ENV["SKIP_REQ_LIMITS"].to_s.in? %w[true yes 1]
+      # Throttle candidate feedback submissions by IP (5rpm)
+      throttle("candidates/feedbacks req/ip", limit: 5, period: 1.minute) do |req|
+        req.ip if req.post? && req.path == "/candidates/feedbacks"
+      end
+
+      # Throttle candidate registration submissions by IP (5rpm)
+      throttle("registrations/confirmation_email req/ip", limit: 5, period: 1.minute) do |req|
+        req.ip if req.post? && req.path.match?(/registrations\/confirmation_email/)
+      end
+    end
+
+    if ENV["FAIL2BAN"].to_s.match? %r{\A\d+\z}
+      FAIL2BAN_TIME = ENV["FAIL2BAN"].to_s.to_i.minutes.freeze
+
+      blocklist("block hostile bots") do |req|
+        Fail2Ban.filter("hostile-bots-#{req.ip}", maxretry: 0, findtime: 1.second, bantime: FAIL2BAN_TIME) do
+          (
+            FAIL2BAN_REGEX.match?(CGI.unescape(req.query_string)) ||
+            FAIL2BAN_REGEX.match?(req.path)
+          ).tap do |should_ban|
+            if should_ban
+              obscured_ip = req.ip.to_s.gsub(%r{\.\d+\.(\d+)\.}, ".***.***.")
+
+              Rails.logger.info(
+                <<~BAN_MESSAGE,
+                  Banning IP: #{obscured_ip} for #{FAIL2BAN_TIME.to_i / 60} minutes
+                  accessing #{req.path} with '#{req.query_string}'
+                BAN_MESSAGE
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+
+  # Redirect to custom response for throttled requests
+  Rack::Attack.throttled_response = lambda do |env|
+    [301, {"Location" => '/429'}, []]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   get "/404", to: "errors#not_found", via: :all
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all
+  get "/429", to: "errors#too_many_requests", via: :all
 
   if Rails.application.config.x.maintenance_mode
     match '*path', to: 'pages#maintenance', via: :all

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,4 +13,6 @@ YAML.load_file(Rails.root.join('db', 'data', 'school_types.yml')).each do |eduba
   Bookings::SchoolType.create(name: name, edubase_id: edubase_id)
 end
 
+# rubocop:disable Rails/Output
 puts "\nYou can import all 47000 schools using 'bundle exec rails data:schools:mass_import'"
+# rubocop:enable Rails/Output

--- a/lib/cloud_front_ip_filter.rb
+++ b/lib/cloud_front_ip_filter.rb
@@ -1,0 +1,25 @@
+class CloudFrontIpFilter
+  def self.configure!
+    Rack::Request.ip_filter = new(Rack::Request.ip_filter)
+  end
+
+  def initialize(original_filter = nil)
+    @original_filter = original_filter
+  end
+
+  def call(ip)
+    @original_filter.call(ip) || cloudfront_ip?(ip)
+  end
+
+private
+
+  def cloudfront_ip?(ip)
+    cloudfront_proxies.any? do |range|
+      range.include? ip
+    end
+  end
+
+  def cloudfront_proxies
+    ActionPack::Cloudfront::IpRanges.cloudfront_proxies
+  end
+end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -21,4 +21,11 @@ RSpec.describe ErrorsController, type: :controller do
       expect(response).to have_http_status(:unprocessable_entity)
     end
   end
+
+  describe "GET #too_many_requests" do
+    it "returns too_many_requests" do
+      get :too_many_requests
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
 end

--- a/spec/lib/cloud_front_ip_filter_spec.rb
+++ b/spec/lib/cloud_front_ip_filter_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "cloud_front_ip_filter"
+
+RSpec.describe CloudFrontIpFilter do
+  before do
+    stub_request(:get, "https://ip-ranges.amazonaws.com/ip-ranges.json")
+      .to_return(status: 401) # will fallback to copy in Gem
+  end
+
+  subject { described_class.new original }
+
+  let(:original) { ->(ip) { /192\.168\.1\./.match?(ip) } }
+
+  describe "#call" do
+    context "with private ips" do
+      it { expect(subject.call("192.168.1.10")).to be true }
+      it { expect(subject.call("192.168.2.10")).to be false }
+      it { expect(subject.call("192.168.1.1")).to be true }
+      it { expect(subject.call("192.168.1.254")).to be true }
+    end
+
+    context "with other ips" do
+      it { expect(subject.call("51.8.222.98")).to be false }
+    end
+
+    context "with cloudfront ips" do
+      it { expect(subject.call("15.207.13.128")).to be true }
+      it { expect(subject.call("15.207.13.254")).to be true }
+    end
+
+    context "with ips just outside cloudfronts ranges" do
+      it { expect(subject.call("15.207.13.1")).to be false }
+      it { expect(subject.call("15.207.13.127")).to be false }
+    end
+  end
+end

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Rate limiting" do
+  let(:ip) { "1.2.3.4" }
+
+  it_behaves_like "an IP-based rate limited endpoint", "POST /candidates/feedbacks", 5, 1.minute do
+    def perform_request
+      key = Candidates::Feedback.model_name.param_key
+      params = { key => attributes_for(:candidates_feedback) }
+      post candidates_feedbacks_path, params: params, headers: { "REMOTE_ADDR" => ip }
+    end
+  end
+
+  describe "registrations endpoints rate limiting" do
+    before do
+      allow_any_instance_of(Candidates::Registrations::ConfirmationEmailsController).to \
+        receive(:current_registration) { registration_session }
+      allow(Candidates::Registrations::SendEmailConfirmationJob).to \
+        receive(:perform_later)
+      allow_any_instance_of(Candidates::Registrations::RegistrationStore).to \
+        receive(:store!)
+    end
+
+    let :registration_session do
+      FactoryBot.build :registration_session, urn: 11_048,
+                                              with: %i[
+                                                personal_information
+                                                contact_information
+                                                education
+                                                teaching_preference
+                                                placement_preference
+                                                background_check
+                                                subject_and_date_information
+                                              ]
+    end
+
+    it_behaves_like "an IP-based rate limited endpoint", "POST /candidates/schools/:school_id/registrations/confirmation_email", 5, 1.minute do
+      def perform_request
+        key = Candidates::Registrations::PrivacyPolicy.model_name.param_key
+        params = { key => { acceptance: '1' } }
+
+        post candidates_school_registrations_confirmation_email_path(11_048), params: params, headers: { "REMOTE_ADDR" => ip }
+      end
+    end
+  end
+end

--- a/spec/support/rate_limiting_support.rb
+++ b/spec/support/rate_limiting_support.rb
@@ -1,0 +1,34 @@
+include ActiveSupport::Testing::TimeHelpers
+
+shared_examples "an IP-based rate limited endpoint" do |desc, limit, period|
+  describe desc do
+    let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
+
+    before do
+      allow(Rack::Attack.cache).to receive(:store) { memory_store }
+      request_count.times { perform_request }
+    end
+
+    subject { response.status }
+
+    context "when fewer than rate limit" do
+      let(:request_count) { limit - 1 }
+
+      it { is_expected.not_to eq(301) }
+    end
+
+    context "when more than rate limit" do
+      let(:request_count) { limit + 1 }
+
+      it { is_expected.to eq(301) }
+
+      context "when time restriction has passed" do
+        it "allows another request" do
+          travel period + 1.second
+          perform_request
+          expect(response.status).not_to eq(301)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/XAIC00Le

### Context
We want to protect the app from hostile bots which pollute our db with spam and can also cause DDoS attacks.

### Changes proposed in this pull request
Add Fail2Ban to ban hostile bots and Rack::Attack to throttle requests to transaction endpoints.

The ban is set to 5mins per ip and the throttling to 5 req/ip.

If a user encounters a rate limit, the app will redirect the request to a 'Too many requests' error page.

