### PR TITLE
Fix the cookies link in the privacy policy page

### DIFF
--- a/app/views/pages/_8da7ae80-82f2-ea11-a815-000d3a44afcc.html.erb
+++ b/app/views/pages/_8da7ae80-82f2-ea11-a815-000d3a44afcc.html.erb
@@ -327,7 +327,7 @@
     </p>
 
     <p>
-      We use cookies to make our services easy, useful and reliable. Find out more on how we use <a href="/cookies">cookies</a>.
+      We use cookies to make our services easy, useful and reliable. Find out more on how we use <a href="/cookies_policy">cookies</a>.
     </p>
   </section>
 </article>


### PR DESCRIPTION
### Trello card
https://trello.com/c/fMj2szXM

### Context
The cookies link at the bottom of the Privacy Policy page is wrong, causing 404s.

### Changes proposed in this pull request
Use the correct link `/cookies_policy`

### Guidance to review

