### PR TITLE
Register the current privacy policy number in the candidates records

### DIFF
--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -105,7 +105,7 @@ module Bookings
       gitis_contact.preferred_teaching_subject_id = api_subject_id_from_gitis_value(teaching_preference.subject_first_choice)
       gitis_contact.secondary_preferred_teaching_subject_id = api_subject_id_from_gitis_value(teaching_preference.subject_second_choice)
 
-      gitis_contact.accepted_policy_id = latest_privacy_policy.id
+      gitis_contact.accepted_policy_id = current_privacy_policy.id
 
       gitis_contact
     end
@@ -150,10 +150,12 @@ module Bookings
       }
     end
 
-    def latest_privacy_policy
-      @latest_privacy_policy ||= begin
+    def current_privacy_policy
+      policy_id = Rails.configuration.x.gitis.privacy_policy_id
+
+      @current_privacy_policy ||= begin
         api = GetIntoTeachingApiClient::PrivacyPoliciesApi.new
-        api.get_latest_privacy_policy
+        api.get_privacy_policy(policy_id)
       end
     end
 

--- a/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/placement_requests_controller_spec.rb
@@ -72,7 +72,7 @@ describe Candidates::Registrations::PlacementRequestsController, type: :request 
       end
 
       context 'registration job not already enqueued' do
-        include_context "api latest privacy policy"
+        include_context "api current privacy policy"
         include_context "api teaching subjects"
         include_context "api add classroom experience note"
 

--- a/spec/features/candidates/api_registrations_spec.rb
+++ b/spec/features/candidates/api_registrations_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 feature 'Candidate Registrations (via the API)', type: :feature do
   include_context "enable git_api feature"
   include_context "api teaching subjects"
-  include_context "api latest privacy policy"
+  include_context "api current privacy policy"
   include_context "api add classroom experience note"
   include_context "api sign up"
   include_context "Stubbed candidates school"

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Bookings::Candidate, type: :model do
 
     context "when the git_api feature is enabled" do
       include_context "enable git_api feature"
-      include_context "api latest privacy policy"
+      include_context "api current privacy policy"
       include_context "api teaching subjects"
 
       before do
@@ -366,7 +366,7 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
 
     context "when the contact is an instance of GetIntoTeachingApi::SchoolsExperienceSignUp" do
-      include_context "api latest privacy policy"
+      include_context "api current privacy policy"
       include_context "api teaching subjects"
       include_context "api sign up"
 

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to have_attributes(_dfe_preferredteachingsubject02_value: teachingsubjectid2) }
 
     context "when contact is an instance of GetIntoTeachingApiClient::SchoolsExperienceSignUp" do
-      include_context "api latest privacy policy"
+      include_context "api current privacy policy"
       include_context "api teaching subjects"
 
       let(:contact) { GetIntoTeachingApiClient::SchoolsExperienceSignUp.new }
@@ -74,7 +74,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
       it { is_expected.to have_attributes(has_dbs_certificate: registration.background_check.has_dbs_check) }
       it { is_expected.to have_attributes(preferred_teaching_subject_id: teachingsubjectid) }
       it { is_expected.to have_attributes(secondary_preferred_teaching_subject_id: teachingsubjectid2) }
-      it { is_expected.to have_attributes(accepted_policy_id: latest_policy.id) }
+      it { is_expected.to have_attributes(accepted_policy_id: current_policy.id) }
 
       context "when has_dbs_certificate is changing" do
         let(:contact) do

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -59,12 +59,12 @@ shared_context "api correct verification code for personal info" do
   end
 end
 
-shared_context "api latest privacy policy" do
-  let(:latest_policy) { build(:api_privacy_policy) }
+shared_context "api current privacy policy" do
+  let(:current_policy) { build(:api_privacy_policy) }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::PrivacyPoliciesApi).to \
-      receive(:get_latest_privacy_policy) { latest_policy }
+      receive(:get_privacy_policy) { current_policy }
   end
 end
 


### PR DESCRIPTION
### Context
We serve a static privacy policy to users and mark the latest in the API as the one they accept against their candidate record, which is fine whilst they’re both one and the same but if the policy changes in the CRM and we don’t reflect it in the app then they could be marked as accepting a policy they haven’t read

### Changes proposed in this pull request
Make it explicit which privacy policy number is being sent to the API.

