### PR TITLE
Display the correct experience type in school pages

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -55,19 +55,6 @@ module Candidates::SchoolHelper
     availability_info.present? ? safe_format(availability_info) : 'No information supplied'
   end
 
-  def format_school_experience_type(type)
-    case type
-    when 'virtual' then placement_date_virtual_tag
-    when 'inschool' then placement_date_virtual_tag
-    else
-      safe_join [
-        placement_date_virtual_tag,
-        " and ",
-        placement_date_inschool_tag
-      ]
-    end
-  end
-
   def format_phases(school)
     school.phases.map(&:name).to_sentence
   end

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -119,7 +119,7 @@
           School experience type
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= format_school_experience_type @school.experience_type %>
+          <%= format_school_placement_locations @school %>
         </dd>
       </div>
 

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -123,7 +123,7 @@
             School experience type
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= format_school_experience_type @presenter.school.experience_type %>
+            <%= format_school_placement_locations @presenter.school %>
           </dd>
       </div>
       <%- end -%>


### PR DESCRIPTION
### Trello card
https://trello.com/c/ONryUTqi

### Context
The school page displays `VIRTUAL` experience type when it's actually set to `IN SCHOOL`. 

### Changes proposed in this pull request
Use the `format_school_placement_locations` helper that is also used to display the correct experience type in the school search page.

Finally, delete the `format_school_experience_type` helper as there's no obvious reasons it should exist.



### Guidance to review

