### PR TITLE
Fix typo in the cancellation page

### DIFF
--- a/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_candidate.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_candidate.html.erb
@@ -12,7 +12,7 @@
       What happens next
     </h2>
     <p>
-      Your request for school experience <%= school_name %> at has been cancelled.
+      Your request for school experience at <%= school_name %> has been cancelled.
     </p>
     <p>
       <strong>The school will be notified about this cancellation.</strong>


### PR DESCRIPTION
### Context
When candidates cancelling their SE request, we display the cancellation page which has a typo in the `What happens next` section.

### Changes proposed in this pull request
Move the `at` preposition in front of the school name.

