### PR TITLE
Fix address number being duplicated

### DIFF
--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -132,7 +132,7 @@ module Bookings
       {
         'phone' => gitis_contact.secondary_telephone.presence || gitis_contact.telephone.presence || gitis_contact.mobile_telephone,
         'building' => gitis_contact.address_line1,
-        'street' => [gitis_contact.address_line1, gitis_contact.address_line2].map(&:presence).compact.join(', '),
+        'street' => gitis_contact.address_line2,
         'town_or_city' => gitis_contact.address_city,
         'county' => gitis_contact.address_state_or_province,
         'postcode' => gitis_contact.address_postcode

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
 
       it { is_expected.to include("phone" => contact.secondary_telephone) }
       it { is_expected.to include("building" => contact.address_line1) }
-      it { is_expected.to include("street" => "#{contact.address_line1}, #{contact.address_line2}") }
+      it { is_expected.to include("street" => contact.address_line2) }
       it { is_expected.to include("town_or_city" => contact.address_city) }
       it { is_expected.to include("county" => contact.address_state_or_province) }
       it { is_expected.to include("postcode" => contact.address_postcode) }


### PR DESCRIPTION
We were combining `address_line1` and `address_line2` for the `street` field, but we already show `address_line1` in the `building` field, so if you went through the experience registration process multiple times (matching back) you ended up with your building number prepended to the address again (and again).