### PR TITLE
Add invisible captcha protection to candidates feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,8 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 # Ignore cloudfront IPs when getting customer IP address
 gem 'actionpack-cloudfront'
 
+gem 'invisible_captcha'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,6 +256,8 @@ GEM
     httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    invisible_captcha (2.0.0)
+      rails (>= 5.0)
     json (2.5.1)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
@@ -596,6 +598,7 @@ DEPENDENCIES
   geocoder
   get_into_teaching_api_client_faraday!
   govuk_elements_form_builder!
+  invisible_captcha
   json (>= 2.3.0)
   kaminari
   listen (>= 3.0.5)

--- a/app/controllers/candidates/feedbacks_controller.rb
+++ b/app/controllers/candidates/feedbacks_controller.rb
@@ -1,5 +1,7 @@
 module Candidates
   class FeedbacksController < ApplicationController
+    invisible_captcha only: [:create], timestamp_threshold: 1.second
+
     def show; end
 
     def new

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -40,6 +40,8 @@
         </p>
       <% end %>
 
+      <%= invisible_captcha %>
+
       <%= f.submit 'Submit feedback' %>
     <% end %>
 

--- a/config/initializers/invisible_captcha.rb
+++ b/config/initializers/invisible_captcha.rb
@@ -1,0 +1,5 @@
+InvisibleCaptcha.setup do |config|
+  # Only enable in production so our automated integration
+  # tests don't fail.
+  config.timestamp_enabled = Rails.env.production?
+end

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.feature "Feedback", type: :feature do
+  scenario "a bot submitting feedback (filling in the honeypot)" do
+    visit new_candidates_feedback_path
+
+    choose "Make a school experience request"
+    choose "Yes"
+    choose "Satisfied"
+    fill_in "If you are a human, ignore this field", with: "i-am-a-bot"
+
+    click_on "Submit feedback"
+
+    expect(page.status_code).to eq(200)
+    expect(page.body).to eq("")
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/ahEcacjs

### Context
At the moment, bots can easily submit the feedback form. We want to prevent that, so to get only real submissions.

### Changes proposed in this pull request
Add invisible captcha protection to candidates feedback form.

### Guidance to review
Fill in the honeypot field and submit the form to trigger the bot protection. An empty page with 200 status code will be returned instead of the "Thank you" page. 