### PR TITLE
Redirect non GET referers to root_path

### DIFF
--- a/spec/features/cookie_preferences_spec.rb
+++ b/spec/features/cookie_preferences_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+feature "Save the referer" do
+  scenario "a user accepts the cookies from invalid path" do
+    visit new_candidates_feedback_path
+
+    click_on "Submit feedback"
+    click_on "Accept cookies"
+
+    expect(page.current_path).to eq(root_path)
+  end
+
+  scenario "a user accepts the cookies from valid path" do
+    visit candidates_signin_path
+
+    click_on "Accept cookies"
+
+    expect(page.current_path).to eq(candidates_signin_path)
+  end
+
+  scenario "a user accepts the cookies from a blacklisted path" do
+    visit edit_cookie_preference_path
+
+    click_on "Accept cookies"
+
+    expect(page.current_path).to eq(edit_cookie_preference_path)
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/ADa84TYk

### Context
Before accepting the cookies, we store the HTTP referer, in order to redirect the users back to the page they were at. However there are cases where the referer is not a GET path, causing 404s because there's nothing to render.

### Changes proposed in this pull request
- Set the redirect link to root path when the referer is not recognised as a GET resource

It's utilising the `Rails.application.routes.recognize_path()` which by default tries to recognise GET paths. If a route is found, then we assume it's safe to redirect to, otherwise the homepage is used as a fallback.

- Remove the `cookies_policy` from the REFERER_BLACKLIST. 

Accepting the cookies from the `/cookies_policy` page, will now keep the users on the same page and won't redirect them to the edit cookies page.

- Rename the misspelled  `save_refererer` method to `save_referer`. 
 
### Guidance to review
The 404 can be reproduced with the following steps:
1. open https://schoolexperience.education.gov.uk/candidates/feedbacks/new in incognito (or clear the cookies)
2. click `Submit feedback` (with empty form)
3. click `Accept cookies` at the top of the page
