### PR TITLE
Handle gracefully the dfe sign in healthchecks

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -41,7 +41,7 @@ class Healthcheck
     return true unless Schools::DFESignInAPI::Organisations.enabled?
 
     Schools::DFESignInAPI::Organisations.new(SecureRandom.uuid).uuids
-  rescue RuntimeError
+  rescue RuntimeError, Rack::Timeout::RequestTimeoutException
     false
   end
 

--- a/app/services/schools/dfe_sign_in_api/client.rb
+++ b/app/services/schools/dfe_sign_in_api/client.rb
@@ -4,7 +4,10 @@ module Schools
 
     class Client
       TIMEOUT_SECS = 15
-      RETRY_EXCEPTIONS = [::Faraday::ConnectionFailed].freeze
+      RETRY_EXCEPTIONS = [
+        ::Faraday::ConnectionFailed,
+        Rack::Timeout::RequestTimeoutException
+      ].freeze
       RETRY_OPTIONS = {
         max: 2,
         methods: %i[get],

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -155,25 +155,27 @@ RSpec.describe Healthcheck do
 
   describe "#test_dfe_signin_api" do
     before do
-      allow_any_instance_of(Schools::DFESignInAPI::Organisations).to receive(:enabled?).and_return(false)
+      allow(Schools::DFESignInAPI::Organisations).to receive(:enabled?).and_return(true)
     end
 
     subject { described_class.new.test_dfe_signin_api }
 
     context "with working connection" do
       before do
-        allow(Schools::DFESignInAPI::Organisations).to receive(:uuids).and_return([])
+        allow_any_instance_of(Schools::DFESignInAPI::Organisations).to receive(:uuids).and_return({})
       end
 
-      xit { is_expected.to be true }
+      it { is_expected.to be_a Hash }
     end
 
     context "with non functional connection" do
-      before do
-        allow(Schools::DFESignInAPI::Client).to receive(:response).and_raise Faraday::TimeoutError
-      end
+      it "returns false" do
+        [RuntimeError, Redis::CannotConnectError].each do |error|
+          allow_any_instance_of(Schools::DFESignInAPI::Organisations).to receive(:response).and_raise error
 
-      xit { is_expected.to be false }
+          is_expected.to be false
+        end
+      end
     end
 
     context "with no configured connection" do


### PR DESCRIPTION
When the api is unreachable the app raises Rack Timeout exceptions which lead to 500 responses.

### Trello card
https://trello.com/c/izJNTyfl

### Context
We want to prevent the 500 responses when the dfe api is unreachable

### Changes proposed in this pull request
Taking two extra measures to handle the timeouts:
  1. Add the Rack::Timeout::RequestTimeoutException to faraday's retry
     exceptions to give it a second chance to succeed
  2. Rescue the Rack Timeouts and return false to prevent the 500s

### Guidance to review
