### PR TITLE
Rescue timeouts when health checking Redis

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -18,7 +18,7 @@ class Healthcheck
     return nil unless ENV["REDIS_URL"]
 
     Redis.current.ping == "PONG"
-  rescue RuntimeError
+  rescue RuntimeError, Errno::ETIMEDOUT
     false
   end
 

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -129,11 +129,12 @@ RSpec.describe Healthcheck do
     end
 
     context "with broken connection" do
-      before do
-        allow(Redis).to receive(:current).and_raise Redis::CannotConnectError
+      it "returns false" do
+        [Errno::ETIMEDOUT, Redis::CannotConnectError].each do |error|
+          allow(Redis).to receive(:current).and_raise error
+          expect(subject).to be false
+        end
       end
-
-      it { is_expected.to be false }
     end
 
     context 'with non functional redis' do


### PR DESCRIPTION
### Trello card
https://trello.com/c/Exs5eBFu

### Context
Sentry has caught `Errno::ETIMEDOUT` exceptions raised by the Redis health checks, which cause error 500.

### Changes proposed in this pull request
Rescue the exception and return false as the Redis status.

