### PR TITLE
Get Healthchecks to display SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,7 +115,7 @@ jobs:
         id:   azSecret
         with:
            keyvault: ${{ secrets.KEY_VAULT}}
-           secrets: 'LOGIT-API'
+           secrets: 'LOGIT-API, HTTPAUTH-USERNAME, HTTPAUTH-PASSWORD'
 
       - uses: hashicorp/setup-terraform@v1.3.2
         with:
@@ -151,9 +151,12 @@ jobs:
         run: |
             if [ "${{steps.variables.outputs.RUN_TEST}}" == "true" ]
             then
-                   tests/confidence/healthcheck.sh  "${{steps.variables.outputs.healthcheck}}"  "sha-${{ steps.sha.outputs.short }}"
+                   tests/confidence/healthcheck.sh  "${{steps.variables.outputs.healthcheck}}"  "${{ steps.sha.outputs.short }}"
             fi
-
+        env:
+             HTTPAUTH_USERNAME: ${{steps.azSecret.outputs.HTTPAUTH-USERNAME}}
+             HTTPAUTH_PASSWORD: ${{steps.azSecret.outputs.HTTPAUTH-PASSWORD}}
+            
       - name: Update ${{ github.event.inputs.environment }} status
         if: always()
         uses: bobheadxi/deployments@v0.6.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,8 @@ RUN gem install bundler --version='~> 2.2.17' && \
 COPY . .
 RUN bundle exec rake assets:precompile SECRET_KEY_BASE=stubbed SKIP_REDIS=true
 
+ARG SHA
+RUN echo "sha-${SHA}" > /etc/school-experience-sha
+
 # Create symlinks for CSS files without digest hashes for use in error pages
 RUN bundle exec rake assets:symlink_non_digested SECRET_KEY_BASE=stubbed SKIP_REDIS=true

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -11,7 +11,7 @@ class Healthcheck
   end
 
   def app_sha
-    read_file "/etc/get-teacher-training-adviser-service-sha"
+    read_file "/etc/school-experience-sha"
   end
 
   def test_redis

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Healthcheck do
   let(:gitsha) { "d64e925a5c70b05246e493de7b60af73e1dfa9dd" }
-  shafile = "/etc/get-teacher-training-adviser-service-sha"
+  shafile = "/etc/school-experience-sha"
 
   describe "#app_sha" do
     subject { described_class.new.app_sha }

--- a/tests/confidence/healthcheck.sh
+++ b/tests/confidence/healthcheck.sh
@@ -1,1 +1,51 @@
-echo "Not really doing anyhing just yet"
+#################################################################################################
+###
+### CURL the deployed containers healthcheck and return the status and SHA.
+### check the SHA against a passed in parameter
+###
+### Input parameters ( not validated )
+### 1 URL
+### 2 APP SHA
+###
+### Returns
+### 1 on failure
+### 0 on sucess
+###
+#################################################################################################
+URL=${1}
+APP_SHA=${2}
+
+#URL="review-schools-experience-1787"
+#APP_SHA="e1c94c1"
+#APP_SHA="e1c94cx"
+
+
+if [ -z "${HTTPAUTH_USERNAME}" ]
+then
+    AUTHORITY=""
+else
+    AUTHORITY="--user ${HTTPAUTH_USERNAME}:${HTTPAUTH_PASSWORD}"
+fi
+
+rval=0
+FULL_URL="https://${URL}.london.cloudapps.digital/healthcheck"
+http_status=$(curl ${AUTHORITY} -o /dev/null -s -w "%{http_code}"  ${FULL_URL})
+if [ "${http_status}" != "200" ]
+then
+    echo "HTTP Status ${http_status}"
+    rval=1
+else
+    echo "HTTP Status is Healthy"
+
+    json=$(curl ${AUTHORITY}  -s -X GET ${FULL_URL})
+
+    sha=$( echo ${json} | jq -r .app_sha)
+    if [ "${sha}" != "sha-${APP_SHA}"  ]
+    then
+        echo "APP SHA (${sha}) is not sha-${APP_SHA}"
+        rval=1
+    else
+        echo "APP SHA is correct"
+    fi
+fi
+exit ${rval}


### PR DESCRIPTION
# Improve Healthcheck
The health check script is disabled. We should get this working.

# Tasks
- The file the sha is kept in has the wrong name, this isn't too important but it does not make sense so corrected it.
- When the docker container is built the file /etc/school-experience-sha is populated.
- Change the test script to work for the returned details

# Review
- SHA now displaying https://review-schools-experience-1787.london.cloudapps.digital/healthcheck
- Health check now working


