### PR TITLE
Healthcheck

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -45,17 +45,17 @@ class Healthcheck
 
   def to_h
     dfe_auth = test_dfe_signin_api
-    api = test_gitis
+    gitis_api = test_gitis
     db = test_postgresql
     redis = test_redis
 
-    is_healthy = dfe_auth && api && db && redis
+    is_healthy = dfe_auth && gitis_api && db && redis
 
     {
       deployment_id: deployment,
       app_sha: app_sha,
       dfe_auth: dfe_auth,
-      api: api,
+      gitis_api: gitis_api,
       db: db,
       cache: redis,
       healthy: is_healthy,

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -38,7 +38,9 @@ class Healthcheck
   end
 
   def test_dfe_signin_api
-    !Schools::DFESignInAPI::Organisations.new(SecureRandom.uuid).uuids.nil?
+    res = Schools::DFESignInAPI::Organisations.new(SecureRandom.uuid).uuids
+
+    ActiveModel::Type::Boolean.new.cast(res)
   rescue RuntimeError, Rack::Timeout::RequestTimeoutException
     false
   end

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -38,25 +38,23 @@ class Healthcheck
   end
 
   def test_dfe_signin_api
-    return true unless Schools::DFESignInAPI::Organisations.enabled?
-
-    Schools::DFESignInAPI::Organisations.new(SecureRandom.uuid).uuids
+    !Schools::DFESignInAPI::Organisations.new(SecureRandom.uuid).uuids.nil?
   rescue RuntimeError, Rack::Timeout::RequestTimeoutException
     false
   end
 
   def to_h
-    auth = test_dfe_signin_api
+    dfe_auth = test_dfe_signin_api
     api = test_gitis
     db = test_postgresql
     redis = test_redis
 
-    is_healthy = auth && api && db && redis
+    is_healthy = dfe_auth && api && db && redis
 
     {
       deployment_id: deployment,
       app_sha: app_sha,
-      auth: auth,
+      dfe_auth: dfe_auth,
       api: api,
       db: db,
       cache: redis,

--- a/spec/controllers/healthchecks_controller_spec.rb
+++ b/spec/controllers/healthchecks_controller_spec.rb
@@ -37,7 +37,7 @@ describe HealthchecksController, type: :request do
       it { expect(response.body).to include_json(cache: true) }
       it { expect(response.body).to include_json(db: true) }
       it { expect(response.body).to include_json(dfe_auth: true) }
-      it { expect(response.body).to include_json(api: true) }
+      it { expect(response.body).to include_json(gitis_api: true) }
       it { expect(response).to have_http_status(:success) }
     end
 
@@ -84,7 +84,7 @@ describe HealthchecksController, type: :request do
         get healthcheck_path
       end
 
-      it { expect(response.body).to include_json(api: false) }
+      it { expect(response.body).to include_json(gitis_api: false) }
       it { expect(response).to have_http_status(:error) }
     end
 
@@ -99,7 +99,7 @@ describe HealthchecksController, type: :request do
           get healthcheck_path
         end
 
-        it { expect(response.body).to include_json(api: false) }
+        it { expect(response.body).to include_json(gitis_api: false) }
         it { expect(response).to have_http_status(:error) }
       end
     end

--- a/spec/controllers/healthchecks_controller_spec.rb
+++ b/spec/controllers/healthchecks_controller_spec.rb
@@ -36,7 +36,7 @@ describe HealthchecksController, type: :request do
 
       it { expect(response.body).to include_json(cache: true) }
       it { expect(response.body).to include_json(db: true) }
-      it { expect(response.body).to include_json(auth: true) }
+      it { expect(response.body).to include_json(dfe_auth: true) }
       it { expect(response.body).to include_json(api: true) }
       it { expect(response).to have_http_status(:success) }
     end

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe Healthcheck do
     it { is_expected.to include :deployment_id }
     it { is_expected.to include :app_sha }
     it { is_expected.to include :dfe_auth }
-    it { is_expected.to include :api }
+    it { is_expected.to include :gitis_api }
     it { is_expected.to include :db }
     it { is_expected.to include :cache }
     it { is_expected.to include :healthy }
@@ -209,7 +209,7 @@ RSpec.describe Healthcheck do
     it { is_expected.to include "deployment_id" }
     it { is_expected.to include "app_sha" }
     it { is_expected.to include "dfe_auth" }
-    it { is_expected.to include "api" }
+    it { is_expected.to include "gitis_api" }
     it { is_expected.to include "db" }
     it { is_expected.to include "cache" }
     it { is_expected.to include "healthy" }

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Healthcheck do
         allow_any_instance_of(Schools::DFESignInAPI::Organisations).to receive(:uuids).and_return({})
       end
 
-      it { is_expected.to be_a Hash }
+      it { is_expected.to be true }
     end
 
     context "with non functional connection" do
@@ -184,7 +184,7 @@ RSpec.describe Healthcheck do
         allow(Schools::DFESignInAPI::Organisations).to receive(:enabled?).and_return(false)
       end
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
   end
 
@@ -194,7 +194,7 @@ RSpec.describe Healthcheck do
     subject { described_class.new.to_h }
     it { is_expected.to include :deployment_id }
     it { is_expected.to include :app_sha }
-    it { is_expected.to include :auth }
+    it { is_expected.to include :dfe_auth }
     it { is_expected.to include :api }
     it { is_expected.to include :db }
     it { is_expected.to include :cache }
@@ -208,7 +208,7 @@ RSpec.describe Healthcheck do
     subject { JSON.parse described_class.new.to_json }
     it { is_expected.to include "deployment_id" }
     it { is_expected.to include "app_sha" }
-    it { is_expected.to include "auth" }
+    it { is_expected.to include "dfe_auth" }
     it { is_expected.to include "api" }
     it { is_expected.to include "db" }
     it { is_expected.to include "cache" }


### PR DESCRIPTION
### Trello card
https://trello.com/c/vMG7Hdpq/

### Context
The current healthcheck is ambiguous as to what API checks. 
It also reports false positive results for the dfe signin check, when the DfE api is either disabled in our end or the credentials are missing.

### Changes proposed in this pull request
* Remove the guard clause that checks if the dfe auth is ok and let the actual request decides the results. Also, change the returned values to boolean.
* Rename the auth and the api labels in the healthcheck results to be more explicit

### Guidance to review
Visit `/healthcheck`

Before
```
{"deployment_id":"Prod-7166","app_sha":"sha-","auth":{},"api":true,"db":true,"cache":true,"healthy":true,"status":"OK"}
```

After
```
{"deployment_id":"Prod-7166","app_sha":"sha-","dfe_auth":true,"gitis_api":true,"db":true,"cache":true,"healthy":true,"status":"OK"}
```