### PR TITLE
Update the dashboard link in the change school page

### DIFF
--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -38,7 +38,7 @@
         </p>
       <% end %>
 
-      <%= link_to "Remain logged in as current school", schools_dashboard_path, class: 'govuk-link' if current_urn %>
+      <%= link_to "Go back to #{@current_school&.name} dashboard", schools_dashboard_path, class: 'govuk-link' if current_urn %>
     <% else %>
       <div class="govuk-warning-text">
         <span class="govuk-warning-text__icon" aria-hidden="true">!</span>

--- a/spec/views/schools/change_schools/show.html.erb_spec.rb
+++ b/spec/views/schools/change_schools/show.html.erb_spec.rb
@@ -40,6 +40,10 @@ describe 'schools/change_schools/show.html.erb', type: :view do
       )
     end
 
+    specify 'there should be a link to go back to dashboard' do
+      expect(rendered).to have_css("a[href='/schools/dashboard']", text: "Go back to #{school.name} dashboard")
+    end
+
     context 'no existing school chosen' do
       let(:school) { nil }
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/AkG0Yv9F

### Context
The current link `Remain logged in as current school` in not very clear to the users.

### Changes proposed in this pull request
Update the copy to make it clear it will lead the users to the dashboard and to also indicate which school they are logged in as.

### Guidance to review
1. sign-in using a user with multiple schools
2. choose a school
3. click the `change school` link

| before  | after |
| - | - |
| ![cs-link-before](https://user-images.githubusercontent.com/951947/125788786-3c45feca-6252-4897-86f8-c7c3dc977dd1.png)| ![cs-link-after](https://user-images.githubusercontent.com/951947/125788800-04da562c-2b3f-4e79-9583-2ab2bc1b9632.png) |

