### PR TITLE
Change typewriter apostrophe to typesetter

### DIFF
--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -21,7 +21,7 @@
 
     <h2>Verify your details to continue</h2>
 
-    <p>We’ve emailed a verification code to:</p>
+    <p>We've emailed a verification code to:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li><%= @email_address %></li>


### PR DESCRIPTION
Making this apostrophe of the typesetter variety (') instead of typewriter (’) for consistency.