### PR TITLE
Alias firstname/lastname on MissingContact

### DIFF
--- a/app/services/bookings/gitis/missing_contact.rb
+++ b/app/services/bookings/gitis/missing_contact.rb
@@ -13,6 +13,8 @@ module Bookings
       end
       alias_method :firstname, :full_name
       alias_method :lastname, :full_name
+      alias_method :first_name, :full_name
+      alias_method :last_name, :full_name
 
       def emailaddress2
         nil

--- a/spec/services/bookings/gitis/missing_contact_spec.rb
+++ b/spec/services/bookings/gitis/missing_contact_spec.rb
@@ -7,6 +7,8 @@ describe Bookings::Gitis::MissingContact do
   it { is_expected.to have_attributes contactid: uuid, id: uuid }
   it { is_expected.to have_attributes firstname: 'Unavailable' }
   it { is_expected.to have_attributes lastname: 'Unavailable' }
+  it { is_expected.to have_attributes first_name: 'Unavailable' }
+  it { is_expected.to have_attributes first_name: 'Unavailable' }
   it { is_expected.to have_attributes full_name: 'Unavailable' }
   it { is_expected.to have_attributes birthdate: nil }
   it { is_expected.to have_attributes date_of_birth: nil }


### PR DESCRIPTION
The old `Contact` method had `firstname` and `lastname` but our new API model as `first_name` and `last_name`. As the `MissingContact` is used in its place in certain situations we need to have parity with the attribute names.

I'm leaving in the original attributes for now as other models still use that naming convention and I don't want to inadvertently break it elsewhere. 

I'll go through and do a repo-wide rename of these attributes in a future PR.
