### PR TITLE
Remove SyncSubjectsWithGitisJob instances

### DIFF
--- a/app/jobs/cron/sync_subjects_with_gitis_job.rb
+++ b/app/jobs/cron/sync_subjects_with_gitis_job.rb
@@ -1,0 +1,19 @@
+# TEMP: removes the subject sync cron job; once
+# this has been shipped to prod it can be removed.
+class Cron::SyncSubjectsWithGitisJob < CronJob
+  self.cron_expression = "30 3 * * *"
+
+  class << self
+    def jobs
+      Delayed::Job
+        .where("handler LIKE ?", "%job_class: #{name}%")
+        .where.not(cron: nil)
+    end
+
+    def schedule
+      jobs.destroy_all
+    end
+  end
+
+  def perform; end
+end

--- a/spec/jobs/cron/sync_subjects_with_gitis_job_spec.rb
+++ b/spec/jobs/cron/sync_subjects_with_gitis_job_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe Cron::SyncSubjectsWithGitisJob, type: :job do
+  it "has a schedule of daily at 03:30" do
+    expect(described_class.cron_expression).to eql("30 3 * * *")
+  end
+
+  describe "#schedule" do
+    before do
+      # As the test queue adapter is in use we need to 'queue' the job
+      # by adding an entry to the database manually.
+      Delayed::Job.new(
+        handler: "job_class: #{described_class.name}",
+        cron: described_class.cron_expression
+      ).save!
+    end
+
+    it "destroys all #{described_class} jobs" do
+      expect { described_class.schedule }.to change {
+        described_class.jobs.count
+      }.from(1).to(0)
+    end
+  end
+end


### PR DESCRIPTION
The `SyncSubjectWithGitisJob` code was removed in an early PR, but the job itself was already in the job queue. It is now failing because it can't find the handler class any longer.

Re-introduce the handler class and override `#schedule` to remove all active instances of the job from the queue. As jobs are scheduled on deployment we should be fine to deploy this then remove it immediately.