### PR TITLE
Update the Help and Support email address

### DIFF
--- a/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
+++ b/app/notify/notify_email/school_request_confirmation_link_only.2a5a54b8-17cb-4da8-94ce-1647d6bf1da3.md
@@ -12,7 +12,7 @@ View the request – ((placement_request_url))
 
 # Help and support
  
-If you’ve got any questions or would like to take part in user testing email us with your URN at organise.schoolexperience@education.gov.uk.
+If you’ve got any questions or would like to take part in user testing email us with your URN at organise.school-experience@education.gov.uk.
 
 # Provide feedback
 

--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -219,7 +219,7 @@
       <p>
         If you change your mind or you are unhappy with our use of your
         personal data please email us at
-        <%= mail_to "organise.schoolexperience@education.gov.uk" %>.
+        <%= mail_to "organise.school-experience@education.gov.uk" %>.
       </p>
 
       <p>


### PR DESCRIPTION
### Context
The `school confirmation` email and the `school privacy policy` page are still using the old help and support email address

### Changes proposed in this pull request
Update the email address to the new one.

### Guidance to review
- For the `School privacy policy` page, visit: https://schoolexperience.education.gov.uk/schools_privacy_policy
- For the `School confirmation` email, do the following:
  - Request a School experience as a candidate to trigger the School confirmation email
  - See the Help and support paragraph in the email