### PR TITLE
Remove unused env vars for direct CRM integration

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -117,7 +117,6 @@ Rails.application.configure do
   end
 
   config.x.gitis.fake_crm_uuid = ENV.fetch('FAKE_CRM_UUID', nil)
-  config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
   config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -119,7 +119,6 @@ Rails.application.configure do
   config.x.gitis.fake_crm_uuid = ENV.fetch('FAKE_CRM_UUID', nil)
   config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
-  config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
   config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -120,7 +120,6 @@ Rails.application.configure do
   config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
   config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET', 'notset')
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
-  config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION', '0')
   config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
   config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -118,7 +118,6 @@ Rails.application.configure do
 
   config.x.gitis.fake_crm_uuid = ENV.fetch('FAKE_CRM_UUID', nil)
   config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
-  config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET', 'notset')
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
   config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
   config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -124,7 +124,6 @@ Rails.application.configure do
   config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)
   config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
-  config.x.gitis.caching = truthy_strings.include?(ENV['CRM_CACHING'].to_s)
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -119,7 +119,6 @@ Rails.application.configure do
   config.x.gitis.fake_crm_uuid = ENV.fetch('FAKE_CRM_UUID', nil)
   config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
   config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET', 'notset')
-  config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID', 'notset')
   config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
   config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION', '0')
   config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID', SecureRandom.uuid)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -118,7 +118,6 @@ Rails.application.configure do
 
   config.x.gitis.fake_crm_uuid = ENV.fetch('FAKE_CRM_UUID', nil)
   config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID', 'notset')
-  config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL', 'notset')
   config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -165,7 +165,6 @@ Rails.application.configure do
 
   if ENV['CRM_CLIENT_ID'].present?
     config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
-    config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
     config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -166,7 +166,6 @@ Rails.application.configure do
   if ENV['CRM_CLIENT_ID'].present?
     config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
-    config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
     config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
     config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -166,7 +166,6 @@ Rails.application.configure do
   if ENV['CRM_CLIENT_ID'].present?
     config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
     config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET')
-    config.x.gitis.auth_tenant_id = ENV.fetch('CRM_AUTH_TENANT_ID')
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
     config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -165,7 +165,6 @@ Rails.application.configure do
 
   if ENV['CRM_CLIENT_ID'].present?
     config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
-    config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET')
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
     config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
     config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -163,11 +163,8 @@ Rails.application.configure do
   config.x.dfe_sign_in_api_school_change_enabled = ENV['DFE_SIGNIN_API_SCHOOL_CHANGE_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_request_organisation_url = "https://services.signin.education.gov.uk/request-organisation/search"
 
-  if ENV['CRM_CLIENT_ID'].present?
-    config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
-    config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
-    config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
-  end
+  config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
+  config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
 
   config.x.features = %i[subject_specific_dates]
   config.x.flipper_password = ENV['FLIPPER_PASSWORD']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -167,7 +167,6 @@ Rails.application.configure do
     config.x.gitis.auth_client_id = ENV.fetch('CRM_CLIENT_ID')
     config.x.gitis.auth_secret = ENV.fetch('CRM_CLIENT_SECRET')
     config.x.gitis.service_url = ENV.fetch('CRM_SERVICE_URL')
-    config.x.gitis.channel_creation = ENV.fetch('CRM_CHANNEL_CREATION')
     config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
     config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
     config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -171,7 +171,6 @@ Rails.application.configure do
     config.x.gitis.country_id = ENV.fetch('CRM_COUNTRY_ID')
     config.x.gitis.privacy_policy_id = ENV['CRM_PRIVACY_POLICY_ID'].presence || '8da7ae80-82f2-ea11-a815-000d3a44afcc'
     config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
-    config.x.gitis.caching = truthy_strings.include?(ENV['CRM_CACHING'].to_s)
   end
 
   config.x.features = %i[subject_specific_dates]

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -39,7 +39,6 @@ Rails.application.configure do
   config.x.gitis.country_id = SecureRandom.uuid
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'
-  config.x.gitis.caching = false
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
 

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -35,7 +35,6 @@ Rails.application.configure do
   config.x.dfe_sign_in_request_organisation_url = ""
   config.x.dfe_sign_in_request_service_url = ""
 
-  config.x.gitis.channel_creation = '0'
   config.x.gitis.country_id = SecureRandom.uuid
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -35,7 +35,6 @@ Rails.application.configure do
   config.x.dfe_sign_in_request_organisation_url = ""
   config.x.dfe_sign_in_request_service_url = ""
 
-  config.x.gitis.country_id = SecureRandom.uuid
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -181,7 +181,6 @@ Rails.application.configure do
 
   config.x.gitis.auth_client_id = nil
   config.x.gitis.service_url = nil
-  config.x.gitis.country_id = SecureRandom.uuid
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -180,7 +180,6 @@ Rails.application.configure do
   config.x.dfe_sign_in_request_organisation_url = nil
 
   config.x.gitis.auth_client_id = nil
-  config.x.gitis.auth_secret = nil
   config.x.gitis.service_url = nil
   config.x.gitis.country_id = SecureRandom.uuid
   config.x.gitis.privacy_policy_id = SecureRandom.uuid

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -180,7 +180,6 @@ Rails.application.configure do
   config.x.dfe_sign_in_request_organisation_url = nil
 
   config.x.gitis.auth_client_id = nil
-  config.x.gitis.service_url = nil
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -186,7 +186,6 @@ Rails.application.configure do
   config.x.gitis.country_id = SecureRandom.uuid
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'
-  config.x.gitis.caching = false
 
   config.x.features = %i[
     subject_specific_dates

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -182,7 +182,6 @@ Rails.application.configure do
   config.x.gitis.auth_client_id = nil
   config.x.gitis.auth_secret = nil
   config.x.gitis.service_url = nil
-  config.x.gitis.channel_creation = '0'
   config.x.gitis.country_id = SecureRandom.uuid
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -181,7 +181,6 @@ Rails.application.configure do
 
   config.x.gitis.auth_client_id = nil
   config.x.gitis.auth_secret = nil
-  config.x.gitis.auth_tenant_id = nil
   config.x.gitis.service_url = nil
   config.x.gitis.channel_creation = '0'
   config.x.gitis.country_id = SecureRandom.uuid

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -179,7 +179,6 @@ Rails.application.configure do
   config.x.dfe_sign_in_admin_role_id = '66666666-5555-4444-3333-222222222222'
   config.x.dfe_sign_in_request_organisation_url = nil
 
-  config.x.gitis.auth_client_id = nil
   config.x.gitis.privacy_policy_id = SecureRandom.uuid
   config.x.gitis.privacy_consent_id = '10'
 

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -34,8 +34,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 `CRM_CLIENT_ID` - Authentication ID for Active Directory tenant controlling access to Dynamics instance
 
-`CRM_CLIENT_SECRET` - Authentication secret for Active Directory
-
 `CRM_SERVICE_URL` - URL for the Dynamics instance to be connected to
 
 `CRM_PRIVACY_POLICY_ID` - GUID for the privacy policy used by candidates - supplied by Gitis team

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -32,8 +32,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 ## Gitis configuration
 
-`CRM_CLIENT_ID` - Authentication ID for Active Directory tenant controlling access to Dynamics instance
-
 `CRM_PRIVACY_POLICY_ID` - GUID for the privacy policy used by candidates - supplied by Gitis team
 
 `CRM_PRIVACY_CONSENT_ID` - GUID for the privacy policy consent id used by candidates - supplied by Gitis team

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -34,8 +34,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 `CRM_CLIENT_ID` - Authentication ID for Active Directory tenant controlling access to Dynamics instance
 
-`CRM_SERVICE_URL` - URL for the Dynamics instance to be connected to
-
 `CRM_PRIVACY_POLICY_ID` - GUID for the privacy policy used by candidates - supplied by Gitis team
 
 `CRM_PRIVACY_CONSENT_ID` - GUID for the privacy policy consent id used by candidates - supplied by Gitis team

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -40,8 +40,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 `CRM_PRIVACY_CONSENT_ID` - GUID for the privacy policy consent id used by candidates - supplied by Gitis team
 
-`CRM_COUNTRY_ID` - GUID for country to attach new Candidates to, supplied by Gitis team
-
 `CRM_OWNER_ID` - GUID for owner of new Contacts, not currently used - supplied by Gitis team
 
 `GIT_API_TOKEN` - API key for the GiT API

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -40,8 +40,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 `CRM_PRIVACY_CONSENT_ID` - GUID for the privacy policy consent id used by candidates - supplied by Gitis team
 
-`CRM_OWNER_ID` - GUID for owner of new Contacts, not currently used - supplied by Gitis team
-
 `GIT_API_TOKEN` - API key for the GiT API
 
 ## DFE Sign-in configuration

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -36,8 +36,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 `CRM_CLIENT_SECRET` - Authentication secret for Active Directory
 
-`CRM_AUTH_TENANT_ID` - GUID for the Active Directory tenant
-
 `CRM_SERVICE_URL` - URL for the Dynamics instance to be connected to
 
 `CRM_PRIVACY_POLICY_ID` - GUID for the privacy policy used by candidates - supplied by Gitis team

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -42,8 +42,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 `CRM_PRIVACY_CONSENT_ID` - GUID for the privacy policy consent id used by candidates - supplied by Gitis team
 
-`CRM_CACHING` - Turn on caching of Contact details, cached for 1 hour into Redis - 1 = on, blank = off
-
 `CRM_CHANNEL_CREATION` - GUID for the channel creation id, supplied by Gitis team
 
 `CRM_COUNTRY_ID` - GUID for country to attach new Candidates to, supplied by Gitis team

--- a/doc/env-vars.md
+++ b/doc/env-vars.md
@@ -42,8 +42,6 @@ If required Exceptions Notifications can be sent to Sentry.
 
 `CRM_PRIVACY_CONSENT_ID` - GUID for the privacy policy consent id used by candidates - supplied by Gitis team
 
-`CRM_CHANNEL_CREATION` - GUID for the channel creation id, supplied by Gitis team
-
 `CRM_COUNTRY_ID` - GUID for country to attach new Candidates to, supplied by Gitis team
 
 `CRM_OWNER_ID` - GUID for owner of new Contacts, not currently used - supplied by Gitis team


### PR DESCRIPTION
As we now integrate with the CRM via the API client we no longer need these CRM-related secrets.

