### PR TITLE
Add the delayed_job script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'acts_as_list'
 gem 'delayed_cron_job'
 gem 'delayed_job_active_record'
 gem 'delayed_job_web'
+gem 'daemons'
 
 gem "redis", "~> 4.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,7 @@ GEM
       cucumber-core (~> 10.0, >= 10.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 17.0, >= 17.0.1)
+    daemons (1.4.0)
     database_cleaner (2.0.1)
       database_cleaner-active_record (~> 2.0.0)
     database_cleaner-active_record (2.0.1)
@@ -591,6 +592,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   capybara-screenshot
   cucumber-rails
+  daemons
   database_cleaner
   delayed_cron_job
   delayed_job_active_record

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize


### PR DESCRIPTION
### Context
Currently we run the workers with `bundle exec rake jobs:work` which is not ideal for production.

### Changes proposed in this pull request
Add the delayed_job script which can be used to:
- daemonize the processes
- spawn multiple processes
- restart the processes

Then we can start the workers with `RAILS_ENV=production bin/delayed_job start`