### PR TITLE
Create a Second Container to Run Delayed Jobs

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -1,16 +1,17 @@
 locals {
-  environment_map = { 
-    REDIS_URL          = local.redis-credentials.uri,
-    DB_DATABASE        = local.postgres-credentials.name
-    DB_HOST            = local.postgres-credentials.host,
-    DB_USERNAME        = local.postgres-credentials.username,
-    DB_PASSWORD        = local.postgres-credentials.password,
-    SKIP_FORCE_SSL     = true,
-    SENTRY_CURRENT_ENV = var.application_environment,
-    SLACK_ENV          = var.application_environment,
-    DFE_SIGNIN_BASE_URL= "https://${cloudfoundry_route.route_cloud.endpoint}"
+  environment_map = {
+    REDIS_URL           = local.redis-credentials.uri,
+    DB_DATABASE         = local.postgres-credentials.name
+    DB_HOST             = local.postgres-credentials.host,
+    DB_USERNAME         = local.postgres-credentials.username,
+    DB_PASSWORD         = local.postgres-credentials.password,
+    SKIP_FORCE_SSL      = true,
+    SENTRY_CURRENT_ENV  = var.application_environment,
+    SLACK_ENV           = var.application_environment,
+    DFE_SIGNIN_BASE_URL = "https://${cloudfoundry_route.route_cloud.endpoint}"
   }
 }
+
 
 resource "cloudfoundry_app" "application" {
   name         = var.paas_application_name
@@ -39,6 +40,37 @@ resource "cloudfoundry_app" "application" {
 
   dynamic "routes" {
     for_each = data.cloudfoundry_route.app_route_internet
+    content {
+      route = routes.value["id"]
+    }
+  }
+
+  environment = merge(local.application_secrets, local.environment_map)
+
+}
+
+resource "cloudfoundry_app" "delayed_jobs" {
+  count             = var.delayed_jobs
+  name              = "${var.paas_application_name}-delayed_job"
+  space             = data.cloudfoundry_space.space.id
+  command           = "bundle exec rake jobs:work"
+  docker_image      = var.paas_docker_image
+  stopped           = var.application_stopped
+  instances         = var.application_instances
+  memory            = var.application_memory
+  disk_quota        = var.application_disk
+  strategy          = var.strategy
+  health_check_type = "process"
+
+  dynamic "service_binding" {
+    for_each = data.cloudfoundry_user_provided_service.logging
+    content {
+      service_instance = service_binding.value["id"]
+    }
+  }
+
+  dynamic "routes" {
+    for_each = cloudfoundry_route.route_delayed
     content {
       route = routes.value["id"]
     }

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -14,6 +14,6 @@ data "azurerm_key_vault_secret" "infrastructure" {
 }
 
 locals {
-  application_secrets = yamldecode(data.azurerm_key_vault_secret.application.value)
+  application_secrets    = yamldecode(data.azurerm_key_vault_secret.application.value)
   infrastructure_secrets = yamldecode(data.azurerm_key_vault_secret.infrastructure.value)
 }

--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -5,7 +5,7 @@ provider "cloudfoundry" {
 }
 
 provider "statuscake" {
-  username = local.infrastructure_secrets.SC-USERNAME 
+  username = local.infrastructure_secrets.SC-USERNAME
   apikey   = local.infrastructure_secrets.SC-PASSWORD
 }
 

--- a/terraform/paas/route.tf
+++ b/terraform/paas/route.tf
@@ -17,6 +17,13 @@ resource "cloudfoundry_route" "route_internal" {
   space    = data.cloudfoundry_space.space.id
 }
 
+resource "cloudfoundry_route" "route_delayed" {
+  count    = var.delayed_jobs
+  domain   = data.cloudfoundry_domain.internal.id
+  hostname = "${var.paas_application_name}-delayed"
+  space    = data.cloudfoundry_space.space.id
+}
+
 locals {
   app_endpoint = "${cloudfoundry_route.route_cloud.hostname}.${data.cloudfoundry_domain.cloudapps.name}"
 }

--- a/terraform/paas/staging.env.tfvars
+++ b/terraform/paas/staging.env.tfvars
@@ -1,22 +1,23 @@
-paas_space                = "get-into-teaching-test"            
+paas_space                = "get-into-teaching-test"
 paas_database_common_name = "school-experience-staging-pg-common-svc"
 paas_redis_1_name         = "school-experience-staging-redis-svc"
 paas_application_name     = "school-experience-app-staging"
 paas_internet_hostnames   = ["staging-schoolexperience"]
 application_instances     = 1
+delayed_jobs              = 1
 environment               = "staging"
 application_environment   = "dfe-school-experience-staging"
-azure_key_vault           = "s105t01-kv"                        
-azure_resource_group      = "s105t01-staging-vault-resource-group"  
+azure_key_vault           = "s105t01-kv"
+azure_resource_group      = "s105t01-staging-vault-resource-group"
 alerts = {
   SchoolExperience_Staging = {
-    website_name  = "School Experience (Staging)"
-    website_url   = "https://school-experience-app-staging.london.cloudapps.digital/healthcheck.json"
-    test_type     = "HTTP"
-    check_rate    = 60
-    contact_group = [185037]
-    trigger_rate  = 0
-    confirmations = 2
+    website_name   = "School Experience (Staging)"
+    website_url    = "https://school-experience-app-staging.london.cloudapps.digital/healthcheck.json"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [185037]
+    trigger_rate   = 0
+    confirmations  = 2
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
   }
 }

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -73,6 +73,10 @@ variable "redis_1_plan" {
   default = "small-ha-5_x"
 }
 
+variable "delayed_jobs" {
+  default = 0
+}
+
 variable "redis_service_key" {
   default = "redis_service_key"
 }
@@ -94,6 +98,6 @@ variable "paas_docker_image" {
 }
 
 variable "alerts" {
-  type = map(any)
+  type    = map(any)
   default = {}
 }


### PR DESCRIPTION
# Delayed Jobs
There is a back ground on School Experience called Delayed_jobs which sends confirmation emails. This job needs to be running when the application is redeployed.

## Problem
The job is a background task and needs to be fired off, manually. 

## Solution
Run the docker image a second time, with a different name. Do not allow the application (PUMA web server ) to start. but run the 'delayed_jobs' service.
The job does not have to run on review applications, and probably in development. so there is a flag that defaults to 0 which prevents the service starting. 
The flag is overriden in staging to start the service.
 



