### PR TITLE
Fix typo in the approver access denied page

### DIFF
--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -16,7 +16,7 @@
         <h1 class="govuk-heading-l">Manage school experience</h1>
 
         <p class="govuk-body-l">
-          You have not yet been granted have access to the Manage school
+          You have not yet been granted access to the Manage school
           experience service.
         </p>
 
@@ -25,7 +25,7 @@
         <h1 class="govuk-heading-l">Manage school experience</h1>
 
         <p class="govuk-body-l">
-          You have not yet been granted have access to the Manage school
+          You have not yet been granted access to the Manage school
           experience service.
         </p>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/oDqI6nt7

### Context
There's a typo in the change school page when the access is denied.

### Changes proposed in this pull request
Remove the typo.

### Guidance to review

