### PR TITLE
Update the form label for the maximum_distance_from_school field

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -746,7 +746,7 @@ en:
         not_on_another_training_course: "They must not have been accepted onto another teacher training course (ie not connected to your school)"
         has_or_working_towards_degree: "They must have or be working towards a degree"
         live_locally: "They must live locally"
-        maximum_distance_from_school: "Tell us within how many miles of your school. For example, 20 miles."
+        maximum_distance_from_school: "Tell us within how many miles of your school. For example, 20."
         provide_photo_identification: "They must provide photo ID"
         photo_identification_details: "Provide details. For example, passport or driving licence."
         other: "Other"

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -42,7 +42,7 @@ Given "I have completed the Candidate Requirements selection step" do
     Given I am on the 'candidate requirements selection' page
     And I check "They must apply or have applied to your or a partner school's teacher training course"
     And I check "They must live locally"
-    And I enter '7' into the 'Tell us within how many miles of your school. For example, 20 miles.' text area
+    And I enter '7' into the 'Tell us within how many miles of your school. For example, 20.' text area
     And I check 'Other'
     And I enter 'Some details' into the 'Provide details.' text area
     When I submit the form


### PR DESCRIPTION
### Trello card
https://trello.com/c/OqYRD1pR

### Context
Some users are confused from the example we provide and try to type the word `miles` in the "maximum distance from school" field.

### Changes proposed in this pull request
Remove the word `miles` from the label to make it a bit more clear that the field expects a number value. 

### Guidance to review

