### PR TITLE
Allow connections to webpack dev server

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -27,11 +27,16 @@ Rails.application.config.content_security_policy_nonce_directives = %w[script-sr
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 # Rails.application.config.content_security_policy_report_only = true
 
+# Allow connections to webpack-dev-server
+if Rails.env.development?
+  connect_src = ['https://localhost:3035', 'wss://localhost:3035']
+end
+
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self
 
   policy.base_uri :self
-  policy.connect_src :self, "https://dc.services.visualstudio.com", "https://www.google-analytics.com"
+  policy.connect_src :self, "https://dc.services.visualstudio.com", "https://www.google-analytics.com", *connect_src
   policy.img_src :self, "https://www.google-analytics.com"
   policy.object_src :none
   policy.script_src :self,

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -52,7 +52,7 @@ development:
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
-    https: false
+    https: true
     host: localhost
     port: 3035
     public: localhost:3035


### PR DESCRIPTION
### Trello card
https://trello.com/c/vWT6CZmd/

### Context
The local dev env is failing to connect to the webpack-dev-server because 
1. it tries `https://localhost:3035`, but the server uses `http://`
2. the CSP is blocking the connections

### Changes proposed in this pull request
Start the server with ssl and update the CSP to allow the connections.

### Guidance to review
Visit https://localhost:3035/sockjs-node/ and accept/allow the self-signed certificate. Then open visit the app and check there are no related errors in the browser's dev console.