### PR TITLE
Make the site header link context dependent

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -112,6 +112,14 @@ module ApplicationHelper
     end
   end
 
+  def site_header_path
+    if in_schools_namespace?
+      schools_dashboard_path
+    else
+      root_path
+    end
+  end
+
 private
 
   def valid_user?(user)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -44,7 +44,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to @site_header_text || 'Get school experience', root_path,
+          <%= link_to @site_header_text || 'Get school experience', site_header_path,
                 class: 'govuk-header__link govuk-header__link--service-name' %>
         </div>
       </div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -108,4 +108,29 @@ describe ApplicationHelper, type: :helper do
       it { expect(page_title).to eql('Page Title | DfE School Experience') }
     end
   end
+
+  describe "#site_header_path" do
+    let(:request) { double('request') }
+    let(:path) { double('path') }
+
+    before do
+      allow(request).to receive(:path).and_return(path)
+    end
+
+    context 'when in schools namespace' do
+      it 'returns the schools dashboard path' do
+        allow(path).to receive(:start_with?).with('/schools').and_return(true)
+
+        expect(site_header_path).to eql(schools_dashboard_path)
+      end
+    end
+
+    context 'when not in schools namespace' do
+      it 'returns the root path' do
+        allow(path).to receive(:start_with?).with('/schools').and_return(false)
+
+        expect(site_header_path).to eql(root_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/fr2sSkra
### Context
Currently the top site header is linked to the homepage, driving the school managers away from the school dashboard when clicking it. Making it context dependent will keep the candidates on the main website and the school managers in the school dashboard.

### Changes proposed in this pull request
Add a helper method to return the school dashboard root path for the school dashboard pages and the root path for any other page.

### Guidance to review
Clicking the "Manage school experience" header from any page in the school dashboard, should send you in the school dashboard root page.
