### PR TITLE
Update Gemfile to reduce vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby File.read(".ruby-version").chomp
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.1.4'
+gem 'rails', '~> 6.1.4', '>= 6.1.4.1'
 
 gem 'json', '>= 2.3.0' # Fix for CVE-2020-10663
 
@@ -23,7 +23,7 @@ gem 'geocoder'
 gem 'puma', '~> 5.4'
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'webpacker'
+gem 'webpacker', '>= 5.4.0'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
@@ -31,7 +31,7 @@ gem 'webpacker'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
-gem 'dotenv-rails'
+gem 'dotenv-rails', '>= 2.7.6'
 
 gem 'govuk_elements_form_builder', github: 'DFE-Digital/govuk_elements_form_builder'
 gem 'notifications-ruby-client'
@@ -48,7 +48,7 @@ gem 'kaminari'
 
 gem 'phonelib'
 gem 'sentry-delayed_job'
-gem 'sentry-rails'
+gem 'sentry-rails', '>= 4.6.5'
 gem 'sentry-ruby'
 
 gem 'rack-attack'
@@ -71,9 +71,9 @@ gem 'flipper-ui'
 gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teaching-api-ruby-client", require: "api/client"
 
 # Ignore cloudfront IPs when getting customer IP address
-gem 'actionpack-cloudfront'
+gem 'actionpack-cloudfront', '>= 1.1.0'
 
-gem 'invisible_captcha'
+gem 'invisible_captcha', '>= 2.0.0'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
@@ -89,9 +89,9 @@ group :development, :test do
   gem 'pry-rails'
 
   # Testing framework
-  gem 'factory_bot_rails'
+  gem 'factory_bot_rails', '>= 6.2.0'
   gem 'rspec_junit_formatter'
-  gem 'rspec-rails', '~> 5.0'
+  gem 'rspec-rails', '~> 5.0', '>= 5.0.2'
   gem 'rspec-sonarqube-formatter'
 
   gem 'brakeman', '>= 4.4.0'
@@ -104,7 +104,7 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5'
-  gem 'web-console'
+  gem 'web-console', '>= 4.1.0'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
@@ -123,10 +123,10 @@ group :test do
   gem 'selenium-webdriver'
   gem 'webdrivers'
 
-  gem 'cucumber-rails', require: false
+  gem 'cucumber-rails', '>= 2.4.0', require: false
   gem 'database_cleaner'
 
-  gem 'rails-controller-testing'
+  gem 'rails-controller-testing', '>= 1.0.5'
   gem "rspec-json_expectations", "~> 2.2"
   gem 'shoulda-matchers', '~> 5.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,28 +34,28 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actioncable (6.1.4)
-      actionpack (= 6.1.4)
-      activesupport (= 6.1.4)
+    actioncable (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       nio4r (~> 2.0)
       websocket-driver (>= 0.6.1)
-    actionmailbox (6.1.4)
-      actionpack (= 6.1.4)
-      activejob (= 6.1.4)
-      activerecord (= 6.1.4)
-      activestorage (= 6.1.4)
-      activesupport (= 6.1.4)
+    actionmailbox (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      activejob (= 6.1.4.1)
+      activerecord (= 6.1.4.1)
+      activestorage (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       mail (>= 2.7.1)
-    actionmailer (6.1.4)
-      actionpack (= 6.1.4)
-      actionview (= 6.1.4)
-      activejob (= 6.1.4)
-      activesupport (= 6.1.4)
+    actionmailer (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      actionview (= 6.1.4.1)
+      activejob (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       mail (~> 2.5, >= 2.5.4)
       rails-dom-testing (~> 2.0)
-    actionpack (6.1.4)
-      actionview (= 6.1.4)
-      activesupport (= 6.1.4)
+    actionpack (6.1.4.1)
+      actionview (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       rack (~> 2.0, >= 2.0.9)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
@@ -63,39 +63,39 @@ GEM
     actionpack-cloudfront (1.1.0)
       actionpack (>= 4.2)
       railties (>= 4.2)
-    actiontext (6.1.4)
-      actionpack (= 6.1.4)
-      activerecord (= 6.1.4)
-      activestorage (= 6.1.4)
-      activesupport (= 6.1.4)
+    actiontext (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      activerecord (= 6.1.4.1)
+      activestorage (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       nokogiri (>= 1.8.5)
-    actionview (6.1.4)
-      activesupport (= 6.1.4)
+    actionview (6.1.4.1)
+      activesupport (= 6.1.4.1)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activejob (6.1.4)
-      activesupport (= 6.1.4)
+    activejob (6.1.4.1)
+      activesupport (= 6.1.4.1)
       globalid (>= 0.3.6)
-    activemodel (6.1.4)
-      activesupport (= 6.1.4)
-    activerecord (6.1.4)
-      activemodel (= 6.1.4)
-      activesupport (= 6.1.4)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activerecord (6.1.4.1)
+      activemodel (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
     activerecord-import (1.2.0)
       activerecord (>= 3.2)
     activerecord-postgis-adapter (7.1.1)
       activerecord (~> 6.1)
       rgeo-activerecord (~> 7.0.0)
-    activestorage (6.1.4)
-      actionpack (= 6.1.4)
-      activejob (= 6.1.4)
-      activerecord (= 6.1.4)
-      activesupport (= 6.1.4)
+    activestorage (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      activejob (= 6.1.4.1)
+      activerecord (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       marcel (~> 1.0.0)
       mini_mime (>= 1.1.0)
-    activesupport (6.1.4)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -300,7 +300,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0704)
-    mini_mime (1.1.0)
+    mini_mime (1.1.1)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
@@ -367,20 +367,20 @@ GEM
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rack-timeout (0.6.0)
-    rails (6.1.4)
-      actioncable (= 6.1.4)
-      actionmailbox (= 6.1.4)
-      actionmailer (= 6.1.4)
-      actionpack (= 6.1.4)
-      actiontext (= 6.1.4)
-      actionview (= 6.1.4)
-      activejob (= 6.1.4)
-      activemodel (= 6.1.4)
-      activerecord (= 6.1.4)
-      activestorage (= 6.1.4)
-      activesupport (= 6.1.4)
+    rails (6.1.4.1)
+      actioncable (= 6.1.4.1)
+      actionmailbox (= 6.1.4.1)
+      actionmailer (= 6.1.4.1)
+      actionpack (= 6.1.4.1)
+      actiontext (= 6.1.4.1)
+      actionview (= 6.1.4.1)
+      activejob (= 6.1.4.1)
+      activemodel (= 6.1.4.1)
+      activerecord (= 6.1.4.1)
+      activestorage (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       bundler (>= 1.15.0)
-      railties (= 6.1.4)
+      railties (= 6.1.4.1)
       sprockets-rails (>= 2.0.0)
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
@@ -394,11 +394,11 @@ GEM
       activesupport (>= 4.2)
       choice (~> 0.2.0)
       ruby-graphviz (~> 1.2)
-    rails-html-sanitizer (1.3.0)
+    rails-html-sanitizer (1.4.1)
       loofah (~> 2.3)
-    railties (6.1.4)
-      actionpack (= 6.1.4)
-      activesupport (= 6.1.4)
+    railties (6.1.4.1)
+      actionpack (= 6.1.4.1)
+      activesupport (= 6.1.4.1)
       method_source
       rake (>= 0.13)
       thor (~> 1.0)
@@ -580,7 +580,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionpack-cloudfront
+  actionpack-cloudfront (>= 1.1.0)
   activerecord-import
   activerecord-postgis-adapter (~> 7.1)
   acts_as_list
@@ -593,14 +593,14 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   capybara-screenshot
-  cucumber-rails
+  cucumber-rails (>= 2.4.0)
   daemons
   database_cleaner
   delayed_cron_job
   delayed_job_active_record
   delayed_job_web
-  dotenv-rails
-  factory_bot_rails
+  dotenv-rails (>= 2.7.6)
+  factory_bot_rails (>= 6.2.0)
   faraday
   flipper
   flipper-active_support_cache_store
@@ -610,7 +610,7 @@ DEPENDENCIES
   geocoder
   get_into_teaching_api_client_faraday!
   govuk_elements_form_builder!
-  invisible_captcha
+  invisible_captcha (>= 2.0.0)
   json (>= 2.3.0)
   kaminari
   listen (>= 3.0.5)
@@ -626,18 +626,18 @@ DEPENDENCIES
   rack-attack
   rack-rewrite
   rack-timeout
-  rails (~> 6.1.4)
-  rails-controller-testing
+  rails (~> 6.1.4, >= 6.1.4.1)
+  rails-controller-testing (>= 1.0.5)
   rails-erd
   redis (~> 4.4)
   rspec-json_expectations (~> 2.2)
-  rspec-rails (~> 5.0)
+  rspec-rails (~> 5.0, >= 5.0.2)
   rspec-sonarqube-formatter
   rspec_junit_formatter
   rubocop-govuk
   selenium-webdriver
   sentry-delayed_job
-  sentry-rails
+  sentry-rails (>= 4.6.5)
   sentry-ruby
   shoulda-matchers (~> 5.0)
   simplecov
@@ -647,10 +647,10 @@ DEPENDENCIES
   tzinfo-data
   uk_postcode
   validates_timeliness (>= 5.0.0.beta1)
-  web-console
+  web-console (>= 4.1.0)
   webdrivers
   webmock
-  webpacker
+  webpacker (>= 5.4.0)
 
 RUBY VERSION
    ruby 2.7.3p183


### PR DESCRIPTION
Snyk created the #1898 #1899 PRs which update the `Gemfile`, but not the `Gemfile.lock`.

This PR replaces both of them.