### PR TITLE
Update the links to GIT

### DIFF
--- a/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
+++ b/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
@@ -14,11 +14,11 @@ Request school experience at other schools - ((school_search_url))
 
 # Arrange independent experience
 
-If you can’t find anything in your area you can arrange school experience independently by contacting schools direct - https://getintoteaching.education.gov.uk/school-experience/arranging-school-experience-independently
+If you can’t find anything in your area you can arrange school experience independently by contacting schools direct - https://getintoteaching.education.gov.uk/steps-to-become-a-teacher
 
 # Help and support
 
 Use our Get Into Teaching service by calling 0800 389 2500 (8am to 8pm, Mon to Fri) or by visiting https://getintoteaching.education.gov.uk/ to:
 
 * receive free one-to-one support and advice and get all your questions about teaching answered by our team of trained professionals
-* reserve your place on one of our free nationwide teaching events - https://getintoteaching.education.gov.uk/teaching-events
+* reserve your place on one of our free nationwide teaching events - https://getintoteaching.education.gov.uk/events

--- a/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
+++ b/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
@@ -14,7 +14,7 @@ Request school experience at other schools - ((school_search_url))
 
 # Arrange independent experience
 
-If you can’t find anything in your area you can arrange school experience independently by contacting schools direct - https://getintoteaching.education.gov.uk/steps-to-become-a-teacher
+If you can’t find anything in your area you can arrange school experience independently by contacting schools direct - https://getintoteaching.education.gov.uk/get-school-experience
 
 # Help and support
 

--- a/app/views/candidates/schools/_expanded_search.html.erb
+++ b/app/views/candidates/schools/_expanded_search.html.erb
@@ -23,7 +23,7 @@
         To find out about arranging school experience with schools who are
         not yet on this website visit
         <%= link_to 'Get into teaching',
-          'https://getintoteaching.education.gov.uk/school-experience/arranging-school-experience-independently' %>.
+          'https://getintoteaching.education.gov.uk/steps-to-become-a-teacher' %>.
       </p>
     <%- end -%>
   </div>

--- a/app/views/candidates/schools/_expanded_search.html.erb
+++ b/app/views/candidates/schools/_expanded_search.html.erb
@@ -23,7 +23,7 @@
         To find out about arranging school experience with schools who are
         not yet on this website visit
         <%= link_to 'Get into teaching',
-          'https://getintoteaching.education.gov.uk/steps-to-become-a-teacher' %>.
+          'https://getintoteaching.education.gov.uk/get-school-experience' %>.
       </p>
     <%- end -%>
   </div>

--- a/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
@@ -52,7 +52,7 @@
     <p>
       If you need any further help and support getting school experience or
       becoming a teacher visit the
-      <%= link_to "Get Into Teaching", 'https://getintoteaching.education.gov.uk/school-experience' %>
+      <%= link_to "Get Into Teaching", 'https://getintoteaching.education.gov.uk/get-school-experience' %>
       website.
     </p>
   </section>

--- a/app/views/schools/placement_requests/cancellations/_letter.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_letter.html.erb
@@ -52,7 +52,7 @@
     <p>
       If you need any further help and support getting school experience or
       becoming a teacher visit the
-      <%= link_to "Get Into Teaching", 'https://getintoteaching.education.gov.uk/school-experience' %>
+      <%= link_to "Get Into Teaching", 'https://getintoteaching.education.gov.uk/get-school-experience' %>
       website.
     </p>
   </section>

--- a/app/views/shared/candidates/_alert_notification.html.erb
+++ b/app/views/shared/candidates/_alert_notification.html.erb
@@ -6,6 +6,6 @@
     <p>In light of measures in place due to the response to coronavirus (COVID-19) school experience may be affected. Some schools are offering online alternatives which can be found in the schools detail page.</p>
 
     <p>More detailed guidance on what this means for teaching training applications can be found here
-      <a href="https://getintoteaching.education.gov.uk/impact-of-covid-19-on-teacher-training">https://getintoteaching.education.gov.uk/impact-of-covid-19-on-teacher-training</a></p>
+      <a href="https://getintoteaching.education.gov.uk/covid-19">https://getintoteaching.education.gov.uk/covid-19</a></p>
   </strong>
 </div>

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -154,6 +154,6 @@ end
 
 Then("there should be a link to Get into teaching") do
   within('#results li.expanded-search-radius') do
-    expect(page).to have_link("Get into teaching", href: 'https://getintoteaching.education.gov.uk/school-experience/arranging-school-experience-independently')
+    expect(page).to have_link("Get into teaching", href: 'https://getintoteaching.education.gov.uk/steps-to-become-a-teacher')
   end
 end

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -154,6 +154,6 @@ end
 
 Then("there should be a link to Get into teaching") do
   within('#results li.expanded-search-radius') do
-    expect(page).to have_link("Get into teaching", href: 'https://getintoteaching.education.gov.uk/steps-to-become-a-teacher')
+    expect(page).to have_link("Get into teaching", href: 'https://getintoteaching.education.gov.uk/get-school-experience')
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/cKz8j36p

### Context
GSE is using old urls to link to GIT service, but they still work because GIT has redirects in place.

### Changes proposed in this pull request
Update the links to GIT based on the GIT redirects.
