### PR TITLE
Migrate the feedback forms to govuk_elements_form_builder

### DIFF
--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,40 +1,40 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Give feedback on this service</h1>
-    <%= form_for feedback do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+    <%= govuk_form_for feedback do |f| %>
+      <%= f.govuk_error_summary %>
       <p>
         Help us improve the school experience service.
       </p>
 
       <%= f.hidden_field :referrer %>
 
-      <%= f.radio_button_fieldset :reason_for_using_service do |fieldset| %>
-        <% f.object.reasons_for_using_service.each do |option| %>
+      <%= f.govuk_radio_buttons_fieldset :reason_for_using_service do %>
+        <% @feedback.reasons_for_using_service.each do |option| %>
           <% if f.object.requires_explanation? option %>
-            <%= fieldset.radio_input option do %>
-              <%= fieldset.text_area :reason_for_using_service_explanation %>
+            <%= f.govuk_radio_button :reason_for_using_service, option, link_errors: true do %>
+              <%= f.govuk_text_area :reason_for_using_service_explanation %>
             <% end %>
           <% else %>
-            <%= fieldset.radio_input option %>
+            <%= f.govuk_radio_button :reason_for_using_service, option, link_errors: true %>
           <% end %>
         <% end %>
       <% end %>
 
-      <%= f.radio_button_fieldset :successful_visit do |fieldset| %>
-        <%= fieldset.radio_input true %>
-        <%= fieldset.radio_input false do %>
-          <%= fieldset.text_area :unsuccessful_visit_explanation %>
+      <%= f.govuk_radio_buttons_fieldset :successful_visit do %>
+        <%= f.govuk_radio_button :successful_visit, 'true', link_errors: true %>
+        <%= f.govuk_radio_button :successful_visit, 'false', link_errors: true do %>
+          <%= f.govuk_text_area :unsuccessful_visit_explanation %>
         <% end %>
       <% end %>
 
-      <%= f.radio_button_fieldset :rating do |fieldset| %>
+      <%= f.govuk_radio_buttons_fieldset :rating do %>
         <% f.object.ratings.each do |option| %>
-          <%= fieldset.radio_input option %>
+          <%= f.govuk_radio_button :rating, option, link_errors: true %>
         <% end %>
       <% end %>
 
-      <%= f.text_area :improvements, rows: 5, label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
+      <%= f.govuk_text_area :improvements, rows: 5, label: { class: 'govuk-heading-m' } do %>
         <p>
           <%= content_for :pii_warning %>
         </p>
@@ -42,7 +42,7 @@
 
       <%= invisible_captcha %>
 
-      <%= f.submit 'Submit feedback' %>
+      <%= f.govuk_submit 'Submit feedback' %>
     <% end %>
 
     <h2 class="govuk-heading-m">Help and support</h2>

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -10,27 +10,27 @@
       <%= f.hidden_field :referrer %>
 
       <%= f.govuk_radio_buttons_fieldset :reason_for_using_service do %>
-        <% @feedback.reasons_for_using_service.each do |option| %>
+        <% @feedback.reasons_for_using_service.each_with_index do |option, i| %>
           <% if f.object.requires_explanation? option %>
-            <%= f.govuk_radio_button :reason_for_using_service, option, link_errors: true do %>
+            <%= f.govuk_radio_button :reason_for_using_service, option, link_errors: i.zero? do %>
               <%= f.govuk_text_area :reason_for_using_service_explanation %>
             <% end %>
           <% else %>
-            <%= f.govuk_radio_button :reason_for_using_service, option, link_errors: true %>
+            <%= f.govuk_radio_button :reason_for_using_service, option, link_errors: i.zero? %>
           <% end %>
         <% end %>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :successful_visit do %>
         <%= f.govuk_radio_button :successful_visit, 'true', link_errors: true %>
-        <%= f.govuk_radio_button :successful_visit, 'false', link_errors: true do %>
+        <%= f.govuk_radio_button :successful_visit, 'false' do %>
           <%= f.govuk_text_area :unsuccessful_visit_explanation %>
         <% end %>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :rating do %>
-        <% f.object.ratings.each do |option| %>
-          <%= f.govuk_radio_button :rating, option, link_errors: true %>
+        <% f.object.ratings.each_with_index do |option, i| %>
+          <%= f.govuk_radio_button :rating, option, link_errors: i.zero? %>
         <% end %>
       <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -111,7 +111,7 @@ en:
       unsuccessful_visit_explanation:
         blank: 'Provide details'
 
-  feedback_fieldset: &feedback_fieldset
+  feedback_legend: &feedback_legend
     reason_for_using_service: What did you come to do on the service?
     rating: Overall, how did you feel about the service you received?
     successful_visit: 'Did you achieve what you wanted from your visit?'
@@ -120,10 +120,10 @@ en:
     improvements: How could we improve the service? (optional)
     reason_for_using_service_explanation: 'Tell us what you came here to do. Do not include any information that could identify you personally - such as your name'
     unsuccessful_visit_explanation: 'Give details'
-    successful_visit:
+    successful_visit_options:
       true: 'Yes'
       false: 'No'
-    rating:
+    rating_options:
       very_satisfied: 'Very satisfied'
       satisfied: 'Satisfied'
       neither_satisfied_or_dissatisfied: 'Neither satisfied or dissatisfied'
@@ -589,11 +589,6 @@ en:
       schools_placement_dates_subject_selection:
         subject_ids: Select school experience subjects
 
-      candidates_feedback:
-        <<: *feedback_fieldset
-      schools_feedback:
-        <<: *feedback_fieldset
-
     hint:
       schools_placement_requests_confirm_booking:
         placement_details: You can add extra experience details
@@ -875,14 +870,23 @@ en:
 
       candidates_feedback:
         <<: *feedback_label
-        reason_for_using_service:
+        reason_for_using_service_options:
           make_a_school_experience_request: 'Make a school experience request'
           withdraw_request_or_cancel_booking: 'Withdraw a request or cancel a booking'
           something_else: 'Something else'
+        successful_visit_options:
+          true: 'Yes'
+          false: 'No'
+        rating_options:
+          very_satisfied: 'Very satisfied'
+          satisfied: 'Satisfied'
+          neither_satisfied_or_dissatisfied: 'Neither satisfied or dissatisfied'
+          dissatisfied: 'Dissatisfied'
+          very_dissatisfied: 'Very dissatisfied'
 
       schools_feedback:
         <<: *feedback_label
-        reason_for_using_service:
+        reason_for_using_service_options:
           set_up_new_school: 'Set up a new school or schools on the service'
           manage_school_experience_requests_and_bookings: 'Manage your school experience requests and bookings'
           set_up_new_school_experience: 'Set up new School Experience Day(s)'
@@ -906,6 +910,11 @@ en:
       schools_csv_export_form:
         from_date: "From date"
         to_date: "To date"
+      candidates_feedback:
+        <<: *feedback_legend
+      schools_feedback:
+        <<: *feedback_legend
+
   views:
     pagination:
       next: Next


### PR DESCRIPTION
### Trello card
https://trello.com/c/oXzEM7Qz/181-migrate-the-feedback-form

### Context
Migrate the feedback forms from the deprecated `govuk_elements_form_builder` to `govuk_elements_form_builder`

### Changes proposed in this pull request
Update the localisation file and the feedback form partial

### Guidance to review
Visit the candidate and school feedback pages.  They should look and behave exactly the same with before.
