### PR TITLE
[WIP] Auto reject candidate requests

### DIFF
--- a/app/controllers/candidates/registrations/background_checks_controller.rb
+++ b/app/controllers/candidates/registrations/background_checks_controller.rb
@@ -7,9 +7,16 @@ module Candidates
 
       def create
         @background_check = BackgroundCheck.new background_check_params
+# binding.pry
         if @background_check.valid?
-          persist @background_check
-          redirect_to next_step_path
+
+          school = Bookings::School.find_by!(urn: params[:school_id])
+          if school.profile&.dbs_requires_check? && @background_check.has_dbs_check == false
+            render :rejected
+          else
+            persist @background_check
+            redirect_to next_step_path
+          end
         else
           render :new
         end
@@ -24,8 +31,13 @@ module Candidates
         @background_check.assign_attributes background_check_params
 
         if @background_check.valid?
-          persist @background_check
-          redirect_to candidates_school_registrations_application_preview_path
+          school = Bookings::School.find_by!(urn: params[:school_id])
+          if school.profile&.dbs_requires_check? && @background_check.has_dbs_check == false
+            render :rejected
+          else
+            persist @background_check
+            redirect_to candidates_school_registrations_application_preview_path
+          end
         else
           render :edit
         end

--- a/app/models/bookings/profile.rb
+++ b/app/models/bookings/profile.rb
@@ -102,6 +102,10 @@ class Bookings::Profile < ApplicationRecord
     dbs_policy_conditions.nil?
   end
 
+  def dbs_requires_check?
+    dbs_policy_conditions != 'notrequired'
+  end
+
 private
 
   def at_least_one_phase
@@ -138,9 +142,5 @@ private
 
   def other_fee_assigned
     other_fee_amount_pounds && other_fee_amount_pounds.to_f.positive?
-  end
-
-  def dbs_requires_check?
-    dbs_policy_conditions != 'notrequired'
   end
 end

--- a/app/services/candidates/registrations/request_rejecter.rb
+++ b/app/services/candidates/registrations/request_rejecter.rb
@@ -1,0 +1,41 @@
+module Candidates
+  module Registrations
+    class RequestRejecter
+      def initialize(school, bg_check, cur_registration)
+        @school = school
+        @bg_check = bg_check
+        @cur_registration = cur_registration
+      end
+
+      def rejected?
+        required_dbs_policy_applies? || inschool_dbs_policy_applies?
+      end
+
+    private
+
+      def school_requires_dbs?
+        @school.profile&.dbs_policy_conditions == "required"
+      end
+
+      def school_requires_dbs_for_inschool_only?
+        @school.profile&.dbs_policy_conditions == "inschool"
+      end
+
+      def candidate_does_not_have_dbs?
+        @bg_check.has_dbs_check == false
+      end
+
+      def candidate_requests_inschool_experience?
+        !@cur_registration.subject_and_date_information.placement_date.virtual?
+      end
+
+      def required_dbs_policy_applies?
+        school_requires_dbs? && candidate_does_not_have_dbs?
+      end
+
+      def inschool_dbs_policy_applies?
+        (school_requires_dbs_for_inschool_only? && candidate_requests_inschool_experience? && candidate_does_not_have_dbs?)
+      end
+    end
+  end
+end

--- a/app/views/candidates/registrations/background_checks/rejected.html.erb
+++ b/app/views/candidates/registrations/background_checks/rejected.html.erb
@@ -1,0 +1,18 @@
+<% self.page_title = 'Request rejected' %>
+
+<%= govuk_back_link edit_candidates_school_registrations_background_check_path(
+          anchor: 'candidates_registrations_background_check_has_dbs_check_container'
+        ) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Your request has been rejected</h1>
+    <p>
+      This school requires to have a DBS certificate.
+    </p>
+    <p>
+      <strong>
+        <%= link_to "Find out more about 'DBS checks' and 'DBS certificates'", 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about' %>
+      </strong>
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
### Trello card
https://trello.com/c/PFqJy41Y/162-dev-add-autoreject-functionality-for-schools-that-require-a-dbs-check

### Context
Many candidate who don't have DBS checks, apply to for school experience to school which require DBS, adding admin burden to the school managers.

### Changes proposed in this pull request
**This is a work in progress.**

Add a service object to reject candidate's request based on their choices and the school requirements.
Add a rejection page

### Guidance to review
There are two cases the request will get auto-rejected:
1. Apply to a school that requires dbs and select `No` in the "Background and security checks" page
2. Apply to a school that requires dbs only for in school experiences and select an `in school` date in the "School experience date" page and then select `No` in the "Background and security checks" page

All the other cases should be accepted. For example: 
- Apply to a school that requires dbs only for `in school` experiences and choose a virtual date and that you don't have  a dbs check. The request should not get auto-rejected.
