### PR TITLE
Migrate the cookie preferences form to govuk_design_system_formbuilder

### DIFF
--- a/app/views/cookie_preferences/edit.html.erb
+++ b/app/views/cookie_preferences/edit.html.erb
@@ -25,12 +25,12 @@
           for us to use.
         </p>
 
-        <%= form_for cookie_preferences do |f| %>
-          <%= GovukElementsErrorsHelper.error_summary @preference, 'There is a problem', '' %>
+        <%= govuk_form_for cookie_preferences do |f| %>
+          <%= f.govuk_error_summary %>
 
-          <%= f.radio_button_fieldset :analytics do |fieldset| %>
-            <%= fieldset.radio_input true %>
-            <%= fieldset.radio_input false %>
+          <%= f.govuk_radio_buttons_fieldset :analytics do |fieldset| %>
+            <%= f.govuk_radio_button :analytics, 'true', link_errors: true %>
+            <%= f.govuk_radio_button :analytics, 'false' %>
           <% end %>
 
           <div class="govuk-form-group">
@@ -60,7 +60,7 @@
             <%= link_to 'Find out more about cookies on this service', cookies_policy_path %>
           </p>
 
-          <%= f.submit 'Save your cookie settings' %>
+          <%= f.govuk_submit 'Save your cookie settings' %>
         <% end %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -732,7 +732,7 @@ en:
       candidates_verification_code:
         code: Enter your verification code here
       cookie_preference:
-        analytics:
+        analytics_options:
           true: "On"
           false: "Off"
       query: Find what?


### PR DESCRIPTION
### Trello card
https://trello.com/c/0JRIkXZE

### Context
Migrate the cookie preferences form from the deprecated `govuk_elements_form_builder` to `govuk_elements_form_builder`

### Changes proposed in this pull request
Update the localisation file and use the `govuk_elements_form_builder` helpers to render the form

### Guidance to review
Visit the cookie page. Should look and behave exactly the same with before.

