### PR TITLE
Rename the Change school button to Select school

### DIFF
--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -18,7 +18,7 @@
             <% end %>
           <% end %>
 
-          <%= f.submit "Change school" %>
+          <%= f.submit "Select school" %>
         <% end %>
 
         <%- if Schools::ChangeSchool.request_approval_url -%>

--- a/features/schools/signin.feature
+++ b/features/schools/signin.feature
@@ -15,12 +15,12 @@ Feature: School Chooser
             | School B |
         But no radio buttons should be selected
         Then I choose 'School A' from the 'Select your school' radio buttons
-        And I click the 'Change school' submit button
+        And I click the 'Select school' submit button
         Then I should be on the 'schools dashboard' page
         Then the page's main heading should be 'Manage requests and bookings at School A'
     
     @mocks
-    Scenario: Changing school
+    Scenario: Selecting school
         Given I am signed in as School A
         And I am on the 'schools dashboard' page
         Then the page's main heading should be 'Manage requests and bookings at School A'
@@ -31,7 +31,7 @@ Feature: School Chooser
             | School B |
         And 'School A' radio button should be selected
         Then I choose 'School B' from the 'Select your school' radio buttons
-        And I click the 'Change school' submit button
+        And I click the 'Select school' submit button
         Then I should be on the 'schools dashboard' page
         Then the page's main heading should be 'Manage requests and bookings at School B'
         

--- a/features/step_definitions/schools/signin_steps.rb
+++ b/features/step_definitions/schools/signin_steps.rb
@@ -18,5 +18,5 @@ end
 Given("I am signed in as School A") do
   step "I am on the 'School chooser' page"
   step "I choose 'School A' from the 'Select your school' radio buttons"
-  step "I click the 'Change school' submit button"
+  step "I click the 'Select school' submit button"
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/lawfXBty/196-dev-update-the-change-school-button-to-say-select-school

### Context
Users find the `Change school` button confusing when there's only one school list. Changing it to `Select school` will hopefully make it less confusing.

### Changes proposed in this pull request
Update the submit button in the Change school page

### Guidance to review
|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/951947/133096488-e3a17f39-31d3-478d-a816-d13fa58fb17e.png)|![after](https://user-images.githubusercontent.com/951947/133096514-8152f34e-ff46-45f0-b59f-68801daa12b2.png)}
