### PR TITLE
Update the change school layout

### DIFF
--- a/app/controllers/schools/change_schools_controller.rb
+++ b/app/controllers/schools/change_schools_controller.rb
@@ -13,6 +13,11 @@ module Schools
     end
 
     def create
+      if change_school_params[:change_to_urn] == "request access"
+        redirect_to schools_request_organisation_path
+        return
+      end
+
       @change_school = Schools::ChangeSchool.new \
         current_user, school_uuids(reload: true), change_school_params
 

--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -16,16 +16,20 @@
                 <% end %>
               </div>
             <% end %>
+            <% if Schools::ChangeSchool.request_approval_url %>
+              <div class= 'govuk-radios__divider'>or</div>
+              <div class="govuk-radios__item">
+                  <%= f.radio_button :change_to_urn, "request access", class: 'govuk-radios__input' %>
+
+                  <%= f.label :change_to_urn, class: 'govuk-label govuk-radios__label', value: "request access" do %>
+                    Request access to another school
+                  <% end %>
+              </div>
+            <% end %>
           <% end %>
 
-          <%= f.submit "Select school" %>
+          <%= f.submit "Continue" %>
         <% end %>
-
-        <%- if Schools::ChangeSchool.request_approval_url -%>
-          <p>
-            <%= govuk_link_to "Request access to a school", schools_request_organisation_path, secondary: true %>
-          </p>
-        <%- end -%>
       <% elsif Schools::ChangeSchool.request_approval_url %>
         <h1 class="govuk-heading-l">Manage school experience</h1>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -247,7 +247,7 @@ en:
         schools/change_school:
           attributes:
             change_to_urn:
-              blank: Select a school
+              blank: Select an option
               inclusion: Select a school from the list
 
         schools/on_boarding/dbs_requirement:

--- a/features/schools/signin.feature
+++ b/features/schools/signin.feature
@@ -15,7 +15,7 @@ Feature: School Chooser
             | School B |
         But no radio buttons should be selected
         Then I choose 'School A' from the 'Select your school' radio buttons
-        And I click the 'Select school' submit button
+        And I click the 'Continue' submit button
         Then I should be on the 'schools dashboard' page
         Then the page's main heading should be 'Manage requests and bookings at School A'
     
@@ -31,7 +31,7 @@ Feature: School Chooser
             | School B |
         And 'School A' radio button should be selected
         Then I choose 'School B' from the 'Select your school' radio buttons
-        And I click the 'Select school' submit button
+        And I click the 'Continue' submit button
         Then I should be on the 'schools dashboard' page
         Then the page's main heading should be 'Manage requests and bookings at School B'
         

--- a/features/step_definitions/schools/signin_steps.rb
+++ b/features/step_definitions/schools/signin_steps.rb
@@ -18,5 +18,5 @@ end
 Given("I am signed in as School A") do
   step "I am on the 'School chooser' page"
   step "I choose 'School A' from the 'Select your school' radio buttons"
-  step "I click the 'Select school' submit button"
+  step "I click the 'Continue' submit button"
 end

--- a/spec/controllers/schools/change_schools_controller_spec.rb
+++ b/spec/controllers/schools/change_schools_controller_spec.rb
@@ -54,15 +54,23 @@ describe Schools::ChangeSchoolsController, type: :request do
       let(:change_school_page) { get '/schools/change' }
       subject { post('/schools/change', params: params) }
 
-      it { is_expected.to redirect_to(schools_dashboard_path) }
+      context 'when the request access to another school option is chosen' do
+        let(:params) { { schools_change_school: { change_to_urn: "request access" } } }
 
-      specify 'it should have updated the urn and name stored in the session' do
-        change_school_page
-        expect(request.session.fetch(:urn)).to eql(old_school.urn)
+        it { is_expected.to redirect_to(schools_request_organisation_path) }
+      end
 
-        subject
-        expect(request.session.fetch(:urn)).to eql(new_school.urn)
-        expect(request.session.fetch(:school_name)).to eql(new_school.name)
+      context 'when a school is chosen' do
+        it { is_expected.to redirect_to(schools_dashboard_path) }
+
+        specify 'it should have updated the urn and name stored in the session' do
+          change_school_page
+          expect(request.session.fetch(:urn)).to eql(old_school.urn)
+
+          subject
+          expect(request.session.fetch(:urn)).to eql(new_school.urn)
+          expect(request.session.fetch(:school_name)).to eql(new_school.name)
+        end
       end
     end
 

--- a/spec/views/schools/change_schools/show.html.erb_spec.rb
+++ b/spec/views/schools/change_schools/show.html.erb_spec.rb
@@ -97,9 +97,8 @@ describe 'schools/change_schools/show.html.erb', type: :view do
 
     before { render }
 
-    specify 'there should be an request access button' do
-      expect(rendered).to have_css "a.govuk-button.govuk-button--secondary",
-        text: 'Request access to a school'
+    specify 'there should be an request access option' do
+      expect(rendered).to have_css("input[type='radio'][value='request access']")
     end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/pSezDoaD

### Context
Users are not clear about the role of the select your school page, and are suffering a number of issues. 

### Changes proposed in this pull request
We've settled on this new design as it helps make clear the different options for the page, either selecting a school, or requesting access to it.

![image](https://user-images.githubusercontent.com/951947/133630855-75cf77f9-a751-482b-b0ec-239b24f4c3be.png)


