### PR TITLE
Adding help text for a common error

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,6 +19,11 @@ class PagesController < ApplicationController
 
   def help_and_support_access_needs; end
 
+  def schools_request_organisation
+    @dfe_sign_in_add_service_url =
+      Rails.application.config.x.dfe_sign_in_add_service_url.presence
+  end
+
   def maintenance
     render status: :service_unavailable
   end

--- a/app/views/pages/_request_organisation_access.html.erb
+++ b/app/views/pages/_request_organisation_access.html.erb
@@ -13,4 +13,26 @@
     <%= govuk_link_to "Request access to a school",
           Schools::ChangeSchool.request_approval_url %>
   </p>
+
+  <details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+    If you receive an error saying "You are already linked to this organisation"
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    This error means you have been associated with this school on DfE Sign In, but you need to have School Experience added to your account by an approver.
+
+    You can request this on DfE Sign In in the 'Services' section.
+
+    <p>
+    # Comment for Leo: I need this to link to the 'Add services to my account' part of DfE Sign in (link on Pre-prod is https://pp-services.signin.education.gov.uk/approvals/select-organisation?services=add)
+    Request access to School Experience.
+
+    </p>
+  </div>
+</details>
+
+
+
 </section>

--- a/app/views/pages/_request_organisation_access.html.erb
+++ b/app/views/pages/_request_organisation_access.html.erb
@@ -24,9 +24,9 @@
     This error means you have been associated with this school on DfE Sign In, but you need to have School Experience added to your account by an approver.
 
     You can request this on DfE Sign In in the 'Services' section.
-    <p>
-      <%= link_to 'Request access to School Experience', @dfe_sign_in_add_service_url %>
-    </p>
+    <div class="govuk-!-margin-top-5">
+      <%= govuk_link_to 'Request access to School Experience', @dfe_sign_in_add_service_url %>
+    </div>
   </div>
 </details>
 

--- a/app/views/pages/_request_organisation_access.html.erb
+++ b/app/views/pages/_request_organisation_access.html.erb
@@ -24,11 +24,8 @@
     This error means you have been associated with this school on DfE Sign In, but you need to have School Experience added to your account by an approver.
 
     You can request this on DfE Sign In in the 'Services' section.
-
     <p>
-    # Comment for Leo: I need this to link to the 'Add services to my account' part of DfE Sign in (link on Pre-prod is https://pp-services.signin.education.gov.uk/approvals/select-organisation?services=add)
-    Request access to School Experience.
-
+      <%= link_to 'Request access to School Experience', @dfe_sign_in_add_service_url %>
     </p>
   </div>
 </details>

--- a/app/views/pages/_request_organisation_access.html.erb
+++ b/app/views/pages/_request_organisation_access.html.erb
@@ -15,21 +15,18 @@
   </p>
 
   <details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">
-    If you receive an error saying "You are already linked to this organisation"
-    </span>
-  </summary>
-  <div class="govuk-details__text">
-    This error means you have been associated with this school on DfE Sign In, but you need to have School Experience added to your account by an approver.
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+      If you receive an error saying "You are already linked to this organisation"
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      This error means you have been associated with this school on DfE Sign In, but you need to have School Experience added to your account by an approver.
 
-    You can request this on DfE Sign In in the 'Services' section.
-    <div class="govuk-!-margin-top-5">
-      <%= govuk_link_to 'Request access to School Experience', @dfe_sign_in_add_service_url %>
+      You can request this on DfE Sign In in the 'Services' section.
+      <div class="govuk-!-margin-top-5">
+        <%= govuk_link_to 'Request access to School Experience', @dfe_sign_in_add_service_url %>
+      </div>
     </div>
-  </div>
-</details>
-
-
-
+  </details>
 </section>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -111,6 +111,7 @@ Rails.application.configure do
   config.x.dfe_sign_in_api_role_check_enabled = ENV['DFE_SIGNIN_API_ROLE_CHECK_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_api_school_change_enabled = ENV['DFE_SIGNIN_API_SCHOOL_CHANGE_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_request_organisation_url = "https://pp-services.signin.education.gov.uk/request-organisation/search"
+  config.x.dfe_sign_in_add_service_url = "https://pp-services.signin.education.gov.uk/approvals/select-organisation?action=add-service"
 
   if ENV['NOTIFY_CLIENT'].present?
     Rails.application.config.x.notify_client = ENV['NOTIFY_CLIENT']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -162,6 +162,7 @@ Rails.application.configure do
   config.x.dfe_sign_in_api_role_check_enabled = ENV['DFE_SIGNIN_API_ROLE_CHECK_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_api_school_change_enabled = ENV['DFE_SIGNIN_API_SCHOOL_CHANGE_ENABLED']&.in?(truthy_strings)
   config.x.dfe_sign_in_request_organisation_url = "https://services.signin.education.gov.uk/request-organisation/search"
+  config.x.dfe_sign_in_add_service_url = "https://services.signin.education.gov.uk/approvals/select-organisation?action=add-service"
 
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
 

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   config.x.dfe_sign_in_api_school_change_enabled = false
   config.x.dfe_sign_in_request_organisation_url = ""
   config.x.dfe_sign_in_request_service_url = ""
+  config.x.dfe_sign_in_add_service_url = ""
 
   config.x.gitis.privacy_consent_id = '10'
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -5,5 +5,6 @@ Rails.application.configure do
   # Override any production defaults here
 
   config.x.dfe_sign_in_request_organisation_url = "https://pp-services.signin.education.gov.uk/request-organisation/search"
+  config.x.dfe_sign_in_add_service_url = "https://pp-services.signin.education.gov.uk/approvals/select-organisation?action=add-service"
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital/api"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -178,6 +178,7 @@ Rails.application.configure do
   config.x.dfe_sign_in_admin_service_id = '66666666-5555-aaaa-bbbb-cccccccccccc'
   config.x.dfe_sign_in_admin_role_id = '66666666-5555-4444-3333-222222222222'
   config.x.dfe_sign_in_request_organisation_url = nil
+  config.x.dfe_sign_in_add_service_url = nil
 
   config.x.gitis.privacy_consent_id = '10'
 


### PR DESCRIPTION
### Trello card
N/A

### Context
We have many user difficulties with where they have been added/associated to a school, but do not have the School Experience service on DfE Sign In.

To rectify this, I've added some help text to a page where users are likely to experience the error.

@leoapost I need you to take this PR and ensure the link to DfE Sign In's add services to my account page: This is the pre-prod link: https://pp-services.signin.education.gov.uk/approvals/select-organisation?services=add

Can you make it so that it's formatted for Ruby in one of the link helpers?

### Changes proposed in this pull request

### Guidance to review

