### PR TITLE
Move the school changes confirmation to the summary page

### DIFF
--- a/app/controllers/schools/on_boarding/confirmations_controller.rb
+++ b/app/controllers/schools/on_boarding/confirmations_controller.rb
@@ -14,8 +14,8 @@ module Schools
           redirect_to schools_on_boarding_confirmation_path
         else
           @school = current_school_profile.bookings_school
-          @presenter = PreviewPresenter.new current_school_profile
-          render 'schools/on_boarding/previews/show'
+          @profile = SchoolProfilePresenter.new(current_school_profile)
+          render 'schools/on_boarding/profiles/show'
         end
       end
 

--- a/app/controllers/schools/on_boarding/previews_controller.rb
+++ b/app/controllers/schools/on_boarding/previews_controller.rb
@@ -11,7 +11,6 @@ module Schools
 
       def show
         @school = current_school_profile.bookings_school
-        @confirmation = Confirmation.new
         @presenter = PreviewPresenter.new current_school_profile
       end
     end

--- a/app/controllers/schools/on_boarding/profiles_controller.rb
+++ b/app/controllers/schools/on_boarding/profiles_controller.rb
@@ -8,6 +8,7 @@ module Schools
       end
 
       def show
+        @confirmation = Confirmation.new
         @profile = SchoolProfilePresenter.new(current_school_profile)
       end
     end

--- a/app/views/schools/on_boarding/previews/show.html.erb
+++ b/app/views/schools/on_boarding/previews/show.html.erb
@@ -6,25 +6,20 @@
   Preview your school experience profile
 </h1>
 
-<%= form_for @confirmation, url: schools_on_boarding_confirmation_path do |f| %>
-  <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
-  <p>
-    This is how your school will appear to candidates.
-  </p>
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    Any changes are not yet published. To publish your changes, go back and press 'Accept and set up profile'
+  </strong>
+</div>
 
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<p>
+  This is how your school will appear to candidates:
+</p>
 
+<div class="school-preview">
   <h2 class="govuk-heading-l govuk-!-margin-top-4"><%= @school.name %></h2>
 
   <%= render 'candidates/schools/phase2', school: @school, include_candidate_request_links: false %>
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-  <h2 class="govuk-heading-m">Set up your school experience profile</h2>
-
-  <div class="govuk-form-group" id="<%= f.form_group_id(:acceptance) %>">
-    <%= f.check_box_input :acceptance %>
-  </div>
-
-  <%= f.submit 'Accept and set up profile' %>
-<% end %>
+</div>

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -14,58 +14,69 @@
     </h1>
 
     <div class="govuk-warning-text">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-    Any changes are not yet saved. To save changes, press continue at the bottom of the page.
-  </strong>
-</div>
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        Any changes are not yet published. To publish changes, press 'Accept and set up profile' at the bottom of the page.
+      </strong>
+    </div>
 
-    <h2 class="govuk-heading-m">School details</h2>
-    <dl class="govuk-summary-list">
-      <%= summary_row 'Full name', @profile.school_name %>
-      <%= summary_row 'Address', @profile.school_address %>
-    </dl>
+    <%= form_for @confirmation, url: schools_on_boarding_confirmation_path do |f| %>
+      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
-    <h2 class="govuk-heading-m">School experience details</h2>
-    <dl class="govuk-summary-list">
-      <%= summary_row 'Fees', @profile.fees, edit_schools_on_boarding_fees_path %>
-      <%= summary_row 'DBS check required', @profile.dbs_check, edit_schools_on_boarding_dbs_requirement_path %>
-      <%= summary_row 'Individual requirements', split_to_list(@profile.individual_requirements), edit_schools_on_boarding_candidate_requirements_choice_path %>
-      <%= summary_row 'School experience phases', @profile.school_experience_phases, edit_schools_on_boarding_phases_list_path %>
-      <%= summary_row 'Primary key stages', @profile.primary_key_stages, \
-        @profile.primary_key_stages_offered? ? edit_schools_on_boarding_key_stage_list_path : edit_schools_on_boarding_phases_list_path %>
-      <%= summary_row 'Subjects', @profile.subjects, \
-        @profile.subjects_offered? ? edit_schools_on_boarding_subjects_path : edit_schools_on_boarding_phases_list_path %>
-      <%= summary_row 'Description', safe_format(@profile.descriptions), edit_schools_on_boarding_description_path %>
-      <%= summary_row 'School experience details', safe_format(@profile.school_experience_details), edit_schools_on_boarding_experience_outline_path %>
-      <%= summary_row 'Teacher training links', @profile.teacher_training_links, edit_schools_on_boarding_experience_outline_path %>
-    </dl>
+      <h2 class="govuk-heading-m">School details</h2>
+      <dl class="govuk-summary-list">
+        <%= summary_row 'Full name', @profile.school_name %>
+        <%= summary_row 'Address', @profile.school_address %>
+      </dl>
 
-    <h2 class="govuk-heading-m">Candidate information</h2>
-    <dl class="govuk-summary-list">
-      <%= summary_row 'Dress code', @profile.dress_code, edit_schools_on_boarding_candidate_experience_detail_path %>
-      <%= summary_row 'Parking', @profile.parking, edit_schools_on_boarding_candidate_experience_detail_path %>
-      <%= summary_row 'Show disabilities and access needs support', @profile.supports_access_needs_description, edit_schools_on_boarding_access_needs_support_path %>
-      <% if @profile.supports_access_needs? %>
-        <%= summary_row 'Disability and access needs', safe_format(@profile.disability_and_access_needs_description), edit_schools_on_boarding_access_needs_detail_path %>
-        <%= summary_row 'Disability Confident employer scheme', @profile.disability_confident_scheme, edit_schools_on_boarding_disability_confident_path %>
-        <%= summary_row 'Disability and access needs policy', @profile.disability_and_access_needs_policy, edit_schools_on_boarding_access_needs_policy_path %>
-      <% end %>
-      <%= summary_row 'Start time', @profile.start_time, edit_schools_on_boarding_candidate_experience_detail_path %>
-      <%= summary_row 'Finish time', @profile.end_time, edit_schools_on_boarding_candidate_experience_detail_path %>
-      <%= summary_row 'Flexible on times', @profile.flexible_on_times, edit_schools_on_boarding_candidate_experience_detail_path %>
-    </dl>
+      <h2 class="govuk-heading-m">School experience details</h2>
+      <dl class="govuk-summary-list">
+        <%= summary_row 'Fees', @profile.fees, edit_schools_on_boarding_fees_path %>
+        <%= summary_row 'DBS check required', @profile.dbs_check, edit_schools_on_boarding_dbs_requirement_path %>
+        <%= summary_row 'Individual requirements', split_to_list(@profile.individual_requirements), edit_schools_on_boarding_candidate_requirements_choice_path %>
+        <%= summary_row 'School experience phases', @profile.school_experience_phases, edit_schools_on_boarding_phases_list_path %>
+        <%= summary_row 'Primary key stages', @profile.primary_key_stages, \
+          @profile.primary_key_stages_offered? ? edit_schools_on_boarding_key_stage_list_path : edit_schools_on_boarding_phases_list_path %>
+        <%= summary_row 'Subjects', @profile.subjects, \
+          @profile.subjects_offered? ? edit_schools_on_boarding_subjects_path : edit_schools_on_boarding_phases_list_path %>
+        <%= summary_row 'Description', safe_format(@profile.descriptions), edit_schools_on_boarding_description_path %>
+        <%= summary_row 'School experience details', safe_format(@profile.school_experience_details), edit_schools_on_boarding_experience_outline_path %>
+        <%= summary_row 'Teacher training links', @profile.teacher_training_links, edit_schools_on_boarding_experience_outline_path %>
+      </dl>
 
-    <h2 class="govuk-heading-m">Admin contact details</h2>
-    <dl class="govuk-summary-list">
-      <%= summary_row 'UK telephone number', @profile.admin_contact_phone, edit_schools_on_boarding_admin_contact_path %>
-      <%= summary_row 'Email address', @profile.admin_contact_email, edit_schools_on_boarding_admin_contact_path %>
-      <% if @profile.admin_contact_email_secondary.present? %>
-        <%= summary_row 'Secondary email address', @profile.admin_contact_email_secondary, edit_schools_on_boarding_admin_contact_path %>
-      <% end %>
-    </dl>
+      <h2 class="govuk-heading-m">Candidate information</h2>
+      <dl class="govuk-summary-list">
+        <%= summary_row 'Dress code', @profile.dress_code, edit_schools_on_boarding_candidate_experience_detail_path %>
+        <%= summary_row 'Parking', @profile.parking, edit_schools_on_boarding_candidate_experience_detail_path %>
+        <%= summary_row 'Show disabilities and access needs support', @profile.supports_access_needs_description, edit_schools_on_boarding_access_needs_support_path %>
+        <% if @profile.supports_access_needs? %>
+          <%= summary_row 'Disability and access needs', safe_format(@profile.disability_and_access_needs_description), edit_schools_on_boarding_access_needs_detail_path %>
+          <%= summary_row 'Disability Confident employer scheme', @profile.disability_confident_scheme, edit_schools_on_boarding_disability_confident_path %>
+          <%= summary_row 'Disability and access needs policy', @profile.disability_and_access_needs_policy, edit_schools_on_boarding_access_needs_policy_path %>
+        <% end %>
+        <%= summary_row 'Start time', @profile.start_time, edit_schools_on_boarding_candidate_experience_detail_path %>
+        <%= summary_row 'Finish time', @profile.end_time, edit_schools_on_boarding_candidate_experience_detail_path %>
+        <%= summary_row 'Flexible on times', @profile.flexible_on_times, edit_schools_on_boarding_candidate_experience_detail_path %>
+      </dl>
 
-    <%= govuk_link_to 'Continue', schools_on_boarding_preview_path %>
+      <h2 class="govuk-heading-m">Admin contact details</h2>
+      <dl class="govuk-summary-list">
+        <%= summary_row 'UK telephone number', @profile.admin_contact_phone, edit_schools_on_boarding_admin_contact_path %>
+        <%= summary_row 'Email address', @profile.admin_contact_email, edit_schools_on_boarding_admin_contact_path %>
+        <% if @profile.admin_contact_email_secondary.present? %>
+          <%= summary_row 'Secondary email address', @profile.admin_contact_email_secondary, edit_schools_on_boarding_admin_contact_path %>
+        <% end %>
+      </dl>
+
+      <div class="govuk-form-group" id="<%= f.form_group_id(:acceptance) %>">
+        <%= f.check_box_input :acceptance %>
+      </div>
+
+      <%= f.submit 'Accept and set up profile' %>
+      <div>
+        <%= govuk_link_to 'Preview profile', schools_on_boarding_preview_path, class: 'govuk-button--secondary' %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/webpacker/stylesheets/application.scss
+++ b/app/webpacker/stylesheets/application.scss
@@ -42,6 +42,7 @@ $govuk-grid-widths: (
 @import "school-dashboard" ;
 @import "alert-counters" ;
 @import "school-placement-dates" ;
+@import "school-preview" ;
 @import "school-profile" ;
 @import "service-update" ;
 @import "map" ;

--- a/app/webpacker/stylesheets/school-preview.scss
+++ b/app/webpacker/stylesheets/school-preview.scss
@@ -1,0 +1,4 @@
+.school-preview {
+  background-color: govuk-colour("light-grey");
+  padding: 50px;
+}

--- a/features/schools/onboarding/preview.feature
+++ b/features/schools/onboarding/preview.feature
@@ -28,7 +28,7 @@ Feature: Preview profile
             | Access needs policy              |                           |
             | Experience Outline               |                           |
             | Admin contact                    |                           |
-        When I click the 'Continue' button
+        When I click the 'Preview profile' button
 
     Scenario: Page contents
         Then I should see the correctly-formatted school placement information I entered in the wizard

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -70,19 +70,17 @@ Feature: School Profile
       | Secondary email address                    | s.skinner@springfield.edu                                                                                                                                                                                                                                   |
 
   Scenario: Publishing without accepting the privacy policy
-      Given I click the 'Continue' button
-      When I click the 'Accept and set up profile' button
+      Given I click the 'Accept and set up profile' button
       Then I should see an error
 
   Scenario: Publishing with accepting the privacy policy
-      Given I click the 'Continue' button
-      And I check the 'By checking this box and setting up your school experience profile' checkbox
+      Given I check the 'By checking this box and setting up your school experience profile' checkbox
       When I click the 'Accept and set up profile' button
       Then the page title should be "You've successfully set up your school experience profile"
 
   @smoke_test
   Scenario: Publishing with accepting the privacy policy
-      Given I click the 'Continue' button
+      Given I click the 'Accept and set up profile' button
       And I check the 'By checking this box and setting up your school experience profile' checkbox
       And I click the 'Accept and set up profile' button
       When I am on the profile page for the school

--- a/spec/controllers/schools/on_boarding/confirmations_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/confirmations_controller_spec.rb
@@ -25,7 +25,7 @@ describe Schools::OnBoarding::ConfirmationsController, type: :request do
       end
 
       it 'rerenders the profile show page' do
-        expect(response).to render_template 'schools/on_boarding/previews/show'
+        expect(response).to render_template 'schools/on_boarding/profiles/show'
       end
 
       it 'does not updated the school profile' do


### PR DESCRIPTION
### Trello card
https://trello.com/c/C5P1oX2U/199-change-the-on-boarding-preview-step-to-be-optional

### Context
The problem is that school managers believe they have published their school profile changes when they see the summary page and they skip the preview and confirmation steps.

In order to make it less confusing, we are changing the workflow to allow school managers to publish their changes from the summary page instead.

### Changes proposed in this pull request
- move the confirmation action that publishes the changes, from the preview page to the summary page
- make the preview page optional with enhanced visuals to spot the preview content easier
