### PR TITLE
Prevent submitting requests that do not meet the school dbs requirements

### DIFF
--- a/app/services/candidates/registrations/dbs_requirments_checker.rb
+++ b/app/services/candidates/registrations/dbs_requirments_checker.rb
@@ -1,0 +1,33 @@
+module Candidates
+  module Registrations
+    class DbsRequirmentsChecker
+      def initialize(school, bg_check, current_registration)
+        @school = school
+        @bg_check = bg_check
+        @current_registration = current_registration
+      end
+
+      def requirements_met?
+        dbs_is_not_required? || candidate_has_dbs? || (dbs_only_for_inschool? && virtual_experience?)
+      end
+
+    private
+
+      def dbs_is_not_required?
+        @school.profile&.dbs_policy_conditions == "notrequired"
+      end
+
+      def dbs_only_for_inschool?
+        @school.profile&.dbs_policy_conditions == "inschool"
+      end
+
+      def candidate_has_dbs?
+        @bg_check.has_dbs_check == true
+      end
+
+      def virtual_experience?
+        @current_registration.subject_and_date_information.placement_date.virtual?
+      end
+    end
+  end
+end

--- a/app/views/candidates/registrations/background_checks/unmet_requirements.html.erb
+++ b/app/views/candidates/registrations/background_checks/unmet_requirements.html.erb
@@ -1,0 +1,16 @@
+<% self.page_title = 'DBS certificate is required' %>
+
+<%= govuk_back_link edit_candidates_school_registrations_background_check_path(
+          anchor: 'candidates_registrations_background_check_has_dbs_check_container'
+        ) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You need a DBS certificate at this school</h1>
+    <p>This school requires you to have a DBS certificate. There are schools on the service that do not require a DBS certificate.</p>
+    <p>
+      <strong>
+        <%= link_to "Find out more about 'DBS checks' and 'DBS certificates'", 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about' %>
+      </strong>
+    </p>
+  </div>
+</div>

--- a/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/background_checks_controller_spec.rb
@@ -182,17 +182,34 @@ describe Candidates::Registrations::BackgroundChecksController, type: :request d
 
       context 'valid' do
         let :background_check do
-          FactoryBot.build :background_check, has_dbs_check: false
+          FactoryBot.build :background_check, has_dbs_check: has_dbs_check
         end
 
-        it 'updates the session with the new details' do
-          expect(registration_session.background_check).to \
-            eq_model background_check
+        context 'with met dbs requirements' do
+          let(:has_dbs_check) { true }
+
+          it 'updates the session with the new details' do
+            expect(registration_session.background_check).to \
+              eq_model background_check
+          end
+
+          it 'redirects to the application preview' do
+            expect(response).to redirect_to \
+              '/candidates/schools/11048/registrations/application_preview'
+          end
         end
 
-        it 'redirects to the application preview' do
-          expect(response).to redirect_to \
-            '/candidates/schools/11048/registrations/application_preview'
+        context 'with unmet dbs requirements' do
+          let(:has_dbs_check) { false }
+
+          it 'updates the session with the new details' do
+            expect(registration_session.background_check).not_to \
+              eq_model background_check
+          end
+
+          it 'redirects to the application preview' do
+            expect(response).to render_template :unmet_requirements
+          end
         end
       end
     end

--- a/spec/services/candidates/registrations/dbs_requirments_checker_spec.rb
+++ b/spec/services/candidates/registrations/dbs_requirments_checker_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+describe Candidates::Registrations::DbsRequirmentsChecker do
+  let(:school) { double(:school) }
+  let(:bg_check) { double(:bg_check) }
+  let(:current_registration) { double(:current_registration) }
+
+  describe '#rejected?' do
+    subject { described_class.new(school, bg_check, current_registration).requirements_met? }
+
+    before do
+      allow(school).to receive_message_chain('profile.dbs_policy_conditions').and_return(dbs_policy)
+      allow(bg_check).to receive(:has_dbs_check).and_return(dbs_check)
+      allow(current_registration).to \
+        receive_message_chain('subject_and_date_information.placement_date.virtual?')
+        .and_return(virtual_date)
+    end
+
+    context 'when school does not requires dbs check' do
+      let(:dbs_policy) { "notrequired" }
+
+      context 'when candidate wants a virtual experience' do
+        let(:virtual_date) { true }
+
+        context 'when candidate has dbs check' do
+          let(:dbs_check) { true }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when candidate does not have dbs check' do
+          let(:dbs_check) { false }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when candidate wants an in-school experience' do
+        let(:virtual_date) { false }
+
+        context 'when candidate has dbs check' do
+          let(:dbs_check) { true }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when candidate does not have dbs check' do
+          let(:dbs_check) { false }
+
+          it { is_expected.to be true }
+        end
+      end
+    end
+
+    context 'when school always requires dbs check' do
+      let(:dbs_policy) { "required" }
+
+      context 'when candidate wants a virtual experience' do
+        let(:virtual_date) { true }
+
+        context 'when candidate has dbs check' do
+          let(:dbs_check) { true }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when candidate does not have dbs check' do
+          let(:dbs_check) { false }
+
+          it { is_expected.to be false }
+        end
+      end
+
+      context 'when candidate wants an in-school experience' do
+        let(:virtual_date) { false }
+
+        context 'when candidate has dbs check' do
+          let(:dbs_check) { true }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when candidate does not have dbs check' do
+          let(:dbs_check) { false }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+
+    context 'when school requires dbs check only for in-school experiences' do
+      let(:dbs_policy) { "inschool" }
+
+      context 'when candidate wants a virtual experience' do
+        let(:virtual_date) { true }
+
+        context 'when candidate has dbs check' do
+          let(:dbs_check) { true }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when candidate does not have dbs check' do
+          let(:dbs_check) { false }
+
+          it { is_expected.to be true }
+        end
+      end
+
+      context 'when candidate wants an in-school experience' do
+        let(:virtual_date) { false }
+
+        context 'when candidate has dbs check' do
+          let(:dbs_check) { true }
+
+          it { is_expected.to be true }
+        end
+
+        context 'when candidate does not have dbs check' do
+          let(:dbs_check) { false }
+
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Decrease admin burden for the school managers and give candidates instant
feedback when their school experience request does not meet the schools
dbs requirements.

### Trello card
https://trello.com/c/PFqJy41Y

### Context
Many candidate requests do not meet the background checks required by the schools which eventually will have to get rejected. 
This cause the following problems: 
1. that the candidates need to wait for their requests to get processed, only to see they were rejected
2. it adds admin burden to the school managers who they have to manually check all the requests

Therefore we are adding an auto-check in the `background checks` step to
- give instant feedback to the users when the school dbs requirements are not met
- prevent the request from being submitted, which will decrease the admin burden

### Changes proposed in this pull request
Cross check the school DBS requirements with the candidate's choices (school experience type and DBS certificate) before candidates submit their request.

### Guidance to review
Apply to a school that required a DBS certificate and choose `No` in the `Background and security checks` step and you should see a new page saying the school requires a DBS certificate. Go back and choose `Yes` and you should see the `Check your answers` page
