### PR TITLE
Use the schools privacy policy in the school dashboard

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,9 +75,15 @@
               <li class="govuk-footer__inline-list-item">
                 <%= link_to 'Cookies', edit_cookie_preference_path, class: 'govuk-footer__link' %>
               </li>
-              <li class="govuk-footer__inline-list-item">
-                <%= link_to 'Privacy policy', privacy_policy_path, class: 'govuk-footer__link' %>
-              </li>
+              <% if in_schools_namespace? %>
+                <li class="govuk-footer__inline-list-item">
+                  <%= link_to 'Privacy policy', schools_privacy_policy_path, class: 'govuk-footer__link' %>
+                </li>
+              <% else %>
+                <li class="govuk-footer__inline-list-item">
+                  <%= link_to 'Privacy policy', privacy_policy_path, class: 'govuk-footer__link' %>
+                </li>
+              <% end %>
               <li class="govuk-footer__inline-list-item">
                 <%= link_to 'Accessibility statement', accessibility_statement_path, class: 'govuk-footer__link' %>
               </li>


### PR DESCRIPTION
### Trello card
https://trello.com/c/hIRbGJtt

### Context
In the footer of the school dashboard we link the `privacy policy` to the latest policy (fetched from the CRM), but there's another policy for the schools which is already used in the on boarding process and probably should be used in the footer as well.

### Changes proposed in this pull request
Use the school privacy policy in the school dashboard footer.

