### PR TITLE
Update start page - new copy PLUS amends to content dashboard

### DIFF
--- a/app/views/candidates/home/index.html.erb
+++ b/app/views/candidates/home/index.html.erb
@@ -16,9 +16,11 @@
     </p>
 
     <p>
-      You’ll need to provide personal details which schools will use to decide
-      whether they can offer you school experience. They may contact you for
-      further information.
+      You will need:
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the right to work in the UK</li>
+        <li>a degree (or be studying for a one)</li>
+      </ul>
     </p>
 
     <% if @applications_deactivated %>
@@ -40,7 +42,13 @@
         Education's <%= link_to 'Get Into Teaching Information Service', 'https://getintoteaching.education.gov.uk/' %>
         to receive tailored advice about becoming a teacher.
       </p>
-
+      
+      <p>
+      You’ll need to provide personal details which schools will use to decide
+      whether they can offer you school experience. They may contact you for
+      further information.
+      </p>            
+      
       <p>
         During school holidays, schools may take longer to respond to requests.
       </p>

--- a/app/views/schools/dashboards/_account_admin.html.erb
+++ b/app/views/schools/dashboards/_account_admin.html.erb
@@ -35,13 +35,13 @@
       <%= link_to "Update school profile", schools_on_boarding_profile_path %>
     </header>
     <span class="govuk-hint">
-      Add, edit and remove school profile details
+      Update school details, placement details and requirements
     </span>
   </div>
 
   <div id="manage-requests" class="subection">
     <header class="dashboard-medium-priority">
-      <%= link_to "Turn requests on / off", edit_schools_enabled_path %>
+      <%= link_to "Switch profile on or off", edit_schools_enabled_path %>
     </header>
     <span class="govuk-hint">
       Choose to stop / start receiving requests from candidates.

--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -14,8 +14,7 @@
       <%= link_to "Change how dates are displayed", edit_schools_availability_preference_path %>
     </header>
     <span class="govuk-hint">
-    Show specific dates, or a description of when you can host candidates
-  </span> 
-
+      Show specific dates, or a description of when you can host candidates
+    </span> 
   </div>
 </section>

--- a/app/views/schools/dashboards/_manage_dates.html.erb
+++ b/app/views/schools/dashboards/_manage_dates.html.erb
@@ -4,7 +4,7 @@
   <%- if @current_school.availability_preference_fixed? -%>
     <div id="add-remove-and-change-dates" class="subsection">
       <header class="dashboard-medium-priority">
-        <%= link_to "Add, remove and change dates", schools_placement_dates_path %>
+        <%= link_to "Manage dates", schools_placement_dates_path %>
       </header>
     </div>
   <%- end -%>

--- a/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
@@ -13,7 +13,7 @@
 
   <div id="bookings" class="subsection">
     <header class="dashboard-high-priority">
-      <%= link_to "Manage bookings", schools_bookings_path  %>
+      <%= link_to "Manage upcoming bookings", schools_bookings_path  %>
       <%= numbered_circle(@bookings_requiring_attention, id: 'new-bookings-counter', aria_label: 'new upcoming bookings') %>
     </header>
     <p class="govuk-hint">View, change or cancel bookings</p>

--- a/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_new_requests_and_bookings.html.erb
@@ -29,9 +29,9 @@
 
   <div id="withdrawn-requests" class="subsection">
     <header class="dashboard-high-priority">
-      <%= link_to "Withdrawn requests", schools_withdrawn_requests_path  %>
+      <%= link_to "View withdrawn requests", schools_withdrawn_requests_path  %>
       <%= numbered_circle(@withdrawn_requests, id: 'withdrawn-requests-counter', aria_label: 'requests withdrawn by candidate') %>
     </header>
-    <p class="govuk-hint">A candidate has cancelled their request</p>
+    <p class="govuk-hint">View details of withdrawn requests, including reasons for withdrawal</p>
   </div>
 </section>

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -58,7 +58,7 @@ Feature: The School Dashboard
         Then I should see the following 'medium-priority' links:
             | Text                                   | Hint | Path                                  |
             | Change how dates are displayed | Show specific dates, or a description of when you can host candidates | /schools/availability_preference/edit |
-            | Add, remove and change dates           | None | /schools/placement_dates              |
+            | Manage dates           | None | /schools/placement_dates              |
 
     Scenario: Adding, removing and changing dates not visible when not fixed and dates not present
         Given my school has fully-onboarded
@@ -67,7 +67,7 @@ Feature: The School Dashboard
         Then I should see the following 'medium-priority' links:
             | Text                                   | Hint | Path                                  |
             | Change how dates are displayed | Show specific dates, or a description of when you can host candidates | /schools/availability_preference/edit |
-            | Add, remove and change dates           | None | /schools/placement_dates              |
+            | Manage dates           | None | /schools/placement_dates              |
 
 
     Scenario: Account admin
@@ -78,8 +78,8 @@ Feature: The School Dashboard
             | View rejected requests         | View request dates, subjects, candidate names and reasons for rejection | /schools/rejected_requests   |
             | View previous bookings         | View booking dates, subjects and candidate names and attendance         | /schools/previous_bookings   |
             | Download requests and bookings | Download all requests and bookings as a CSV file                        | /schools/csv_export          |
-            | Update school profile          | Add, edit and remove school profile details                             | /schools/on_boarding/profile |
-            | Turn requests on / off         | Choose to stop / start receiving requests from candidates               | /schools/toggle_enabled/edit |
+            | Update school profile          | Update school details, placement details and requirements                             | /schools/on_boarding/profile |
+            | Switch profile on or off         | Choose to stop / start receiving requests from candidates               | /schools/toggle_enabled/edit |
 
     Scenario: Low priority headings
         Given my school has fully-onboarded
@@ -110,12 +110,12 @@ Feature: The School Dashboard
     Scenario: Hide the enable/disable link if schools not onboarded
         Given my school has not yet fully-onboarded
         When I am on the 'schools dashboard' page
-        Then there should be no 'Turn requests on / off' link
+        Then there should be no 'Switch profile on or off' link
 
     Scenario: Show the enable/disable link when schools are onboarded
         Given my school has fully-onboarded
         When I am on the 'schools dashboard' page
-        Then I should see a 'Turn requests on / off' link to the 'toggle requests' page
+        Then I should see a 'Switch profile on or off' link to the 'toggle requests' page
 
     Scenario: Displaying a warning when fixed with no dates
         Given my school has fully-onboarded

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -40,7 +40,7 @@ Feature: The School Dashboard
         Then I should see the following 'high-priority' links:
             | Text            | Hint                                           | Path                        |
             | Manage requests | Accept, reject or revisit outstanding requests | /schools/placement_requests |
-            | Manage bookings | View, change or cancel bookings                | /schools/bookings           |
+            | Manage upcoming bookings | View, change or cancel bookings                | /schools/bookings           |
 
     Scenario: Manage dates
         Given my school has fully-onboarded


### PR DESCRIPTION
Following prototype by Gary. Link here: https://get-school-experience-prototype.london.cloudapps.digital/reduce-rejection/start-page#

Removed one bullet point on advice from policy officials.

The aim of this is to reduce rejection rates by being clearer upfront on some of the requirements.

---

Also, updating some indentation from a previous PR.