### PR TITLE
Content improvements and update tests (requests on/off pages)

### DIFF
--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -22,7 +22,7 @@ module Schools::DashboardsHelper
   end
 
   def school_enabled_description(school)
-    school.enabled? ? "enabled" : "disabled"
+    school.enabled? ? "on" : "off"
   end
 
   def show_no_placement_dates_warning?(school)

--- a/app/views/schools/dashboards/_account_admin.html.erb
+++ b/app/views/schools/dashboards/_account_admin.html.erb
@@ -41,7 +41,7 @@
 
   <div id="manage-requests" class="subection">
     <header class="dashboard-medium-priority">
-      <%= link_to "Switch profile on or off", edit_schools_enabled_path %>
+      <%= link_to "Turn profile on or off", edit_schools_enabled_path %>
     </header>
     <span class="govuk-hint">
       Choose to stop or start receiving requests.

--- a/app/views/schools/dashboards/_account_admin.html.erb
+++ b/app/views/schools/dashboards/_account_admin.html.erb
@@ -44,8 +44,8 @@
       <%= link_to "Switch profile on or off", edit_schools_enabled_path %>
     </header>
     <span class="govuk-hint">
-      Choose to stop or start receiving requests from candidates.
-      Requests are currently <strong><%= school_enabled_description(@current_school) %></strong>.
+      Choose to stop or start receiving requests.
+      Your profile is currently <strong><%= school_enabled_description(@current_school) %></strong>.
     </span>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,7 +507,7 @@ en:
       bookings_booking:
         date: Booking date
       bookings_school:
-        enabled: Turn requests on or off
+        enabled: Turn profile on or off
         availability_preference_fixed: Choose how dates are displayed
         experience_type: School experience type
       bookings_placement_date:
@@ -594,8 +594,8 @@ en:
         placement_details: You can add extra experience details
       bookings_school:
         enabled: |
-          Turning requests off will prevent your school from appearing in candidate searches.
-          Requests that are already in-progress will continue as normal.
+          Turning your profile off will stop your school from appearing in searches.
+          Requests that are already in progress will continue as normal.
         availability_preference_fixed: Select how you'd like to present school experience dates to candidates.
         experience_type: Do you offer school experiences in school, via the internet or both
       bookings_placement_date:

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -79,7 +79,7 @@ Feature: The School Dashboard
             | View previous bookings         | View booking dates, subjects, candidate names and attendance         | /schools/previous_bookings   |
             | Download requests and bookings | Download all requests and bookings as a CSV file                        | /schools/csv_export          |
             | Update school profile          | Update school details, placement details and requirements                             | /schools/on_boarding/profile |
-            | Turn profile on or off         | Choose to stop or start receiving requests from candidates               | /schools/toggle_enabled/edit |
+            | Turn profile on or off         | Choose to stop or start receiving requests               | /schools/toggle_enabled/edit |
 
     Scenario: Low priority headings
         Given my school has fully-onboarded

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -79,7 +79,7 @@ Feature: The School Dashboard
             | View previous bookings         | View booking dates, subjects, candidate names and attendance         | /schools/previous_bookings   |
             | Download requests and bookings | Download all requests and bookings as a CSV file                        | /schools/csv_export          |
             | Update school profile          | Update school details, placement details and requirements                             | /schools/on_boarding/profile |
-            | Switch profile on or off         | Choose to stop or start receiving requests from candidates               | /schools/toggle_enabled/edit |
+            | Turn profile on or off         | Choose to stop or start receiving requests from candidates               | /schools/toggle_enabled/edit |
 
     Scenario: Low priority headings
         Given my school has fully-onboarded
@@ -110,12 +110,12 @@ Feature: The School Dashboard
     Scenario: Hide the enable/disable link if schools not onboarded
         Given my school has not yet fully-onboarded
         When I am on the 'schools dashboard' page
-        Then there should be no 'Switch profile on or off' link
+        Then there should be no 'Turn profile on or off' link
 
     Scenario: Show the enable/disable link when schools are onboarded
         Given my school has fully-onboarded
         When I am on the 'schools dashboard' page
-        Then I should see a 'Switch profile on or off' link to the 'toggle requests' page
+        Then I should see a 'Turn profile on or off' link to the 'toggle requests' page
 
     Scenario: Displaying a warning when fixed with no dates
         Given my school has fully-onboarded

--- a/features/schools/toggle_enabling_and_disabling.feature
+++ b/features/schools/toggle_enabling_and_disabling.feature
@@ -13,14 +13,14 @@ Feature: Toggling being enabled and disabled
 
     Scenario: Page contents
         Given I am on the 'toggle requests' page
-        Then I should see radio buttons for 'Turn requests on or off' with the following options:
+        Then I should see radio buttons for 'Turn profile on or off' with the following options:
             | Allow requests        |
             | Do not allow requests |
 
     Scenario: Disabling an enabled school
         Given my school is enabled
         And I am on the 'toggle requests' page
-        When I choose 'Do not allow requests' from the 'Turn requests on or off' radio buttons
+        When I choose 'Do not allow requests' from the 'Turn profile on or off' radio buttons
         And I submit the form
         Then I should be on the 'schools dashboard' page
         And my school should be disabled
@@ -28,7 +28,7 @@ Feature: Toggling being enabled and disabled
     Scenario: Enabling a disabled school
         Given my school is disabled
         And I am on the 'toggle requests' page
-        When I choose 'Allow requests' from the 'Turn requests on or off' radio buttons
+        When I choose 'Allow requests' from the 'Turn profile on or off' radio buttons
         And I submit the form
         Then I should be on the 'schools dashboard' page
         And my school should be enabled

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -53,17 +53,17 @@ describe Schools::DashboardsHelper, type: 'helper' do
   describe '#school_enabled_description' do
     subject { school_enabled_description(school) }
 
-    context 'when enabled' do
+    context 'when on' do
       let(:school) { build(:bookings_school) }
-      specify "should be 'enabled' when enabled is true" do
-        expect(subject).to eql('enabled')
+      specify "should be 'on' when on is true" do
+        expect(subject).to eql('on')
       end
     end
 
-    context 'when disabled' do
-      let(:school) { build(:bookings_school, :disabled) }
-      specify "should be 'disabled' when enabled is false" do
-        expect(subject).to eql('disabled')
+    context 'when off' do
+      let(:school) { build(:bookings_school, :off) }
+      specify "should be 'off' when on is false" do
+        expect(subject).to eql('off')
       end
     end
   end

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -55,15 +55,15 @@ describe Schools::DashboardsHelper, type: 'helper' do
 
     context 'when enabled' do
       let(:school) { build(:bookings_school) }
-      specify "should be 'on' when enabled is true" do
-        expect(subject).to eql('on')
+      specify "should be 'enabled' when enabled is true" do
+        expect(subject).to eql('enabled')
       end
     end
 
     context 'when disabled' do
       let(:school) { build(:bookings_school, :disabled) }
-      specify "should be 'off' when enabled is false" do
-        expect(subject).to eql('off')
+      specify "should be 'disabled' when enabled is false" do
+        expect(subject).to eql('disabled')
       end
     end
   end

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -61,7 +61,7 @@ describe Schools::DashboardsHelper, type: 'helper' do
     end
 
     context 'when off' do
-      let(:school) { build(:bookings_school, :off) }
+      let(:school) { build(:bookings_school, :disabled) }
       specify "should be 'off' when on is false" do
         expect(subject).to eql('off')
       end

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -55,15 +55,15 @@ describe Schools::DashboardsHelper, type: 'helper' do
 
     context 'when enabled' do
       let(:school) { build(:bookings_school) }
-      specify "should be 'enabled' when enabled is true" do
-        expect(subject).to eql('enabled')
+      specify "should be 'on' when enabled is true" do
+        expect(subject).to eql('on')
       end
     end
 
     context 'when disabled' do
       let(:school) { build(:bookings_school, :disabled) }
-      specify "should be 'disabled' when enabled is false" do
-        expect(subject).to eql('disabled')
+      specify "should be 'off' when enabled is false" do
+        expect(subject).to eql('off')
       end
     end
   end


### PR DESCRIPTION
Comments from content designer to improve consistency and clarity of pages related to candidate requests.

Also merged #1989 into this following @peteryates comments on that.