### PR TITLE
update error message and tests

### DIFF
--- a/app/views/schools/dashboards/_your_school_is_disabled.html.erb
+++ b/app/views/schools/dashboards/_your_school_is_disabled.html.erb
@@ -1,15 +1,14 @@
 <div class="govuk-error-summary" role="alert" tabindex="-1" data-module="govuk-error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
-    Your school is currently disabled
+    Your school profile is currently turned off
   </h2>
   <div class="govuk-error-summary__body">
     <p>
-      You need to enable your school for it to appear in candidate
-      search results.
+      You need to turn your school profile on for it to appear in candidate search results.
     </p>
     <ul class="govuk-list govuk-error-summary__list">
       <li>
-        <%= link_to "Enable #{@current_school.name}",
+        <%= link_to "Turn profile on",
           edit_schools_enabled_path,
           class: 'govuk-se-warning__link govuk-!-font-weight-bold'
         %>

--- a/features/step_definitions/schools/dashboard_steps.rb
+++ b/features/step_definitions/schools/dashboard_steps.rb
@@ -80,7 +80,7 @@ Then("there should be no {string} link") do |link_text|
 end
 
 Then("I should see a warning that my school is disabled") do
-  expect(page).to have_css('.govuk-error-summary h2', text: 'Your school is currently disabled')
+  expect(page).to have_css('.govuk-error-summary h2', text: 'Your school profile is currently turned off')
 end
 
 Then("I shouldn't see any warnings") do


### PR DESCRIPTION
This is an update to mirror the new language on Profiles being 'on' instead of 'enabled'. Our error messages should be reflective of this new language.
