### PR TITLE
Add Routine to get next available static route

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,6 +360,14 @@ jobs:
            REFERENCE=${{github.ref}}   
            echo "REFERENCE=${REFERENCE}" >> $GITHUB_ENV
 
+      - name: Install Cloud Foundry
+        if: matrix.environment == 'Review' 
+        run: |
+          wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+          echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+          sudo apt-get update
+          sudo apt-get install cf7-cli  
+
       - name: Set Review specific variables
         if: matrix.environment == 'Review' 
         run: |
@@ -376,12 +384,29 @@ jobs:
            keyvault: ${{ secrets.KEY_VAULT}}
            secrets: 'SLACK-WEBHOOK, ACTIONS-API-ACCESS-TOKEN'
 
+      - uses: Azure/get-keyvault-secrets@v1.2
+        if: matrix.environment == 'Review' 
+        id:   azSecretPaaS
+        with:
+           keyvault: ${{ secrets.KEY_VAULT}}
+           secrets: 'PAAS-USERNAME, PAAS-PASSWORD'
+
+      - name: Login to Cloud Foundry
+        if: matrix.environment == 'Review' 
+        run: cf login -a api.london.cloud.service.gov.uk -u ${{steps.azSecretPaaS.outputs.PAAS-USERNAME}} -p ${{steps.azSecretPaaS.outputs.PAAS-PASSWORD}} -s get-into-teaching
+
+      - name: Get Static Route 
+        if: matrix.environment == 'Review' 
+        run: |
+              STATIC_ROUTE=$( ${GITHUB_WORKSPACE}/script/get_next_mapping.sh ${{env.REVIEW_APPLICATION}}-${{github.event.number}} )
+              echo "STATIC_ROUTE=${STATIC_ROUTE}" >> $GITHUB_ENV
+
       - name: Trigger Deployment to ${{matrix.environment}}
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
           token: ${{ steps.azSecret.outputs.ACTIONS-API-ACCESS-TOKEN }}
-          inputs: '{"environment": "${{matrix.environment}}", "sha": "${{ github.sha }}" , "pr": "${{github.event.number}}" }'
+          inputs: '{"environment": "${{matrix.environment}}", "sha": "${{ github.sha }}" , "pr": "${{github.event.number}}" , "static": "${{env.STATIC_ROUTE}}" }'
           ref: ${{env.REFERENCE}}
 
       - name: Wait for Deployment to ${{matrix.environment}}
@@ -402,7 +427,9 @@ jobs:
         if: matrix.environment == 'Review' 
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          message: Review app deployed to https://${{env.REVIEW_APPLICATION}}-${{github.event.number}}.${{env.DOMAIN}}
+          message: |
+                   Review app deployed to https://${{env.REVIEW_APPLICATION}}-${{github.event.number}}.${{env.DOMAIN}}
+                   Static DFE_SIGNIN Path used https://${{env.STATIC_ROUTE}}.london.cloudapps.digital
 
       - name: Add Review Label
         if: matrix.environment == 'Review' && contains(github.event.pull_request.user.login, 'dependabot') == false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
       pr:
         description: Pull Request Reference
         required: false
+      static:
+        description: Static Route
+        required: false
 
 jobs:
   validate:
@@ -80,6 +83,7 @@ jobs:
                  echo ::set-output name=healthcheck::${pr_name}
                  echo ::set-output name=key::${pr_name}
                  echo "TF_VAR_paas_application_name=${pr_name}" >> $GITHUB_ENV
+                 echo "TF_VAR_static_route=${{ github.event.inputs.static }}" >> $GITHUB_ENV
                  echo ::set-output name=docker_image::${{env.DOCKER_REPOSITORY}}:review-${{steps.sha.outputs.short}}
              fi
 

--- a/script/get_next_mapping.sh
+++ b/script/get_next_mapping.sh
@@ -1,0 +1,67 @@
+# Input variables
+ADD_ROUTE=${1}
+
+# Static Variables
+DOMAIN="london.cloudapps.digital"
+URL="https://api.london.cloud.service.gov.uk/v3/"
+STATIC="review-school-experience-"
+STATIC_START=1
+STATIC_END=10
+create=0
+
+# Get the token needed to run this
+TOKEN=$(cf oauth-token)
+
+
+#  List all the applications that we are interested in
+APPS=$(curl -s "${URL}/apps?per_page=2000"  -X GET  -H "Authorization: ${TOKEN}" | jq '.resources[] | select(.name | startswith("review-school-experience"))  | {name,guid}')
+
+# Check the route we want to add exists
+CURRENT=$(echo ${APPS} | jq --arg ROUTE "${ADD_ROUTE}"  '. | select (.name==$ROUTE) | {name,guid} ')
+if [[ -z "${CURRENT}"  ]] ; then
+   create=1
+else
+   create=1
+   GUID=$(echo ${CURRENT}  | jq -r '.guid' ) 
+   LIST_OF_ROUTES=$(curl -s "${URL}/routes?app_guids=${GUID}"  -X GET  -H "Authorization: ${TOKEN}" | jq '.resources[] | {host,guid,url}')
+   while read i; do
+      for (( v=${STATIC_START} ; v<${STATIC_END}+1 ; v++ )) 
+      do 
+          if [[ "${i}" == "${STATIC}${v}" ]] ; then
+	      echo "${i}"
+              create=0
+	      break
+          fi
+      done
+    done <<< "$( echo "${LIST_OF_ROUTES}" | jq -r  '.host ' )"
+fi
+
+if [[ ${create} == 1 ]]; then
+
+	   CSV_LIST=$( echo "${APPS}" | jq -r -c  '.guid ' | tr '\n' ',' )
+
+           LIST_OF_ROUTES=$(curl -s "${URL}/routes?per_page=2000&app_guids=${CSV_LIST}"  -X GET  -H "Authorization: ${TOKEN}" | jq '.resources[] | {host,guid,url}')
+
+	   for (( v=${STATIC_START} ; v<${STATIC_END}+1 ; v++ )) 
+           do 
+              USED[$v]=0
+              echo "${LIST_OF_ROUTES}" | jq -r -c  '.url ' | while read i; do
+		if [[ "${STATIC}${v}.${DOMAIN}" == ${i} ]]; then
+                    USED[$v]=1
+		fi
+              done
+           done
+
+	   c=${STATIC_START}
+	   for i in "${USED[@]}"; do 
+		   if [[ ${i} == 0 ]] ; then
+	              echo "${STATIC}${c}"
+	              #echo cf map-route ${ADD_ROUTE}  ${DOMAIN} --hostname ${STATIC}${c} 
+	              #echo cf set-env ${ADD_ROUTE} DFE_SIGNIN_BASE_URL https://${STATIC}${c}.${DOMAIN}
+	              #echo cf restage  ${ADD_ROUTE}
+		      break
+	           fi
+		   ((c+=1))
+	   done
+
+fi

--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -8,6 +8,7 @@ locals {
     SKIP_FORCE_SSL      = true,
     SENTRY_CURRENT_ENV  = var.application_environment,
     SLACK_ENV           = var.application_environment,
+    DFE_SIGNIN_BASE_URL = var.static_route == "" ? local.application_secrets.DFE_SIGNIN_BASE_URL :  "https://${var.static_route}.${data.cloudfoundry_domain.cloudapps.name}"
   }
 }
 
@@ -39,6 +40,13 @@ resource "cloudfoundry_app" "application" {
 
   dynamic "routes" {
     for_each = data.cloudfoundry_route.app_route_internet
+    content {
+      route = routes.value["id"]
+    }
+  }
+
+  dynamic "routes" {
+    for_each = cloudfoundry_route.static_route
     content {
       route = routes.value["id"]
     }

--- a/terraform/paas/route.tf
+++ b/terraform/paas/route.tf
@@ -24,6 +24,14 @@ resource "cloudfoundry_route" "route_delayed" {
   space    = data.cloudfoundry_space.space.id
 }
 
+resource "cloudfoundry_route" "static_route" {
+  count    = var.static_route == "" ? 0 :1 
+  domain   = data.cloudfoundry_domain.cloudapps.id
+  hostname = var.static_route
+  space    = data.cloudfoundry_space.space.id
+}
+
+
 locals {
   app_endpoint = "${cloudfoundry_route.route_cloud.hostname}.${data.cloudfoundry_domain.cloudapps.name}"
 }

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -97,6 +97,10 @@ variable "paas_application_name" {
   default = "dfe-school-experience-app"
 }
 
+variable "static_route" {
+  default = ""
+}
+
 variable "paas_docker_image" {
   default = "ghcr.io/dfe-digital/schools-experience:master"
 }


### PR DESCRIPTION
## Problem
When using Review Applications the name of the application constantly changes, and therefore does not match a DFE_SIGNIN Url, there is no API for DFE_SIGNIN.
So there are two solutions:
1. Dummy the DFE_SIGNIN .. This has been dismissed as a lot of development and this application requires data from DFE_SIGNIN and would need every condition stubbing.
2. Create a set of 10 static URLS and link the Review to the first available free one.

### Option chosen 2

### Process
1.  On review deployment, 
2. cf cli installed
3. script executed that finds current or latest available static address
4. address passed to terraform
5.  terraform applies it on build and sets DFE_SIGNIN_BASE_URL
6. after deployment comment added to github 