### PR TITLE
Flag placement requests from recurring candidates

### DIFF
--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -7,9 +7,11 @@ module Schools::PlacementRequestsHelper
     unless status.in? HIDDEN_STATUSES
 
       css_class = if placement_request.cancelled?
-                    'govuk-tag-red'
+                    'govuk-tag govuk-tag--red'
+                  elsif status == 'Flagged'
+                    'govuk-tag govuk-tag--yellow'
                   else
-                    'govuk-tag'
+                    'govuk-tag govuk-tag--green'
                   end
 
       tag.span status, class: css_class

--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -132,4 +132,8 @@ class Bookings::Candidate < ApplicationRecord
 
     gitis_contact
   end
+
+  def attended_bookings
+    bookings.includes(:bookings_placement_request).attendance_logged
+  end
 end

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -178,6 +178,7 @@ module Bookings
       return 'Withdrawn'              if candidate_cancellation&.sent?
       return 'Rejected'               if school_cancellation&.sent?
       return 'Viewed'                 if viewed?
+      return 'Flagged'                if candidate.attended_bookings.any?
 
       'New'
     end

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -10,6 +10,16 @@
 
 <%= govuk_back_link schools_placement_requests_path %>
 
+<% if @placement_request.candidate.attended_bookings.any? %>
+  <div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+      <span class="govuk-warning-text__assistive">Warning</span>
+      This candidate has already attended a school experience placement.
+    </strong>
+  </div>
+<% end %>
+
 <% if @placement_request.candidate_cancellation&.sent? %>
   <h1><%= gitis_contact_full_name(@gitis_contact) %> has withdrawn their request</h1>
 <% elsif @placement_request.school_cancellation&.sent? %>

--- a/app/webpacker/stylesheets/global-styles.scss
+++ b/app/webpacker/stylesheets/global-styles.scss
@@ -117,8 +117,3 @@ section.govuk-se-letter {
 ul.govuk-se-spaced-list li {
   @include govuk-responsive-margin(2, "bottom");
 }
-
-.govuk-tag-red {
-  @extend .govuk-tag;
-  background-color: govuk-colour("red");
-}

--- a/features/schools/placement_requests/index.feature
+++ b/features/schools/placement_requests/index.feature
@@ -50,3 +50,8 @@ Feature: Viewing all placement requests
         Given there are some viewed placement requests
         When I am on the 'placement requests' page
         Then the viewed requests should have no status
+
+    Scenario: Placement requests from candidate who already had attended bookings
+        Given there are placement requests from candidate who already had attended bookings
+        When I am on the 'placement requests' page
+        Then these requests should have a status of Flagged

--- a/features/schools/placement_requests/show.feature
+++ b/features/schools/placement_requests/show.feature
@@ -71,3 +71,8 @@ Feature: Viewing a placement request
         And the request has been rejected
         When I am on the placement request page
         Then I should see the rejection details
+
+    Scenario: Viewing a flagged request
+        Given there are placement requests from candidate who already had attended bookings
+        When I am on the flagged placement request page
+        Then I should see the warning details

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -2,6 +2,10 @@ Given("there are some upcoming requests") do
   step 'there are some placement requests'
 end
 
+Given("there are placement requests from candidate who already had attended bookings") do
+  @placement_requests = FactoryBot.create(:recurring_candidate, school: @school).placement_requests
+end
+
 Given("there are some placement requests") do
   @placement_requests = FactoryBot.create_list \
     :placement_request,
@@ -180,7 +184,7 @@ end
 
 Then("the cancelled requests should have a status of {string}") do |status|
   within('table#placement-requests') do
-    expect(page).to have_css('.govuk-tag-red', text: /#{status}/i, count: @cancelled_placement_requests_count)
+    expect(page).to have_css('.govuk-tag--red', text: /#{status}/i, count: @cancelled_placement_requests_count)
   end
 end
 
@@ -257,5 +261,24 @@ Then("I should see the withdrawn details with the following values:") do |table|
       expect(page).to have_css('dt', text: row['Heading'])
       expect(page).to have_css('dd', text: /#{row['Value']}/i)
     end
+  end
+end
+
+Then("these requests should have a status of Flagged") do
+  within('table#placement-requests') do
+    expect(page).to have_css('.govuk-tag--yellow', text: 'Flagged')
+  end
+end
+
+When("I am on the flagged placement request page") do
+  path = path_for('placement request', placement_request: @placement_requests.last)
+  visit(path)
+  expect(page.current_path).to eql(path)
+end
+
+Then("I should see the warning details") do
+  within '.govuk-warning-text' do
+    expect(page).to have_css 'span', text: 'Warning'
+    expect(page).to have_css 'strong', text: 'This candidate has already attended a school experience placement.'
   end
 end

--- a/spec/factories/bookings/candidates_factory.rb
+++ b/spec/factories/bookings/candidates_factory.rb
@@ -10,5 +10,26 @@ FactoryBot.define do
       gitis_contact { build(:api_schools_experience_sign_up) }
       gitis_uuid { gitis_contact.candidate_id }
     end
+
+    trait :with_attended_booking do
+      after :create do |candidate|
+        FactoryBot.create(:placement_request, :with_attended_booking, candidate: candidate)
+      end
+    end
+  end
+
+  factory :recurring_candidate, class: 'Bookings::Candidate' do
+    transient do
+      school { nil }
+    end
+
+    gitis_uuid { SecureRandom.uuid }
+
+    after :create do |candidate, evaluator|
+      school = evaluator.school || FactoryBot.create(:bookings_school)
+
+      FactoryBot.create(:placement_request, :with_attended_booking, candidate: candidate, school: school)
+      FactoryBot.create(:placement_request, candidate: candidate, school: school)
+    end
   end
 end

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -83,6 +83,18 @@ FactoryBot.define do
       end
     end
 
+    trait :with_attended_booking do
+      after :create do |placement_request|
+        FactoryBot.create \
+          :bookings_booking,
+          :with_existing_subject,
+          :attended,
+          bookings_school: placement_request.school,
+          bookings_placement_request: placement_request,
+          bookings_placement_request_id: placement_request.id
+      end
+    end
+
     trait :viewed do
       after :create, &:viewed!
     end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -343,4 +343,26 @@ RSpec.describe Bookings::Candidate, type: :model do
         email: subject.gitis_contact.email
     end
   end
+
+  describe '#attended_bookings' do
+    context 'when attended bookings exist' do
+      subject { create(:recurring_candidate).attended_bookings }
+
+      it { is_expected.to all(be_a Bookings::Booking) }
+
+      it 'returns attended bookings only' do
+        subject.each do |booking|
+          expect(booking.attended).to be_truthy
+        end
+      end
+    end
+
+    context 'when there are no attended bookings' do
+      subject { create(:candidate).attended_bookings }
+
+      it 'returns an empty array' do
+        expect(subject).to eq([])
+      end
+    end
+  end
 end

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -791,6 +791,11 @@ describe Bookings::PlacementRequest, type: :model do
 
       it { is_expected.to eq 'School cancellation' }
     end
+
+    context 'when candidate has attended previous school experiences' do
+      subject { create(:placement_request, :with_attended_booking).status }
+      it { is_expected.to eq 'Flagged' }
+    end
   end
 
   context '#dbs' do


### PR DESCRIPTION
### Trello card
https://trello.com/c/nccQYRPi

### Context
Most of the schools don't accept candidates who had previously been on a school experience or have been accepted to one and it's very time consuming for the school managers to check the candidates for all the placement requests they receive.

We want the service to check the candidates instead and flag their placement requests, so to make it easier for the school managers to either approve or reject the request. 
Also, display a warning message in the placement request page so the school managers know why the request was flagged.

### Changes proposed in this pull request
- Introduce the 'Flagged' status for the placement requests. Use the yellow tag colour to separate it from the rest. 
- Update the rest tag colours based on the latest design system
- Add a warning message at the top of the placement request page

### Guidance to review
| Before | After |
|-|-|
|![screenshot_20211005-114754](https://user-images.githubusercontent.com/951947/136009162-a98c3383-7144-43a7-9a30-793a0139a1d6.png)|![screenshot_20211005-114710](https://user-images.githubusercontent.com/951947/136009219-5141e76e-f312-4e5d-96bc-7b75856f67f4.png)|