### PR TITLE
Comment about Review Applications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -398,6 +398,7 @@ jobs:
       - name: Get Static Route 
         if: matrix.environment == 'Review' 
         run: |
+              cf delete-orphaned-routes -f
               STATIC_ROUTE=$( ${GITHUB_WORKSPACE}/script/get_next_mapping.sh ${{env.REVIEW_APPLICATION}}-${{github.event.number}} )
               echo "STATIC_ROUTE=${STATIC_ROUTE}" >> $GITHUB_ENV
 

--- a/README.md
+++ b/README.md
@@ -154,3 +154,8 @@ or
 ```bash
 redis-server
 ```
+
+## Deployment
+### Review Applications
+
+When deploying a review application a script is run to find the first available static route (review-school-experience[1-10] ) and attach that to the review, via terraform. This enables the DFE Sign In process to work.


### PR DESCRIPTION
## Change
Comments in Readme changed, to force a job to run through with no change to the application, but allow a full pipeline test of a review apps and the static DFE Sign in routes.

## Bugfix
So it seems terraform will create a route and map it to an application, but if the route is removed it may just be unmapped. to help overcome this we are running delete-orphaned-routes prior to the deployment.
