### PR TITLE
Font size change for help and support

### DIFF
--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -41,7 +41,7 @@
 
         <%- if @latest_service_update -%>
         <div id="service-updates-and-guidance" class="subsection">
-          <header class="dashboard-low-priority">
+          <header class="dashboard-medium-priority">
             <%= link_to "Service updates and guidance - #{@latest_service_update.date.to_formatted_s(:govuk)}", service_updates_path %>
           </header>
           <span class="govuk-hint">
@@ -51,7 +51,7 @@
         <%- end -%>
 
         <div id="request-dsi-org-access" class="subsection">
-        <header class="dashboard-low-priority">
+        <header class="dashboard-medium-priority">
           <%= link_to "Request access to another organisation",
                       schools_organisation_access_request_path %>
         </header>
@@ -61,7 +61,7 @@
       </div>
 
         <div id="contact-us" class="subsection">
-          <header class="dashboard-low-priority">
+          <header class="dashboard-medium-priority">
             <%= link_to 'Contact us', schools_contact_us_path %>
           </header>
           <span class="govuk-hint">

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -79,14 +79,8 @@ Feature: The School Dashboard
             | View previous bookings         | View booking dates, subjects, candidate names and attendance         | /schools/previous_bookings   |
             | Update school profile          | Update school details, placement details and requirements                             | /schools/on_boarding/profile |
             | Turn profile on or off         | Choose to stop or start receiving requests               | /schools/toggle_enabled/edit |
-
-    Scenario: Low priority headings
-        Given my school has fully-onboarded
-        When I am on the 'schools dashboard' page
-        Then I should see the following 'low-priority' links:
-            | Text       | Hint                                            | Path                |
             | Contact us | Get in touch if you need help using the service | /schools/contact_us |
-
+    
     Scenario: Candidate requests counter
         Given my school has fully-onboarded
         And there are 5 new requests


### PR DESCRIPTION
### Trello card
N/A

### Context
We want to update the font size for some of the new dashboard, this ups the size of 'Help and Support' to match everything below the main features.

### Changes proposed in this pull request
Amending `low-priority` class on dashboard to `medium-priority`. Also amending the tests.


