### PR TITLE
Reject analytics cookies by default

### DIFF
--- a/app/models/cookie_preference.rb
+++ b/app/models/cookie_preference.rb
@@ -84,7 +84,7 @@ class CookiePreference
               attributes[category(cookie_category_or_name).to_s]
             end
 
-    value.nil? || value == true
+    value == true
   end
 
   class UnknownCookieError < RuntimeError; end

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -75,9 +75,13 @@ RSpec.describe Candidates::SchoolsController, type: :request do
 
     context 'analytics tracking' do
       # set the uuid cookie, grab it then do a search
-      before { get new_candidates_school_search_path }
-      before { @uuid = cookies[:analytics_tracking_uuid] }
-      before { get candidates_schools_path(query_params) }
+      before do
+        allow_any_instance_of(CookiePreference).to receive(:allowed?).with(:analytics_tracking_uuid).and_return(true)
+
+        get new_candidates_school_search_path
+        @uuid = cookies[:analytics_tracking_uuid]
+        get candidates_schools_path(query_params)
+      end
 
       specify 'should persist the analytics_tracking_uuid if present' do
         expect(Bookings::SchoolSearch.last.analytics_tracking_uuid).to eql(@uuid)

--- a/spec/models/cookie_preference_spec.rb
+++ b/spec/models/cookie_preference_spec.rb
@@ -136,7 +136,7 @@ describe CookiePreference, type: :model do
 
       context 'for neither accepted nor rejected' do
         let(:params) { {} }
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
 
       context 'for accepted' do
@@ -155,7 +155,7 @@ describe CookiePreference, type: :model do
 
       context 'without neither accepted or rejected' do
         let(:params) { {} }
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
 
       context 'with accepted' do

--- a/spec/requests/google_analytics/presence_spec.rb
+++ b/spec/requests/google_analytics/presence_spec.rb
@@ -14,6 +14,8 @@ describe "candidates/home/index.html.erb", type: :request do
   context 'When GA_TRACKING_ID is present in the environment' do
     before do
       allow_any_instance_of(ActionController::Base::HelperMethods).to receive(:content_security_policy_nonce).and_return('noncevalue')
+      allow_any_instance_of(CookiePreference).to receive(:allowed?).with(:analytics).and_return(true)
+
       @orig_tracking_id = ENV[tracking_id_key]
       ENV[tracking_id_key] = tracking_id
     end


### PR DESCRIPTION
### Trello card
https://trello.com/c/9JpQwYId

### Context
We want to load analytics olny after users accept the cookies.

### Changes proposed in this pull request
Change the ` CookiesPreferences#allowed?` to allow only cookies that users have explicitly accepted.

### Guidance to review
Remove the GSE cookies from your browser and visit GSE. Use your browser's dev tools to confirm the analytics cookies are loading only after accepting the cookies.

