### PR TITLE
Semantic Logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,10 @@ gem 'webpacker', '>= 5.4.0'
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 
+# Install Semantic Logger, this is needed to make Logit.io work with PaaS
+gem 'amazing_print'
+gem 'rails_semantic_logger'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
+    amazing_print (1.4.0)
     ast (2.4.2)
     attr_required (1.0.1)
     bindata (2.4.10)
@@ -409,6 +410,10 @@ GEM
       ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.4.2)
       loofah (~> 2.3)
+    rails_semantic_logger (4.6.1)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.8)
     railties (6.1.4.1)
       actionpack (= 6.1.4.1)
       activesupport (= 6.1.4.1)
@@ -493,6 +498,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    semantic_logger (4.8.2)
+      concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
     sentry-delayed_job (4.7.3)
       delayed_job (>= 4.0)
@@ -598,6 +605,7 @@ DEPENDENCIES
   activerecord-postgis-adapter (~> 7.1)
   acts_as_list
   addressable
+  amazing_print
   application_insights!
   bootsnap (>= 1.1.0)
   brakeman (>= 4.4.0)
@@ -643,6 +651,7 @@ DEPENDENCIES
   rails (~> 6.1.4, >= 6.1.4.1)
   rails-controller-testing (>= 1.0.5)
   rails-erd
+  rails_semantic_logger
   redis (~> 4.4)
   rspec-json_expectations (~> 2.2)
   rspec-rails (~> 5.0, >= 5.0.2)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,6 +5,9 @@ Rails.application.configure do
   config.webpacker.check_yarn_integrity = true
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # In development log more information
+  config.log_level = :debug
+
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,9 +44,18 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  # Logging
+  config.log_level = :error
+  config.rails_semantic_logger.format = :json
+  config.semantic_logger.backtrace_level = :error
+  config.rails_semantic_logger.add_file_appender = false
+  config.active_record.logger = nil # Don't log SQL in production
+  config.active_record.dump_schema_after_migration = false # Do not dump schema after migrations.
+  config.semantic_logger.add_appender(io: $stdout, level: config.log_level, formatter: config.rails_semantic_logger.format)
+
+  config.logger = ActiveSupport::Logger.new($stdout)
+
+  # Inserts middleware to perform automatic connection switching.
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id, ->(_) { "PID:#{Process.pid}" }]
@@ -77,23 +86,10 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
   # Use a different logger for distributed setups.
   # require "syslog/logger"
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
-  # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
-
-  # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write
   # to send a subsequent read to the primary.


### PR DESCRIPTION
## [Semantic Logger](https://trello.com/c/KJqNUK5i/83-fix-output-logs-fix-appinsights-integrate-logit-or-switch-to-aci)

## Logging
When running applications in GOVUK PaaS, it is recommended to log to STDOUT and use the syslog integration service with logit.io. 

[Suggested Documentation](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/2045870109/Configuring+Rails+logger+for+GOVUK+PaaS) 


