### PR TITLE
Recreate Review comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -457,6 +457,7 @@ jobs:
         if: matrix.environment == 'Review' 
         uses: marocchino/sticky-pull-request-comment@v2
         with:
+          recreate: true
           message: |
                    Review app deployed to https://${{env.REVIEW_APPLICATION}}-${{github.event.number}}.${{env.DOMAIN}}
                    Static DFE_SIGNIN Path used https://${{env.STATIC_ROUTE}}.london.cloudapps.digital


### PR DESCRIPTION
### Tello Card
https://trello.com/c/Zr56PfxZ/262-ensure-that-review-apps-are-reposted-on-a-pr-when-someone-pushes-a-new-change

### Context
On GitHub we currently only have one mention of a preview app (when it's first created). Get Into Teaching reposted these links after each fresh commit

### Changes proposed in this pull request
ON SE we use an out of the box solution rather than a bespoke solution we used on Get Into Teaching, when we created the one on GiT the OOB didn't exist.  The OOB solution has an option to delete and recreate, which will remove the old comment and add a new one at the end, I think this should help remove the clutter of lots of comments as well as make it clear where the comment is.

