### PR TITLE
Add a search bar to the search results page

### DIFF
--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -8,6 +8,22 @@
 </div>
 
 <div class="govuk-grid-row">
+  <section id="search-bar" class="govuk-grid-column-full">
+    <%= govuk_form_for @search, as: '', url: candidates_schools_path, method: :get do |f| %>
+          <%= f.govuk_text_field :location, label: -> { nil }, width: 'full', placeholder: 'Location or postcode' %>
+
+          <%= f.govuk_select :distance, label: { text: 'Search radius' } do
+                options_from_collection_for_select(Candidates::SchoolSearch.distances, :first, :last, params[:distance])
+              end unless f.object.whitelisted_urns?
+          %>
+
+          <div class="govuk-form-group">
+            <%= f.govuk_submit 'Search', name: nil, aria: { label: 'Search for schools offering school experience' } %>
+          </div>
+      <% end %>
+    <hr />
+  </section>
+
   <aside class="govuk-grid-column-one-third filter-list" aria-label="Filter search results">
     <div data-controller="collapsible" id="search-filter">
       <button data-action="collapsible#toggle">

--- a/app/webpacker/stylesheets/school-search.scss
+++ b/app/webpacker/stylesheets/school-search.scss
@@ -121,3 +121,32 @@
 #candidate-application-notification {
   margin-top: 0;
 }
+
+#search-bar {
+  hr {
+    @extend .govuk-section-break ;
+    @extend .govuk-section-break--m ;
+    @extend .govuk-section-break--visible ;
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    #distance-field {
+      min-width: 12em;
+      width: 100%;
+    }
+
+    @include govuk-media-query($from: tablet) {
+      flex-direction: row;
+      .govuk-form-group {
+        margin-right: 2em;
+        margin-bottom: 0em !important;
+      }
+
+      #location-field, .govuk-button {
+        margin-top: 1.5em;
+      }
+    }
+  }
+}

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
       expect(rendered).to have_css '#search-results'
     end
 
+    it "shows the search bar" do
+      expect(rendered).to have_css '#search-bar'
+      expect(rendered).to have_css 'input#location-field'
+      expect(rendered).to have_css 'button[type="submit"]'
+    end
+
     it "shows filled in subject filter" do
       expect(rendered).to have_css '#search-filter'
       expect(rendered).to have_checked_field 'subjects[]', count: 2


### PR DESCRIPTION
### Trello card
https://trello.com/c/0oDk642f

### Context
Adding a search bar at the top of the search results page, so the users don't have to press back, amend search and click search to amend their searches.

### Changes proposed in this pull request
Add a search form in the search results page with the same fields we have in the search page.

### Guidance to review
|Before | After|
|-|-|
|![screenshot_20211013-120935](https://user-images.githubusercontent.com/951947/137121950-967acbe9-dfd6-4969-bf40-1b2cd41a207a.png) |  ![screenshot_20211013-120953](https://user-images.githubusercontent.com/951947/137122013-f8d4c363-36d8-4d90-8334-e99208706890.png)|
