### PR TITLE
Fix request access link

### DIFF
--- a/app/controllers/schools/change_schools_controller.rb
+++ b/app/controllers/schools/change_schools_controller.rb
@@ -6,6 +6,9 @@ module Schools
     rescue_from Schools::ChangeSchool::InaccessibleSchoolError, with: :access_denied
 
     def show
+      @dfe_sign_in_add_service_url =
+        Rails.application.config.x.dfe_sign_in_add_service_url.presence
+
       @change_school = Schools::ChangeSchool.new \
         current_user, school_uuids(reload: true), change_to_urn: current_urn
 

--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -30,7 +30,7 @@
 
           <%= f.submit "Continue" %>
         <% end %>
-      <% elsif Schools::ChangeSchool.request_approval_url %>
+      <% elsif @dfe_sign_in_add_service_url %>
         <h1 class="govuk-heading-l">Manage school experience</h1>
 
         <p class="govuk-body-l">

--- a/spec/controllers/schools/change_schools_controller_spec.rb
+++ b/spec/controllers/schools/change_schools_controller_spec.rb
@@ -35,6 +35,19 @@ describe Schools::ChangeSchoolsController, type: :request do
       let(:current_urn) { nil }
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_rendered :show }
+
+      context 'when add service url is set' do
+        let(:dfe_sign_in_url) { "www.dfe-sign-in.com/sign-in-service" }
+        before do
+          allow(Rails.application.config.x).to receive(:dfe_sign_in_add_service_url) do
+            dfe_sign_in_url
+          end
+        end
+
+        it 'renders the URL' do
+          expect(subject.body).to include(dfe_sign_in_url)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/xIOSpZKc)

### Context
The `ChangeSchoolsController` `show` action loads a partial which needs a DfE sign in add service URL. This wasn't set so the  'Request access to schools experience' button was redirecting to the same page instead of to DfE sign in

### Changes proposed in this pull request
- Fix request access link
- Update the view logic (I think the logic was copied wrong or left over from a previous change). Changing a school is already handled [here?](https://github.com/DFE-Digital/schools-experience/blob/07f3faf51d0fe5f2c034d4bb6cb07a3b0972a333/app/views/schools/change_schools/show.html.erb#L19)