### PR TITLE
Database Migrate

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -87,3 +87,25 @@ resource "cloudfoundry_app" "delayed_jobs" {
 
 }
 
+resource "cloudfoundry_app" "database_migration" {
+  name              = "${var.paas_application_name}-database_migration"
+  space             = data.cloudfoundry_space.space.id
+  command           = "bundle exec rails db:migrate"
+  docker_image      = var.paas_docker_image
+  stopped           = var.application_stopped
+  instances         = var.delayed_job_instances
+  memory            = var.application_memory
+  disk_quota        = var.application_disk
+  health_check_type = "none"
+
+  dynamic "service_binding" {
+    for_each = data.cloudfoundry_user_provided_service.logging
+    content {
+      service_instance = service_binding.value["id"]
+    }
+  }
+
+  environment = merge(local.application_secrets, local.environment_map)
+
+}
+


### PR DESCRIPTION
### Context
Database migrations are not carried out automatically.

### Changes proposed in this pull request
Create a new instance of the application, using the latest docker container and when it starts run the ```bundle exec rails db:migrate``` command. This should migrate the database when necessary.

### Guidance to review
No impact on the Applications
