### PR TITLE
Allow non-signed in users to visit the `contact us` page

### DIFF
--- a/app/controllers/schools/contact_us_controller.rb
+++ b/app/controllers/schools/contact_us_controller.rb
@@ -1,9 +1,9 @@
 module Schools
   class ContactUsController < BaseController
-    skip_before_action :ensure_onboarded
+    skip_before_action :ensure_onboarded, :require_auth, :set_current_school
 
     def show
-      @school = current_school
+      @signed_in = user_signed_in?
     end
   end
 end

--- a/app/views/schools/contact_us/show.html.erb
+++ b/app/views/schools/contact_us/show.html.erb
@@ -10,7 +10,11 @@
     </p>
 
     <p class="govuk-!-margin-top-6">
-      <%= govuk_link_to 'Return to requests and bookings', schools_dashboard_path %>
+      <% if @signed_in %>
+        <%= govuk_link_to 'Go to dashboard', schools_dashboard_path %>
+      <% else %>
+        <%= govuk_link_to 'Return to manage school experience', schools_path %>
+      <% end %>
     </p>
   <div>
 </div>

--- a/features/schools/contact_us.feature
+++ b/features/schools/contact_us.feature
@@ -9,4 +9,4 @@ Feature: The School Dashboard
     Scenario: Links
         Given I am on the 'contact us' page
         Then I should see a email link to 'organise.school-experience@education.gov.uk'
-        And I should see a 'Return to requests and bookings' link to the 'schools dashboard'
+        And I should see a 'Go to dashboard' link to the 'schools dashboard'

--- a/spec/controllers/schools/contact_us_spec.rb
+++ b/spec/controllers/schools/contact_us_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::ContactUsController, type: :request do
+  shared_examples 'return to manage' do
+    it "has a 'Return to manage school experience' button" do
+      expect(subject.search(".govuk-button").any? { |button| button.content == "Go to dashboard" }).to be(false)
+      expect(subject.search(".govuk-button").any? { |button| button.content == "Return to manage school experience" }).to be(true)
+    end
+  end
+
+  shared_examples 'return to dashboard' do
+    it "has a 'Go to dashboard' button" do
+      expect(subject.search(".govuk-button").any? { |button| button.content == "Go to dashboard" }).to be(true)
+      expect(subject.search(".govuk-button").any? { |button| button.content == "Return to manage school experience" }).to be(false)
+    end
+  end
+
+  subject do
+    get schools_contact_us_path
+    Nokogiri.parse(response.body)
+  end
+
+  context "when signed in" do
+    include_context "logged in DfE user"
+
+    include_examples "return to dashboard"
+  end
+
+  context "when signed in with school profile" do
+    include_context "logged in DfE user for school with profile"
+
+    include_examples "return to dashboard"
+  end
+
+  context "when not signed in" do
+    include_examples "return to manage"
+  end
+end


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/TtrLAK6P)

### Context
Currently, users who aren't signed in can't visit the contact us page. This means if you are struggling to onboard, you can't get help easily.

### Changes proposed in this pull request
Skip authentication for this page, and conditionally set the destination and text of the button based on whether the user is signed in or not. If a user is not signed in they can go back to the main schools page, if they are signed in they can go to the dashboard.

### Guidance to review
Is this the correct behaviour and correct button text? I think there are three scenarios:
1. Signed in with a school profile
2. Signed in without a school profile
3. Not signed in
