### PR TITLE
Amend profile pages

### DIFF
--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -42,6 +42,8 @@
       <%- end -%>
     </dl>
 
+  </aside>
+
   <article class="govuk-grid-column-two-thirds" id="candidate-school-profile">
 
     <%- if @school.placement_info.present? -%>
@@ -146,5 +148,4 @@
     </div>
   <%- end -%>
 
-  </aside>
 </div>

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -1,4 +1,47 @@
 <div class="govuk-grid-row govuk-!-margin-top-4">
+    
+    <aside class="govuk-grid-column-one-third column-top-border">
+
+    <dl class="govuk-summary-list govuk-summary-list--no-border vertical">
+      <div id="school-address" class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Address
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= format_school_address @school, tag(:br) %>
+        </dd>
+      </div>
+
+      <div id="school-availability-info" class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Placement availability
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= format_school_availability(@school.availability_info) %>
+        </dd>
+      </div>
+
+      <div id="school-experience-type" class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          School experience type
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= format_school_placement_locations @school %>
+        </dd>
+      </div>
+
+      <%- if @school.teacher_training_provider? -%>
+      <div id="school-teacher-training-info" class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Teacher training offered
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= safe_format(@school.teacher_training_info) %>
+        </dd>
+      </div>
+      <%- end -%>
+    </dl>
+
   <article class="govuk-grid-column-two-thirds" id="candidate-school-profile">
 
     <%- if @school.placement_info.present? -%>
@@ -93,47 +136,6 @@
 
   </article>
 
-  <aside class="govuk-grid-column-one-third column-top-border">
-
-    <dl class="govuk-summary-list govuk-summary-list--no-border vertical">
-      <div id="school-address" class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Address
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= format_school_address @school, tag(:br) %>
-        </dd>
-      </div>
-
-      <div id="school-availability-info" class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Placement availability
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= format_school_availability(@school.availability_info) %>
-        </dd>
-      </div>
-
-      <div id="school-experience-type" class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          School experience type
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= format_school_placement_locations @school %>
-        </dd>
-      </div>
-
-      <%- if @school.teacher_training_provider? -%>
-      <div id="school-teacher-training-info" class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Teacher training offered
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= safe_format(@school.teacher_training_info) %>
-        </dd>
-      </div>
-      <%- end -%>
-    </dl>
 
     <%- if @school.has_availability? -%>
     <div class="school-start-request-button__mobile">

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -1,103 +1,6 @@
 <div class="govuk-grid-row govuk-!-margin-top-4">
-  <div class="govuk-grid-column-two-thirds" id="candidate-school-profile">
-    <%- if @presenter.description_details.present? -%>
-    <section id="school-placement-info">
-      <%= safe_format @presenter.description_details %>
-    </section>
-    <%- end -%>
-
-    <div>
-      <h2>
-        About our school experience
-      </h2>
-
-      <dl class="govuk-summary-list govuk-summary-list--no-border inline">
-        <%= dlist_item 'Individual requirements:', id: 'individual-requirements' do %>
-          <%= content_or_msg split_to_list(@presenter.individual_requirements), "No requirements specified" %>
-        <% end %>
-
-        <%= dlist_item 'Details:', id: 'experience-details' do %>
-          <%= conditional_format content_or_msg @presenter.experience_details, "No information supplied" %>
-        <% end %>
-
-        <%= dlist_item 'Subjects:', id: "school-subjects" do %>
-          <%= format_school_subjects @presenter.school %>
-        <% end %>
-      </dl>
-
-      <% if @presenter.school.availability_preference_fixed? %>
-        <%= render partial: 'candidates/schools/placement_dates', locals: { primary_dates: @presenter.primary_dates, secondary_dates_grouped_by_date: @presenter.secondary_dates_grouped_by_date } %>
-      <% end %>
-
-    </div>
-
-    <div>
-      <h2>Location</h2>
-
-      <%= school_location_map @presenter.school %>
-
-      <p class="directions-link">
-        <%= link_to 'Get directions', external_map_url(
-          latitude: @presenter.school.coordinates.latitude,
-          longitude: @presenter.school.coordinates.longitude,
-          name: @presenter.school.name),
-          'aria-label': "Get directions for #{@school.name}"
-        %>
-      </p>
-    </div>
-
-    <div>
-      <p>
-        <strong>
-          For more information about our school:
-        </strong>
-      </p>
-
-      <ul id="school-websites">
-        <%- if @presenter.website.present? -%>
-        <li id="school-website">
-          <%= link_to "#{@presenter.school.name} website", @presenter.website %>
-        </li>
-        <%- end -%>
-
-        <li>
-          <%= link_to "#{@presenter.school.name} Get Information About Schools",
-                      gias_school_url(@presenter.urn) %>
-        </li>
-
-        <li>
-          <%= link_to "Ofsted report: #{@presenter.school.name}",
-                      ofsted_report_url(@presenter.urn) %>
-        </li>
-
-        <li>
-          <%= link_to "Performance information: #{@presenter.school.name}",
-                      performance_report_url(@presenter.urn) %>
-        </li>
-
-        <%- if @presenter.teacher_training_url.present? -%>
-        <li>
-          <%= link_to "Teacher training: #{@presenter.name}",
-            cleanup_school_url(@presenter.teacher_training_url) %>
-        </li>
-        <%- end -%>
-      </ul>
-    </div>
-
-    <% if include_candidate_request_links %>
-      <div class="school-start-request-button__tablet_plus govuk-!-margin-top-8">
-        <%= render 'start_request', profile: @presenter %>
-
-      </div>
-
-      <p>
-        <%= link_to 'Back to search results', :back,
-                    data: {controller: 'back-link'} %>
-      </p>
-    <% end %>
-  </div>
-
-  <div class="candidate-profile-sidebar govuk-grid-column-one-third column-top-border">
+  
+    <div class="candidate-profile-sidebar govuk-grid-column-one-third column-top-border">
     <dl class="govuk-summary-list govuk-summary-list--no-border vertical">
 
       <%= dlist_item 'School phases', id: 'school-phases' do %>
@@ -210,6 +113,104 @@
         </p>
       <% end if @presenter.teacher_training_info.present? %>
     </dl>
+
+  <div class="govuk-grid-column-two-thirds" id="candidate-school-profile">
+    <%- if @presenter.description_details.present? -%>
+    <section id="school-placement-info">
+      <%= safe_format @presenter.description_details %>
+    </section>
+    <%- end -%>
+
+    <div>
+      <h2>
+        About our school experience
+      </h2>
+
+      <dl class="govuk-summary-list govuk-summary-list--no-border inline">
+        <%= dlist_item 'Individual requirements:', id: 'individual-requirements' do %>
+          <%= content_or_msg split_to_list(@presenter.individual_requirements), "No requirements specified" %>
+        <% end %>
+
+        <%= dlist_item 'Details:', id: 'experience-details' do %>
+          <%= conditional_format content_or_msg @presenter.experience_details, "No information supplied" %>
+        <% end %>
+
+        <%= dlist_item 'Subjects:', id: "school-subjects" do %>
+          <%= format_school_subjects @presenter.school %>
+        <% end %>
+      </dl>
+
+      <% if @presenter.school.availability_preference_fixed? %>
+        <%= render partial: 'candidates/schools/placement_dates', locals: { primary_dates: @presenter.primary_dates, secondary_dates_grouped_by_date: @presenter.secondary_dates_grouped_by_date } %>
+      <% end %>
+
+    </div>
+
+    <div>
+      <h2>Location</h2>
+
+      <%= school_location_map @presenter.school %>
+
+      <p class="directions-link">
+        <%= link_to 'Get directions', external_map_url(
+          latitude: @presenter.school.coordinates.latitude,
+          longitude: @presenter.school.coordinates.longitude,
+          name: @presenter.school.name),
+          'aria-label': "Get directions for #{@school.name}"
+        %>
+      </p>
+    </div>
+
+    <div>
+      <p>
+        <strong>
+          For more information about our school:
+        </strong>
+      </p>
+
+      <ul id="school-websites">
+        <%- if @presenter.website.present? -%>
+        <li id="school-website">
+          <%= link_to "#{@presenter.school.name} website", @presenter.website %>
+        </li>
+        <%- end -%>
+
+        <li>
+          <%= link_to "#{@presenter.school.name} Get Information About Schools",
+                      gias_school_url(@presenter.urn) %>
+        </li>
+
+        <li>
+          <%= link_to "Ofsted report: #{@presenter.school.name}",
+                      ofsted_report_url(@presenter.urn) %>
+        </li>
+
+        <li>
+          <%= link_to "Performance information: #{@presenter.school.name}",
+                      performance_report_url(@presenter.urn) %>
+        </li>
+
+        <%- if @presenter.teacher_training_url.present? -%>
+        <li>
+          <%= link_to "Teacher training: #{@presenter.name}",
+            cleanup_school_url(@presenter.teacher_training_url) %>
+        </li>
+        <%- end -%>
+      </ul>
+    </div>
+
+    <% if include_candidate_request_links %>
+      <div class="school-start-request-button__tablet_plus govuk-!-margin-top-8">
+        <%= render 'start_request', profile: @presenter %>
+
+      </div>
+
+      <p>
+        <%= link_to 'Back to search results', :back,
+                    data: {controller: 'back-link'} %>
+      </p>
+    <% end %>
+  </div>
 
     <% if include_candidate_request_links %>
       <div class="school-start-request-button__mobile">

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -114,6 +114,8 @@
       <% end if @presenter.teacher_training_info.present? %>
     </dl>
 
+  </div>
+
   <div class="govuk-grid-column-two-thirds" id="candidate-school-profile">
     <%- if @presenter.description_details.present? -%>
     <section id="school-placement-info">
@@ -217,5 +219,5 @@
         <%= render 'start_request', profile: @presenter %>
       </div>
     <% end %>
-  </div>
+
 </div>


### PR DESCRIPTION
### Trello card

### Context

This comes from our content review earlier in the month. Users typically use an 'F shaped' reading pattern. This switches columns to ensure that key school/user generated content is placed in those regions that get the most eyeballs/attention.

### Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/35870975/139452708-afb995e1-48a0-40d9-8ffe-f46d66c91d4b.png)

After:
![image](https://user-images.githubusercontent.com/35870975/139452609-62755041-d1ea-4bd0-8fd9-0ea19b061720.png)

I've also amended it such that the preview feature in profile editing is changed. 

### Guidance to review

