### PR TITLE
Allow all the enabled schools to be crawled by robots

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -28,6 +28,12 @@ class PagesController < ApplicationController
     render status: :service_unavailable
   end
 
+  def robots
+    @enabled_schools_urns = Bookings::School.enabled.pluck(:urn)
+
+    render "robots.txt", layout: false
+  end
+
 private
 
   def sanitise_page

--- a/app/views/pages/robots.txt.erb
+++ b/app/views/pages/robots.txt.erb
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /$
+Allow: /schools$
+<% @enabled_schools_urns.each do |urn| %>
+Allow: /candidates/schools/<%= urn %>
+<% end %>
+Disallow: /*

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   get '/service_update', to: 'service_updates#index'
   get '/help_and_support_access_needs', to: 'pages#help_and_support_access_needs'
   get '/dfe_signin_help', to: 'pages#dfe_signin_help'
+  get '/robots', to: 'pages#robots', constraints: ->(req) { req.format == :text }
 
   resource :cookie_preference, only: %i[show edit update]
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Allow: /$
-Allow: /schools$
-Disallow: /*

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -31,4 +31,13 @@ describe PagesController, type: :request do
       expect(response).to have_attributes body: /service is unavailable/i
     end
   end
+
+  describe '#robots' do
+    before do
+      get '/robots.txt'
+    end
+
+    it { expect(response).to have_http_status(:success) }
+    it { expect(response).to render_template 'robots.txt' }
+  end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/b/nS4OTSIl/get-school-experience

### Context
We want to allow robots to crawl enabled schools.

### Changes proposed in this pull request
Add the controller method, view and route to create the robots.txt dynamically on each request.

### Guidance to review
Visit `/robots.txt` and it should return an `Allow` rule for each enabled school.
