### PR TITLE
Remove date of birth

### DIFF
--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -11,7 +11,6 @@ module Candidates
       attribute :first_name
       attribute :last_name
       attribute :email
-      attribute :date_of_birth, :date
       attribute :read_only, :boolean, default: false
 
       validates :first_name, presence: true, length: { maximum: 50 }, unless: :read_only


### PR DESCRIPTION
Date of birth was kept here to support users who were part-way through their sign up journey at the time the change to remove date of birth was merged. We can safely remove it now.