### PR TITLE
Set X-Robots-Tag header to all when visiting school profiles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::Base
 
 protected
 
-  def add_x_robots_tag
-    headers["X-Robots-Tag"] = if request.path.in?(CRAWLABLE_PATHS)
+  def add_x_robots_tag(set_to_all: false)
+    headers["X-Robots-Tag"] = if set_to_all || request.path.in?(CRAWLABLE_PATHS)
                                 "all"
                               else
                                 "none"

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -27,6 +27,8 @@ class Candidates::SchoolsController < ApplicationController
       return redirect_to candidates_root_path
     end
 
+    add_x_robots_tag(set_to_all: @school.enabled)
+
     @school.increment!(:views)
 
     if @school.private_beta?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -14,11 +14,24 @@ describe ApplicationController, type: :request do
       end
     end
 
+    context 'when school profile paths' do
+      let(:disabled_school) { create(:bookings_school, enabled: false) }
+
+      specify "should add 'X-Robots-Tag: all' for enabled schools" do
+        head candidates_school_path(school)
+        expect(response.headers[header]).to eql('all')
+      end
+
+      specify "should add 'X-Robots-Tag: none' for disabled schools" do
+        head candidates_school_path(disabled_school)
+        expect(response.headers[header]).to eql('none')
+      end
+    end
+
     specify "should add 'X-Robots-Tag: none' to uncrawlable paths" do
       [
         "/healthcheck.txt",
         candidates_schools_path,
-        candidates_school_path(school),
         new_candidates_school_registrations_background_check_path(school),
         new_candidates_school_registrations_personal_information_path(school)
 


### PR DESCRIPTION
### Trello card
N/A

### Context
The robots.txt was updated recently to include `allow` rules for all the enabled schools, but the robots still won't crawl them because the `X-Robots-Tag` header is set to `none`.

### Changes proposed in this pull request
Set the header value to `all` when visiting profiles of enabled schools.

### Guidance to review
Check the headers when visiting a disabled/enabled school profile.
