### PR TITLE
Update Stimulus.js data target attributes

### DIFF
--- a/app/helpers/candidates/maps_helper.rb
+++ b/app/helpers/candidates/maps_helper.rb
@@ -64,7 +64,7 @@ module Candidates::MapsHelper
 
     tag.div class: "embedded-map", data: map_data, **aria_attributes do
       tag.div class: 'embedded-map__inner-container',
-              data: { target: 'map.container' } do
+              data: { map_target: 'container' } do
         image_tag static_url, class: "embedded-map__nojs-img", alt: "Map showing #{title}", **aria_attributes
       end
     end

--- a/app/views/candidates/registrations/educations/_form.html.erb
+++ b/app/views/candidates/registrations/educations/_form.html.erb
@@ -9,7 +9,7 @@
 <%= form_for education, url: candidates_school_registrations_education_path, data: { controller: 'education-form' } do |f| %>
   <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
 
-  <section id="education-degree-stage-container" data-target="education-form.degreeStagesContainer">
+  <section id="education-degree-stage-container" data-education-form-target="degreeStagesContainer">
     <%= f.radio_button_fieldset :degree_stage do |fieldset| %>
       <% f.object.available_degree_stages.each do |degree_stage| %>
         <% if f.object.requires_explanation_for_degree_stage? degree_stage %>
@@ -29,7 +29,7 @@
     <% end %>
   </section>
 
-  <section id="education-degree-subject-container" data-target="education-form.degreeSubjectContainer">
+  <section id="education-degree-subject-container" data-education-form-target="degreeSubjectContainer">
     <%= f.collection_select \
       :degree_subject,
       f.object.available_degree_subjects,
@@ -39,7 +39,7 @@
       {
         class: 'govuk-select govuk-!-width-one-half',
         data: {
-          target: 'education-form.degreeSubject',
+          education_form_target: 'degreeSubject',
           value_for_no_degree: f.object.no_degree_subject
         },
         label_options: { class: 'govuk-heading-m' }


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/QBfndLQ4)

### Context
In Stimulus.js 2.0, we need to include the controller name in the data target attributes. 

This was showing up as a warning in the development console. 👇 

![image](https://user-images.githubusercontent.com/47089130/139708539-6a071773-95a1-455a-b312-040bbf1e0d81.png)

### Changes proposed in this pull request
- Update Stimulus.js data target attributes