### PR TITLE
Move prevent double click JavaScript into Stimulus.js controller

### DIFF
--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row" id="application-preview">
   <%= form_for @privacy_policy,
         url: candidates_school_registrations_confirmation_email_path,
-        html: { onsubmit: 'preventDoubleClick(this)' } do |f| %>
+        data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Check your answers before requesting your school experience</h1>
     <p>You'll receive an email with the following details once you've sent your school experience request.</p>
@@ -132,9 +132,9 @@
         <%= f.check_box_input :acceptance %>
       </div>
       <% if candidate_signed_in? %>
-        <%= f.submit 'Accept and send', class: 'govuk-button' %>
+        <%= f.submit 'Accept and send', class: 'govuk-button', data: { prevent_double_click_target: "submitButton" } %>
       <% else %>
-        <%= f.submit 'Continue', class: 'govuk-button' %>
+        <%= f.submit 'Continue', class: 'govuk-button', data: { prevent_double_click_target: "submitButton" } %>
       <% end %>
   </div>
   <% end %>

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -21,7 +21,7 @@
 
         <%= form_for personal_information,
               url: candidates_school_registrations_personal_information_path,
-              html: { onsubmit: 'preventDoubleClick(this)' } do |f| %>
+              data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
 
           <%= GovukElementsErrorsHelper.error_summary personal_information, 'There is a problem', '' %>
 
@@ -37,7 +37,7 @@
                 readonly: personal_information.read_only,
                 disabled: personal_information.read_only %>
 
-          <%= f.submit 'Continue' %>
+          <%= f.submit 'Continue', data: { prevent_double_click_target: "submitButton" } %>
         <% end %>
       </div>
     </div>

--- a/app/webpacker/controllers/prevent_double_click_controller.js
+++ b/app/webpacker/controllers/prevent_double_click_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ 'submitButton' ]
+
+  disableSubmitButton() {
+    this.submitButtonTarget.disabled = true;
+  };
+}

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -64,13 +64,3 @@ if (CookiePreferences.allowed('analytics')) {
     });
   });
 }
-
-global.preventDoubleClick = function(form) {
-  let buttons = form.querySelectorAll('input[type=submit],button[type=submit]') ;
-
-  for (let button of buttons) {
-    button.setAttribute('disabled', true) ;
-  }
-
-  return true ;
-};


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/zfyJ8gFM)

### Context
Our CSP policy was blocking the prevent double click inline JavaScript from executing.

We could use a hash or nonce for this, but the CSP policy and the project's JavaScript will be easier to maintain if moved into a Stimulus.js controller.

### Changes proposed in this pull request
- Move prevent double click JavaScript into a Stimulus.js controller
