### PR TITLE
Add sitemap.xml

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   before_action :set_manage_site_header
+  before_action :set_enabled_schools_urns, only: %i[robots sitemap]
 
   def show
     render template: sanitise_page
@@ -29,10 +30,10 @@ class PagesController < ApplicationController
   end
 
   def robots
-    @enabled_schools_urns = Bookings::School.enabled.pluck(:urn)
-
     render "robots.txt", layout: false
   end
+
+  def sitemap; end
 
 private
 
@@ -54,5 +55,9 @@ private
     if request.path.start_with? '/schools/'
       @site_header_text = "Manage school experience"
     end
+  end
+
+  def set_enabled_schools_urns
+    @enabled_schools_urns = Bookings::School.enabled.pluck(:urn)
   end
 end

--- a/app/views/pages/robots.txt.erb
+++ b/app/views/pages/robots.txt.erb
@@ -5,3 +5,4 @@ Allow: /schools$
 Allow: /candidates/schools/<%= urn %>
 <% end %>
 Disallow: /*
+Sitemap: <%= sitemap_url(format: :xml) %>

--- a/app/views/pages/sitemap.xml.builder
+++ b/app/views/pages/sitemap.xml.builder
@@ -1,0 +1,16 @@
+xml.instruct! :xml, version: "1.0"
+xml.tag! 'urlset', 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
+  xml.url do
+    xml.loc root_url
+  end
+
+  xml.url do
+    xml.loc schools_url
+  end
+
+  @enabled_schools_urns.each do |urn|
+    xml.url do
+      xml.loc candidates_school_url(urn)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Rails.application.routes.draw do
   get '/help_and_support_access_needs', to: 'pages#help_and_support_access_needs'
   get '/dfe_signin_help', to: 'pages#dfe_signin_help'
   get '/robots', to: 'pages#robots', constraints: ->(req) { req.format == :text }
+  get '/sitemap', to: 'pages#sitemap', constraints: ->(req) { req.format == :xml }
 
   resource :cookie_preference, only: %i[show edit update]
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -40,4 +40,13 @@ describe PagesController, type: :request do
     it { expect(response).to have_http_status(:success) }
     it { expect(response).to render_template 'robots.txt' }
   end
+
+  describe '#sitemap' do
+    before do
+      get sitemap_path(format: :xml)
+    end
+
+    it { expect(response).to have_http_status(:success) }
+    it { expect(response).to render_template 'sitemap' }
+  end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/KBsWDeyO

### Context
The robots.txt was recently updated to allow the enabled school profiles to be crawled, however there are no links in the service to these pages. Adding a sitemap.xml will help robots find them.

### Changes proposed in this pull request
Add the controller method, view and route to create the `sitemap.xml` dynamically on each request.

### Guidance to review
Visit the `/sitemap.xml` and it should include records for the enabled profiles
