### PR TITLE
Make the /robots.txt and /sitemap.xml crawlable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   rescue_from ActionController::InvalidAuthenticityToken, with: :session_expired
 
-  CRAWLABLE_PATHS = %w[/ /candidates].freeze
+  CRAWLABLE_PATHS = %w[/ /candidates /robots.txt /sitemap.xml].freeze
   before_action :add_x_robots_tag
 
 protected

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -38,6 +38,7 @@ describe PagesController, type: :request do
     end
 
     it { expect(response).to have_http_status(:success) }
+    it { expect(response.headers['X-Robots-Tag']).to eq('all') }
     it { expect(response).to render_template 'robots.txt' }
   end
 
@@ -47,6 +48,7 @@ describe PagesController, type: :request do
     end
 
     it { expect(response).to have_http_status(:success) }
+    it { expect(response.headers['X-Robots-Tag']).to eq('all') }
     it { expect(response).to render_template 'sitemap' }
   end
 end


### PR DESCRIPTION
### Trello card
N/A

### Context
Google console can't read the sitemap, but Bing parsed it just fine. We suspect it's because the `X-Robots-Tag` header. 

### Changes proposed in this pull request
Include the `/robots.txt` and `/sitemap.xml` in the CRAWLABLE_PATHS which will set `X-Robots-Tag` to `all`

### Guidance to review

