### PR TITLE
Add Allow rules for the robots and sitemap paths

### DIFF
--- a/app/views/pages/robots.txt.erb
+++ b/app/views/pages/robots.txt.erb
@@ -1,6 +1,8 @@
 User-agent: *
 Allow: /$
 Allow: /schools$
+Allow: /robots.txt
+Allow: /sitemap.xml
 <% @enabled_schools_urns.each do |urn| %>
 Allow: /candidates/schools/<%= urn %>
 <% end %>


### PR DESCRIPTION
### Trello card
N/A

### Context
Google console fails when parsing the robots.txt and annotates the `Disallow: /*` rule.

### Changes proposed in this pull request
Add `Allow` rules for the robots and sitemap paths in the robots.txt

### Guidance to review

