### PR TITLE
Change the schedule time of the sync school job

### DIFF
--- a/app/jobs/cron/sync_schools_job.rb
+++ b/app/jobs/cron/sync_schools_job.rb
@@ -1,5 +1,5 @@
 class Cron::SyncSchoolsJob < CronJob
-  self.cron_expression = '30 4 * * *'
+  self.cron_expression = '30 7 * * *'
 
   def perform
     Bookings::SchoolSync.new.sync

--- a/spec/jobs/cron/sync_schools_job_spec.rb
+++ b/spec/jobs/cron/sync_schools_job_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 describe Cron::SyncSchoolsJob, type: :job do
-  specify 'should have a schedule of daily at 04:30' do
-    expect(described_class.cron_expression).to eql('30 4 * * *')
+  specify 'should have a schedule of daily at 07:30' do
+    expect(described_class.cron_expression).to eql('30 7 * * *')
   end
 
   describe '#perform' do


### PR DESCRIPTION
### Trello card
N/A

### Context
The Job runs off hours and started failing few days ago when downloading the csv file with Invalid URI error, but the job works fine when we manually run it during working hours. We suspect the file may not be ready early in the morning anymore, so we want to schedule it few hours later and see if it will fail again.

### Changes proposed in this pull request
Set the job to run at 7.30am

### Guidance to review
