### PR TITLE
Add meta description tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem "get_into_teaching_api_client_faraday", github: "DFE-Digital/get-into-teachi
 gem 'actionpack-cloudfront', '>= 1.1.0'
 
 gem 'invisible_captcha', '>= 2.0.0'
+gem 'meta-tags', '~> 2.16'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,6 +311,8 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.16.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -639,6 +641,7 @@ DEPENDENCIES
   json (>= 2.3.0)
   kaminari
   listen (>= 3.0.5)
+  meta-tags (~> 2.16)
   notifications-ruby-client
   openid_connect
   parallel_tests

--- a/app/views/candidates/home/index.html.erb
+++ b/app/views/candidates/home/index.html.erb
@@ -1,3 +1,6 @@
+<% description 'The Department for Education service for finding school experience.
+Visit schools to see how teachers plan lessons, manage classrooms and teach subjects.' %>
+
 <% self.page_title = 'Get school experience' %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -1,4 +1,6 @@
 <% self.page_title = @school.name %>
+<% description "#{@school.name} is offering School Experience opportunities through DFE's GiT service.
+Find out more about career in teaching, experience days and how to apply." %>
 
 <%= govuk_back_link javascript: true %>
 

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -1,5 +1,5 @@
 <% self.page_title = @school.name %>
-<% description "#{@school.name} is offering School Experience opportunities through DFE's GiT service.
+<% description "#{@school.name} is offering school experience opportunities through the DfE's service.
 Find out more about career in teaching, experience days and how to apply." %>
 
 <%= govuk_back_link javascript: true %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <title><%= page_title %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= display_meta_tags %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: asset_pack_url('media/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>

--- a/spec/controllers/candidates/home_controller_spec.rb
+++ b/spec/controllers/candidates/home_controller_spec.rb
@@ -2,9 +2,16 @@ require 'rails_helper'
 
 RSpec.describe Candidates::HomeController, type: :request do
   describe "GET #index" do
-    it "returns http success with the Candidate landing page" do
+    before do
       get candidates_root_path
+    end
+
+    it "returns http success with the Candidate landing page" do
       expect(response).to have_http_status(:success)
+    end
+
+    it 'includes a meta description tag' do
+      expect(response.body).to include('<meta name="description" content="The Department for Education')
     end
   end
 end

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -127,6 +127,10 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         expect(school.reload.views).to eql(count + 1)
       end
     end
+
+    it "renders a meta description tag" do
+      expect(response.body).to include("<meta name=\"description\" content=\"#{school.name} is offering")
+    end
   end
 
   context 'when candidate applications are deactivated' do


### PR DESCRIPTION
### Trello card
https://trello.com/c/Qyi2xcFU

### Context
We want to add meta descriptions to improve the GSE's SEO

### Changes proposed in this pull request
Install the meta-tags gem
Add meta description to Homepage and school profiles

### Guidance to review
Visit the Homepage and some school profiles and look for the meta tags in the source of the pages.
