### PR TITLE
Update the gitis candidate name when missing

### DIFF
--- a/app/models/candidates/verification_code.rb
+++ b/app/models/candidates/verification_code.rb
@@ -35,7 +35,12 @@ class Candidates::VerificationCode
 
     request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(identity_data)
     api = GetIntoTeachingApiClient::SchoolsExperienceApi.new
-    api.exchange_access_token_for_schools_experience_sign_up(code, request)
+    existing_sign_up = api.exchange_access_token_for_schools_experience_sign_up(code, request)
+
+    existing_sign_up.tap do |info|
+      info.first_name = firstname if info.first_name.blank? && firstname.present?
+      info.last_name = lastname if info.last_name.blank? && lastname.present?
+    end
   rescue GetIntoTeachingApiClient::ApiError
     errors.add(:code, :invalid)
     nil

--- a/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
@@ -4,7 +4,7 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
   include_context 'Stubbed current_registration'
   let!(:school) { create(:bookings_school, urn: 11_048) }
 
-  let(:gitis_contact) { build(:api_schools_experience_sign_up) }
+  let(:gitis_contact) { build(:api_schools_experience_sign_up_with_name) }
 
   context 'without existing contact information in the session' do
     let :registration_session do

--- a/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/sign_ins_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
     context "when the Candidate already exists" do
       include_context "candidate signin"
 
-      let(:sign_up) { build(:api_schools_experience_sign_up, candidate_id: gitis_contact_attrs[:candidate_id]) }
+      let(:sign_up) { build(:api_schools_experience_sign_up_with_name, candidate_id: gitis_contact_attrs[:candidate_id]) }
 
       it "will not create another Candidate and redirect_to ConfirmationInformation step" do
         expect { perform_request }.not_to(change { Bookings::Candidate.count })
@@ -100,7 +100,7 @@ RSpec.describe Candidates::Registrations::SignInsController, type: :request do
     end
 
     context "with valid code but invalid Gitis data" do
-      let(:sign_up) { build(:api_schools_experience_sign_up) }
+      let(:sign_up) { build(:api_schools_experience_sign_up_with_name) }
 
       before { perform_request }
 

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -3,9 +3,6 @@ FactoryBot.define do
     candidate_id { SecureRandom.uuid }
     master_id { nil }
     merged { false }
-    sequence(:first_name) { |i| "First#{i}" }
-    sequence(:last_name) { |i| "Last#{i}" }
-    full_name { "#{first_name} #{last_name}" }
     email { "email@address.com" }
     secondary_email { "email2@address.com" }
     telephone { "111111111" }
@@ -26,6 +23,12 @@ FactoryBot.define do
     trait :merged do
       master_id { SecureRandom.uuid }
       merged { true }
+    end
+
+    factory :api_schools_experience_sign_up_with_name do
+      sequence(:first_name) { |i| "First#{i}" }
+      sequence(:last_name) { |i| "Last#{i}" }
+      full_name { "#{first_name} #{last_name}" }
     end
   end
 

--- a/spec/factories/bookings/candidates_factory.rb
+++ b/spec/factories/bookings/candidates_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     trait :with_api_contact do
-      gitis_contact { build(:api_schools_experience_sign_up) }
+      gitis_contact { build(:api_schools_experience_sign_up_with_name) }
       gitis_uuid { gitis_contact.candidate_id }
     end
 

--- a/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :gitis_registration_session, parent: :registration_session,
                                        class: Candidates::Registrations::GitisRegistrationSession do
-    gitis_contact { build(:api_schools_experience_sign_up) }
+    gitis_contact { build(:api_schools_experience_sign_up_with_name) }
 
     initialize_with do
       new \

--- a/spec/helpers/gitis_contact_helper_spec.rb
+++ b/spec/helpers/gitis_contact_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe GitisContactHelper, type: :helper do
   describe "#gitis_contact_display_phone" do
     it "returns first non-nil of secondary_telephone, telephone then mobile_telephone" do
-      contact = build(:api_schools_experience_sign_up, telephone: nil, secondary_telephone: nil)
+      contact = build(:api_schools_experience_sign_up_with_name, telephone: nil, secondary_telephone: nil)
       expect(helper.gitis_contact_display_phone(contact)).to eq(contact.mobile_telephone)
 
       contact.telephone = "11111111"
@@ -16,7 +16,7 @@ describe GitisContactHelper, type: :helper do
 
   describe "#gitis_contact_display_address" do
     it "returns the formatted address" do
-      contact = build(:api_schools_experience_sign_up)
+      contact = build(:api_schools_experience_sign_up_with_name)
       address = helper.gitis_contact_display_address(contact)
       expect(address).to eq(
         "3 Main Street, Botchergate, Carlisle, Cumbria, TE7 1NG"
@@ -26,7 +26,7 @@ describe GitisContactHelper, type: :helper do
 
   describe "#gitis_contact_full_name" do
     it "returns the full name" do
-      contact = build(:api_schools_experience_sign_up)
+      contact = build(:api_schools_experience_sign_up_with_name)
       full_name = helper.gitis_contact_full_name(contact)
       expect(full_name).to eq("#{contact.first_name} #{contact.last_name}")
     end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Bookings::Candidate, type: :model do
   end
 
   describe '.find_by_gitis_contact' do
-    let(:gitis_contact) { build(:api_schools_experience_sign_up) }
+    let(:gitis_contact) { build(:api_schools_experience_sign_up_with_name) }
 
     context 'with existing Candidate' do
       let!(:candidate) { create(:candidate, gitis_uuid: gitis_contact.candidate_id) }
@@ -84,7 +84,7 @@ RSpec.describe Bookings::Candidate, type: :model do
   end
 
   describe '.find_by_gitis_contact!' do
-    let(:gitis_contact) { build(:api_schools_experience_sign_up) }
+    let(:gitis_contact) { build(:api_schools_experience_sign_up_with_name) }
 
     context 'with existing Candidate' do
       let!(:candidate) { create(:candidate, gitis_uuid: gitis_contact.candidate_id) }
@@ -109,7 +109,7 @@ RSpec.describe Bookings::Candidate, type: :model do
   end
 
   describe '.find_or_create_from_gitis_contact!' do
-    let(:gitis_contact) { build(:api_schools_experience_sign_up) }
+    let(:gitis_contact) { build(:api_schools_experience_sign_up_with_name) }
 
     subject do
       Bookings::Candidate.find_or_create_from_gitis_contact! gitis_contact
@@ -196,7 +196,7 @@ RSpec.describe Bookings::Candidate, type: :model do
     end
 
     context 'with an existing contact but not candidate' do
-      let(:contact) { build(:api_schools_experience_sign_up) }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name) }
 
       subject do
         Bookings::Candidate.create_or_update_from_registration_session! \
@@ -267,7 +267,7 @@ RSpec.describe Bookings::Candidate, type: :model do
   end
 
   describe '#assign_gitis_contact' do
-    let(:contact) { build(:api_schools_experience_sign_up) }
+    let(:contact) { build(:api_schools_experience_sign_up_with_name) }
     let(:candidate) { create(:candidate) }
     let(:candidate_uuid) { candidate.gitis_uuid }
     before { candidate.assign_gitis_contact contact }

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
   end
 
   describe "#contact_to_personal_information" do
-    let(:contact) { build(:api_schools_experience_sign_up) }
+    let(:contact) { build(:api_schools_experience_sign_up_with_name) }
     let(:registration) { build(:registration_session) }
     let(:mapper) { described_class.new(registration, contact) }
     subject { mapper.contact_to_personal_information }
@@ -101,7 +101,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to include("email" => contact.email) }
 
     context 'with whitespace in email address' do
-      let(:contact) { build(:api_schools_experience_sign_up, email: "  someone@education.gov.uk  ") }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name, email: "  someone@education.gov.uk  ") }
 
       it "will strip the whitespace" do
         is_expected.to include("email" => "someone@education.gov.uk")
@@ -110,7 +110,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
   end
 
   describe "#contact_to_contact_information" do
-    let(:contact) { build(:api_schools_experience_sign_up) }
+    let(:contact) { build(:api_schools_experience_sign_up_with_name) }
     let(:registration) { build(:registration_session) }
     let(:mapper) { described_class.new(registration, contact) }
     subject { mapper.contact_to_contact_information }
@@ -123,13 +123,13 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to include("postcode" => contact.address_postcode) }
 
     context "when secondary_telephone is not present" do
-      let(:contact) { build(:api_schools_experience_sign_up, secondary_telephone: nil) }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name, secondary_telephone: nil) }
 
       it { is_expected.to include("phone" => contact.telephone) }
     end
 
     context "when secondary_telephone and telephone are not present" do
-      let(:contact) { build(:api_schools_experience_sign_up, secondary_telephone: nil, telephone: nil) }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name, secondary_telephone: nil, telephone: nil) }
 
       it { is_expected.to include("phone" => contact.mobile_telephone) }
     end
@@ -142,7 +142,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     let(:english) { Bookings::Subject.find_by!(name: 'English') }
     let(:contact) do
       build(
-        :api_schools_experience_sign_up,
+        :api_schools_experience_sign_up_with_name,
         preferred_teaching_subject_id: maths.gitis_uuid,
         secondary_preferred_teaching_subject_id: english.gitis_uuid,
       )

--- a/spec/models/candidates/verification_code_spec.rb
+++ b/spec/models/candidates/verification_code_spec.rb
@@ -52,6 +52,18 @@ describe Candidates::VerificationCode do
           end
         end
       end
+
+      context "when gitis contact is missing the first or last name" do
+        include_context "api correct verification code for personal info without name"
+
+        it "updates the first name" do
+          expect(exchange.first_name).not_to be_empty
+        end
+
+        it "updates the last name" do
+          expect(exchange.last_name).not_to be_empty
+        end
+      end
     end
 
     describe "#issue_verification_code" do

--- a/spec/models/schools/csv_export_row_spec.rb
+++ b/spec/models/schools/csv_export_row_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Schools::CsvExportRow do
   describe "#row" do
     subject { Hash[Schools::CsvExport::HEADER.zip(row)] }
 
-    let(:contact) { build :api_schools_experience_sign_up }
+    let(:contact) { build :api_schools_experience_sign_up_with_name }
 
     let(:row) do
       pr.gitis_contact = contact

--- a/spec/services/bookings/gitis/contact_fetcher_spec.rb
+++ b/spec/services/bookings/gitis/contact_fetcher_spec.rb
@@ -13,22 +13,22 @@ describe Bookings::Gitis::ContactFetcher do
     subject { fetcher.been_merged?(contact) }
 
     context 'correct merged' do
-      let(:contact) { build(:api_schools_experience_sign_up, :merged) }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name, :merged) }
       it { is_expected.to be true }
     end
 
     context 'correct unmerged' do
-      let(:contact) { build(:api_schools_experience_sign_up) }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name) }
       it { is_expected.to be false }
     end
 
     context 'merged without master' do
-      let(:contact) { build(:api_schools_experience_sign_up, :merged, master_id: nil) }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name, :merged, master_id: nil) }
       it { expect { subject }.to raise_exception described_class::InconsistentContactState }
     end
 
     context 'master but not merged' do
-      let(:contact) { build(:api_schools_experience_sign_up, :merged, merged: false) }
+      let(:contact) { build(:api_schools_experience_sign_up_with_name, :merged, merged: false) }
       it { expect { subject }.to raise_exception described_class::InconsistentContactState }
     end
   end
@@ -66,13 +66,13 @@ describe Bookings::Gitis::ContactFetcher do
   end
 
   describe 'merged records' do
-    let(:first) { build :api_schools_experience_sign_up }
-    let(:second) { build :api_schools_experience_sign_up }
+    let(:first) { build :api_schools_experience_sign_up_with_name }
+    let(:second) { build :api_schools_experience_sign_up_with_name }
     let(:merged) do
-      build :api_schools_experience_sign_up, :merged, master_id: first.candidate_id
+      build :api_schools_experience_sign_up_with_name, :merged, master_id: first.candidate_id
     end
     let(:chained) do
-      build :api_schools_experience_sign_up, :merged, master_id: merged.candidate_id, first_name: 'chained'
+      build :api_schools_experience_sign_up_with_name, :merged, master_id: merged.candidate_id, first_name: 'chained'
     end
 
     context 'for single record' do
@@ -111,9 +111,9 @@ describe Bookings::Gitis::ContactFetcher do
       end
 
       context 'with max chained records' do
-        let(:fourth) { build :api_schools_experience_sign_up, :merged, master_id: chained.candidate_id }
-        let(:fifth) { build :api_schools_experience_sign_up, :merged, master_id: fourth.candidate_id }
-        let(:sixth) { build :api_schools_experience_sign_up, :merged, master_id: fifth.candidate_id }
+        let(:fourth) { build :api_schools_experience_sign_up_with_name, :merged, master_id: chained.candidate_id }
+        let(:fifth) { build :api_schools_experience_sign_up_with_name, :merged, master_id: fourth.candidate_id }
+        let(:sixth) { build :api_schools_experience_sign_up_with_name, :merged, master_id: fifth.candidate_id }
 
         before do
           allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \

--- a/spec/services/bookings/reminder_spec.rb
+++ b/spec/services/bookings/reminder_spec.rb
@@ -11,7 +11,7 @@ describe Bookings::Reminder do
 
   describe '#deliver' do
     it "delivers one job per provided booking" do
-      sign_up = build(:api_schools_experience_sign_up)
+      sign_up = build(:api_schools_experience_sign_up_with_name)
 
       expect_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
         receive(:get_schools_experience_sign_up).with(booking.contact_uuid) { sign_up }

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Candidates::Registrations::GitisRegistrationSession do
-  let(:contact) { build(:api_schools_experience_sign_up) }
+  let(:contact) { build(:api_schools_experience_sign_up_with_name) }
 
   let(:key) { model.model_name.param_key }
   let(:model_name) { model.model_name.element }
@@ -121,7 +121,7 @@ describe Candidates::Registrations::GitisRegistrationSession do
 
         context 'with some blank fields in gitis data' do
           let(:contact) do
-            build :api_schools_experience_sign_up,
+            build :api_schools_experience_sign_up_with_name,
               first_name: " ",
               last_name: " "
           end
@@ -157,7 +157,7 @@ describe Candidates::Registrations::GitisRegistrationSession do
 
         context 'with some blank fields in gitis data' do
           let(:contact) do
-            build :api_schools_experience_sign_up,
+            build :api_schools_experience_sign_up_with_name,
               first_name: " ",
               last_name: " "
           end

--- a/spec/support/candidate_signin.rb
+++ b/spec/support/candidate_signin.rb
@@ -1,6 +1,6 @@
 shared_context 'candidate signin' do
-  let(:gitis_contact_attrs) { attributes_for(:api_schools_experience_sign_up) }
-  let(:gitis_contact) { build(:api_schools_experience_sign_up, gitis_contact_attrs) }
+  let(:gitis_contact_attrs) { attributes_for(:api_schools_experience_sign_up_with_name) }
+  let(:gitis_contact) { build(:api_schools_experience_sign_up_with_name, gitis_contact_attrs) }
   let(:current_candidate) { create(:candidate, gitis_uuid: gitis_contact.candidate_id) }
 
   before do

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -54,7 +54,7 @@ end
 
 shared_context "api correct verification code" do
   let(:code) { "123456" }
-  let(:sign_up) { build(:api_schools_experience_sign_up) }
+  let(:sign_up) { build(:api_schools_experience_sign_up_with_name) }
 
   before do
     allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
@@ -64,6 +64,24 @@ shared_context "api correct verification code" do
 end
 
 shared_context "api correct verification code for personal info" do
+  let(:code) { "123456" }
+  let(:request) do
+    GetIntoTeachingApiClient::ExistingCandidateRequest.new(
+      firstName: personal_info.first_name,
+      lastName: personal_info.last_name,
+      email: personal_info.email
+    )
+  end
+  let(:sign_up) { build(:api_schools_experience_sign_up_with_name) }
+
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+      receive(:exchange_access_token_for_schools_experience_sign_up)
+      .with(code, request) { sign_up }
+  end
+end
+
+shared_context "api correct verification code for personal info without name" do
   let(:code) { "123456" }
   let(:request) do
     GetIntoTeachingApiClient::ExistingCandidateRequest.new(
@@ -104,7 +122,7 @@ shared_context "api sign up" do
     allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
       receive(:sign_up_schools_experience_candidate)
         .with(an_instance_of(GetIntoTeachingApiClient::SchoolsExperienceSignUp)) do
-          build(:api_schools_experience_sign_up)
+          build(:api_schools_experience_sign_up_with_name)
         end
   end
 end
@@ -120,7 +138,7 @@ end
 shared_context "api sign ups for requests" do
   let(:ids) { requests.map(&:contact_uuid) }
   let(:sign_ups) do
-    ids.map { |id| build(:api_schools_experience_sign_up, candidate_id: id) }
+    ids.map { |id| build(:api_schools_experience_sign_up_with_name, candidate_id: id) }
   end
 
   before do
@@ -136,6 +154,6 @@ shared_context "api sign up for first request" do
 
     allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
       receive(:get_schools_experience_sign_up)
-        .with(id) { build(:api_schools_experience_sign_up, candidate_id: id) }
+        .with(id) { build(:api_schools_experience_sign_up_with_name, candidate_id: id) }
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/Ua10iIgf

### Context
Some DFE services now allow candidates to register in gitis without a name, but GSE still needs it so it fails when these candidates try to confirm their school experience requests.

### Changes proposed in this pull request
Update the candidate name in gitis when missing to ensure the CRM contact always has a name

### Guidance to review

