### PR TITLE
Hide request button

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -172,7 +172,7 @@ class Bookings::School < ApplicationRecord
   end
 
   def has_availability?
-    !availability_preference_fixed? || has_available_dates?
+    has_available_flex_dates? || has_available_fix_dates?
   end
 
   def notification_emails
@@ -237,8 +237,12 @@ class Bookings::School < ApplicationRecord
 
 private
 
-  def has_available_dates?
+  def has_available_fix_dates?
     bookings_placement_dates.available.any?
+  end
+
+  def has_available_flex_dates?
+    !availability_preference_fixed? && availability_info?
   end
 
   def nilify_availability_info

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -135,7 +135,7 @@
       <%- end -%>
     </dl>
 
-    <%- if @school.has_availability? -%>
+    <%- if @school.enabled? && @school.has_availability? -%>
     <div class="school-start-request-button__mobile">
       <%= govuk_link_to "Start request",
         new_candidates_school_registrations_personal_information_path(@school),

--- a/app/views/candidates/schools/_phase2.html.erb
+++ b/app/views/candidates/schools/_phase2.html.erb
@@ -84,7 +84,7 @@
       </ul>
     </div>
 
-    <% if include_candidate_request_links %>
+    <% if @presenter.school.enabled? && @presenter.school.has_availability? && include_candidate_request_links %>
       <div class="school-start-request-button__tablet_plus govuk-!-margin-top-8">
         <%= render 'start_request', profile: @presenter %>
 
@@ -211,7 +211,7 @@
       <% end if @presenter.teacher_training_info.present? %>
     </dl>
 
-    <% if include_candidate_request_links %>
+    <% if @presenter.school.enabled? && @presenter.school.has_availability? && include_candidate_request_links %>
       <div class="school-start-request-button__mobile">
         <%= render 'start_request', profile: @presenter %>
       </div>

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -58,6 +58,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_unavailable_placement_dates do
+      after :create do |school|
+        FactoryBot.create(:bookings_placement_date, active: false, bookings_school: school)
+      end
+    end
+
     trait :with_teacher_training_info do
       teacher_training_info { 'We offer a PGCE in partnership with Chester University. We are a lead school for School Direct' }
     end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -465,22 +465,32 @@ describe Bookings::School, type: :model do
   describe 'Methods' do
     describe '#has_availability?' do
       context 'when flexible' do
-        subject { build(:bookings_school) }
-        it { is_expected.to have_availability }
-      end
-
-      context 'when fixed with no dates' do
-        subject { build(:bookings_school, :with_fixed_availability_preference) }
-        it { is_expected.not_to have_availability }
-      end
-
-      context 'when fixed with no dates' do
-        subject { create(:bookings_school, :with_fixed_availability_preference) }
-        let!(:available_date) do
-          create(:bookings_placement_date, date: 1.week.from_now, bookings_school: subject)
+        context 'with availability_info' do
+          subject { build(:bookings_school) }
+          it { is_expected.to have_availability }
         end
 
-        it { is_expected.to have_availability }
+        context 'without availability_info' do
+          subject { build(:bookings_school, availability_info: nil) }
+          it { is_expected.not_to have_availability }
+        end
+      end
+
+      context 'when fixed' do
+        context 'with no dates' do
+          subject { build(:bookings_school, :with_fixed_availability_preference) }
+          it { is_expected.not_to have_availability }
+        end
+
+        context 'with unavailable dates' do
+          subject { create(:bookings_school, :with_fixed_availability_preference, :with_unavailable_placement_dates) }
+          it { is_expected.not_to have_availability }
+        end
+
+        context 'with available dates' do
+          subject { create(:bookings_school, :with_fixed_availability_preference, :with_placement_dates) }
+          it { is_expected.to have_availability }
+        end
       end
     end
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/OvwmD6hw

### Context
We want to display the `Start request` button only in school profiles of enabled schools that offer flex or fixed dates

### Changes proposed in this pull request
Display the button only for enable schools with available fixed dates or flex dates with description.

### Guidance to review
Visit the page of a:
1. disabled school
2. enabled school without dates
3. enabled school with unavailable dates
4. enabled school with available dates. 
 
The button should appear only in the profile of the enabled school with available dates.
