### PR TITLE
Add banner in school profiles to promote the search page

### DIFF
--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -4,6 +4,18 @@ Find out more about a career in teaching, experience days and how to apply." %>
 
 <%= govuk_back_link javascript: true %>
 
+<% if !@school.private_beta? %>
+  <div class="govuk-inset-text">
+    This school has not yet joined the Get School Experience service.
+    <%= link_to 'Search for schools offering school experience', new_candidates_school_search_path %>
+  </div>
+<% elsif !@school.has_availability? %>
+  <div class="govuk-inset-text">
+    This school does not currently have placement availability.
+    <%= link_to 'Search for schools offering school experience', new_candidates_school_search_path %>
+  </div>
+<% end %>
+
 <h1 class="govuk-heading-l govuk-!-margin-top-4"><%= @school.name %></h1>
 
 <%= render (@presenter ? 'phase2' : 'phase1'), school: @school, include_candidate_request_links: true %>

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -28,6 +28,11 @@ FactoryBot.define do
       sequence(:county) { |n| "#{n} Something county" }
     end
 
+    trait :without_availability do
+      availability_info { nil }
+      experience_type { nil }
+    end
+
     trait :with_fixed_availability_preference do
       availability_preference_fixed { true }
     end

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
     end
 
     context 'with availability' do
-      it "has a banner to promote the search page" do
+      it "doesn't have a banner to promote the search page" do
         expect(rendered).not_to have_css("div.govuk-inset-text > a", text: 'Search for schools offering school experience')
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
     context 'without availability' do
       let(:urn) { create(:bookings_school, :without_availability).urn }
 
-      it "doesn't have the search page promote banner" do
+      it "has a banner to promote the search page" do
         allow(school).to receive(:has_availability?).and_return(false)
 
         expect(rendered).to have_css("div.govuk-inset-text", text: 'This school does not currently have placement availability.')

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
   let(:school) { Candidates::School.find(urn) }
 
   context 'with profile' do
-    let(:profile) { build(:bookings_profile, school: school) }
+    let(:profile) { create(:bookings_profile, school: school) }
     let(:presenter) { Candidates::SchoolPresenter.new(school, profile) }
 
     before do
@@ -32,6 +32,23 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
         expect(rendered).to have_css("div.#{css_class} > a", text: 'Start request')
       end
     end
+
+    context 'with availability' do
+      it "has a banner to promote the search page" do
+        expect(rendered).not_to have_css("div.govuk-inset-text > a", text: 'Search for schools offering school experience')
+      end
+    end
+
+    context 'without availability' do
+      let(:urn) { create(:bookings_school, :without_availability).urn }
+
+      it "doesn't have the search page promote banner" do
+        allow(school).to receive(:has_availability?).and_return(false)
+
+        expect(rendered).to have_css("div.govuk-inset-text", text: 'This school does not currently have placement availability.')
+        expect(rendered).to have_css("div.govuk-inset-text > a", text: 'Search for schools offering school experience')
+      end
+    end
   end
 
   context 'without profile' do
@@ -53,6 +70,11 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
       %w[school-start-request-button__tablet_plus school-start-request-button__mobile].each do |css_class|
         expect(rendered).to have_css("div.#{css_class} > a", text: 'Start request')
       end
+    end
+
+    it "has a banner to promote the search page" do
+      expect(rendered).to have_css("div.govuk-inset-text", text: 'This school has not yet joined the Get School Experience service.')
+      expect(rendered).to have_css("div.govuk-inset-text > a", text: 'Search for schools offering school experience')
     end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/41scHves
https://trello.com/c/VKcPBKd5

### Context
The goal is to inform the candidates that the school they are looking is either not onboarded yet or it doesn't offer any placements at the moment and point them to the Search page.

### Changes proposed in this pull request
Add inset banners in the school profile page

### Guidance to review

