### PR TITLE
Hide the placement details for non-onboarded schools

### DIFF
--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -105,6 +105,7 @@
         </dd>
       </div>
 
+      <%- if @school.private_beta? && !@school.availability_preference_fixed? -%>
       <div id="school-availability-info" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Placement availability
@@ -114,7 +115,6 @@
         </dd>
       </div>
 
-      <%- if @school.private_beta? && !@school.availability_preference_fixed? -%>
       <div id="school-experience-type" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           School experience type

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -114,6 +114,7 @@
         </dd>
       </div>
 
+      <%- if @school.private_beta? && !@school.availability_preference_fixed? -%>
       <div id="school-experience-type" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           School experience type
@@ -122,6 +123,7 @@
           <%= format_school_placement_locations @school %>
         </dd>
       </div>
+      <%- end -%>
 
       <%- if @school.teacher_training_provider? -%>
       <div id="school-teacher-training-info" class="govuk-summary-list__row">

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
       expect(rendered).to have_css("div.govuk-inset-text > a", text: 'Search for schools offering school experience')
     end
 
-    it "doesn't render the experience type section" do
+    it "doesn't render the imported flex dates" do
+      expect(rendered).not_to have_css("div#school-availability-info")
       expect(rendered).not_to have_css("div#school-experience-type")
     end
   end

--- a/spec/views/candidates/schools/show.html.erb_spec.rb
+++ b/spec/views/candidates/schools/show.html.erb_spec.rb
@@ -76,5 +76,9 @@ RSpec.describe "candidates/schools/show.html.erb", type: :view do
       expect(rendered).to have_css("div.govuk-inset-text", text: 'This school has not yet joined the Get School Experience service.')
       expect(rendered).to have_css("div.govuk-inset-text > a", text: 'Search for schools offering school experience')
     end
+
+    it "doesn't render the experience type section" do
+      expect(rendered).not_to have_css("div#school-experience-type")
+    end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/0EOQv5td

### Context
There's a bug that displays the `placement` details (experience type and availability info) in profiles of non-onboarded schools.

### Changes proposed in this pull request
Hide the placement details for non-onboarded schools

### Guidance to review
