### PR TITLE
Remove Google Analytics automatic cookie domain configuration

### DIFF
--- a/app/views/application/_google_analytics.html.erb
+++ b/app/views/application/_google_analytics.html.erb
@@ -1,7 +1,7 @@
 <%- if cookie_preferences.allowed?(:analytics) -%>
   <%= javascript_tag nonce: true do -%>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', '<%= google_analytics_tracking_id %>', 'auto');
+    ga('create', '<%= google_analytics_tracking_id %>');
     ga('send', 'pageview');
   <% end -%>
 

--- a/spec/requests/google_analytics/presence_spec.rb
+++ b/spec/requests/google_analytics/presence_spec.rb
@@ -7,7 +7,7 @@ describe "candidates/home/index.html.erb", type: :request do
   let(:ga_identifiers) do
     [
       '<script src="https://www.google-analytics.com/analytics.js" nonce="noncevalue" async="async"></script>',
-      "ga('create', '#{tracking_id}', 'auto');"
+      "ga('create', '#{tracking_id}');"
     ]
   end
 


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/CEMSsELU)

### Context
When `auto` is specified for the Google Analytics cookie domain (which it is in the recommended snippet), then it will be set to the highest possible domain level. For School Experience, this will be `.education.gov.uk`. 

However, Rails ActionDispatch::Cookies defaults to the full domain including subdomains (`schoolexperience.education.gov.uk`).

This meant that we were adding the Google Analytics cookies on `.education.gov.uk`, but trying to remove them from `schoolexperience.education.gov.uk` when the user opts out. The domains must match, so the cookies weren't being removed.

Removing the `auto` setting means that the cookies use the default value of the full domain instead.

### Changes proposed in this pull request
- Remove Google Analytics automatic cookie domain configuration.
