### PR TITLE
Use `document.location.hostname` for Google Analytics cookies domain

### DIFF
--- a/app/views/application/_google_analytics.html.erb
+++ b/app/views/application/_google_analytics.html.erb
@@ -1,7 +1,7 @@
 <%- if cookie_preferences.allowed?(:analytics) -%>
   <%= javascript_tag nonce: true do -%>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', '<%= google_analytics_tracking_id %>');
+    ga('create', '<%= google_analytics_tracking_id %>', document.location.hostname);
     ga('send', 'pageview');
   <% end -%>
 

--- a/spec/requests/google_analytics/presence_spec.rb
+++ b/spec/requests/google_analytics/presence_spec.rb
@@ -7,7 +7,7 @@ describe "candidates/home/index.html.erb", type: :request do
   let(:ga_identifiers) do
     [
       '<script src="https://www.google-analytics.com/analytics.js" nonce="noncevalue" async="async"></script>',
-      "ga('create', '#{tracking_id}');"
+      "ga('create', '#{tracking_id}', document.location.hostname);"
     ]
   end
 


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/CEMSsELU)

### Context
Using the default value for the Google Analytics cookies domain includes a leading dot (`.schoolexperience.education.gov.uk`) which doesn't match the other cookies. Instead, use `document.location.hostname`.

![image](https://user-images.githubusercontent.com/47089130/141975512-4b03f984-83bf-4804-bfdf-4624928535a3.png)

### Changes proposed in this pull request
- Use `document.location.hostname` for Google Analytics cookies domain
