### PR TITLE
Hard code the cookie domain in Rails

### DIFF
--- a/app/controllers/cookie_preferences_controller.rb
+++ b/app/controllers/cookie_preferences_controller.rb
@@ -33,12 +33,13 @@ private
       expires: preferences.expires,
       value: preferences.to_json,
       httponly: false,
+      domain: CookiePreference.domain,
     }
   end
 
   def remove_rejected_cookies(preferences)
     preferences.rejected_cookies.each do |cookie_key|
-      cookies.delete cookie_key
+      cookies.delete cookie_key, domain: CookiePreference.domain
     end
   end
 

--- a/app/models/cookie_preference.rb
+++ b/app/models/cookie_preference.rb
@@ -18,6 +18,12 @@ class CookiePreference
   delegate :to_json, to: :attributes
 
   class << self
+    def domain
+      # The domain name, as determined by Google Analytics, contains a leading
+      # dot. The domain here must match in order to correctly add and remove cookies
+      Rails.application.config.x.cookie_domain.presence
+    end
+
     def cookie_key
       "#{model_name.param_key}-#{VERSION}"
     end

--- a/app/views/application/_google_analytics.html.erb
+++ b/app/views/application/_google_analytics.html.erb
@@ -1,7 +1,7 @@
 <%- if cookie_preferences.allowed?(:analytics) -%>
   <%= javascript_tag nonce: true do -%>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', '<%= google_analytics_tracking_id %>', document.location.hostname);
+    ga('create', '<%= google_analytics_tracking_id %>');
     ga('send', 'pageview');
   <% end -%>
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -137,6 +137,7 @@ Rails.application.configure do
   config.x.google_maps_key = ENV['GOOGLE_MAPS_KEY'].presence || Rails.application.credentials[:google_maps_key]
 
   config.x.base_url = ENV.fetch('DFE_SIGNIN_BASE_URL') { 'https://schoolexperience.education.gov.uk' }
+  config.x.cookie_domain = '.schoolexperience.education.gov.uk'
   config.x.oidc_client_id = ENV.fetch('DFE_SIGNIN_CLIENT_ID') { 'schoolexperience' }
   config.x.oidc_client_secret = ENV.fetch('DFE_SIGNIN_SECRET') do
     msg = "DFE_SIGNIN_SECRET has not been set"

--- a/spec/models/cookie_preference_spec.rb
+++ b/spec/models/cookie_preference_spec.rb
@@ -22,7 +22,7 @@ describe CookiePreference, type: :model do
 
       it do
         is_expected.not_to allow_value(nil).for(:analytics)
-          .with_message('Choose On or Off for cookies which measure website use')
+                                           .with_message('Choose On or Off for cookies which measure website use')
       end
     end
   end
@@ -64,6 +64,26 @@ describe CookiePreference, type: :model do
     let(:json) { { analytics: true }.to_json }
     subject { described_class.from_json(json) }
     it { is_expected.to have_attributes analytics: true }
+  end
+
+  describe '.domain' do
+    subject { described_class.domain }
+
+    context "when in config" do
+      before do
+        allow(Rails.application.config.x).to receive(:cookie_domain) { ".schoolexperience.education.gov.uk" }
+      end
+
+      it { is_expected.to eq ".schoolexperience.education.gov.uk" }
+    end
+
+    context "when not in config" do
+      before do
+        allow(Rails.application.config.x).to receive(:cookie_domain) { nil }
+      end
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe '.from_cookie' do

--- a/spec/requests/google_analytics/presence_spec.rb
+++ b/spec/requests/google_analytics/presence_spec.rb
@@ -7,7 +7,7 @@ describe "candidates/home/index.html.erb", type: :request do
   let(:ga_identifiers) do
     [
       '<script src="https://www.google-analytics.com/analytics.js" nonce="noncevalue" async="async"></script>',
-      "ga('create', '#{tracking_id}', document.location.hostname);"
+      "ga('create', '#{tracking_id}');"
     ]
   end
 


### PR DESCRIPTION
### Context
Google always adds a leading dot to any domain name passed into the Analytics create method.

This needs to match the domain specified in the `cookie_preferences_controller`. Add the domain with a leading dot to the Rails production config.

### Changes proposed in this pull request
- Let Google Analytics use the default domain of `.schoolexperience.educaiton.gov.uk`
- Add `.schoolexperience.educaiton.gov.uk` to the production config to be supplied when adding/removing cookies.

### Guidance to review

