### PR TITLE
Set Google analytics domain options to `none`

### DIFF
--- a/app/views/application/_google_analytics.html.erb
+++ b/app/views/application/_google_analytics.html.erb
@@ -1,7 +1,7 @@
 <%- if cookie_preferences.allowed?(:analytics) -%>
   <%= javascript_tag nonce: true do -%>
     window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', '<%= google_analytics_tracking_id %>', document.location.hostname);
+    ga('create', '<%= google_analytics_tracking_id %>', 'none');
     ga('send', 'pageview');
   <% end -%>
 

--- a/spec/requests/google_analytics/presence_spec.rb
+++ b/spec/requests/google_analytics/presence_spec.rb
@@ -7,7 +7,7 @@ describe "candidates/home/index.html.erb", type: :request do
   let(:ga_identifiers) do
     [
       '<script src="https://www.google-analytics.com/analytics.js" nonce="noncevalue" async="async"></script>',
-      "ga('create', '#{tracking_id}', document.location.hostname);"
+      "ga('create', '#{tracking_id}', 'none');"
     ]
   end
 


### PR DESCRIPTION
### Context
There is a domain option `none`, which sets the cookies to host-only (no leading dot). This has been tested locally by editing `etc/hosts` to have a proper domain name.