### PR TITLE
Add the candidate name in the request rejection email

### DIFF
--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -46,7 +46,8 @@ module Schools
             rejection_reasons: cancellation.rejection_description,
             extra_details: cancellation.extra_details,
             dates_requested: cancellation.dates_requested,
-            school_search_url: new_candidates_school_search_url
+            school_search_url: new_candidates_school_search_url,
+            candidate_name: cancellation.candidate_name
           ).despatch_later!
         end
       end

--- a/app/notify/notify_email/candidate_request_rejection.rb
+++ b/app/notify/notify_email/candidate_request_rejection.rb
@@ -4,14 +4,16 @@ class NotifyEmail::CandidateRequestRejection < Notify
     :rejection_reasons,
     :extra_details,
     :dates_requested,
-    :school_search_url
+    :school_search_url,
+    :candidate_name
 
-  def initialize(to:, school_name:, rejection_reasons:, extra_details:, dates_requested:, school_search_url:)
+  def initialize(to:, school_name:, rejection_reasons:, extra_details:, dates_requested:, school_search_url:, candidate_name:)
     self.school_name       = school_name
     self.rejection_reasons = rejection_reasons
     self.extra_details     = extra_details
     self.dates_requested   = dates_requested
     self.school_search_url = school_search_url
+    self.candidate_name    = candidate_name
     super(to: to)
   end
 
@@ -27,7 +29,8 @@ private
       rejection_reasons: rejection_reasons,
       extra_details: extra_details,
       dates_requested: dates_requested,
-      school_search_url: school_search_url
+      school_search_url: school_search_url,
+      candidate_name: candidate_name
     }
   end
 end

--- a/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
+++ b/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
@@ -1,4 +1,4 @@
-Hello ((candidate_name)),
+Dear ((candidate_name)),
 
 ((school_name)) has turned down your school experience request for the following dates: 
 * ((dates_requested))

--- a/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
+++ b/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
@@ -1,4 +1,4 @@
-Hello,
+Hello ((candidate_name)),
 
 ((school_name)) has turned down your school experience request for the following dates: 
 * ((dates_requested))

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -68,8 +68,8 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
           rejection_reasons: cancellation.rejection_description,
           extra_details: cancellation.extra_details,
           dates_requested: cancellation.dates_requested,
-          school_search_url: new_candidates_school_search_url
-
+          school_search_url: new_candidates_school_search_url,
+          candidate_name: gitis_contact.full_name
         expect(candidate_request_rejection_notification).to \
           have_received :despatch_later!
       end

--- a/spec/notify/notify_email/candidate_request_rejection_spec.rb
+++ b/spec/notify/notify_email/candidate_request_rejection_spec.rb
@@ -6,5 +6,6 @@ describe NotifyEmail::CandidateRequestRejection do
     rejection_reasons: "Failed security checks",
     extra_details: 'HawHaw',
     dates_requested: 'Whenever really',
-    school_search_url: 'https://example.com/'
+    school_search_url: 'https://example.com/',
+    candidate_name: 'Jane Doe'
 end

--- a/spec/support/fake_get_into_teaching_api_client.rb
+++ b/spec/support/fake_get_into_teaching_api_client.rb
@@ -65,6 +65,7 @@ private
       candidateId: fake_candidate_id,
       firstName: 'Matthew',
       lastName: 'Richards',
+      fullName: 'Matthew Richards',
       mobileTelephone: '07123 456789',
       telephone: '01234 567890',
       email: 'first@thisaddress.com',


### PR DESCRIPTION
### Trello card
N/A

### Context
We want to greet the candidates with their name when sending the request rejection email.

### Changes proposed in this pull request
Add the `candidate_name` placeholder in the email template and provide the candidate's name to the template when sending the email.

### Guidance to review

