### PR TITLE
Remove CRM from healthcheck

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -4,7 +4,6 @@ class Healthcheck
   delegate :to_json, to: :to_h
 
   FUNCTIONAL_API_STATUS_CODES = %w[healthy degraded].freeze
-  HEALTHY_CRM_STATUS_CODE = "ok".freeze
 
   def deployment
     ENV.fetch('DEPLOYMENT_ID') { 'not set' }
@@ -32,8 +31,7 @@ class Healthcheck
   def test_gitis
     health = GetIntoTeachingApiClient::OperationsApi.new.health_check
 
-    FUNCTIONAL_API_STATUS_CODES.any?(health.status) &&
-      health.crm == HEALTHY_CRM_STATUS_CODE
+    FUNCTIONAL_API_STATUS_CODES.any?(health.status)
   rescue Faraday::Error, GetIntoTeachingApiClient::ApiError
     false
   end

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -44,12 +44,6 @@ RSpec.describe Healthcheck do
 
       it { is_expected.to be true }
     end
-
-    context "with a degraded connection (CRM offline)" do
-      include_context "api degraded (CRM offline)"
-
-      it { is_expected.to be false }
-    end
   end
 
   describe "test_postgresql" do

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -44,14 +44,6 @@ shared_context "api degraded (CRM online)" do
   end
 end
 
-shared_context "api degraded (CRM offline)" do
-  before do
-    response = GetIntoTeachingApiClient::HealthCheckResponse.new(status: "degraded", crm: "offline")
-    allow_any_instance_of(GetIntoTeachingApiClient::OperationsApi).to \
-      receive(:health_check) { response }
-  end
-end
-
 shared_context "api correct verification code" do
   let(:code) { "123456" }
   let(:sign_up) { build(:api_schools_experience_sign_up_with_name) }


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/KFPSyYa4)

### Context
We have added some resilience to the candidate sign up and classroom experience note by queueing requests in the API when the CRM integration is paused.

We don't want to be alerted anymore via Slack and StatusCake when the CRM integration is paused.

Some operations will remain unavailable such as fetching a candidate (which should be a rare occurrence), but we will see these as Sentry errors.

### Changes proposed in this pull request
- Remove CRM from healthcheck