### PR TITLE
Re-enable buttons when navigating to page with browser back button

### DIFF
--- a/app/webpacker/controllers/prevent_double_click_controller.js
+++ b/app/webpacker/controllers/prevent_double_click_controller.js
@@ -3,6 +3,16 @@ import { Controller } from "stimulus"
 export default class extends Controller {
   static targets = [ 'submitButton' ]
 
+  connect() {
+    window.addEventListener( "pageshow", ( event ) => {
+      this.enableSubmitButton()
+    });
+  }
+
+  enableSubmitButton() {
+    this.submitButtonTarget.disabled = false;
+  }
+
   disableSubmitButton() {
     this.submitButtonTarget.disabled = true;
   };


### PR DESCRIPTION
### Context
We recently fixed some JavaScript that disables buttons so that a user can't submit a form multiple times.

However, pages don't reload fully when navigating back using the browser's back button, so the button remains disabled.

We can add an event listener for the "pageshow" event to re-enable the button when this happens.

### Changes proposed in this pull request
- Re-enable buttons when navigating to page with browser back button
