### PR TITLE
Validate that candidate second subject choice is different than first

### DIFF
--- a/app/services/candidates/registrations/behaviours/teaching_preference.rb
+++ b/app/services/candidates/registrations/behaviours/teaching_preference.rb
@@ -13,6 +13,7 @@ module Candidates
           validates :subject_first_choice, inclusion: { in: :available_subject_choices }, if: -> { subject_first_choice.present? }
           validates :subject_second_choice, presence: true
           validates :subject_second_choice, inclusion: { in: :second_subject_choices }, if: -> { subject_second_choice.present? }
+          validate :second_choice_different_than_first_choice, if: -> { subject_second_choice.present? }
         end
 
         def available_teaching_stages
@@ -40,6 +41,12 @@ module Candidates
 
         def all_available_subject_choices
           Candidates::School.subjects.map(&:last)
+        end
+
+        def second_choice_different_than_first_choice
+          if subject_second_choice == subject_first_choice
+            errors.add(:subject_second_choice, "Second choice must be different than first choice")
+          end
         end
       end
     end

--- a/spec/factories/bookings/placement_requests_factory.rb
+++ b/spec/factories/bookings/placement_requests_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     degree_subject { "Bioscience" }
     teaching_stage { "It’s just an idea" }
     subject_first_choice { "Biology" }
-    subject_second_choice { "Biology" }
+    subject_second_choice { "Chemistry" }
     has_dbs_check { true }
     availability { "Every second Thursday" }
     association :school, factory: :bookings_school

--- a/spec/services/candidates/registrations/teaching_preference_spec.rb
+++ b/spec/services/candidates/registrations/teaching_preference_spec.rb
@@ -34,6 +34,18 @@ describe Candidates::Registrations::TeachingPreference, type: :model do
       is_expected.to validate_inclusion_of(:subject_second_choice).in_array \
         second_subject_choices
     end
+
+    context "when first subject choice has a value" do
+      before { subject.subject_first_choice = "Biology" }
+
+      it "allows second choice to be a different value" do
+        is_expected.to allow_value("Chemistry").for :subject_second_choice
+      end
+
+      it "returns a validation error when second subject has the same value" do
+        is_expected.to_not allow_value("Biology").for :subject_second_choice
+      end
+    end
   end
 
   context '#available_subject_choices' do


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/P8NMlBNb)

### Context
Currently, a candidate can choose the same subject for their first choice and second choice. 

Add some validation to prevent this.

### Changes proposed in this pull request
- Validate that candidate second subject choice is different than first

### Guidance to review
Is this better? Is the message okay?
