### PR TITLE
Create a page to display the expired requests older than a month

### DIFF
--- a/app/controllers/schools/archived_placement_requests_controller.rb
+++ b/app/controllers/schools/archived_placement_requests_controller.rb
@@ -1,0 +1,20 @@
+module Schools
+  class ArchivedPlacementRequestsController < BaseController
+    def index
+      @placement_requests = placement_requests
+      assign_gitis_contacts(@placement_requests)
+    end
+
+  private
+
+    def placement_requests
+      current_school
+      .placement_requests
+      .unprocessed
+      .old_expired_requests
+      .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date, :booking, :subject)
+      .order(created_at: 'desc')
+      .page(params[:page])
+    end
+  end
+end

--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -37,6 +37,7 @@ module Schools
       current_school
         .placement_requests
         .unbooked
+        .excluding_old_expired_requests
         .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date, :booking, :subject)
         .order(created_at: 'desc')
         .page(params[:page])

--- a/app/views/schools/archived_placement_requests/index.html.erb
+++ b/app/views/schools/archived_placement_requests/index.html.erb
@@ -1,14 +1,10 @@
-<% self.page_title = "All placement requests" %>
+<% self.page_title = "Archived placement requests" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= govuk_back_link schools_dashboard_path %>
+    <%= govuk_back_link schools_placement_requests_path %>
 
-    <h1>Manage requests</h1>
-
-    <div class="govuk-inset-text">
-      We now hide expired requests after 30 days. If you need to view them and accept or decline them, view the <%= link_to 'archived requests' , schools_archived_placement_requests_path, class: 'govuk-notification-banner__link' %> page
-    </div>
+    <h1>Archived requests</h1>
 
     <% if @placement_requests.any? %>
       <%= pagination_bar @placement_requests %>
@@ -23,10 +19,6 @@
         There are no requests.
       </p>
     <% end %>
-
-    <p>
-      <%= link_to "Download your requests and bookings", schools_csv_export_path %> as a CSV export.
-    </p>
 
     <%= govuk_link_to "Return to requests and bookings", schools_dashboard_path, secondary: true %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
         controller: 'placement_requests/past_attendance'
       put "/schools/placement_requests/place_under_consideration", to: "/schools/placement_requests/under_consideration#place_under_consideration"
     end
+    resources :archived_placement_requests, only: %i[index]
     resources :withdrawn_requests, only: %i[index show]
     resources :rejected_requests, only: %i[index show]
     resources :confirmed_bookings, path: 'bookings', as: 'bookings', only: %i[index show] do

--- a/spec/controllers/schools/archived_placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/archived_placement_requests_controller_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::ArchivedPlacementRequestsController, type: :request do
+  include_context "logged in DfE user"
+
+  let(:school) { Bookings::School.find_by! urn: urn }
+  let!(:profile) { create :bookings_profile, school: school }
+
+  before do
+    school.subjects << create_list(:bookings_subject, 1)
+  end
+
+  describe '#index' do
+    subject { response }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to render_template 'index' }
+
+    before do
+      school.update(availability_preference_fixed: true)
+      create(:placement_request, :with_a_fixed_date_in_the_past, school: school)
+
+      get schools_archived_placement_requests_path
+    end
+
+    it 'displays only placement requests that expired longer than a month ago' do
+      expect(assigns(:placement_requests).count).to eq(1)
+    end
+
+    context 'with long expired and processed requests' do
+      it 'does not displays them' do
+        create(:placement_request, :with_a_fixed_date_in_the_past, :cancelled_by_school, school: school)
+
+        expect(assigns(:placement_requests).count).to eq(1)
+      end
+    end
+
+    context 'with processed requests' do
+      it 'does not displays them' do
+        create(:placement_request, :with_a_fixed_date, :cancelled_by_school, school: school)
+
+        expect(assigns(:placement_requests).count).to eq(1)
+      end
+    end
+
+    context 'with unprocessed requests' do
+      it 'does not displays them' do
+        create_list :placement_request, 2, :with_a_fixed_date, school: school
+
+        expect(assigns(:placement_requests).count).to eq(1)
+      end
+    end
+
+    context 'with recently expired requests' do
+      it 'does not displays them' do
+        create(:placement_request, :with_a_fixed_date_in_the_recent_past, school: school)
+
+        expect(assigns(:placement_requests).count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/factories/bookings/placement_dates.rb
+++ b/spec/factories/bookings/placement_dates.rb
@@ -11,6 +11,11 @@ FactoryBot.define do
       to_create { |instance| instance.save(validate: false) }
     end
 
+    trait :in_the_recent_past do
+      date { 1.week.ago }
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     trait :active do
       active { true }
     end

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -116,5 +116,15 @@ FactoryBot.define do
       availability { nil }
       association :placement_date, factory: :bookings_placement_date
     end
+
+    trait :with_a_fixed_date_in_the_recent_past do
+      availability { nil }
+      association :placement_date, :in_the_recent_past, factory: :bookings_placement_date
+    end
+
+    trait :with_a_fixed_date_in_the_past do
+      availability { nil }
+      association :placement_date, :in_the_past, factory: :bookings_placement_date
+    end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/C6leT8zo

### Context
Schools received some placement requests ages ago which they don't want to trigger the emails by accepting/rejecting the, so they just sitting in the manage requests page.

To make this a bit more manageable for the school managers, we want to move placement requests that expired more than a month ago to their own page. 

### Changes proposed in this pull request
Keep displaying recently expired requests (no more than a month ago) in the placement requests
Create a new archive page to display unprocessed requests that expired a month ago
Add a message in the placement requests page to inform the school managers about the new changes that also includes a link to access the archive page

### Guidance to review

