### PR TITLE
Update the cookie banner to the latest design

### DIFF
--- a/app/views/shared/application/_cookie_banner.html.erb
+++ b/app/views/shared/application/_cookie_banner.html.erb
@@ -1,22 +1,28 @@
 <% if show_cookie_message? %>
-  <div id="cookie-banner" aria-label="cookie banner" role="region">
-    <div id="cookie-banner-message" class="govuk-width-container">
-      <p>
-        School experience uses cookies which are essential for the site to work.
-        We also use non-essential cookies to help us improve the school
-        experience service. By continuing to use this site, you agree to our use
-        of cookies.
-      </p>
+  <div class="govuk-cookie-banner " data-nosnippet role="region" aria-label="Cookies on School experience">
+    <div class="govuk-cookie-banner__message govuk-width-container">
 
-      <p>
-        <%= link_to("Find out more about cookies", cookies_policy_path) %>
-      </p>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-cookie-banner__heading govuk-heading-m">Cookies on School experience</h2>
 
-      <%= govuk_button_to 'Accept cookies',
-          cookie_preference_path(cookie_preference: {all: 'true'}),
-          method: :patch %>
+          <div class="govuk-cookie-banner__content">
+            <p class="govuk-body">We use some essential cookies to make this service work.</p>
+            <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service
+              and make improvements.</p>
+          </div>
+        </div>
+      </div>
 
-      <%= govuk_link_to 'Cookie settings', edit_cookie_preference_path %>
+      <div class="govuk-button-group">
+        <%= govuk_button_to "Accept analytics cookies",
+                            cookie_preference_path(cookie_preference: { all: true }),
+                            method: :put %>
+        <%= govuk_button_to "Reject analytics cookies",
+                            cookie_preference_path(cookie_preference: { analytics: false }),
+                            method: :put %>
+        <%= link_to("View cookies", cookies_policy_path, class: "govuk-link") %>
+      </div>
     </div>
   </div>
 <% elsif flash[:cookies].present? %>

--- a/app/webpacker/stylesheets/cookie-banner.scss
+++ b/app/webpacker/stylesheets/cookie-banner.scss
@@ -1,3 +1,9 @@
+.govuk-cookie-banner {
+  form {
+    display: contents;
+  }
+}
+
 #cookie-banner {
   background-color: lighten(govuk-colour("blue"), 55%);
   padding: 0.6rem 0rem 0.4rem;

--- a/spec/features/cookie_preferences_spec.rb
+++ b/spec/features/cookie_preferences_spec.rb
@@ -5,7 +5,7 @@ feature "Save the referer" do
     visit new_candidates_feedback_path
 
     click_on "Submit feedback"
-    click_on "Accept cookies"
+    click_on "Accept analytics cookies"
 
     expect(page.current_path).to eq(root_path)
   end
@@ -13,7 +13,7 @@ feature "Save the referer" do
   scenario "a user accepts the cookies from valid path" do
     visit candidates_signin_path
 
-    click_on "Accept cookies"
+    click_on "Accept analytics cookies"
 
     expect(page.current_path).to eq(candidates_signin_path)
   end
@@ -21,7 +21,7 @@ feature "Save the referer" do
   scenario "a user accepts the cookies from a blacklisted path" do
     visit edit_cookie_preference_path
 
-    click_on "Accept cookies"
+    click_on "Accept analytics cookies"
 
     expect(page.current_path).to eq(edit_cookie_preference_path)
   end

--- a/spec/requests/cookie_banner_spec.rb
+++ b/spec/requests/cookie_banner_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe "Displaying the cookie banner", type: :request do
   let(:cookie_name) { 'seen_cookie_message' }
-  let(:banner_contents) { /School experience uses cookies/ }
+  let(:banner_contents) { /Cookies on School experience/ }
 
   context 'on the first visit (when the seen_cookie_message cookie is absent)' do
     specify "the cookie should not be set to 'yes'" do


### PR DESCRIPTION
### Trello card
[Trello](https://trello.com/c/9eQtXD4X)

### Changes proposed in this pull request
- Update the cookie banner to the latest design. This is more descriptive because it explicitly mentions analytics cookies.

### Guidance to review
