### PR TITLE
Usability fix of H3 -> H2

### DIFF
--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -8,7 +8,7 @@
       </h1>
     </div>
 
-    <h3 class="govuk-heading-m">What happens next</h3>
+    <h2 class="govuk-heading-m">What happens next</h2>
 
     <p>
       You'll be contacted about your request. Schools aim to get in touch


### PR DESCRIPTION
### Trello card

N/A

### Context
Following Adam's review of DAC report from 2019, this was a small usability fix of changing a H3 to a H2. We had a H1, but no corresponding H2. It's potentially jarring to hop straight from H1 -> H3.

### Changes proposed in this pull request
Usability fix of H3 -> H2 on Request confirmation page.
### Guidance to review

