### PR TITLE
Fix the broken feature tests

### DIFF
--- a/features/schools/attendances/index.feature
+++ b/features/schools/attendances/index.feature
@@ -6,6 +6,7 @@ Feature: Viewing historical attendances
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
+        And the school has subjects
     
     Scenario: Page title
         Given I am on the 'attendances' page

--- a/features/schools/confirm_attendance.feature
+++ b/features/schools/confirm_attendance.feature
@@ -5,7 +5,7 @@ Feature: Confirming candidate attendance
 
     Background:
         Given I am logged in as a DfE user
-        And the school offers 'Biology, Chemistry'
+        And the school offers 'Biology, Maths'
         And my school is fully-onboarded
 
     Scenario: When there are no bookings

--- a/features/schools/confirmed_bookings/editing_a_date.feature
+++ b/features/schools/confirmed_bookings/editing_a_date.feature
@@ -6,6 +6,7 @@ Feature: Updating a date
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
+        And the school has subjects
         And the scheduled booking date is in the future
 
     Scenario: Page title

--- a/features/schools/confirmed_bookings/index.feature
+++ b/features/schools/confirmed_bookings/index.feature
@@ -6,6 +6,7 @@ Feature: Viewing all bookings
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
+        And the school has subjects
 
     Scenario: Page title
         Given I am on the 'bookings' page

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -6,6 +6,7 @@ Feature: Viewing a booking
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
+        And the school has subjects
         And the scheduled booking date is in the future
 
     Scenario: Page title
@@ -55,7 +56,7 @@ Feature: Viewing a booking
             | Degree subject                          | Bioscience                        |
             | Teaching stage                          | I want to be a teacher            |
             | Teaching subject                        | First choice: Biology             |
-            | Teaching subject                        | Second choice: Biology            |
+            | Teaching subject                        | Second choice: Maths              |
 
     Scenario: Without a candidate cancellation
         Given there is at least one booking

--- a/features/schools/previous_bookings/index.feature
+++ b/features/schools/previous_bookings/index.feature
@@ -6,6 +6,7 @@ Feature: Viewing previous bookings
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
+        And the school has subjects
     
     Scenario: Page title
         Given I am on the 'previous bookings' page

--- a/features/schools/previous_bookings/show.feature
+++ b/features/schools/previous_bookings/show.feature
@@ -6,6 +6,7 @@ Feature: Viewing a previous booking
     Background:
         Given I am logged in as a DfE user
         And my school is fully-onboarded
+        And the school has subjects
         And the scheduled booking date is in the past
 
     Scenario: Page title
@@ -55,7 +56,7 @@ Feature: Viewing a previous booking
             | Degree subject                          | Bioscience                        |
             | Teaching stage                          | I want to be a teacher            |
             | Teaching subject                        | First choice: Biology             |
-            | Teaching subject                        | Second choice: Biology            |
+            | Teaching subject                        | Second choice: Maths              |
 
     Scenario: Without a candidate cancellation
         Given there is at least one previous booking

--- a/features/step_definitions/schools/attendances_steps.rb
+++ b/features/step_definitions/schools/attendances_steps.rb
@@ -1,5 +1,5 @@
 Given("there are some bookings with attendance recorded") do
-  biology = FactoryBot.create :bookings_subject, name: 'Biology'
+  biology = @school.subjects.find_by(name: 'Biology')
 
   FactoryBot.create :bookings_booking, :accepted, :previous, :attended,
     bookings_school: @school,
@@ -11,7 +11,6 @@ Given("there are some bookings with attendance recorded") do
 end
 
 Given("there are no bookings with attendance recorded") do
-  FactoryBot.create :bookings_subject, name: 'Biology'
   FactoryBot.create :bookings_booking, :accepted, :previous,
     bookings_school: @school
 end

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -11,9 +11,6 @@ Given("there is at least one booking") do
 end
 
 Given("there is a booking cancelled by the candidate") do
-  unless @school.subjects.where(name: 'Biology').any?
-    @school.subjects << FactoryBot.create(:bookings_subject, name: 'Biology')
-  end
   @booking = FactoryBot.create :bookings_booking,
     :cancelled_by_candidate,
     bookings_school: @school,
@@ -24,9 +21,6 @@ Given("there is a booking cancelled by the candidate") do
 end
 
 Given("there is a booking cancelled by the school") do
-  unless @school.subjects.where(name: 'Biology').any?
-    @school.subjects << FactoryBot.create(:bookings_subject, name: 'Biology')
-  end
   @booking = FactoryBot.create :bookings_booking,
     :cancelled_by_school,
     bookings_school: @school,
@@ -43,9 +37,6 @@ Given("I am viewing my chosen booking") do
 end
 
 And("there is/are {int} booking/bookings") do |count|
-  unless @school.subjects.where(name: 'Biology').any?
-    @school.subjects << FactoryBot.create(:bookings_subject, name: 'Biology')
-  end
   @bookings = (1..count).map do |index|
     FactoryBot.create(
       :bookings_booking,

--- a/features/step_definitions/schools/previous_bookings_steps.rb
+++ b/features/step_definitions/schools/previous_bookings_steps.rb
@@ -16,9 +16,6 @@ And("there is/are {int} previous booking/bookings") do |count|
   now = Time.zone.today
 
   travel_to 1.year.ago do
-    unless @school.subjects.where(name: 'Biology').any?
-      @school.subjects << FactoryBot.create(:bookings_subject, name: 'Biology')
-    end
     @bookings = (1..count).map do |index|
       FactoryBot.create(
         :bookings_booking,
@@ -56,10 +53,6 @@ Given("the scheduled booking date is in the past") do
 end
 
 Given("there is a cancelled previous booking") do
-  unless @school.subjects.where(name: 'Biology').any?
-    @school.subjects << FactoryBot.create(:bookings_subject, name: 'Biology')
-  end
-
   last_week = 1.week.ago.to_date
 
   travel_to 1.month.ago do

--- a/spec/factories/bookings/placement_requests_factory.rb
+++ b/spec/factories/bookings/placement_requests_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     degree_subject { "Bioscience" }
     teaching_stage { "It’s just an idea" }
     subject_first_choice { "Biology" }
-    subject_second_choice { "Chemistry" }
+    subject_second_choice { "Maths" }
     has_dbs_check { true }
     availability { "Every second Thursday" }
     association :school, factory: :bookings_school


### PR DESCRIPTION
### Trello card
N/A

### Context
#2106 broke some feature tests because certain placement requests use the Chemistry subject which doesn't exist in the school subjects.

### Changes proposed in this pull request
Add the schools subjects step in the failing tests which creates and associates three subjects to the school and use one of them as the second subject choice in the placement requests.

### Guidance to review

