### PR TITLE
Do not display rejected requests in the manage requests page

### DIFF
--- a/app/controllers/schools/placement_requests_controller.rb
+++ b/app/controllers/schools/placement_requests_controller.rb
@@ -36,7 +36,7 @@ module Schools
     def placement_requests
       current_school
         .placement_requests
-        .unbooked
+        .unprocessed
         .excluding_old_expired_requests
         .eager_load(:candidate, :candidate_cancellation, :school_cancellation, :placement_date, :booking, :subject)
         .order(created_at: 'desc')

--- a/features/schools/placement_requests/index.feature
+++ b/features/schools/placement_requests/index.feature
@@ -36,11 +36,6 @@ Feature: Viewing all placement requests
         When I am on the 'placement requests' page
         Then every request should contain a link to view more details
 
-    Scenario: Cancelled placement requests
-        Given there are some cancelled placement requests
-        When I am on the 'placement requests' page
-        Then the cancelled requests should have a status of 'Withdrawn'
-
     Scenario: Unviewed placement requests
         Given there are some unviewed placement requests
         When I am on the 'placement requests' page

--- a/features/step_definitions/schools/placement_request_steps.rb
+++ b/features/step_definitions/schools/placement_request_steps.rb
@@ -173,21 +173,6 @@ Then("I should see a table with the following headings:") do |table|
   end
 end
 
-Given("there are some cancelled placement requests") do
-  @cancelled_placement_requests_count = 3
-  @cancelled_placement_requests = FactoryBot.create_list \
-    :placement_request,
-    @cancelled_placement_requests_count,
-    :cancelled,
-    school: @school
-end
-
-Then("the cancelled requests should have a status of {string}") do |status|
-  within('table#placement-requests') do
-    expect(page).to have_css('.govuk-tag--red', text: /#{status}/i, count: @cancelled_placement_requests_count)
-  end
-end
-
 Then("the under consideration request should have a status of 'Under consideration'") do
   within('table#placement-requests') do
     expect(page).to have_css('.govuk-tag--blue', text: /Under consideration/)

--- a/spec/controllers/schools/placement_requests_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests_controller_spec.rb
@@ -84,6 +84,20 @@ describe Schools::PlacementRequestsController, type: :request do
       end
     end
 
+    context 'after placement requests have been rejected' do
+      let(:rejected) { placement_requests.last }
+      before do
+        create :cancellation, :cancelled_by_school,
+          placement_request: rejected
+
+        get '/schools/placement_requests'
+      end
+
+      specify 'they should be omitted' do
+        expect(assigns(:placement_requests)).not_to include(rejected)
+      end
+    end
+
     context "with a timeout response from the API" do
       before do
         ids = placement_requests.map(&:contact_uuid)

--- a/spec/factories/bookings/placement_request/cancellations_factory.rb
+++ b/spec/factories/bookings/placement_request/cancellations_factory.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     trait :cancelled_by_school do
       rejection_category { 'fully_booked' }
       cancelled_by { 'school' }
+      sent
     end
 
     trait :cancelled_by_candidate do


### PR DESCRIPTION
### Trello card
https://trello.com/c/kKDRkiFJ

### Context
Displaying the rejected requests in the manage requests page is a bit confusing, especially when they have their own page.

### Changes proposed in this pull request
Use the `unprocessed` scope when retrieving the placement requests in the manage requests page.

### Guidance to review
