### PR TITLE
Expire flex requests only when they are archived

### DIFF
--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -266,7 +266,7 @@ module Bookings
     end
 
     def flex_date_expired?
-      placement_date.nil? && created_at.before?(Date.today)
+      placement_date.nil? && created_at.before?(2.months.ago)
     end
 
     def completed?

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -804,12 +804,38 @@ describe Bookings::PlacementRequest, type: :model do
       it { is_expected.to eq 'Flagged' }
     end
 
-    context 'when placement date has lapsed' do
-      it 'returns Expired' do
-        request = create(:placement_request, :with_a_fixed_date)
+    context 'when expired request' do
+      context 'when fixed placement request' do
+        it 'returns Expired when the placement date has lapsed' do
+          request = create(:placement_request, :with_a_fixed_date)
 
-        travel 1.year do
-          expect(request.status).to eq 'Expired'
+          travel 1.year do
+            expect(request.status).to eq 'Expired'
+          end
+        end
+
+        it 'does not returns Expired when the placement date has not lapsed' do
+          request = create(:placement_request, :with_a_fixed_date)
+
+          expect(request.status).not_to eq 'Expired'
+        end
+      end
+
+      context 'when flex placement request' do
+        it 'returns Expired when it is older than two months' do
+          request = create(:placement_request)
+
+          travel 3.months do
+            expect(request.status).to eq 'Expired'
+          end
+        end
+
+        it 'does not returns Expired when it is not older than two months' do
+          request = create(:placement_request)
+
+          travel 2.months do
+            expect(request.status).not_to eq 'Expired'
+          end
         end
       end
     end


### PR DESCRIPTION
### Trello card
https://trello.com/c/aV8OpoWy

### Context
Placement requests for flex dates are expired the next day after they are created, which is confusing for the school managers. 

We want to mark them as expired when they are archived (2 months after they are received).

### Changes proposed in this pull request
Update the placement request `#flex_date_expired?` to return true after two months of the created_at date. 

### Guidance to review

