### PR TITLE
Improve dates position for long subject lists

### DIFF
--- a/app/webpacker/stylesheets/subject-and-date-information.scss
+++ b/app/webpacker/stylesheets/subject-and-date-information.scss
@@ -21,5 +21,8 @@
     }
   }
 
+  .govuk-summary-list__key {
+    vertical-align: top;
+  }
 
 }


### PR DESCRIPTION
### Trello card
https://trello.com/c/B6HExWgC

### Context
Currently, we display fixed dates at the bottom of the subject lists when we ask a user to select a date and subject, making it hard for the user to see the dates when the school offers placements dates with long subject lists.

### Changes proposed in this pull request
Change the vertical alignment of the date to top.

### Guidance to review
|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/951947/145189563-3f164e4f-e0c4-4fc1-8a54-db6fd9e120de.png)|![after](https://user-images.githubusercontent.com/951947/145189576-9fde8276-298e-4676-96e9-50c612ab5b5a.png)|


