### PR TITLE
Remove the DSI service list links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -72,9 +72,7 @@ module ApplicationHelper
                  "Welcome #{current_user_full_name user}"
                end
 
-    switch_service = link_to("switch service", Rails.configuration.x.oidc_services_list_url)
-
-    safe_join([greeting, logout_link, "or", switch_service].compact, " ")
+    safe_join([greeting, logout_link].compact, " ")
   end
 
   def current_user_full_name(user)

--- a/app/views/shared/application/_phase_banner.html.erb
+++ b/app/views/shared/application/_phase_banner.html.erb
@@ -10,9 +10,6 @@
     <div class="govuk-phase-banner__text auth">
       <%= current_user_info_and_logout_link current_user %>
     </div>
-
-    <%- elsif in_schools_namespace? -%>
-      <%= link_to 'Choose another service', Rails.configuration.x.oidc_services_list_url %>
     <%- end -%>
   </div>
 </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -105,7 +105,6 @@ Rails.application.configure do
   config.x.oidc_client_id = 'schoolexperience'
   config.x.oidc_client_secret = Rails.application.credentials[:dfe_pp_signin_secret]
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
-  config.x.oidc_services_list_url = 'https://pp-services.signin.education.gov.uk/my-services'
   config.x.dfe_sign_in_api_host = 'pp-api.signin.education.gov.uk'
 
   truthy_strings = %w[true 1 yes]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -144,9 +144,6 @@ Rails.application.configure do
     ''
   end
   config.x.oidc_host = ENV.fetch('DFE_SIGNIN_HOST') { 'pp-oidc.signin.education.gov.uk' }
-  config.x.oidc_services_list_url = ENV.fetch('DFE_SERVICES_LIST_URL') do
-    'https://services.signin.education.gov.uk/my-services'
-  end
 
   config.x.dfe_sign_in_api_host = ENV.fetch('DFE_SIGNIN_API_ENDPOINT') do
     'api.signin.education.gov.uk'

--- a/config/environments/servertest.rb
+++ b/config/environments/servertest.rb
@@ -27,7 +27,6 @@ Rails.application.configure do
   config.x.oidc_client_id = 'schoolexperience'
   config.x.oidc_client_secret = Rails.application.credentials[:dfe_pp_signin_secret]
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
-  config.x.oidc_services_list_url = 'https://some-oidc.provider.com/my-services'
   config.x.dfe_sign_in_api_host = 'pp-api.signin.education.gov.uk'
   config.x.dfe_sign_in_api_enabled = false
   config.x.dfe_sign_in_api_role_check_enabled = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -168,7 +168,6 @@ Rails.application.configure do
   config.x.oidc_client_id = 'se-test'
   config.x.oidc_client_secret = 'abc123'
   config.x.oidc_host = 'some-oidc-host.education.gov.uk'
-  config.x.oidc_services_list_url = 'https://some-oidc.provider.com/my-services'
 
   config.x.dfe_sign_in_api_host = 'some-signin-host.signin.education.gov.uk'
 

--- a/features/schools/landing_page.feature
+++ b/features/schools/landing_page.feature
@@ -11,8 +11,3 @@ Feature: The School Landing Page
     Scenario: Start now button
         Given I am on the 'schools' page
         Then there should be a 'Start now' link to the 'schools dashboard'
-
-    Scenario: Choose another service link
-        Given I am not logged in
-        When I am on the 'schools' page
-        Then there should be a 'Choose another service' link to the DfE services list page

--- a/features/step_definitions/schools/account_steps.rb
+++ b/features/step_definitions/schools/account_steps.rb
@@ -14,7 +14,3 @@ end
 Given("I am not logged in") do
   # do nothing
 end
-
-Then("there should be a {string} link to the DfE services list page") do |link|
-  expect(page).to have_link(link, href: Rails.configuration.x.oidc_services_list_url)
-end


### PR DESCRIPTION
### Trello card
https://trello.com/c/J44GrRUH

### Context
It's not expected the GSE users to be using the switch service function often given that they're are using the service to manage school experience and not anything else.

### Changes proposed in this pull request
Remove both links appearing in the phase banner when school managers are logged in and logged out.

### Guidance to review

