### PR TITLE
Fix N+1 in the rejected request page

### DIFF
--- a/app/controllers/schools/rejected_requests_controller.rb
+++ b/app/controllers/schools/rejected_requests_controller.rb
@@ -2,7 +2,7 @@ module Schools
   class RejectedRequestsController < Schools::BaseController
     def index
       @requests = scope
-        .includes(:candidate, :school_cancellation, placement_date: :subjects)
+        .includes(:candidate, :school_cancellation, :subject, placement_date: :subjects)
         .page(params[:page])
         .per(50)
 


### PR DESCRIPTION
### Trello card
N/A

### Context
Bullet caught a N+1 problem with the subjects in the rejected requests page.

### Changes proposed in this pull request
Eager load the `subject` association

### Guidance to review

