### PR TITLE
Add Disability Confident filter in the search page

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -48,7 +48,7 @@ private
 
   def search_params
     params.permit(
-      :query, :location, :latitude, :longitude, :page, :distance,
+      :query, :location, :latitude, :longitude, :page, :distance, :disability_confident,
       :max_fee, phases: [], subjects: [], dbs_policies: []
     )
   end

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -124,6 +124,12 @@ module Candidates::SchoolHelper
     )
   end
 
+  def school_search_disability_confident_filter_description(search)
+    return if search.disability_confident.nil?
+
+    t('helpers.candidates.school_search.disability_confident_filter.text_html')
+  end
+
   def cleanup_school_url(url)
     if url.blank?
       '#'

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -159,6 +159,15 @@ class Bookings::School < ApplicationRecord
     end
   }
 
+  scope :disability_confident, lambda { |option|
+    if option.present?
+      joins(:profile)
+        .where('bookings_profiles.disability_confident IS ?', option)
+    else
+      all
+    end
+  }
+
   def to_param
     urn.to_s.presence
   end

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -93,6 +93,7 @@ private
       .distinct
       .includes([:available_placement_dates])
       .with_dbs_policies(dbs_options)
+      .disability_confident(disability_confident)
   end
 
   def whitelisted_base_query

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -19,7 +19,7 @@ module Candidates
       ['90', 'up to £90']
     ].freeze
 
-    attr_accessor :query, :location, :latitude,
+    attr_accessor :query, :location, :latitude, :disability_confident,
                   :longitude, :page, :analytics_tracking_uuid
     attr_reader :distance, :max_fee
 
@@ -69,6 +69,12 @@ module Candidates
     def dbs_policies=(dbs_policy_ids)
       @dbs_policies = Array.wrap(dbs_policy_ids).map(&:presence).compact.map(&:to_i)
     end
+
+    # def disability_confident=(value)
+    #   if value == '1'
+    #     @disability_confident = value
+    #   end
+    # end
 
     def subject_names
       Candidates::School.subjects.map { |s|
@@ -124,7 +130,8 @@ module Candidates
         max_fee: max_fee,
         page: page,
         analytics_tracking_uuid: analytics_tracking_uuid,
-        dbs_policies: dbs_policies
+        dbs_policies: dbs_policies,
+        disability_confident: disability_confident
       )
     end
 

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -46,6 +46,7 @@
 
           <%= f.collection_check_boxes :subjects, Candidates::School.subjects, :first, :last %>
           <%= f.collection_check_boxes :dbs_policies, [[2, nil]], :first, :last %>
+          <%= f.check_box_fieldset :disability_confident, [:disability_confident], include_hidden: false %>
 
           <%= f.submit 'Update schools list', name: nil %>
         <% end %>
@@ -54,7 +55,7 @@
   </aside>
 
   <section class="govuk-grid-column-two-thirds" id="search-results" aria-label="Search results">
-    <%- if @search.subjects.any? || @search.phases.any? || @search.dbs_policies.any? -%>
+    <%- if @search.subjects.any? || @search.phases.any? || @search.dbs_policies.any? || @search.disability_confident.present? -%>
       <div class="school-search-filter-info">
         <div>
           <%= school_search_phase_filter_description @search %>
@@ -66,6 +67,9 @@
 
         <div>
           <%= school_search_dbs_policies_filter_description @search %>
+        </div>
+        <div>
+          <%= school_search_disability_confident_filter_description(@search) %>
         </div>
       </div>
     <%- end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -512,6 +512,7 @@ en:
         rejection_category: Rejection reason
       phases: Education phases
       dbs_policies: DBS check
+      disability_confident: Disability and access needs
       fees: Fees
       subjects: Subjects
       candidates_registrations_background_check:
@@ -637,6 +638,7 @@ en:
 
     label:
       dbs_policies_2: Only show placements that do not require a DBS check
+      disability_confident: Only show Disability Confident schools
       schools_placement_requests_confirm_booking:
         bookings_subject_id: Confirm subject
         placement_details: Confirm experience details
@@ -899,6 +901,8 @@ en:
       school_search:
         phases_filter_html: "Education phases: %{phase_names}"
         subjects_filter_html: "Placement subjects: %{subject_names}"
+        disability_confident_filter:
+          text_html: "Disability Confident schools: <strong>Yes</strong>"
         dbs_policies_filter:
           text_html: "DBS check: %{dbs_policies_options}"
           options:

--- a/db/migrate/20211210132724_add_disability_confident_to_bookings_school_search.rb
+++ b/db/migrate/20211210132724_add_disability_confident_to_bookings_school_search.rb
@@ -1,0 +1,5 @@
+class AddDisabilityConfidentToBookingsSchoolSearch < ActiveRecord::Migration[6.1]
+  def change
+    add_column :bookings_school_searches, :disability_confident, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_20_103656) do
+ActiveRecord::Schema.define(version: 2021_12_10_132724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 2021_10_20_103656) do
     t.integer "duration", default: 1, null: false
     t.datetime "accepted_at"
     t.boolean "attended"
-    t.datetime "under_consideration_at"
     t.index ["bookings_placement_request_id"], name: "index_bookings_bookings_on_bookings_placement_request_id", unique: true
     t.index ["bookings_school_id"], name: "index_bookings_bookings_on_bookings_school_id"
     t.index ["bookings_subject_id"], name: "index_bookings_bookings_on_bookings_subject_id"
@@ -195,6 +194,7 @@ ActiveRecord::Schema.define(version: 2021_10_20_103656) do
     t.datetime "updated_at", null: false
     t.uuid "analytics_tracking_uuid"
     t.integer "dbs_policies", array: true
+    t.boolean "disability_confident"
   end
 
   create_table "bookings_school_types", force: :cascade do |t|

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         subjects: %w[2 3],
         max_fee: '30',
         order: 'Name',
-        dbs_policies: %w[1]
+        dbs_policies: %w[1],
+        disability_confident: '1'
       }
     end
 
@@ -28,6 +29,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       expect(assigns(:search).subjects).to eq([2, 3])
       expect(assigns(:search).max_fee).to eq('30')
       expect(assigns(:search).dbs_policies).to eq([1])
+      expect(assigns(:search).disability_confident).to eq('1')
 
       # note, this search will yield no results so the search radius will
       # automatically be expanded from 10 to the value at EXPANDED_SEARCH_RADIUS

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -248,6 +248,29 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
     end
   end
 
+  context '.school_search_disability_confident_filter_description' do
+    context 'when the disability confident filter is not selected' do
+      subject do
+        double('Bookings::SchoolSearch', disability_confident: nil)
+      end
+
+      it("should return a nil") do
+        expect(school_search_disability_confident_filter_description(subject)).to be_nil
+      end
+    end
+
+    context 'when the disability confident filter is selected' do
+      subject do
+        double('Bookings::SchoolSearch', disability_confident: '1')
+      end
+
+      it("should return yes") do
+        expect(school_search_disability_confident_filter_description(subject)).to \
+          eq("Disability Confident schools: <strong>Yes</strong>")
+      end
+    end
+  end
+
   describe '#cleanup_school_url' do
     context 'with blank url' do
       subject { cleanup_school_url(' ') }

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -328,6 +328,23 @@ describe Bookings::SchoolSearch do
             expect(subject).not_to include(non_matching_school)
           end
         end
+
+        context 'Filtering on disability confident' do
+          before do
+            create(:bookings_profile, school: matching_school)
+            create(:bookings_profile, :without_supports_access_needs, school: non_matching_school)
+          end
+
+          subject { Bookings::SchoolSearch.new(query: '', location: coords_in_manchester, disability_confident: '1').results }
+
+          specify 'should return matching results' do
+            expect(subject).to include(matching_school)
+          end
+
+          specify 'should omit non-matching results' do
+            expect(subject).not_to include(non_matching_school)
+          end
+        end
       end
 
       context 'Chaining' do

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -371,6 +371,30 @@ describe Bookings::School, type: :model do
           end
         end
       end
+
+      context 'by disability confident' do
+        before do
+          create(:bookings_profile, school: school_a)
+          create(:bookings_profile, school: school_b)
+          create(:bookings_profile, :without_supports_access_needs, school: school_c)
+        end
+
+        context 'when no options suplied' do
+          specify 'should return all schools' do
+            expect(subject.disability_confident(nil)).to include(school_a, school_b, school_c)
+          end
+        end
+
+        context 'when true' do
+          specify 'should return all disability confident schools' do
+            expect(subject.disability_confident(true)).to include(school_a, school_b)
+          end
+
+          specify 'should not return school that are not disability confident' do
+            expect(subject.disability_confident(true)).not_to include(school_c)
+          end
+        end
+      end
     end
 
     context 'Availability and placement dates' do

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Candidates::SchoolSearch do
         max_fee: '30',
         phases: [1, 2, 3],
         subjects: [4, 5, 6],
-        dbs_policies: [2]
+        dbs_policies: [2],
+        disability_confident: '1'
       )
     end
 
@@ -22,6 +23,7 @@ RSpec.describe Candidates::SchoolSearch do
       expect(subject.phases).to eq([1, 2, 3])
       expect(subject.subjects).to eq([4, 5, 6])
       expect(subject.dbs_policies).to eq([2])
+      expect(subject.disability_confident).to eq('1')
     end
   end
 

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
     let(:max_fee) { '60' }
     let(:subjects) { %w[1 3] }
     let(:dbs_policies) { %w[2] }
+    let(:disability_confident) { '1' }
 
     before do
       allow(Candidates::School).to receive(:subjects).and_return(
@@ -64,6 +65,11 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
     it "shows the dbs filter" do
       expect(rendered).to have_css('.govuk-label', text: 'DBS check')
       expect(rendered).to have_css '#search-filter input[name="dbs_policies[]"]'
+    end
+
+    it "shows the disability confident filter" do
+      expect(rendered).to have_css('.govuk-fieldset__heading', text: 'Disability and access needs')
+      expect(rendered).to have_css '#search-filter input[name="disability_confident"]'
     end
 
     it "shows results" do


### PR DESCRIPTION
### Trello card
https://trello.com/c/ziNY8XII

### Context
Some school have signed up to the Disability Confident scheme and we want to make it easier for candidates to find them.

### Changes proposed in this pull request
Add a filter in the search results page to return schools that are 'Disability Confident'

### Guidance to review
|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/951947/145838501-cb368579-2584-4a57-bfd7-7d73383e5d2f.png)|![after](https://user-images.githubusercontent.com/951947/145838515-3e514ddd-d58f-4873-bdcc-be7b99f01bf0.png)|
