### PR TITLE
Inherit the booking duration from the placement date

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
@@ -33,6 +33,7 @@ module Schools
         def booking_params
           params.require(:bookings_booking).permit(
             :date,
+            :duration,
             :bookings_subject_id,
             :contact_name,
             :contact_number,

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -1,6 +1,7 @@
 module Bookings
   class Booking < ApplicationRecord
     MIN_BOOKING_DELAY = 1.day.freeze
+    DEFAULT_DURATION = 1
 
     belongs_to :bookings_placement_request,
       class_name: 'Bookings::PlacementRequest',
@@ -110,13 +111,15 @@ module Bookings
       date = if placement_request&.fixed_date_is_bookable?
                placement_request.fixed_date
              end
+      duration = placement_request.placement_date&.duration || DEFAULT_DURATION
 
       new(
         bookings_school: placement_request.school,
         bookings_placement_request: placement_request,
         date: date,
         bookings_subject_id: placement_request.requested_subject.id,
-        placement_details: placement_request.school.placement_info
+        placement_details: placement_request.school.placement_info,
+        duration: duration
       )
     end
 

--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -45,6 +45,9 @@
         <%- end -%>
 
         <%= f.date_field :date, heading: true %>
+        <% if @placement_request.placement_date %>
+          <%= f.number_field :duration, width: 3, required: true, label_options: { class: 'govuk-heading-m', overwrite_defaults!: true } %>
+        <% end %>
         <%= f.collection_select :bookings_subject_id, @subjects, :id, :name, {}, label_options: { class: 'govuk-heading-m' } %>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,6 +468,10 @@ en:
               blank: Enter a booking date
               on_or_after: Date must be in the future
               not_changed: Date has not been changed
+            duration:
+              blank: Enter the duration
+              not_a_number: Must be a number
+              greater_than: Must be greater than zero
             contact_name:
               blank: You must provide a contact name to the candidate
             contact_email:
@@ -594,6 +598,8 @@ en:
           Requests that are already in progress will continue as normal.
         availability_preference_fixed: Select how you'd like to present school experience dates to candidates.
         experience_type: Do you offer school experiences in school, via the internet or both
+      bookings_booking:
+        duration: Enter number of days.
       bookings_placement_date:
         date: For example, 01 09 2020.
         duration: Enter number of days.
@@ -675,6 +681,7 @@ en:
           candidate_not_local: We are looking for candidates that live locally to the school
           duplicate: This is a duplicate request
       bookings_booking:
+        duration: How long will it last?
         contact_name: Name
         contact_number: Telephone number
         contact_email: Email address

--- a/features/schools/placement_requests/acceptance/confirming_a_request_with_a_future_date.feature
+++ b/features/schools/placement_requests/acceptance/confirming_a_request_with_a_future_date.feature
@@ -31,6 +31,19 @@ Feature: Confirming a request with a future date
             | Admin details     |
         And there should be an 'Continue' button and a 'Make changes' link
 
+    Scenario: Page content: when the school offers fixed placement dates
+        Given I am on the 'make changes' page for my fixed placement request
+        Then I should see a form with the following fields:
+            | Label                  | Type   |
+            | Booking date           | date   |
+            | How long will it last? | number |
+
+    Scenario: Page content: when the school offers flex placement dates
+        Given I am on the 'make changes' page for my fixed placement request
+        Then I should see a form with the following fields:
+            | Label                  | Type   |
+            | Booking date           | date   |
+
     Scenario: Confirming a booking
         Given the school has a prior booking
         And I am on the 'confirm booking' page for the placement request

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 describe Bookings::Booking do
+  describe 'Constants' do
+    describe 'DEFAULT_DURATION' do
+      it 'returns 1' do
+        expect(described_class::DEFAULT_DURATION).to eq 1
+      end
+    end
+  end
+
   describe 'Columns' do
     it do
       is_expected.to have_db_column(:bookings_subject_id)
@@ -486,8 +494,16 @@ describe Bookings::Booking do
     let(:placement_request) { create(:bookings_placement_request, placement_date: placement_date) }
     subject { described_class.from_placement_request(placement_request) }
 
+    context 'when there is no placement date' do
+      let(:placement_request) { create(:bookings_placement_request) }
+
+      specify 'should have the default duration' do
+        expect(subject.duration).to eql(described_class::DEFAULT_DURATION)
+      end
+    end
+
     context 'when the placement date is in the future' do
-      let(:placement_date) { create(:bookings_placement_date) }
+      let(:placement_date) { create(:bookings_placement_date, duration: 5) }
 
       specify 'should set the date' do
         expect(subject.date).to be_present
@@ -498,6 +514,10 @@ describe Bookings::Booking do
         expect(subject.bookings_placement_request).to eql(placement_request)
         expect(subject.bookings_subject_id).to eql(placement_request.requested_subject.id)
         expect(subject.placement_details).to eql(placement_request.school.placement_info)
+      end
+
+      specify 'should inherit the the placement date duration' do
+        expect(subject.duration).to eql(placement_date.duration)
       end
     end
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/lvDPPg6S

### Context
Schools can offer placement dates which can last multiple days, however the booking duration always defaults to 1 day when they accept requests.

The booking duration should be as long as the placement dates are and also allow the school managers to change it when making changes during the acceptance process.

### Changes proposed in this pull request
- Update the booking model to inherit the placement date duration for fixed placement dates.
- Add a number field to allow to change the duration in the `acceptance/make_changes` page

### Guidance to review
1. Accept a request for a fixed date
2. Click `Make changes`

There should be a duration field under the date field, which should have the placement date duration prefilled and allow you to update it.

The changes should be reflected in the confirmation email preview.
