### PR TITLE
Prevent the confirmation email from failing when the experience_details is nil

### DIFF
--- a/app/notify/notify_email/candidate_booking_confirmation.rb
+++ b/app/notify/notify_email/candidate_booking_confirmation.rb
@@ -91,7 +91,7 @@ class NotifyEmail::CandidateBookingConfirmation < NotifyDespatchers::Email
       school_teacher_name: booking.contact_name,
       school_teacher_email: booking.contact_email,
       school_teacher_telephone: booking.contact_number,
-      placement_details: profile.experience_details,
+      placement_details: profile.experience_details.to_s,
       candidate_instructions: booking.candidate_instructions,
       subject_name: booking.bookings_subject.name,
       cancellation_url: cancellation_url
@@ -119,7 +119,7 @@ private
       school_teacher_name: school_teacher_name,
       school_teacher_email: school_teacher_email,
       school_teacher_telephone: school_teacher_telephone,
-      placement_details: placement_details,
+      placement_details: placement_details.to_s,
       candidate_instructions: candidate_instructions,
       subject_name: subject_name,
       cancellation_url: cancellation_url

--- a/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_confirmation_spec.rb
@@ -106,6 +106,14 @@ describe NotifyEmail::CandidateBookingConfirmation do
         expect(subject.school_teacher_telephone).to eql(booking.contact_number)
       end
 
+      context 'when the profile experience details is missing' do
+        let!(:profile) { create(:bookings_profile, experience_details: nil, school: school) }
+
+        specify 'placement_details is assigned to empty string' do
+          expect(subject.placement_details).to eql ''
+        end
+      end
+
       specify 'placement_details is correctly-assigned' do
         expect(subject.placement_details).to eql(school.profile.experience_details)
       end


### PR DESCRIPTION
### Trello card
https://trello.com/c/CJUzMsIa

### Context
Some schools don't provide any experience details since it's optional, but 
the acceptance confirmation email fails because it expects non-nil values.

### Changes proposed in this pull request
Call `to_s` on the experience_details attribute to get an empty string when it's nil.

### Guidance to review

