### PR TITLE
Auto-enable school when adds availability

### DIFF
--- a/app/controllers/schools/availability_info_controller.rb
+++ b/app/controllers/schools/availability_info_controller.rb
@@ -5,6 +5,7 @@ class Schools::AvailabilityInfoController < Schools::BaseController
     @current_school.assign_attributes(placement_date_params)
 
     if @current_school.save(context: :configuring_availability)
+      auto_enable_school
       redirect_to schools_dashboard_path
     else
       render :edit

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -80,5 +80,9 @@ module Schools
     def show_candidate_alert_notification?
       false
     end
+
+    def auto_enable_school
+      current_school.update(enabled: true) unless current_school.enabled?
+    end
   end
 end

--- a/app/controllers/schools/placement_dates/configurations_controller.rb
+++ b/app/controllers/schools/placement_dates/configurations_controller.rb
@@ -24,6 +24,7 @@ module Schools
         if @configuration.subject_specific?
           new_schools_placement_date_subject_selection_path @placement_date
         else
+          auto_enable_school
           schools_placement_dates_path
         end
       end

--- a/app/controllers/schools/placement_dates/subject_selections_controller.rb
+++ b/app/controllers/schools/placement_dates/subject_selections_controller.rb
@@ -11,6 +11,7 @@ module Schools
         @subject_selection = SubjectSelection.new subject_selection_params
 
         if @subject_selection.save @placement_date
+          auto_enable_school
           redirect_to schools_placement_dates_path
         else
           render :new

--- a/app/controllers/schools/placement_dates_controller.rb
+++ b/app/controllers/schools/placement_dates_controller.rb
@@ -57,6 +57,7 @@ private
       redirect_to new_schools_placement_date_configuration_path(placement_date)
     else
       placement_date.update! published_at: DateTime.now
+      auto_enable_school
       redirect_to schools_placement_dates_path
     end
   end

--- a/features/schools/availability_information/edit.feature
+++ b/features/schools/availability_information/edit.feature
@@ -36,3 +36,11 @@ Feature: Editing availability info
         And I click the 'Save availability description' submit button
         Then I should be on the 'schools dashboard' page
         And my school's availabiltiy info should have been updated
+
+    Scenario: Auto-enabling school
+        Given my school is disabled
+        And I am on the 'availability information' page
+        When I enter 'Every third Tuesday' into the 'Describe your school experience availability' text area
+        And I choose 'Virtual experience' from the "School experience type" radio buttons
+        And I click the 'Save availability description' submit button
+        Then my school should be enabled

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -31,6 +31,7 @@ Feature: Creating new placement dates
         And I fill in the 'Enter start date' date field with an invalid date of 31st September next year
         When I submit the form
         Then I should see an error message stating 'Enter a start date'
+        And my school should be disabled
 
     Scenario: Filling in and submitting the form
         Given my school is a 'primary' school
@@ -38,6 +39,7 @@ Feature: Creating new placement dates
         When I fill in the form with a future date and duration of 3
         And I submit the form
         Then I should be on the 'placement dates' page
+        And my school should be enabled
 
     Scenario: Primary and secondary schools: extra option
         Given my school is a 'primary and secondary' school
@@ -53,6 +55,7 @@ Feature: Creating new placement dates
         And I choose 'Primary including early years, key stage 1 and key stage 2' from the 'Select school experience phase' radio buttons
         And I submit the form
         Then I should be on the 'placement dates' page
+        And my school should be enabled
 
     Scenario: Primary and secondary schools: selecting secondary
         Given my school is a 'primary and secondary' school


### PR DESCRIPTION
### Trello card
https://trello.com/c/zpLjmwOV

### Context
Disabled or newly on-boarded schools need an extra step to enable their profile after adding availability, but we want to make their journey shorter and more seamless by auto-enabling them.

### Changes proposed in this pull request
Add a method in the schools base controller to update the school's `enable` attribute and call it when adding availability.

### Guidance to review
1. Turn off the profile the school
2. Confirm the "profile is turned off" warning message is displayed in the dashboard
2. Add availability (either fixed or flex dates)
3. The school should be enabled and the warning message should not be in the dashboard anymore