### PR TITLE
Update the reasons list in the rejection form

### DIFF
--- a/app/models/bookings/placement_request/cancellation.rb
+++ b/app/models/bookings/placement_request/cancellation.rb
@@ -9,6 +9,10 @@ class Bookings::PlacementRequest::Cancellation < ApplicationRecord
     no_phase_availability
     candidate_not_local
     duplicate
+    info_not_provided
+    cancelation_requested
+    wrong_choice_secondary
+    wrong_choice_primary
     other
   ].freeze
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,12 +674,16 @@ en:
         reason: Cancellation reasons
         rejection_category:
           fully_booked: The date you requested is fully booked
-          accepted_on_ttc: We cannot offer you school experience because you have already been accepted on a Teacher Training Course
-          date_not_available: We cannot support the date you have requested
-          no_relevant_degree: We do not believe you have a relevant degree for the school experience you are applying for
-          no_phase_availability: We are unable to offer you school experience for the teaching phase you are interested in
-          candidate_not_local: We are looking for candidates that live locally to the school
+          accepted_on_ttc: We cannot offer you school experience because you've already been accepted on a teacher training course
+          date_not_available: We can no longer offer the date you've requested
+          no_relevant_degree: We do not believe you have a relevant degree for the school experience you're applying for
+          no_phase_availability: We're unable to offer you school experience for the teaching phase you're interested in
+          candidate_not_local: We're looking for candidates that live locally to the school
           duplicate: This is a duplicate request
+          info_not_provided: We did not hear back from you after contacting you for more information
+          cancelation_requested: You asked us to cancel your request
+          wrong_choice_secondary: You've told us you want to get primary school experience, but you've chosen a secondary school placement
+          wrong_choice_primary: You've told us you want to get secondary school experience, but you've chosen a primary school placement
       bookings_booking:
         duration: How long will it last?
         contact_name: Name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -674,16 +674,16 @@ en:
         reason: Cancellation reasons
         rejection_category:
           fully_booked: The date you requested is fully booked
-          accepted_on_ttc: We cannot offer you school experience because you've already been accepted on a teacher training course
-          date_not_available: We can no longer offer the date you've requested
-          no_relevant_degree: We do not believe you have a relevant degree for the school experience you're applying for
-          no_phase_availability: We're unable to offer you school experience for the teaching phase you're interested in
-          candidate_not_local: We're looking for candidates that live locally to the school
+          accepted_on_ttc: We cannot offer you school experience because you've already been accepted on a teacher training course.
+          date_not_available: We can no longer offer the date you've requested.
+          no_relevant_degree: We do not believe you have a relevant degree for the school experience you're applying for.
+          no_phase_availability: We're unable to offer you school experience for the teaching phase you're interested in.
+          candidate_not_local: We're looking for candidates that live locally to the school.
           duplicate: This is a duplicate request
-          info_not_provided: We did not hear back from you after contacting you for more information
-          cancelation_requested: You asked us to cancel your request
-          wrong_choice_secondary: You've told us you want to get primary school experience, but you've chosen a secondary school placement
-          wrong_choice_primary: You've told us you want to get secondary school experience, but you've chosen a primary school placement
+          info_not_provided: We did not hear back from you after contacting you for more information.
+          cancelation_requested: You asked us to cancel your request.
+          wrong_choice_secondary: You've told us you want to get primary school experience, but you've chosen a secondary school placement.
+          wrong_choice_primary: You've told us you want to get secondary school experience, but you've chosen a primary school placement.
       bookings_booking:
         duration: How long will it last?
         contact_name: Name

--- a/features/schools/placement_requests/cancelling.feature
+++ b/features/schools/placement_requests/cancelling.feature
@@ -41,12 +41,16 @@ Feature: Rejecting placement requests
         When I am on the reject placement request page
         Then I should see radio buttons for 'Rejection reason' with the following options:
             | The date you requested is fully booked                                                                    |
-            | We cannot offer you school experience because you have already been accepted on a Teacher Training Course |
-            | We cannot support the date you have requested                                                             |
-            | We do not believe you have a relevant degree for the school experience you are applying for               |
-            | We are unable to offer you school experience for the teaching phase you are interested in                 |
-            | We are looking for candidates that live locally to the school                                             |
+            | We cannot offer you school experience because you've already been accepted on a teacher training course   |
+            | We can no longer offer the date you've requested                                                          |
+            | We do not believe you have a relevant degree for the school experience you're applying for                |
+            | We're unable to offer you school experience for the teaching phase you're interested in                   |
+            | We're looking for candidates that live locally to the school                                              |
             | This is a duplicate request                                                                               |
+            | We did not hear back from you after contacting you for more information                                   |
+            | You asked us to cancel your request                                                                       |
+            | You've told us you want to get primary school experience, but you've chosen a secondary school placement  |
+            | You've told us you want to get secondary school experience, but you've chosen a primary school placement  |
             | Other                                                                                                     |
         And there should be a 'Extra details' text area
         And the submit button should contain text 'Preview rejection email'
@@ -55,7 +59,7 @@ Feature: Rejecting placement requests
     Scenario: Rejecting the requests
         Given there is at least one placement request
         And I am on the reject placement request page
-        And I choose 'We cannot support the date you have requested' from the 'Rejection reason' radio buttons
+        And I choose 'You asked us to cancel your request' from the 'Rejection reason' radio buttons
         And I have entered a extra details in the extra details text area
         When I click the 'Preview rejection email' button
         Then I should see a preview of what I have entered

--- a/features/schools/rejected_requests/index.feature
+++ b/features/schools/rejected_requests/index.feature
@@ -25,7 +25,7 @@ Feature: Viewing rejected requests
         Then I should see the rejected requests listed
 
     Scenario: Rejection category
-        Given a request has been rejected because of 'date_not_available'
+        Given a request has been rejected because of 'cancelation_requested'
         When I am on the 'rejected requests' page
         Then I should see a rejected request with the rejection reason displayed
 

--- a/features/schools/rejected_requests/show.feature
+++ b/features/schools/rejected_requests/show.feature
@@ -33,7 +33,7 @@ Feature: Viewing a rejected request
 
     @smoke_test
     Scenario: Rejection category
-        Given a request has been rejected because of 'date_not_available'
+        Given a request has been rejected because of 'cancelation_requested'
         When I am viewing the rejected request
         Then I should see a rejected request with the rejection reason displayed in full
 

--- a/features/step_definitions/schools/placement_requests/cancelling_steps.rb
+++ b/features/step_definitions/schools/placement_requests/cancelling_steps.rb
@@ -17,7 +17,7 @@ end
 
 Then("I should see a preview of what I have entered") do
   within '#rejection-details' do
-    expect(page).to have_content 'We cannot support the date you have requested'
+    expect(page).to have_content 'You asked us to cancel your request'
   end
 
   within '#extra-details' do

--- a/features/step_definitions/schools/rejected_requests_steps.rb
+++ b/features/step_definitions/schools/rejected_requests_steps.rb
@@ -90,9 +90,9 @@ Given("a request has been rejected because of {string}") do |rejection_category|
 end
 
 Then("I should see a rejected request with the rejection reason displayed") do
-  expect(page).to have_css('td', text: 'We cannot support the date you have requested', count: 1)
+  expect(page).to have_css('td', text: 'You asked us to cancel your request', count: 1)
 end
 
 Then("I should see a rejected request with the rejection reason displayed in full") do
-  expect(page).to have_css('dd', text: 'We cannot support the date you have requested', count: 1)
+  expect(page).to have_css('dd', text: 'You asked us to cancel your request', count: 1)
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/6lM3d3W2

### Context
One of our researches showed that we could help schools by adding some new rejection reasons into the decline/reject email. 

We also want to refresh the content of some of the current reasons.

### Changes proposed in this pull request
- Update the content of the current reasons
- Add the new reasons in the Cancellation model and en.yml

### Guidance to review
1. Visit the school dashboard
2. Click Manage requests 
2. View a placement request by clicking the View action
3. Click Reject request to see the rejection form
4. The form should have the new reasons
5. Chose one of the new reasons and click the preview button
6. The preview page should display the chosen reason
7. Click Send rejection email
8. The confirmation email should include the chosen reason
9. The chosen reason should also be displayed in the rejected request page (Dashboard > History section > Rejected requests > View request)
