### PR TITLE
Remove the profile confirmation container for onboarded schools

### DIFF
--- a/app/controllers/schools/on_boarding/profiles_controller.rb
+++ b/app/controllers/schools/on_boarding/profiles_controller.rb
@@ -11,6 +11,14 @@ module Schools
         @confirmation = Confirmation.new
         @profile = SchoolProfilePresenter.new(current_school_profile)
       end
+
+      def publish
+        if current_school.private_beta?
+          Bookings::ProfilePublisher.new(current_school, current_school_profile).update!
+        end
+
+        redirect_to schools_on_boarding_confirmation_path
+      end
     end
   end
 end

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -69,11 +69,16 @@
         <% end %>
       </dl>
 
-      <div class="govuk-form-group" id="<%= f.form_group_id(:acceptance) %>">
-        <%= f.check_box_input :acceptance %>
-      </div>
+      <% unless @current_school.private_beta? %>
+        <div class="govuk-form-group" id="<%= f.form_group_id(:acceptance) %>">
+          <%= f.check_box_input :acceptance %>
+        </div>
 
-      <%= f.submit 'Accept and set up profile' %>
+        <%= f.submit 'Accept and set up profile' %>
+      <% else %>
+        <%= govuk_link_to 'Publish changes', schools_on_boarding_profile_publish_path, method: :put %>
+      <% end %>
+
       <div>
         <%= govuk_link_to 'Preview profile', schools_on_boarding_preview_path, class: 'govuk-button--secondary' %>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,8 @@ Rails.application.routes.draw do
       resource :profile, only: :show
       resource :preview, only: :show
       resource :confirmation, only: %i[create show]
+
+      put "profile/publish", to: "profiles#publish"
     end
 
     resources :feedbacks, only: %i[new create show]

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -100,3 +100,9 @@ Feature: School Profile
           | Parking                      | Not available on site\nCarpark next door         |
           | School teacher training info | We run our own training\nFind out more about     |
      And I should see the accessability information I have entered
+
+  Scenario: Confirmation acceptance for onboarded school
+      Given my school is fully-onboarded
+      And I am on the 'Profile' page
+      Then I should not see the confirmation acceptance container
+      And I should see a 'Publish changes' link

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -55,6 +55,10 @@ Then("I should see a {string} link to the {string} page") do |link_text, path|
   expect(page).to have_link(link_text, href: path_for(path))
 end
 
+Then('I should see a {string} link/button') do |link_text|
+  expect(page).to have_link(link_text)
+end
+
 Then("the page title should be {string}") do |title|
   title_suffix = "DfE School Experience"
   expect(title).to be_present

--- a/features/step_definitions/schools/profile_steps.rb
+++ b/features/step_definitions/schools/profile_steps.rb
@@ -1,0 +1,3 @@
+Then "I should not see the confirmation acceptance container" do
+  expect(page).not_to have_css('#schools_on_boarding_confirmation_acceptance_container')
+end

--- a/spec/controllers/schools/on_boarding/profiles_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/profiles_controller_spec.rb
@@ -5,23 +5,23 @@ require Rails.root.join("spec", "controllers", "schools", "session_context")
 describe Schools::OnBoarding::ProfilesController, type: :request do
   include_context "logged in DfE user"
 
-  context '#show' do
-    context 'with an incomplete profile' do
-      let! :school_profile do
-        FactoryBot.create :school_profile
-      end
-
-      before do
-        get '/schools/on_boarding/profile'
-      end
-
-      it 'redirects to the first incompleted step' do
-        expect(response).to \
-          redirect_to '/schools/on_boarding/dbs_requirement/new'
-      end
+  context 'with an incomplete profile' do
+    let! :school_profile do
+      FactoryBot.create :school_profile
     end
 
-    context 'with a complete profile' do
+    before do
+      get '/schools/on_boarding/profile'
+    end
+
+    it 'redirects to the first incompleted step' do
+      expect(response).to \
+        redirect_to '/schools/on_boarding/dbs_requirement/new'
+    end
+  end
+
+  context 'with a complete profile' do
+    context '#show' do
       let! :school_profile do
         FactoryBot.create :school_profile, :completed
       end
@@ -37,6 +37,55 @@ describe Schools::OnBoarding::ProfilesController, type: :request do
 
       it 'renders the show template' do
         expect(response).to render_template :show
+      end
+    end
+
+    context '#publish' do
+      context 'when the school is onboarded' do
+        let(:bookings_profile) do
+          FactoryBot.create :bookings_profile
+        end
+
+        let!(:school_profile) do
+          FactoryBot.create :school_profile, :completed
+        end
+
+        before do
+          school_profile.bookings_school.profile = bookings_profile
+          school_profile.update(description_details: 'new description')
+
+          put schools_on_boarding_profile_publish_path
+        end
+
+        it 'publishes the changes' do
+          profile = school_profile.reload.bookings_school.profile
+
+          expect(profile.description_details).to eq('new description')
+        end
+
+        it 'redirects the to the confirmation show path' do
+          expect(response).to redirect_to schools_on_boarding_confirmation_path
+        end
+      end
+
+      context 'when the school is not onboarded' do
+        let!(:school_profile) do
+          FactoryBot.create :school_profile, :completed
+        end
+
+        before do
+          school_profile.update(description_details: 'new description')
+
+          put schools_on_boarding_profile_publish_path
+        end
+
+        it 'does not publishes the profile' do
+          expect(school_profile.reload.bookings_school.profile).to be_nil
+        end
+
+        it 'redirects the to the confirmation show path' do
+          expect(response).to redirect_to schools_on_boarding_confirmation_path
+        end
       end
     end
   end

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -104,5 +104,9 @@ FactoryBot.define do
     trait :with_profile do
       association :profile, factory: :bookings_profile
     end
+
+    trait :with_school_profile do
+      association :school_profile, factory: %i[school_profile completed]
+    end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/vnLofAdF

### Context
We want to remove the checkbox for Providers that are 'updating' their profile and instead display a publish button.

### Changes proposed in this pull request
- Add a new route and a method in the school profile controller to publish profile changes for onboarded schools
- Update the profile page to display the publish button instead of the confirmation box for onboarded schools

### Guidance to review

