### PR TITLE
Update to v2 of the API client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,10 @@
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: f31165f8773798a88358e793661c9c25923ca6be
+  revision: dc673e63f1ee99c53fbf0e1d7db873dea3bad783
   specs:
-    get_into_teaching_api_client (1.1.17)
-      addressable (~> 2.3, >= 2.3.0)
-      json (~> 2.1, >= 2.1.0)
-      typhoeus (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (0.1.48)
+    get_into_teaching_api_client (2.0.0)
+      faraday (~> 1.0, >= 1.0.1)
+    get_into_teaching_api_client_faraday (2.0.0)
       activesupport
       faraday
       faraday-encoding
@@ -207,8 +205,6 @@ GEM
     erubi (1.10.0)
     et-orbi (1.2.6)
       tzinfo
-    ethon (0.15.0)
-      ffi (>= 1.15.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.2.0)
@@ -557,8 +553,6 @@ GEM
     thor (1.1.0)
     tilt (2.0.10)
     timeliness (0.4.4)
-    typhoeus (1.4.0)
-      ethon (>= 0.9.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uk_postcode (2.1.7)
@@ -688,4 +682,4 @@ RUBY VERSION
    ruby 2.7.5p203
 
 BUNDLED WITH
-   2.2.33
+   2.3.4

--- a/app/controllers/concerns/gitis_authentication.rb
+++ b/app/controllers/concerns/gitis_authentication.rb
@@ -17,7 +17,7 @@ protected
   def current_contact
     return nil unless session[:gitis_contact]
 
-    GetIntoTeachingApiClient::SchoolsExperienceSignUp.new(session[:gitis_contact])
+    GetIntoTeachingApiClient::SchoolsExperienceSignUp.build_from_hash(session[:gitis_contact])
   end
 
   def current_contact=(contact)

--- a/app/models/candidates/verification_code.rb
+++ b/app/models/candidates/verification_code.rb
@@ -27,13 +27,7 @@ class Candidates::VerificationCode
   def exchange
     return false unless valid?
 
-    identity_data = {
-      firstName: firstname,
-      lastName: lastname,
-      email: email
-    }
-
-    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(identity_data)
+    request = GetIntoTeachingApiClient::ExistingCandidateRequest.new(matchback_attributes)
     api = GetIntoTeachingApiClient::SchoolsExperienceApi.new
     existing_sign_up = api.exchange_access_token_for_schools_experience_sign_up(code, request)
 
@@ -51,8 +45,8 @@ private
   def matchback_attributes
     {
       email: email,
-      firstName: firstname,
-      lastName: lastname
+      first_name: firstname,
+      last_name: lastname
     }
   end
 end

--- a/app/services/bookings/gitis/event_logger.rb
+++ b/app/services/bookings/gitis/event_logger.rb
@@ -30,11 +30,11 @@ module Bookings
 
       def classroom_experience_note
         GetIntoTeachingApiClient::ClassroomExperienceNote.new(
-          recordedAt: @recorded_date,
+          recorded_at: @recorded_date,
           action: @action,
           date: @date,
-          schoolUrn: @urn,
-          schoolName: @name,
+          school_urn: @urn,
+          school_name: @name,
         )
       end
 

--- a/app/services/candidates/registrations/personal_information.rb
+++ b/app/services/candidates/registrations/personal_information.rb
@@ -55,8 +55,8 @@ module Candidates
       def matchback_attributes
         {
           email: email,
-          firstName: first_name,
-          lastName: last_name
+          first_name: first_name,
+          last_name: last_name
         }
       end
     end

--- a/config/initializers/git_api_client.rb
+++ b/config/initializers/git_api_client.rb
@@ -1,5 +1,5 @@
 GetIntoTeachingApiClient.configure do |config|
-  config.api_key["Authorization"] = Rails.application.config.x.git_api_token.presence
+  config.api_key["apiKey"] = Rails.application.config.x.git_api_token.presence
 
   endpoint = Rails.application.config.x.git_api_endpoint.presence
 
@@ -10,5 +10,8 @@ GetIntoTeachingApiClient.configure do |config|
     config.base_path = parsed.path.gsub(%r{\A/api}, "")
   end
 
+  config.server_index = nil
+  config.api_key_prefix["apiKey"] = "Bearer"
+  config.scheme = "https"
   config.cache_store = Rails.application.config.x.api_client_cache_store
 end

--- a/spec/features/candidates/api_registrations_spec.rb
+++ b/spec/features/candidates/api_registrations_spec.rb
@@ -112,8 +112,8 @@ feature 'Candidate Registrations (via the API)', type: :feature do
       let(:candidate2) { create(:candidate, :confirmed, :with_api_contact) }
       let(:request2) do
         GetIntoTeachingApiClient::ExistingCandidateRequest.new(
-          firstName: candidate2.gitis_contact.first_name,
-          lastName: candidate2.gitis_contact.last_name,
+          first_name: candidate2.gitis_contact.first_name,
+          last_name: candidate2.gitis_contact.last_name,
           email: candidate2.gitis_contact.email
         )
       end

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     context "when has_dbs_certificate is changing" do
       let(:contact) do
         GetIntoTeachingApiClient::SchoolsExperienceSignUp.new(
-          hasDbsCertificate: !registration.background_check.has_dbs_check
+          has_dbs_certificate: !registration.background_check.has_dbs_check
         )
       end
 

--- a/spec/models/candidates/verification_code_spec.rb
+++ b/spec/models/candidates/verification_code_spec.rb
@@ -72,8 +72,8 @@ describe Candidates::VerificationCode do
       let(:request) do
         GetIntoTeachingApiClient::ExistingCandidateRequest.new(
           email: personal_info.email,
-          firstName: personal_info.first_name,
-          lastName: personal_info.last_name
+          first_name: personal_info.first_name,
+          last_name: personal_info.last_name
         )
       end
 

--- a/spec/services/bookings/gitis/event_logger_spec.rb
+++ b/spec/services/bookings/gitis/event_logger_spec.rb
@@ -32,17 +32,21 @@ describe Bookings::Gitis::EventLogger, type: :model do
     describe "#classroom_experience_note" do
       subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-      it { is_expected.to include(recordedAt: today) }
-      it { is_expected.to include(action: "REQUEST") }
-      it { is_expected.to include(schoolUrn: school.urn) }
-      it { is_expected.to include(schoolName: school.name) }
+      it "has expected attributes" do
+        is_expected.to have_attributes(
+          recorded_at: today,
+          action: "REQUEST",
+          school_urn: school.urn,
+          school_name: school.name
+        )
+      end
 
       context "with fixed dates" do
         let(:date) { create(:bookings_placement_date, bookings_school: log_subject.school) }
 
         before { log_subject.update!(placement_date: date) }
 
-        it { is_expected.to include(date: date.date) }
+        it { is_expected.to have_attributes(date: date.date) }
       end
     end
   end
@@ -61,11 +65,15 @@ describe Bookings::Gitis::EventLogger, type: :model do
     describe "#classroom_experience_note" do
       subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-      it { is_expected.to include(recordedAt: today) }
-      it { is_expected.to include(action: "ACCEPTED") }
-      it { is_expected.to include(date: log_subject.date) }
-      it { is_expected.to include(schoolUrn: school.urn) }
-      it { is_expected.to include(schoolName: school.name) }
+      it "has expected attributes" do
+        is_expected.to have_attributes(
+          recorded_at: today,
+          action: "ACCEPTED",
+          date: log_subject.date,
+          school_urn: school.urn,
+          school_name: school.name
+        )
+      end
     end
   end
 
@@ -85,10 +93,14 @@ describe Bookings::Gitis::EventLogger, type: :model do
       describe "#classroom_experience_note" do
         subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-        it { is_expected.to include(recordedAt: today) }
-        it { is_expected.to include(action: "CANCELLED BY CANDIDATE") }
-        it { is_expected.to include(schoolUrn: school.urn) }
-        it { is_expected.to include(schoolName: school.name) }
+        it "has expected attributes" do
+          is_expected.to have_attributes(
+            recorded_at: today,
+            action: "CANCELLED BY CANDIDATE",
+            school_urn: school.urn,
+            school_name: school.name
+          )
+        end
       end
     end
 
@@ -105,10 +117,14 @@ describe Bookings::Gitis::EventLogger, type: :model do
       describe "#classroom_experience_note" do
         subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-        it { is_expected.to include(recordedAt: today) }
-        it { is_expected.to include(action: "CANCELLED BY SCHOOL") }
-        it { is_expected.to include(schoolUrn: school.urn) }
-        it { is_expected.to include(schoolName: school.name) }
+        it "has expected attributes" do
+          is_expected.to have_attributes(
+            recorded_at: today,
+            action: "CANCELLED BY SCHOOL",
+            school_urn: school.urn,
+            school_name: school.name
+          )
+        end
       end
     end
 
@@ -126,11 +142,15 @@ describe Bookings::Gitis::EventLogger, type: :model do
       describe "#classroom_experience_note" do
         subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-        it { is_expected.to include(recordedAt: today) }
-        it { is_expected.to include(action: "CANCELLED BY CANDIDATE") }
-        it { is_expected.to include(date: booking.date) }
-        it { is_expected.to include(schoolUrn: school.urn) }
-        it { is_expected.to include(schoolName: school.name) }
+        it "has expected attributes" do
+          is_expected.to have_attributes(
+            recorded_at: today,
+            date: booking.date,
+            action: "CANCELLED BY CANDIDATE",
+            school_urn: school.urn,
+            school_name: school.name
+          )
+        end
       end
     end
 
@@ -148,11 +168,15 @@ describe Bookings::Gitis::EventLogger, type: :model do
       describe "#classroom_experience_note" do
         subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-        it { is_expected.to include(recordedAt: today) }
-        it { is_expected.to include(action: "CANCELLED BY SCHOOL") }
-        it { is_expected.to include(date: booking.date) }
-        it { is_expected.to include(schoolUrn: school.urn) }
-        it { is_expected.to include(schoolName: school.name) }
+        it "has expected attributes" do
+          is_expected.to have_attributes(
+            recorded_at: today,
+            date: booking.date,
+            action: "CANCELLED BY SCHOOL",
+            school_urn: school.urn,
+            school_name: school.name
+          )
+        end
       end
     end
   end
@@ -175,11 +199,15 @@ describe Bookings::Gitis::EventLogger, type: :model do
       describe "#classroom_experience_note" do
         subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-        it { is_expected.to include(recordedAt: today) }
-        it { is_expected.to include(action: "ATTENDED") }
-        it { is_expected.to include(date: booking.date) }
-        it { is_expected.to include(schoolUrn: school.urn) }
-        it { is_expected.to include(schoolName: school.name) }
+        it "has expected attributes" do
+          is_expected.to have_attributes(
+            recorded_at: today,
+            date: booking.date,
+            action: "ATTENDED",
+            school_urn: school.urn,
+            school_name: school.name
+          )
+        end
       end
     end
 
@@ -195,11 +223,15 @@ describe Bookings::Gitis::EventLogger, type: :model do
       describe "#classroom_experience_note" do
         subject { described_class.new(log_type, log_subject).classroom_experience_note }
 
-        it { is_expected.to include(recordedAt: today) }
-        it { is_expected.to include(action: "DID NOT ATTEND") }
-        it { is_expected.to include(date: booking.date) }
-        it { is_expected.to include(schoolUrn: school.urn) }
-        it { is_expected.to include(schoolName: school.name) }
+        it "has expected attributes" do
+          is_expected.to have_attributes(
+            recorded_at: today,
+            date: booking.date,
+            action: "DID NOT ATTEND",
+            school_urn: school.urn,
+            school_name: school.name
+          )
+        end
       end
     end
   end

--- a/spec/services/candidates/registrations/personal_information_spec.rb
+++ b/spec/services/candidates/registrations/personal_information_spec.rb
@@ -45,8 +45,8 @@ describe Candidates::Registrations::PersonalInformation, type: :model do
     let(:request) do
       GetIntoTeachingApiClient::ExistingCandidateRequest.new(
         email: pinfo.email,
-        firstName: pinfo.first_name,
-        lastName: pinfo.last_name
+        first_name: pinfo.first_name,
+        last_name: pinfo.last_name
       )
     end
 

--- a/spec/support/fake_get_into_teaching_api_client.rb
+++ b/spec/support/fake_get_into_teaching_api_client.rb
@@ -62,22 +62,21 @@ private
 
   def fake_sign_up_data
     {
-      candidateId: fake_candidate_id,
-      firstName: 'Matthew',
-      lastName: 'Richards',
-      fullName: 'Matthew Richards',
-      mobileTelephone: '07123 456789',
+      candidate_id: fake_candidate_id,
+      first_name: 'Matthew',
+      last_name: 'Richards',
+      full_name: 'Matthew Richards',
+      mobile_telephone: '07123 456789',
       telephone: '01234 567890',
       email: 'first@thisaddress.com',
-      secondaryEmail: 'second@thisaddress.com',
-      addressLine1: 'First Line',
-      addressLine2: 'Second Line',
-      addressLine3: 'Third Line',
-      addressCity: 'Manchester',
-      addressStateOrProvince: 'Manchester',
-      addressPostcode: 'TE57 1NG',
-      addressTelephone: '01234 567890',
-      dateOfBirth: '1980-01-01',
+      secondary_email: 'second@thisaddress.com',
+      address_line1: 'First Line',
+      address_line2: 'Second Line',
+      address_line3: 'Third Line',
+      address_city: 'Manchester',
+      address_state_or_province: 'Manchester',
+      address_postcode: 'TE57 1NG',
+      address_telephone: '01234 567890',
       merged: false
     }
   end

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -59,8 +59,8 @@ shared_context "api correct verification code for personal info" do
   let(:code) { "123456" }
   let(:request) do
     GetIntoTeachingApiClient::ExistingCandidateRequest.new(
-      firstName: personal_info.first_name,
-      lastName: personal_info.last_name,
+      first_name: personal_info.first_name,
+      last_name: personal_info.last_name,
       email: personal_info.email
     )
   end
@@ -77,8 +77,8 @@ shared_context "api correct verification code for personal info without name" do
   let(:code) { "123456" }
   let(:request) do
     GetIntoTeachingApiClient::ExistingCandidateRequest.new(
-      firstName: personal_info.first_name,
-      lastName: personal_info.last_name,
+      first_name: personal_info.first_name,
+      last_name: personal_info.last_name,
       email: personal_info.email
     )
   end


### PR DESCRIPTION
### Trello card

[Trello-2777](https://trello.com/c/oYLSzOTp/2777-monkey-patch-api-client-models-to-support-snakecase-attributes-in-initializer?filter=member:rossoliver15)

### Context

The API client v2 uses `snake_case` attributes in the initializers instead of `camelCase`; this updates all the references.

### Changes proposed in this pull request

- Update to v2 of the API client

### Guidance to review

