### PR TITLE
Remove non-primary phone numbers and email address

### DIFF
--- a/app/helpers/gitis_contact_helper.rb
+++ b/app/helpers/gitis_contact_helper.rb
@@ -1,9 +1,4 @@
 module GitisContactHelper
-  def gitis_contact_display_phone(contact)
-    contact.secondary_telephone.presence ||
-      contact.telephone.presence || contact.mobile_telephone
-  end
-
   def gitis_contact_display_address(contact)
     [
       contact.address_line1,

--- a/app/models/bookings/registration_contact_mapper.rb
+++ b/app/models/bookings/registration_contact_mapper.rb
@@ -13,12 +13,8 @@ module Bookings
     def registration_to_contact
       gitis_contact.first_name = personal_information.first_name
       gitis_contact.last_name = personal_information.last_name
-      gitis_contact.email ||= personal_information.email
-      gitis_contact.secondary_email = personal_information.email
-
-      gitis_contact.secondary_telephone = contact_information.phone
-      gitis_contact.telephone ||= contact_information.phone
-      gitis_contact.address_telephone ||= contact_information.phone
+      gitis_contact.email = personal_information.email
+      gitis_contact.telephone = contact_information.phone
       gitis_contact.address_line1 = contact_information.building
       gitis_contact.address_line2 = contact_information.street
       gitis_contact.address_line3 = ""
@@ -42,7 +38,7 @@ module Bookings
 
     def contact_to_contact_information
       {
-        'phone' => gitis_contact.secondary_telephone.presence || gitis_contact.telephone.presence || gitis_contact.mobile_telephone,
+        'phone' => gitis_contact.telephone,
         'building' => gitis_contact.address_line1,
         'street' => gitis_contact.address_line2,
         'town_or_city' => gitis_contact.address_city,

--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -24,7 +24,7 @@
           <section id="booking-details">
             <dl class="govuk-summary-list">
               <%= summary_row 'Subject', @booking.bookings_subject.name %>
-              <%= summary_row 'UK telephone number', gitis_contact_display_phone(@booking.gitis_contact) %>
+              <%= summary_row 'UK telephone number', @booking.gitis_contact.telephone %>
               <%= summary_row 'Email address', @booking.gitis_contact.email %>
               <%= summary_row 'Request received', @booking.received_on.to_formatted_s(:govuk) %>
             </dl>

--- a/app/views/schools/placement_requests/_personal_details.html.erb
+++ b/app/views/schools/placement_requests/_personal_details.html.erb
@@ -3,7 +3,7 @@
 
   <dl class="govuk-summary-list">
     <%= summary_row 'Address', gitis_contact_display_address(personal_details) %>
-    <%= summary_row 'UK telephone number', gitis_contact_display_phone(personal_details) %>
+    <%= summary_row 'UK telephone number', personal_details.telephone %>
     <%= summary_row 'Email address', personal_details.email %>
   </dl>
 </section>

--- a/app/views/schools/placement_requests/show.html.erb
+++ b/app/views/schools/placement_requests/show.html.erb
@@ -52,7 +52,7 @@
           UK telephone number
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= gitis_contact_display_phone(@gitis_contact) %>
+          <%= @gitis_contact.telephone %>
         </dd>
       </div>
 

--- a/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/contact_informations_controller_spec.rb
@@ -82,7 +82,7 @@ describe Candidates::Registrations::ContactInformationsController, type: :reques
 
       it 'populates the form with the values from gitis' do
         expect(assigns(:contact_information)).to have_attributes \
-          phone: gitis_contact.secondary_telephone,
+          phone: gitis_contact.telephone,
           postcode: gitis_contact.address_postcode
       end
 

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -4,11 +4,7 @@ FactoryBot.define do
     master_id { nil }
     merged { false }
     email { "email@address.com" }
-    secondary_email { "email2@address.com" }
     telephone { "111111111" }
-    secondary_telephone { "222222222" }
-    address_telephone { "333333333" }
-    mobile_telephone { "444444444" }
     address_line1 { "3 Main Street" }
     address_line2 { "Botchergate" }
     address_line3 { "" }

--- a/spec/helpers/gitis_contact_helper_spec.rb
+++ b/spec/helpers/gitis_contact_helper_spec.rb
@@ -1,19 +1,6 @@
 require 'rails_helper'
 
 describe GitisContactHelper, type: :helper do
-  describe "#gitis_contact_display_phone" do
-    it "returns first non-nil of secondary_telephone, telephone then mobile_telephone" do
-      contact = build(:api_schools_experience_sign_up_with_name, telephone: nil, secondary_telephone: nil)
-      expect(helper.gitis_contact_display_phone(contact)).to eq(contact.mobile_telephone)
-
-      contact.telephone = "11111111"
-      expect(helper.gitis_contact_display_phone(contact)).to eq(contact.telephone)
-
-      contact.secondary_telephone = "22222222"
-      expect(helper.gitis_contact_display_phone(contact)).to eq(contact.secondary_telephone)
-    end
-  end
-
   describe "#gitis_contact_display_address" do
     it "returns the formatted address" do
       contact = build(:api_schools_experience_sign_up_with_name)

--- a/spec/models/bookings/registration_contact_mapper_spec.rb
+++ b/spec/models/bookings/registration_contact_mapper_spec.rb
@@ -43,10 +43,7 @@ RSpec.describe Bookings::RegistrationContactMapper do
     it { is_expected.to have_attributes(first_name: registration.personal_information.first_name) }
     it { is_expected.to have_attributes(last_name: registration.personal_information.last_name) }
     it { is_expected.to have_attributes(email: registration.personal_information.email) }
-    it { is_expected.to have_attributes(secondary_email: registration.personal_information.email) }
-    it { is_expected.to have_attributes(secondary_telephone: registration.contact_information.phone) }
     it { is_expected.to have_attributes(telephone: registration.contact_information.phone) }
-    it { is_expected.to have_attributes(address_telephone: registration.contact_information.phone) }
     it { is_expected.to have_attributes(address_line1: registration.contact_information.building) }
     it { is_expected.to have_attributes(address_line2: registration.contact_information.street) }
     it { is_expected.to have_attributes(address_line3: "") }
@@ -66,27 +63,6 @@ RSpec.describe Bookings::RegistrationContactMapper do
       end
 
       it { is_expected.to have_attributes(dbs_certificate_issued_at: nil) }
-    end
-
-    context "when email is already present on the contact" do
-      let(:existing_email) { "existing@email.com" }
-      let(:contact) { GetIntoTeachingApiClient::SchoolsExperienceSignUp.new(email: existing_email) }
-
-      it { is_expected.to have_attributes(email: existing_email) }
-    end
-
-    context "when telephone is already present on the contact" do
-      let(:existing_telephone) { "123456789" }
-      let(:contact) { GetIntoTeachingApiClient::SchoolsExperienceSignUp.new(telephone: existing_telephone) }
-
-      it { is_expected.to have_attributes(telephone: existing_telephone) }
-    end
-
-    context "when address_telephone is already present on the contact" do
-      let(:existing_address_telephone) { "123456789" }
-      let(:contact) { GetIntoTeachingApiClient::SchoolsExperienceSignUp.new(addressTelephone: existing_address_telephone) }
-
-      it { is_expected.to have_attributes(address_telephone: existing_address_telephone) }
     end
   end
 
@@ -115,24 +91,12 @@ RSpec.describe Bookings::RegistrationContactMapper do
     let(:mapper) { described_class.new(registration, contact) }
     subject { mapper.contact_to_contact_information }
 
-    it { is_expected.to include("phone" => contact.secondary_telephone) }
+    it { is_expected.to include("phone" => contact.telephone) }
     it { is_expected.to include("building" => contact.address_line1) }
     it { is_expected.to include("street" => contact.address_line2) }
     it { is_expected.to include("town_or_city" => contact.address_city) }
     it { is_expected.to include("county" => contact.address_state_or_province) }
     it { is_expected.to include("postcode" => contact.address_postcode) }
-
-    context "when secondary_telephone is not present" do
-      let(:contact) { build(:api_schools_experience_sign_up_with_name, secondary_telephone: nil) }
-
-      it { is_expected.to include("phone" => contact.telephone) }
-    end
-
-    context "when secondary_telephone and telephone are not present" do
-      let(:contact) { build(:api_schools_experience_sign_up_with_name, secondary_telephone: nil, telephone: nil) }
-
-      it { is_expected.to include("phone" => contact.mobile_telephone) }
-    end
   end
 
   describe "#contact_to_teaching_preference" do

--- a/spec/services/candidates/registrations/gitis_registration_session_spec.rb
+++ b/spec/services/candidates/registrations/gitis_registration_session_spec.rb
@@ -42,7 +42,7 @@ describe Candidates::Registrations::GitisRegistrationSession do
   describe 'Contact Information' do
     let(:model) { Candidates::Registrations::ContactInformation }
     let(:data) { { 'phone' => '01111 222333' } }
-    let(:gitis_data) { { 'phone' => contact.secondary_telephone } }
+    let(:gitis_data) { { 'phone' => contact.telephone } }
 
     describe '#contact_information_attributes' do
       include_examples "attributes with and without gitis data"


### PR DESCRIPTION
### Trello card
https://trello.com/c/ILVGaw8n

### Context
Currently, if primary phone number or primary email address has a value in the CRM, we update secondary phone number or email instead.

This was a decision made in phase 1, but following a discussion with the CRM team, we have decided that we should change the behaviour and overwrite primary phone number after a matchback, so that the contact information is always up to date (email won't actually be affected because we don't allow candidates to update their email following a matchback).

I have removed everything expect `telephone` and `email address` from the API sign up request.

### Changes proposed in this pull request
- Remove non-primary phone numbers and email address

### Guidance to review
I have done a sign up and matchback. The candidate details seem to be fine in the Manage section.
