### PR TITLE
Introduce Periodic Review Apps Cleaner

### DIFF
--- a/.github/workflows/clean_reviews.yml
+++ b/.github/workflows/clean_reviews.yml
@@ -34,11 +34,11 @@ jobs:
 
       - name: Delete Closed Review Applications 
         run: |
-            APPS=$(cf apps | cut -d ' ' -f1 | grep ${ENV.REVIEW_PREFIX} )
+            APPS=$(cf apps | cut -d ' ' -f1 | grep ${REVIEW_PREFIX} )
             for CHECK in $( echo $APPS ); do
-                PR="${CHECK/${ENV.REVIEW_PREFIX}-/}"
-                STATE=$(curl --header "Authorization: token ${secret.GITHUB_TOKEN}"  -s -X GET "https://api.github.com/repos/${ENV.REPOSITORY}/pulls/${PR}" | jq -r '.state ')
-                echo "${ENV.REPOSITORY} Checking for PR - ${PR} ${STATE}"
+                PR="${CHECK/${REVIEW_PREFIX}-/}"
+                STATE=$(curl --header "Authorization: token ${secret.GITHUB_TOKEN}"  -s -X GET "https://api.github.com/repos/${REPOSITORY}/pulls/${PR}" | jq -r '.state ')
+                echo "${REPOSITORY} Checking for PR - ${PR} ${STATE}"
                 if [[ ${STATE} == "closed" ]]; then
                    echo cf delete -f -r  ${CHECK}
                 fi

--- a/.github/workflows/clean_reviews.yml
+++ b/.github/workflows/clean_reviews.yml
@@ -37,7 +37,7 @@ jobs:
             APPS=$(cf apps | cut -d ' ' -f1 | grep ${REVIEW_PREFIX} )
             for CHECK in $( echo $APPS ); do
                 PR="${CHECK/${REVIEW_PREFIX}-/}"
-                STATE=$(curl --header "Authorization: token ${secret.GITHUB_TOKEN}"  -s -X GET "https://api.github.com/repos/${REPOSITORY}/pulls/${PR}" | jq -r '.state ')
+                STATE=$(curl --header "Authorization: token ${GITHUB_TOKEN}"  -s -X GET "https://api.github.com/repos/${REPOSITORY}/pulls/${PR}" | jq -r '.state ')
                 echo "${REPOSITORY} Checking for PR - ${PR} ${STATE}"
                 if [[ ${STATE} == "closed" ]]; then
                    echo cf delete -f -r  ${CHECK}
@@ -46,7 +46,8 @@ jobs:
         env:
            REVIEW_PREFIX: review-school-experience
            REPOSITORY:    'DFE-Digital/schools-experience'
-            
+           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+           
       - name: Clean up Orphaned Routes
         run:  cf delete-orphaned-routes -f
 

--- a/.github/workflows/clean_reviews.yml
+++ b/.github/workflows/clean_reviews.yml
@@ -1,4 +1,4 @@
-name: Clean Closed Review Applications
+name: Clean Review Applications
 
 on:
   workflow_dispatch:
@@ -16,14 +16,14 @@ jobs:
         id: PAAS-USERNAME
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
-          yaml_secret: SE-INFRA-KEYS
+          yaml_secret: SE-INFRA-SECRETS
           secret: PAAS-USERNAME
 
       - uses: DFE-Digital/github-actions/keyvault-yaml-secret@master
         id: PAAS-PASSWORD
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
-          yaml_secret: SE-INFRA-KEYS
+          yaml_secret: SE-INFRA-SECRETS
           secret: PAAS-PASSWORD
           
       - uses: DFE-Digital/github-actions/setup-cf-cli@master

--- a/.github/workflows/clean_reviews.yml
+++ b/.github/workflows/clean_reviews.yml
@@ -40,7 +40,7 @@ jobs:
                 STATE=$(curl --header "Authorization: token ${GITHUB_TOKEN}"  -s -X GET "https://api.github.com/repos/${REPOSITORY}/pulls/${PR}" | jq -r '.state ')
                 echo "${REPOSITORY} Checking for PR - ${PR} ${STATE}"
                 if [[ ${STATE} == "closed" ]]; then
-                   echo cf delete -f -r  ${CHECK}
+                   cf delete -f -r  ${CHECK}
                 fi
             done
         env:


### PR DESCRIPTION
After each review app is finished with it, it is destroyed and the application is deleted.
However, there are the odd conditions where this fails, usually with dependabot changes.
It isnt such a difficult job to delete them manually, but it is better practice to have checks in place so a script I wrote to clean this up has been put into github_actions so that it can be run by the team, and even periodically if deemed necessary

