### PR TITLE
Add full stops in the rejection reasons

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -673,13 +673,13 @@ en:
       bookings_placement_request_cancellation:
         reason: Cancellation reasons
         rejection_category:
-          fully_booked: The date you requested is fully booked
+          fully_booked: The date you requested is fully booked.
           accepted_on_ttc: We cannot offer you school experience because you've already been accepted on a teacher training course.
           date_not_available: We can no longer offer the date you've requested.
           no_relevant_degree: We do not believe you have a relevant degree for the school experience you're applying for.
           no_phase_availability: We're unable to offer you school experience for the teaching phase you're interested in.
           candidate_not_local: We're looking for candidates that live locally to the school.
-          duplicate: This is a duplicate request
+          duplicate: This is a duplicate request.
           info_not_provided: We did not hear back from you after contacting you for more information.
           cancelation_requested: You asked us to cancel your request.
           wrong_choice_secondary: You've told us you want to get primary school experience, but you've chosen a secondary school placement.


### PR DESCRIPTION
### Trello card
https://trello.com/c/6lM3d3W2

### Context
We recently updated the rejections reasons and added full stop marks at the end of them, but missed some.

### Changes proposed in this pull request
Add full stops to the rejection reasons that don't have.
