### PR TITLE
Change the profile publish route to GET

### DIFF
--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -76,7 +76,7 @@
 
         <%= f.submit 'Accept and set up profile' %>
       <% else %>
-        <%= govuk_link_to 'Publish changes', schools_on_boarding_profile_publish_path, method: :put %>
+        <%= govuk_link_to 'Publish changes', schools_on_boarding_profile_publish_path %>
       <% end %>
 
       <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,7 +146,7 @@ Rails.application.routes.draw do
       resource :preview, only: :show
       resource :confirmation, only: %i[create show]
 
-      put "profile/publish", to: "profiles#publish"
+      get "profile/publish", to: "profiles#publish"
     end
 
     resources :feedbacks, only: %i[new create show]

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -101,8 +101,8 @@ Feature: School Profile
           | School teacher training info | We run our own training\nFind out more about     |
      And I should see the accessability information I have entered
 
-  Scenario: Confirmation acceptance for onboarded school
+  Scenario: Publish profile for onboarded school
       Given my school is fully-onboarded
       And I am on the 'Profile' page
-      Then I should not see the confirmation acceptance container
-      And I should see a 'Publish changes' link
+      And I click the 'Publish changes' button
+      Then the page title should be "You've successfully set up your school experience profile"

--- a/spec/controllers/schools/on_boarding/profiles_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/profiles_controller_spec.rb
@@ -54,7 +54,7 @@ describe Schools::OnBoarding::ProfilesController, type: :request do
           school_profile.bookings_school.profile = bookings_profile
           school_profile.update(description_details: 'new description')
 
-          put schools_on_boarding_profile_publish_path
+          get schools_on_boarding_profile_publish_path
         end
 
         it 'publishes the changes' do
@@ -76,7 +76,7 @@ describe Schools::OnBoarding::ProfilesController, type: :request do
         before do
           school_profile.update(description_details: 'new description')
 
-          put schools_on_boarding_profile_publish_path
+          get schools_on_boarding_profile_publish_path
         end
 
         it 'does not publishes the profile' do


### PR DESCRIPTION
### Trello card
N/A

### Context
Since we need to support browsers with disabled javascript, the profile publish route needs to be changed to GET for the publish button to work.

### Changes proposed in this pull request
Update the route and the button

### Guidance to review
1. Go to school dashboard 
2. Click update profile
3. Make some changes to the profile
3. Click publish changes
4. Should take you to the confirmation page
5. Go back to the profile to confirm it's updated
