### PR TITLE
Update candidate registration flow to use GOV.UK form builder

### DIFF
--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -1,13 +1,13 @@
 <% self.page_title = 'Check your answers' %>
 <%= govuk_back_link %>
 <div class="govuk-grid-row" id="application-preview">
-  <%= form_for @privacy_policy,
+  <%= govuk_form_for @privacy_policy,
         url: candidates_school_registrations_confirmation_email_path,
         data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Check your answers before requesting your school experience</h1>
     <p>You'll receive an email with the following details once you've sent your school experience request.</p>
-    <%= GovukElementsErrorsHelper.error_summary @privacy_policy, 'There is a problem', '' %>
+    <%= f.govuk_error_summary %>
 
     <h2 class="govuk-heading-m">Personal details</h2>
     <dl class="govuk-summary-list">
@@ -127,14 +127,26 @@
     </dl>
   </div>
   <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">Send your school experience request</h2>
-      <div class="govuk-form-group" id="<%= f.form_group_id(:acceptance) %>">
-        <%= f.check_box_input :acceptance %>
+      <div class="govuk-form-group">
+        <%= f.govuk_check_boxes_fieldset :acceptance, multiple: false do %>
+          <%= f.govuk_check_box :acceptance, 1, 0, multiple: false, link_errors: true, label: { text: "By checking this box you're confirming that:" } %>
+          <p>
+            <ul class="govuk-list govuk-list--bullet">
+              <li>the details you've provided are correct</li>
+              <li>you're aged 18 or over</li>
+              <li>you've read our <a href="/privacy_policy" class="govuk-link">privacy policy</a></li>
+              <li>you understand that the DfE's
+              <a href="https://getintoteaching.education.gov.uk/" class="govuk-link">Get Into Teaching Information Service</a>
+              will use your personal details to provide you with
+              tailored advice and information about teacher training and a career as a teacher</li>
+            </ul>
+          </p>
+        <% end %>
       </div>
       <% if candidate_signed_in? %>
-        <%= f.submit 'Accept and send', class: 'govuk-button', data: { prevent_double_click_target: "submitButton" } %>
+        <%= f.govuk_submit 'Accept and send', class: 'govuk-button', data: { prevent_double_click_target: "submitButton" } %>
       <% else %>
-        <%= f.submit 'Continue', class: 'govuk-button', data: { prevent_double_click_target: "submitButton" } %>
+        <%= f.govuk_submit 'Continue', class: 'govuk-button', data: { prevent_double_click_target: "submitButton" } %>
       <% end %>
   </div>
   <% end %>

--- a/app/views/candidates/registrations/background_checks/_form.html.erb
+++ b/app/views/candidates/registrations/background_checks/_form.html.erb
@@ -20,19 +20,19 @@
       </strong>
     </p>
 
-    <%= form_for background_check, url: candidates_school_registrations_background_check_path do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary background_check, 'There is a problem', '' %>
+    <%= govuk_form_for background_check, url: candidates_school_registrations_background_check_path do |f| %>
+      <%= f.govuk_error_summary %>
 
       <% # force the params to submit if the user has not selected an option %>
       <%= f.hidden_field :has_dbs_check, value: nil %>
 
-      <%= f.radio_button_fieldset :has_dbs_check do |fieldset| %>
-        <%= fieldset.radio_input true %>
-        <%= fieldset.radio_input false %>
+      <%= f.govuk_radio_buttons_fieldset :has_dbs_check do %>
+        <%= f.govuk_radio_button :has_dbs_check, true, label: { text: "Yes" } %>
+        <%= f.govuk_radio_button :has_dbs_check, false, label: { text: "No" } %>
       <% end %>
 
       <fieldset class="govuk-fieldset">
-        <%= f.submit 'Continue' %>
+        <%= f.govuk_submit 'Continue' %>
       </fieldset>
     <% end %>
   </div>

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -20,23 +20,23 @@
           Schools will use these details to contact you about school experience once you've sent them a request.
         </p>
 
-        <%= form_for contact_information, url: candidates_school_registrations_contact_information_path do |f| %>
-          <%= GovukElementsErrorsHelper.error_summary contact_information, 'There is a problem', '' %>
+        <%= govuk_form_for contact_information, url: candidates_school_registrations_contact_information_path do |f| %>
+          <%= f.govuk_error_summary %>
 
-          <%= f.telephone_field :phone, autocomplete: 'on' %>
+          <%= f.govuk_phone_field :phone, autocomplete: 'on' %>
 
           <h2 class="govuk-heading-m">Address</h2>
-          <%= f.text_field :building, autocomplete: 'home address-line1' %>
+          <%= f.govuk_text_field :building, autocomplete: 'home address-line1' %>
           <% if f.object.errors[:street].any? %>
-            <%= f.text_field :street, autocomplete: 'home address-line2' %>
+            <%= f.govuk_text_field :street, autocomplete: 'home address-line2' %>
           <% else %>
-            <%= f.text_field :street, autocomplete: 'home address-line2', label_options: { class: 'govuk-visually-hidden' } %>
+            <%= f.govuk_text_field :street, autocomplete: 'home address-line2', label: { class: 'govuk-visually-hidden' } %>
           <% end %>
-          <%= f.text_field :town_or_city, autocomplete: 'home address-level2', class: 'govuk-!-width-two-thirds' %>
-          <%= f.text_field :county, autocomplete: 'home address-level1', class: 'govuk-!-width-two-thirds' %>
-          <%= f.text_field :postcode, autocomplete: 'home postal-code', class: 'govuk-input govuk-input--width-10' %>
+          <%= f.govuk_text_field :town_or_city, autocomplete: 'home address-level2', class: 'govuk-!-width-two-thirds' %>
+          <%= f.govuk_text_field :county, autocomplete: 'home address-level1', class: 'govuk-!-width-two-thirds' %>
+          <%= f.govuk_text_field :postcode, autocomplete: 'home postal-code', class: 'govuk-input govuk-input--width-10' %>
 
-          <%= f.submit 'Continue' %>
+          <%= f.govuk_submit 'Continue' %>
         <% end %>
       </div>
     </div>

--- a/app/views/candidates/registrations/educations/_form.html.erb
+++ b/app/views/candidates/registrations/educations/_form.html.erb
@@ -5,22 +5,21 @@
   The following will be used to help schools offer you school experience.
 </p>
 
-
-<%= form_for education, url: candidates_school_registrations_education_path, data: { controller: 'education-form' } do |f| %>
-  <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+<%= govuk_form_for education, url: candidates_school_registrations_education_path, data: { controller: 'education-form' } do |f| %>
+  <%= f.govuk_error_summary %>
 
   <section id="education-degree-stage-container" data-education-form-target="degreeStagesContainer">
-    <%= f.radio_button_fieldset :degree_stage do |fieldset| %>
-      <% f.object.available_degree_stages.each do |degree_stage| %>
+    <%= f.govuk_radio_buttons_fieldset :degree_stage do %>
+      <% f.object.available_degree_stages.each_with_index do |degree_stage, index| %>
         <% if f.object.requires_explanation_for_degree_stage? degree_stage %>
-          <%= fieldset.radio_input degree_stage, data: {
+          <%= f.govuk_radio_button :degree_stage, degree_stage, link_errors: index == 0, label: { text: degree_stage }, data: {
             action: 'click->education-form#degreeStageSelected',
             requires_subject: f.object.requires_subject_for_degree_stage?(degree_stage)
           } do %>
-            <%= fieldset.text_area :degree_stage_explaination %>
+            <%= f.govuk_text_area :degree_stage_explaination %>
           <% end %>
         <% else %>
-          <%= fieldset.radio_input degree_stage, data: {
+          <%= f.govuk_radio_button :degree_stage, degree_stage, link_errors: index == 0, label: { text: degree_stage }, data: {
             action: 'click->education-form#degreeStageSelected',
             requires_subject: f.object.requires_subject_for_degree_stage?(degree_stage)
           } %>
@@ -30,25 +29,23 @@
   </section>
 
   <section id="education-degree-subject-container" data-education-form-target="degreeSubjectContainer">
-    <%= f.collection_select \
+    <%= f.govuk_collection_select \
       :degree_subject,
       f.object.available_degree_subjects,
       :to_s,
       :to_s,
-      { include_blank: 'Select' },
-      {
-        class: 'govuk-select govuk-!-width-one-half',
-        data: {
-          education_form_target: 'degreeSubject',
-          value_for_no_degree: f.object.no_degree_subject
-        },
-        label_options: { class: 'govuk-heading-m' }
-      } do %>
+      options: { prompt: "Select" },
+      data: {
+        education_form_target: 'degreeSubject',
+        value_for_no_degree: f.object.no_degree_subject
+      },
+      class: "govuk-select govuk-!-width-one-half",
+      label: { class: "govuk-heading-m" } do %>
       <p>
         Select the nearest or equivalent subject.
       </p>
-      <% end %>
+    <% end %>
   </section>
 
-  <%= f.submit 'Continue' %>
+  <%= f.govuk_submit 'Continue' %>
 <% end %>

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -19,25 +19,25 @@
         Get Into Teaching offers help and advice about becoming a teacher.
         </p>
 
-        <%= form_for personal_information,
+        <%= govuk_form_for personal_information,
               url: candidates_school_registrations_personal_information_path,
               data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
 
-          <%= GovukElementsErrorsHelper.error_summary personal_information, 'There is a problem', '' %>
+          <%= f.govuk_error_summary %>
 
-          <%= f.text_field :first_name, autocomplete: 'given-name',
+          <%= f.govuk_text_field :first_name, autocomplete: 'given-name',
                 readonly: personal_information.read_only,
                 disabled: personal_information.read_only %>
 
-          <%= f.text_field :last_name, autocomplete: 'family-name',
+          <%= f.govuk_text_field :last_name, autocomplete: 'family-name',
                 readonly: personal_information.read_only,
                 disabled: personal_information.read_only %>
 
-          <%= f.email_field :email, autocomplete: 'on',
+          <%= f.govuk_email_field :email, autocomplete: 'on',
                 readonly: personal_information.read_only,
                 disabled: personal_information.read_only %>
 
-          <%= f.submit 'Continue', data: { prevent_double_click_target: "submitButton" } %>
+          <%= f.govuk_submit 'Continue', data: { prevent_double_click_target: "submitButton" } %>
         <% end %>
       </div>
     </div>

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -4,16 +4,16 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Request school experience</h1>
 
-    <%= form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary placement_preference, 'There is a problem', '' %>
+    <%= govuk_form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>
+      <%= f.govuk_error_summary %>
 
       <%- unless @school.availability_preference_fixed? %>
-        <%= f.text_area_with_maxwords \
+        <%= f.govuk_text_area \
             :availability,
             rows: 5,
-            maxwords: { count: 150 },
+            max_words: 150,
             'aria-describedby': 'candidates_registrations_placement_preference_availability_label',
-            label_options: { overwrite_defaults!: true, class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_availability_label' } do %>
+            label: { class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_availability_label' } do %>
 
             <p>For example, if you're:</p>
 
@@ -49,25 +49,25 @@
         <% end %>
       <%- end -%>
 
-     <%= f.text_area_with_maxwords \
+     <%= f.govuk_text_area \
           :objectives,
           rows: 5,
-          maxwords: { count: 150 },
+          max_words: 150,
           'aria-describedby': 'candidates_registrations_placement_preference_objectives_label',
-          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_objectives_label' } do %>
-          
+          label: { class: 'govuk-heading-m', id: 'candidates_registrations_placement_preference_objectives_label' } do %>
 
-    
+
+
           <p>
-            Provide a short explanation to help the school offer you 
-            the kind of experience you’re looking for. For example, 
-            you may want to find out if teaching is the right career for you, 
+            Provide a short explanation to help the school offer you
+            the kind of experience you’re looking for. For example,
+            you may want to find out if teaching is the right career for you,
             or to observe how teachers teach your subject.
           </p>
 
             <% end %>
-    
-      <%= f.submit 'Continue' %>
+
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -27,14 +27,16 @@
       <li><%= @email_address %></li>
     </ul>
 
-    <%= form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>
+    <%= govuk_form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
       <%= f.hidden_field :email %>
       <%= f.hidden_field :firstname %>
       <%= f.hidden_field :lastname %>
 
-      <%= f.text_field :code %>
+      <%= f.govuk_text_field :code %>
 
-      <%= f.submit "Submit" %>
+      <%= f.govuk_submit "Submit" %>
     <% end %>
 
     <p>

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -4,8 +4,8 @@
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Choose a date</h1>
-    <%= form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary subject_and_date_information, 'There is a problem', '' %>
+    <%= govuk_form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
+      <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :date_and_subject_ids %>
 
@@ -21,10 +21,10 @@
           <section class="date-selector date-selector-primary">
             <h3 class="govuk-heading-m">Primary school dates</h3>
 
-            <%= f.radio_button_fieldset :date_and_subject_ids,
-              choices: format_primary_date_options(@subject_and_date_information.primary_placement_dates),
-              value_method: :first,
-              text_method: :last -%>
+            <%= f.govuk_collection_radio_buttons :date_and_subject_ids,
+              format_primary_date_options(@subject_and_date_information.primary_placement_dates),
+              :first, :last, include_hidden: false %>
+
           </section>
         <%- end -%>
 
@@ -41,11 +41,9 @@
               </dt>
 
               <dd class="govuk-summary-list__value date-selector date-selector-secondary">
-                <%= f.radio_button_fieldset :date_and_subject_ids,
-                  choices: secondary_placement_dates.sort,
-                  value_method: :id,
-                  text_method: :name_with_duration
-                -%>
+                <%= f.govuk_collection_radio_buttons :date_and_subject_ids,
+                  secondary_placement_dates.sort,
+                  :id, :name_with_duration, include_hidden: false %>
               </dd>
             </div>
           <% end %>
@@ -55,7 +53,7 @@
 
       </section>
 
-      <%= f.submit 'Continue' %>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
 
   </div>

--- a/app/views/candidates/registrations/teaching_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/teaching_preferences/_form.html.erb
@@ -1,14 +1,10 @@
 <% self.page_title = 'Which of the following best describes how you feel about teaching?' %>
 <%= govuk_back_link %>
 <div id="teaching-preference">
-  <%= form_for teaching_preference, url: candidates_school_registrations_teaching_preference_path, data: { controller: 'subject-preference-form' } do |f| %>
-    <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+  <%= govuk_form_for teaching_preference, url: candidates_school_registrations_teaching_preference_path, data: { controller: 'subject-preference-form' } do |f| %>
+    <%= f.govuk_error_summary %>
 
-    <%= f.radio_button_fieldset :teaching_stage do |fieldset| %>
-      <% f.object.available_teaching_stages.each do |teaching_stage| %>
-        <%= fieldset.radio_input teaching_stage, text_method: :to_s %>
-      <% end %>
-    <% end %>
+    <%= f.govuk_collection_radio_buttons :teaching_stage, f.object.available_teaching_stages, :to_s, :to_s %>
 
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
@@ -18,26 +14,25 @@
         Select the nearest or equivalent subject and at least 1 subject.
       </p>
       <div class="govuk-form-group">
-        <%= f.collection_select \
+        <%= f.govuk_collection_select \
           :subject_first_choice,
           f.object.available_subject_choices.sort,
           :to_s,
           :to_s,
-          { prompt: 'Select' },
-          { class: 'govuk-select govuk-!-width-one-half' } %>
+          options: { prompt: "Select" },
+          class: 'govuk-select govuk-!-width-one-half' %>
       </div>
 
       <div class="govuk-form-group">
-        <%= f.collection_select \
+        <%= f.govuk_collection_select \
           :subject_second_choice,
           f.object.second_subject_choices,
           :to_s,
           :to_s,
-          {},
-          { class: 'govuk-select govuk-!-width-one-half' } %>
+          class: 'govuk-select govuk-!-width-one-half' %>
       </div>
     </fieldset>
 
-    <%= f.submit 'Continue' %>
+    <%= f.govuk_submit 'Continue' %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -695,6 +695,8 @@ en:
         building: "Building and street"
         phone: "UK telephone number"
       candidates_registrations_personal_information:
+        first_name: First name
+        last_name: Last name
         email: 'Email address'
       candidates_registrations_teaching_preference:
         teaching_stage: Which of the following best describes how you feel about teaching?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -519,8 +519,6 @@ en:
       disability_confident: Disability and access needs
       fees: Fees
       subjects: Subjects
-      candidates_registrations_background_check:
-        has_dbs_check: Do you have a DBS certificate?
       candidates_registrations_teaching_preference:
         teaching_stage: Which of the following best describes how you feel about teaching?
       candidates_registrations_subject_preference:
@@ -709,10 +707,6 @@ en:
         degree_subject: If you have or are studying for a degree, tell us about your degree subject
         subject_first_choice: "First choice"
         subject_second_choice: "Second choice"
-      candidates_registrations_background_check:
-        has_dbs_check:
-          true: "Yes"
-          false: "No"
       candidates_registrations_placement_preference:
         availability: Tell us about your availability
         objectives: What do you want to get out of your school experience?
@@ -933,6 +927,8 @@ en:
         degree_stage: What stage are you at with your degree?
       candidates_registrations_teaching_preference:
         teaching_stage: Which of the following best describes how you feel about teaching?
+      candidates_registrations_background_check:
+        has_dbs_check: Do you have a DBS certificate?
 
   views:
     pagination:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,8 +521,6 @@ en:
       subjects: Subjects
       candidates_registrations_background_check:
         has_dbs_check: Do you have a DBS certificate?
-      candidates_registrations_education:
-        degree_stage: What stage are you at with your degree?
       candidates_registrations_teaching_preference:
         teaching_stage: Which of the following best describes how you feel about teaching?
       candidates_registrations_subject_preference:
@@ -932,6 +930,8 @@ en:
         <<: *feedback_legend
       schools_feedback:
         <<: *feedback_legend
+      candidates_registrations_education:
+        degree_stage: What stage are you at with your degree?
 
   views:
     pagination:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,6 +694,7 @@ en:
       candidates_registrations_contact_information:
         building: "Building and street"
         phone: "UK telephone number"
+        town_or_city: "Town or city"
       candidates_registrations_personal_information:
         first_name: First name
         last_name: Last name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -698,7 +698,6 @@ en:
         last_name: Last name
         email: 'Email address'
       candidates_registrations_teaching_preference:
-        teaching_stage: Which of the following best describes how you feel about teaching?
         subject_first_choice: "First choice"
         subject_second_choice: "Second choice"
       candidates_registrations_education:
@@ -932,6 +931,8 @@ en:
         <<: *feedback_legend
       candidates_registrations_education:
         degree_stage: What stage are you at with your degree?
+      candidates_registrations_teaching_preference:
+        teaching_stage: Which of the following best describes how you feel about teaching?
 
   views:
     pagination:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -710,17 +710,6 @@ en:
       candidates_registrations_placement_preference:
         availability: Tell us about your availability
         objectives: What do you want to get out of your school experience?
-      candidates_registrations_privacy_policy:
-        acceptance_html:
-          "<p>By checking this box you're confirming that:</p>
-          <ul class=\"govuk-list govuk-list--bullet\">
-            <li>the details you've provided are correct</li>
-            <li>you're aged 18 or over</li>
-            <li>you've read our <a href=\"/privacy_policy\" class=\"govuk-link\">privacy policy</a></li>
-            <li>you understand that the DfE's
-            <a href=\"https://getintoteaching.education.gov.uk/\" class=\"govuk-link\">Get Into Teaching Information Service</a>
-            will use your personal details to provide you with
-            tailored advice and information about teacher training and a career as a teacher</li>"
       candidates_session:
         firstname: First name
         lastname: Last name
@@ -929,6 +918,8 @@ en:
         teaching_stage: Which of the following best describes how you feel about teaching?
       candidates_registrations_background_check:
         has_dbs_check: Do you have a DBS certificate?
+      candidates_registrations_privacy_policy:
+        acceptance: Send your school experience request
 
   views:
     pagination:

--- a/spec/features/candidates/api_registrations_spec.rb
+++ b/spec/features/candidates/api_registrations_spec.rb
@@ -268,7 +268,7 @@ feature 'Candidate Registrations (via the API)', type: :feature do
       "We've sent a link to the following email address:\ntest@example.com"
 
     # Submit email confirmation form successfully
-    check "candidates_registrations_privacy_policy_acceptance"
+    check "candidates_registrations_privacy_policy[acceptance]"
     click_button button_text
   end
 

--- a/spec/views/candidates/registrations/personal_informations/_form.html.erb_spec.rb
+++ b/spec/views/candidates/registrations/personal_informations/_form.html.erb_spec.rb
@@ -2,15 +2,15 @@ require 'rails_helper'
 
 RSpec.describe "candidates/registrations/personal_informations/_form.html.erb", type: :view do
   let(:email_selector) do
-    "input#candidates_registrations_personal_information_email"
+    "input#candidates-registrations-personal-information-email-field"
   end
 
   let(:fname_selector) do
-    "input#candidates_registrations_personal_information_first_name"
+    "input#candidates-registrations-personal-information-first-name-field"
   end
 
   let(:lname_selector) do
-    "input#candidates_registrations_personal_information_last_name"
+    "input#candidates-registrations-personal-information-last-name-field"
   end
 
   before do


### PR DESCRIPTION
### Trello card

[Trello-177](https://trello.com/c/CxfaV95I/177-migrate-the-candidates-registrations-forms)

### Context

Updates the main candidate registration flow steps to use the GOV.UK form builder components.

### Changes proposed in this pull request

- Use GOV.UK form builder for sign in step

- Use GOV.UK form builder for personal informations step

Add missing translations for first/last name (the old form builder must have inferred these from the field names).

Checked readonly/disabled state still behaves and double click prevention is still firing.

- Use GOV.UK form builder for contact information step

Adds missing translations.

Checked conditional logic around street label appearing on validation errors.

- Use GOV.UK form builder for education step

Moved translation to work correctly with legend.

Checked various states/errors work as certain fields are shown/hidden depending on radio selection.

- Use GOV.UK form builder for teaching preference step

- Use GOV.UK form builder for placement preferences step

Use standard `govuk_text_area` with `max_words` option; appears to behave consistently.

Remove `overwrite_defaults!: true` label option; I'm not sure what this was doing but it doesn't appear to be necessary any longer.

- Use GOV.UK form builder for background checks step

- Use GOV.UK form builder for application preview step

Minor update to styling of accept checkbox and surrounding text; the left-margin is lost on the bullet list, which brings it more inline with the examples in the GOV.UK form builder.

- Use GOV.UK form builder for subject/date information step

### Guidance to review

The only visual change is on the application preview step, where the bullet list next to the acceptance checkbox is no longer indented. I could _probably_ get it to indent again if anyone feels strongly about it, but it goes against the examples in the form builder so I've left it like this.

| Before      | After |
| ----------- | ----------- |
|  <img width="705" alt="Screenshot 2022-01-05 at 12 10 38" src="https://user-images.githubusercontent.com/29867726/148215567-c301396c-5d21-4440-ad68-7e1d4af2a13d.png">      | <img width="715" alt="Screenshot 2022-01-05 at 12 10 23" src="https://user-images.githubusercontent.com/29867726/148215538-68ffd3f7-42ef-4518-a7a5-0241b65a74f2.png">       |



