### PR TITLE
Update placement cancellation forms to use GOV.UK form builder

### DIFF
--- a/app/views/candidates/placement_requests/cancellations/_new_booking.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_new_booking.html.erb
@@ -2,7 +2,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Cancel booking</h1>
-      <%= form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
+      <%= govuk_form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
+        <%= f.govuk_error_summary %>
+
         <p>
           You've chosen to cancel your school experience booking for <%= cancellation.school_name %>.
         </p>
@@ -19,7 +21,7 @@
           </strong>
         </div>
 
-        <%= f.text_area :reason,
+        <%= f.govuk_text_area :reason,
             rows: 5,
             label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
 
@@ -28,7 +30,7 @@
             </p>
         <% end %>
 
-        <%= f.submit 'Cancel booking' %>
+        <%= f.govuk_submit 'Cancel booking' %>
 
         <% # TODO add link to 'Contact school' booking show path %>
         <% # TODO add link to 'Your requests and bookings' booking index path %>

--- a/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
@@ -3,8 +3,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Cancel request</h1>
-      <%= form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
-        <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+      <%= govuk_form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
+        <%= f.govuk_error_summary %>
 
       <p>
       You've chosen to cancel your school experience request for <%= f.object.school_name %>.
@@ -14,16 +14,16 @@
         Request sent: <%= f.object.placement_request.sent_at.to_date.to_formatted_s :govuk %>
       </p>
 
-      <%= f.text_area :reason,
+      <%= f.govuk_text_area :reason,
           rows: 5,
-          label_options: { overwrite_defaults!: true, class: 'govuk-heading-m' } do %>
+          label: { class: 'govuk-heading-m' } do %>
 
           <p>
             Tell us a why you want to cancel your request so we can let the school know you no longer want school experience.
           </p>
       <% end %>
 
-      <%= f.submit 'Cancel request' %>
+      <%= f.govuk_submit 'Cancel request' %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Trello card

[Trello-176](https://trello.com/c/KcjjK7R1/176-migrate-the-candidates-placementrequests-cancellations-forms)

### Context

Update cancellation forms to use GOV.UK form builder.

### Changes proposed in this pull request

- Use GOV.UK form builder for cancellation forms

### Guidance to review

To view these two forms you need to:

1. Create a booking and hit the cancel link in the email.
2. Create a booking, login as the school and accept it, then click the cancel link in the subsequent confirmation email.
