### PR TITLE
Display a publish confirmation page when updating the profile

### DIFF
--- a/app/controllers/schools/on_boarding/profiles_controller.rb
+++ b/app/controllers/schools/on_boarding/profiles_controller.rb
@@ -17,8 +17,10 @@ module Schools
           Bookings::ProfilePublisher.new(current_school, current_school_profile).update!
         end
 
-        redirect_to schools_on_boarding_confirmation_path
+        redirect_to schools_on_boarding_profile_publish_confirmation_path
       end
+
+      def publish_confirmation; end
     end
   end
 end

--- a/app/views/schools/on_boarding/profiles/publish_confirmation.html.erb
+++ b/app/views/schools/on_boarding/profiles/publish_confirmation.html.erb
@@ -1,0 +1,26 @@
+<%
+  self.breadcrumbs = {
+    @current_school.name => schools_dashboard_path,
+    "You've updated your profile" => nil
+  }
+%>
+
+<% self.page_title = "You've updated your profile" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        You've updated your profile
+      </h1>
+    </div>
+
+    <p>
+      You have published your recent changes. Your school profile is now up to date.
+    </p>
+
+    <p>
+      <%= govuk_link_to 'Return to dashboard', schools_dashboard_path %>
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,6 +147,7 @@ Rails.application.routes.draw do
       resource :confirmation, only: %i[create show]
 
       get "profile/publish", to: "profiles#publish"
+      get "profile/publish_confirmation", to: "profiles#publish_confirmation"
     end
 
     resources :feedbacks, only: %i[new create show]

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -101,8 +101,8 @@ Feature: School Profile
           | School teacher training info | We run our own training\nFind out more about     |
      And I should see the accessability information I have entered
 
-  Scenario: Publish profile for onboarded school
+  Scenario: Publishing profile for onboarded school
       Given my school is fully-onboarded
       And I am on the 'Profile' page
       And I click the 'Publish changes' button
-      Then the page title should be "You've successfully set up your school experience profile"
+      Then the page title should be "You've updated your profile"

--- a/spec/controllers/schools/on_boarding/profiles_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/profiles_controller_spec.rb
@@ -63,8 +63,8 @@ describe Schools::OnBoarding::ProfilesController, type: :request do
           expect(profile.description_details).to eq('new description')
         end
 
-        it 'redirects the to the confirmation show path' do
-          expect(response).to redirect_to schools_on_boarding_confirmation_path
+        it 'redirects the to the publish confirmation page' do
+          expect(response).to redirect_to schools_on_boarding_profile_publish_confirmation_path
         end
       end
 
@@ -84,7 +84,7 @@ describe Schools::OnBoarding::ProfilesController, type: :request do
         end
 
         it 'redirects the to the confirmation show path' do
-          expect(response).to redirect_to schools_on_boarding_confirmation_path
+          expect(response).to redirect_to schools_on_boarding_profile_publish_confirmation_path
         end
       end
     end


### PR DESCRIPTION
### Trello card
https://trello.com/c/GrO7j5zN

### Context
Currently we display the confirmation page for the onboarding completion when schools updating their profile. That page has content related to the onboarding flow and can be confusing to see when updating the profile.

Displaying a confirmation page with content more relevant to the profile update seems more appropriate.

### Changes proposed in this pull request
Create a new page to display when onboarded schools update their profile.

### Guidance to review
Onboarded schools
1. Update the profile and click `Publish changes`
2. The new confirmation page for updating the profile should be displayed

Non onboarded schools
1. Complete the profile and click `Accept and set up profile`
2. The confirmation for setting up the profile should be displayed
