### PR TITLE
Update the onboarding confirmation page

### DIFF
--- a/app/views/schools/on_boarding/confirmations/show.html.erb
+++ b/app/views/schools/on_boarding/confirmations/show.html.erb
@@ -5,28 +5,37 @@
   }
 %>
 
-<% self.page_title = "You've successfully set up your school experience profile" %>
+<% self.page_title = "You've completed step one of onboarding" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        You've set up your profile
+        You've completed step one of onboarding
       </h1>
     </div>
 
     <p>
-      You can now receive school experience requests from candidates.
+      Next you need to add placement dates to your profile.
     </p>
 
     <p>
-      <strong>
-        Try and respond to requests within 10 working days during term time.
-      </strong>
+      You can choose to add specific dates, or a description of when you can
+      offer school experience.
     </p>
 
     <p>
-      <%= govuk_link_to 'Your requests and bookings', schools_dashboard_path %>
+      Your profile will not be live until you've added dates.
     </p>
+    <p>
+      If you want to add dates later, return to your dashboard.
+    </p>
+
+    <div>
+      <%= govuk_link_to 'Add placement dates', edit_schools_availability_preference_path %>
+    </div>
+    <div>
+      <%= govuk_link_to 'Return to dashboard', schools_dashboard_path, secondary: true %>
+    </div>
   </div>
 </div>

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -76,7 +76,7 @@ Feature: School Profile
   Scenario: Publishing with accepting the privacy policy
       Given I check the 'By checking this box and setting up your school experience profile' checkbox
       When I click the 'Accept and set up profile' button
-      Then the page title should be "You've successfully set up your school experience profile"
+      Then the page title should be "You've completed step one of onboarding"
 
   @smoke_test
   Scenario: Publishing with accepting the privacy policy


### PR DESCRIPTION
### Trello card
https://trello.com/c/qCHStwuY

### Context
The current profile setup confirmation page has outdated content that needs to be updated.

### Changes proposed in this pull request
Update the confirmation page

### Guidance to review
1. Visit the dashboard of a non-onboarded school
2. Complete the profile and click the set up profile button
3. The new content should be displayed in the confirmation page