### PR TITLE
Update placement dates subject selection/configuration to use new GOV.UK form builder

### DIFF
--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -6,35 +6,36 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @configuration, method: :post, url: schools_placement_date_configuration_path(@placement_date) do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+    <%= govuk_form_for @configuration, method: :post, url: schools_placement_date_configuration_path(@placement_date) do |f| %>
+      <%= f.govuk_error_summary %>
 
       <% if Feature.instance.active? :capped_bookings %>
-        <%= f.radio_button_fieldset :has_limited_availability do |fieldset| %>
+        <%= f.govuk_radio_buttons_fieldset :has_limited_availability do %>
           <p>
             Once you’ve accepted the maximum number of bookings this date will not be shown to candidates.
           </p>
-          <%= f.radio_input true do %>
-            <%= f.number_field :max_bookings_count, class: 'govuk-!-width-one-half' %>
+
+          <%= f.govuk_radio_button :has_limited_availability, true do %>
+            <%= f.govuk_number_field :max_bookings_count, class: 'govuk-!-width-one-half' %>
           <% end %>
-          <%= f.radio_input false %>
+          <%= f.govuk_radio_button :has_limited_availability, false, label: { text: t("helpers.label.schools_placement_dates_configuration_form.has_limited_availability_options.false") } %>
         <% end %>
       <% end %>
 
       <%- if @placement_date.supports_subjects? -%>
         <%= f.hidden_field :available_for_all_subjects, value: nil %>
 
-        <%= f.radio_button_fieldset :available_for_all_subjects do |fieldset| %>
+        <%= f.govuk_radio_buttons_fieldset :available_for_all_subjects do %>
           <p>
             Tell us if this is a general experience <strong>or</strong> is
             specific to a subject.
           </p>
-          <%= f.radio_input true %>
-          <%= f.radio_input false %>
+          <%= f.govuk_radio_button :available_for_all_subjects, true %>
+          <%= f.govuk_radio_button :available_for_all_subjects, false, label: { text: t("helpers.label.schools_placement_dates_configuration_form.available_for_all_subjects_options.false") } %>
         <% end %>
       <% end %>
 
-      <%= f.submit 'Continue' %>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -16,7 +16,7 @@
 </p>
 
 
-<%= form_for @placement_date, url: schools_placement_date_path(@placement_date), method: :put do |form| %>
+<%= govuk_form_for @placement_date, url: schools_placement_date_path(@placement_date), method: :put do |f| %>
 
   <div>
     <h2 class="govuk-heading-m">Start date</h2>
@@ -25,15 +25,17 @@
     </p>
   </div>
 
-  <%= form.number_field :duration, width: 3, required: true, label_options: { class: 'govuk-heading-m', overwrite_defaults!: true }  %>
+  <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m govuk-!-margin-0' }  %>
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
-      <%= form.check_box_input :active %>
+      <%= f.govuk_check_boxes_fieldset :active, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :active, 1, 0, multiple: false, link_errors: true %>
+      <% end %>
     </fieldset>
   </div>
 
-  <%= form.submit 'Continue' %>
+  <%= f.govuk_submit 'Continue' %>
 <%- end -%>
 
 <% unless Feature.instance.active? :subject_specific_dates %>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -19,16 +19,22 @@
   at your school.
 </p>
 
-<%= form_for @placement_date, url: schools_placement_dates_path, method: :post do |form| %>
-  <%= GovukElementsErrorsHelper.error_summary form.object, 'There is a problem', '' %>
-  <%= form.date_field :date, heading: true %>
-  <%= form.number_field :duration, width: 3, required: true, label_options: { class: 'govuk-heading-m', overwrite_defaults!: true } %>
-  <%= form.radio_button_fieldset :virtual, choices: [true, false] %>
+<%= govuk_form_for @placement_date, url: schools_placement_dates_path, method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+  <%= f.govuk_date_field :date, heading: true %>
+  <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m' } %>
+  <%= f.govuk_radio_buttons_fieldset :virtual do %>
+    <%= f.govuk_radio_button :virtual, true %>
+    <%= f.govuk_radio_button :virtual, false, label: { text: t("helpers.label.bookings_placement_date.virtual_options.false") }, hint: nil %>
+  <% end %>
 
   <% if show_subject_support_option(@current_school) %>
-    <%= form.radio_button_fieldset :supports_subjects, choices: [false, true] %>
+    <%= f.govuk_radio_buttons_fieldset :supports_subjects do %>
+      <%= f.govuk_radio_button :supports_subjects, false, label: { text: t("helpers.label.bookings_placement_date.supports_subjects_options.false") } %>
+      <%= f.govuk_radio_button :supports_subjects, true %>
+    <% end %>
   <% end %>
-  <%= form.submit 'Continue' %>
+  <%= f.govuk_submit 'Continue' %>
 <%- end -%>
 
 <% unless Feature.instance.active? :subject_specific_dates %>

--- a/app/views/schools/placement_dates/subject_selections/new.html.erb
+++ b/app/views/schools/placement_dates/subject_selections/new.html.erb
@@ -4,11 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @subject_selection, method: :post, url: schools_placement_date_subject_selection_path(@placement_date) do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+    <%= govuk_form_for @subject_selection, method: :post, url: schools_placement_date_subject_selection_path(@placement_date) do |f| %>
+      <%= f.govuk_error_summary %>
 
-      <%= f.collection_check_boxes :subject_ids, @placement_date.bookings_school.subjects, :id, :name, { page_heading: true} %>
-      <%= f.submit 'Continue' %>
+      <%= f.govuk_collection_check_boxes :subject_ids, @placement_date.bookings_school.subjects, :id, :name, legend: { tag: "h1", size: "l" } %>
+
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -577,9 +577,6 @@ en:
         has_limited_availability: Is there a maximum number of bookings you’ll accept for this date?
         available_for_all_subjects: Select type of experience
 
-      schools_placement_dates_subject_selection:
-        subject_ids: Select school experience subjects
-
     hint:
       schools_placement_requests_confirm_booking:
         placement_details: You can add extra experience details
@@ -918,6 +915,8 @@ en:
         date: Enter start date
         supports_subjects: Select school experience phase
         virtual: Experience type
+      schools_placement_dates_subject_selection:
+        subject_ids: Select school experience subjects
 
   views:
     pagination:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -654,7 +654,8 @@ en:
 
       bookings_placement_date:
         duration: How long will it last?
-        active: Make this date available to candidates?
+        active_options:
+          1: Make this date available to candidates?
         supports_subjects:
           yes: Secondary including secondary schools, sixth-forms, colleges and 16 to 18 years
           no: Primary including early years, key stage 1 and key stage 2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -573,10 +573,6 @@ en:
       schools_on_boarding_experience_outline:
         provides_teacher_training: 'Do you run your own teacher training or have any links to teacher training organisations and providers?'
 
-      schools_placement_dates_configuration_form:
-        has_limited_availability: Is there a maximum number of bookings you’ll accept for this date?
-        available_for_all_subjects: Select type of experience
-
     hint:
       schools_placement_requests_confirm_booking:
         placement_details: You can add extra experience details
@@ -837,10 +833,10 @@ en:
         early_years: 'Early years foundation stage (EYFS)'
 
       schools_placement_dates_configuration_form:
-        has_limited_availability:
+        has_limited_availability_options:
           true: 'Yes'
           false: 'No'
-        available_for_all_subjects:
+        available_for_all_subjects_options:
           true: 'General experience'
           false: 'Specific to a subject'
         max_bookings_count: 'Enter maximum number of bookings.'
@@ -917,6 +913,9 @@ en:
         virtual: Experience type
       schools_placement_dates_subject_selection:
         subject_ids: Select school experience subjects
+      schools_placement_dates_configuration_form:
+        has_limited_availability: Is there a maximum number of bookings you’ll accept for this date?
+        available_for_all_subjects: Select type of experience
 
   views:
     pagination:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -507,10 +507,6 @@ en:
       bookings_school:
         availability_preference_fixed: Choose how dates are displayed
         experience_type: School experience type
-      bookings_placement_date:
-        date: Enter start date
-        supports_subjects: Select school experience phase
-        virtual: Experience type
       bookings_placement_request_cancellation:
         rejection_category: Rejection reason
       phases: Education phases
@@ -656,10 +652,10 @@ en:
         duration: How long will it last?
         active_options:
           1: Make this date available to candidates?
-        supports_subjects:
-          yes: Secondary including secondary schools, sixth-forms, colleges and 16 to 18 years
-          no: Primary including early years, key stage 1 and key stage 2
-        virtual:
+        supports_subjects_options:
+          true: Secondary including secondary schools, sixth-forms, colleges and 16 to 18 years
+          false: Primary including early years, key stage 1 and key stage 2
+        virtual_options:
           true: Virtual experience
           false: In school experience
       bookings_placement_request_cancellation:
@@ -918,6 +914,10 @@ en:
         acceptance: Send your school experience request
       bookings_school:
         enabled: Turn profile on or off
+      bookings_placement_date:
+        date: Enter start date
+        supports_subjects: Select school experience phase
+        virtual: Experience type
 
   views:
     pagination:

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -69,13 +69,8 @@ Then("I should see a select box containing school subjects labelled {string}") d
 end
 
 Then("I fill in the date field {string} with {int}-{int}-{int}") do |field, day, month, year|
-  # Some of the designs call for the field name to be styled as a heading
-  date_field_set = \
-    begin
-      page.find '.govuk-label', text: field
-    rescue Capybara::ElementNotFound
-      page.find '.govuk-fieldset__heading', text: field
-    end
+  # Some of the designs call for the field name to be styled as a heading/legend
+  date_field_set = page.find '.govuk-label, .govuk-fieldset__heading, .govuk-fieldset__legend', text: field
 
   within(date_field_set.ancestor('.govuk-form-group')) do
     fill_in 'Day',   with: day


### PR DESCRIPTION
### Trello card

[Trello-186](https://trello.com/c/PULJYgGN/186-migrate-the-schools-placementdates-forms)

### Context

We want to use the new GOV.UK form builder for all the forms in SE.

### Changes proposed in this pull request

- Use GOV.UK form builder on edit placement date

- Use GOV.UK form builder on new placement date

The `false` label text is manually mapped as the form builder doesn't seem to map it to the `false` key correctly, I'm not sure why.

- Use GOV.UK form builder for subject selections form

- Use GOV.UK form builder for placement dates configuration form

### Guidance to review

The placement dates subject selection and configuration paths are feature switched off in production. You can access them at:

```
/schools/placement_dates/:id/subject_selection/new
/schools/placement_dates/:id/configuration/new
```
