### PR TITLE
Dont send sms non prod

### DIFF
--- a/app/notify/notify_despatchers/sms.rb
+++ b/app/notify/notify_despatchers/sms.rb
@@ -1,5 +1,7 @@
 class NotifyDespatchers::Sms < NotifyDespatchers::Base
   def despatch_later!
+    return unless Feature.active? :sms
+
     validate_personalisation!
 
     to.each do |phone_number|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -159,7 +159,12 @@ Rails.application.configure do
 
   config.x.gitis.privacy_consent_id = ENV['CRM_PRIVACY_CONSENT_ID'].presence || '222750001'
 
-  config.x.features = %i[subject_specific_dates reminders]
+  config.x.features = %i[
+    subject_specific_dates
+    reminders
+    sms
+  ]
+
   config.x.flipper_password = ENV['FLIPPER_PASSWORD']
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 70)

--- a/spec/notify/notify_despatchers/notify_spec.rb
+++ b/spec/notify/notify_despatchers/notify_spec.rb
@@ -186,6 +186,16 @@ describe NotifyDespatchers::Sms do
     end
   end
 
+  before { allow(Feature).to receive(:active?).with(:sms) { true } }
+
   subject { StubSmsNotification }
   include_examples "notify_client"
+
+  context "when in non-production environments" do
+    before { allow(Feature).to receive(:active?).with(:sms) { false } }
+
+    it "does not despatch SMS" do
+      expect(NotifyService.instance).not_to have_received(notify_method)
+    end
+  end
 end

--- a/spec/services/bookings/reminder_spec.rb
+++ b/spec/services/bookings/reminder_spec.rb
@@ -10,6 +10,8 @@ describe Bookings::Reminder, type: :request do
 
   subject { Bookings::Reminder.new(booking, time_until_booking, time_until_booking_descriptive) }
 
+  before { allow(Feature).to receive(:active?).with(:sms) { true } }
+
   describe '#deliver' do
     it "queues an email and sms per provided booking" do
       sign_up = build(:api_schools_experience_sign_up_with_name)

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -12,6 +12,8 @@ shared_examples_for "sms template" do |template_id, personalisation|
   let(:to) { "07777777777" }
   let(:template_folder) { "notify_sms" }
 
+  before { allow(Feature).to receive(:active?).with(:sms) { true } }
+
   include_examples "notify template", template_id, personalisation
 end
 


### PR DESCRIPTION
### Context
Currently, in order to test the SMS notifications we have been sending messages from our local Dev environments. However, ideally, we don't want to exceed our quota of free messages. (though a few messages won't really make a difference with the size of the free quota)

To help us stay under this quota, only send SMS in production.

This will also make any reports generated from Gov Notify more accurate, as they won't contain our Dev messages.

### Changes proposed in this pull request
- Don't send SMS in non-production environments