### PR TITLE
Update school availability forms to use GOV.UK form builder

### DIFF
--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -9,10 +9,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @current_school, url: schools_availability_info_path, method: :patch do |form| %>
+    <%= govuk_form_for @current_school, url: schools_availability_info_path, method: :patch do |f| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <%= form.text_area :availability_info, rows: 7, label_options: { overwrite_defaults!: true, class: 'govuk-heading-l' } do %>
+          <%= f.govuk_text_area :availability_info, rows: 7, label: { class: 'govuk-heading-l' } do %>
             <p>
               Outline when you offer in school or virtual school experiences at
               your school.
@@ -32,9 +32,9 @@
 
       </div>
 
-      <%= form.radio_button_fieldset :experience_type, choices: form.object.class::EXPERIENCE_TYPES %>
+      <%= f.govuk_collection_radio_buttons :experience_type, f.object.class::EXPERIENCE_TYPES, :to_s %>
 
-      <%= form.submit 'Save availability description' %>
+      <%= f.govuk_submit 'Save availability description' %>
     <%- end -%>
   </div>
 </div>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -9,13 +9,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for @current_school, url: schools_availability_preference_path, method: 'patch' do |f| %>
-      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
-      <%= f.radio_button_fieldset :availability_preference_fixed, choices: %w(true false) do |fieldset| %>
+    <%= govuk_form_for @current_school, url: schools_availability_preference_path, method: 'patch' do |f| %>
+      <%= f.govuk_error_summary f.object %>
+      <%= f.govuk_radio_buttons_fieldset :availability_preference_fixed do %>
 
         <%= f.hidden_field :availability_preference_fixed %>
 
-        <%= fieldset.radio_input true, 'aria-describedby': 'bookings-school-availability-preference-fixed-true-hint' %>
+        <%= f.govuk_radio_button :availability_preference_fixed, "true", 'aria-describedby': 'bookings-school-availability-preference-fixed-true-hint', link_errors: true %>
 
         <div id="bookings-school-availability-preference-fixed-true-hint" class="govuk-hint govuk-radios__hint preference-info">
           <p>
@@ -41,7 +41,7 @@
           </details>
         </div>
 
-        <%= fieldset.radio_input false, 'aria-describedby': 'bookings-school-availability-preference-fixed-false-hint'  %>
+        <%= f.govuk_radio_button :availability_preference_fixed, "false", 'aria-describedby': 'bookings-school-availability-preference-fixed-false-hint'  %>
 
         <div id="bookings-school-availability-preference-fixed-false-hint" class="govuk-hint govuk-radios__hint preference-info">
           <p>
@@ -64,7 +64,7 @@
         </div>
 
       <% end %>
-      <%= f.submit 'Continue' %>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -613,6 +613,11 @@ en:
         availability_preference_fixed_options:
           true: Show specific dates
           false: Show a description of when you can host candidates
+        availability_info: Availability info
+        experience_type_options:
+          virtual: Virtual experience
+          inschool: In school experience
+          both: Both virtual and in school experiences
       bookings_placement_date:
         duration: How long will it last?
         active_options:
@@ -890,6 +895,8 @@ en:
         acceptance: Send your school experience request
       bookings_school:
         enabled: Turn profile on or off
+        availability_preference_fixed: Choose how dates are displayed
+        experience_type: School experience type
       bookings_placement_date:
         date: Enter start date
         supports_subjects: Select school experience phase
@@ -924,8 +931,7 @@ en:
         has_access_needs_policy: 'Do you have any online information which covers your disability and access needs policy?'
       schools_on_boarding_experience_outline:
         provides_teacher_training: 'Do you run your own teacher training or have any links to teacher training organisations and providers?'
-      bookings_school:
-        availability_preference_fixed: Choose how dates are displayed
+
   views:
     pagination:
       next: Next

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -609,7 +609,10 @@ en:
           virtual: Virtual experience
           inschool: In school experience
           both: Both virtual and in school experiences
-
+      bookings_school:
+        availability_preference_fixed_options:
+          true: Show specific dates
+          false: Show a description of when you can host candidates
       bookings_placement_date:
         duration: How long will it last?
         active_options:
@@ -921,7 +924,8 @@ en:
         has_access_needs_policy: 'Do you have any online information which covers your disability and access needs policy?'
       schools_on_boarding_experience_outline:
         provides_teacher_training: 'Do you run your own teacher training or have any links to teacher training organisations and providers?'
-
+      bookings_school:
+        availability_preference_fixed: Choose how dates are displayed
   views:
     pagination:
       next: Next


### PR DESCRIPTION
### Trello card

[Trello-182](https://trello.com/c/ndMLK0xG/182-migrate-the-schools-availabilityinfo-forms)

### Context

We want to use the new GOV.UK form builder for all of the school experience forms.

### Changes proposed in this pull request

- Use GOV.UK form builder for availability preferences form
- Use GOV.UK form builder for availability info form

### Guidance to review

Sign in as a school and go to "Change how available dates are displayed" to test these forms.

There's no error summary on one of the forms; instead of adding it I've left it consistent with master for now.