### PR TITLE
Update school change form to use GOV.UK form builder

### DIFF
--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -2,33 +2,22 @@
   <div class="govuk-grid-column-two-thirds">
     <% if Schools::ChangeSchool.allow_school_change_in_app? %>
       <% if @schools.any? %>
-        <%= form_for @change_school, url: schools_change_path, method: :post do |f| %>
-          <%= f.radio_button_fieldset :change_to_urn, page_heading: true do %>
+        <%= govuk_form_for @change_school, url: schools_change_path, method: :post do |f| %>
+          <%= f.govuk_radio_buttons_fieldset :change_to_urn, legend: { tag: "h1", size: "l" } do %>
             <% @schools.each do |school| %>
-              <div class="govuk-radios__item">
-                <%= f.radio_button :change_to_urn, school.urn, class: 'govuk-radios__input' %>
-
-                <%= f.label :change_to_urn, class: 'govuk-label govuk-radios__label', value: school.urn do %>
-                  <%= school.name %>
-
-                  <%= numbered_circle f.object.task_count_for_urn(school.urn),
-                        aria_label: "outstanding bookings and requests for #{school.name}" %>
-                <% end %>
-              </div>
+              <%= f.govuk_radio_button :change_to_urn, school.urn, label: -> do %>
+                <%= school.name %>
+                <%= numbered_circle f.object.task_count_for_urn(school.urn),
+                  aria_label: "outstanding bookings and requests for #{school.name}" %>
+              <% end %>
             <% end %>
             <% if Schools::ChangeSchool.request_approval_url %>
               <div class= 'govuk-radios__divider'>or</div>
-              <div class="govuk-radios__item">
-                  <%= f.radio_button :change_to_urn, "request access", class: 'govuk-radios__input' %>
-
-                  <%= f.label :change_to_urn, class: 'govuk-label govuk-radios__label', value: "request access" do %>
-                    Request access to another school
-                  <% end %>
-              </div>
+              <%= f.govuk_radio_button :change_to_urn, "request access", label: { text: "Request access to another school" } %>
             <% end %>
           <% end %>
 
-          <%= f.submit "Continue" %>
+          <%= f.govuk_submit "Continue" %>
         <% end %>
       <% elsif @dfe_sign_in_add_service_url %>
         <h1 class="govuk-heading-l">Manage school experience</h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -537,8 +537,6 @@ en:
           </p>
       schools_on_boarding_availability_preference:
         fixed: 'Enter school experience availability or fixed dates'
-      schools_change_school:
-        change_to_urn: Select your school
       schools_on_boarding_candidate_experience_detail:
         disabled_facilities: 'Do you provide facilities or support for candidates with disabilities or access needs?'
 
@@ -931,6 +929,8 @@ en:
         has_access_needs_policy: 'Do you have any online information which covers your disability and access needs policy?'
       schools_on_boarding_experience_outline:
         provides_teacher_training: 'Do you run your own teacher training or have any links to teacher training organisations and providers?'
+      schools_change_school:
+        change_to_urn: Select your school
 
   views:
     pagination:


### PR DESCRIPTION
### Trello card

[Trello-183](https://trello.com/c/uGlMsppl/183-migrate-the-schools-changeschools-form)

### Context

We want to use the new GOV.UK form builder for all of the school experience forms.

### Changes proposed in this pull request

- Use GOV.UK form builder on school change form

### Guidance to review

