### PR TITLE
Update cancellation edit forms to use GOV.UK form builder

### DIFF
--- a/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
@@ -1,14 +1,14 @@
 <%- self.page_title = "Review and send cancellation email to candidate" %>
 <%= govuk_back_link schools_dashboard_path %>
 
-<%= form_for cancellation, url: schools_booking_cancellation_path do |f| %>
+<%= govuk_form_for cancellation, url: schools_booking_cancellation_path do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">
         Review and send cancellation email to candidate
       </h1>
 
-      <%= GovukElementsErrorsHelper.error_summary f.object, 'There is a problem', '' %>
+      <%= f.govuk_error_summary %>
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
@@ -19,22 +19,22 @@
           <%= render partial: "letter", locals: {
             cancellation: cancellation,
             reason: capture do
-              f.text_area :reason,
+              f.govuk_text_area :reason,
                 rows: 7,
                 placeholder: "Explain why the booking was cancelled. For example, the school is fully booked or there's no longer school experience available on the requested date",
-                label_options: { overwrite_defaults!: true, class: 'govuk-visually-hidden' }
+                label: { class: 'govuk-visually-hidden' }
             end,
             extra_details: capture do
-              f.text_area :extra_details,
+              f.govuk_text_area :extra_details,
                 rows: 7,
                 placeholder: "Add any extra details. For example, you may have availability on a different date or you can offer school experience in another subject",
-                label_options: { overwrite_defaults!: true, class: 'govuk-visually-hidden' }
+                label: { class: 'govuk-visually-hidden' }
             end
           } %>
 
           <section>
             <p>
-              <%= f.submit 'Preview cancellation email' %>
+              <%= f.govuk_submit 'Preview cancellation email' %>
             </p>
 
             <p>

--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -4,8 +4,6 @@
   <div class="govuk-grid-column-two-thirds">
      <%= govuk_back_link schools_booking_path(@booking) %>
 
-     <%= GovukElementsErrorsHelper.error_summary @booking, 'There is a problem', '' %>
-
     <h1>Change the booking date for <%= gitis_contact_full_name(@booking.gitis_contact) %></h1>
 
     <p>
@@ -18,8 +16,10 @@
       booking date.
     </p>
 
-    <%= form_for @booking, url: schools_booking_date_path(@booking), method: 'patch' do |f| %>
-      <%= f.date_field :date, heading: true %>
+    <%= govuk_form_for @booking, url: schools_booking_date_path(@booking), method: 'patch' do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_date_field :date, heading: true %>
         <div id="school-booking-show" class="booking">
           <section id="booking-details">
             <dl class="govuk-summary-list">
@@ -31,7 +31,7 @@
           </section>
         </div>
 
-      <%= f.submit 'Continue' %>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,8 +502,6 @@ en:
   helpers:
     fieldset:
       order: Sorted by
-      bookings_booking:
-        date: Booking date
       bookings_school:
         availability_preference_fixed: Choose how dates are displayed
         experience_type: School experience type
@@ -931,6 +929,8 @@ en:
         provides_teacher_training: 'Do you run your own teacher training or have any links to teacher training organisations and providers?'
       schools_change_school:
         change_to_urn: Select your school
+      bookings_booking:
+        date: Booking date
 
   views:
     pagination:


### PR DESCRIPTION
### Trello card

[Trello-184](https://trello.com/c/KQaVZXmx/184-dev-migrate-the-schools-confirmedbookings-forms)

### Context

We want to use the new GOV.UK form builder for all of the school experience forms.

### Changes proposed in this pull request

- Use GOV.UK form builder on booking cancellation form
- Use GOV.UK form builder on cancellation date form

### Guidance to review

Relevant paths:

```
/schools/bookings/:id/cancellation/new
/schools/bookings/:id/date/edit
```
