### PR TITLE
Update school search forms to use GOV.UK form builder

### DIFF
--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -14,23 +14,21 @@
   <div class="govuk-grid-column-one-half">
     <div id="search-form">
 
-      <%= form_for(@search,
+      <%= govuk_form_for(@search,
         as: '',
         url: candidates_schools_path,
         method: :get,
         html: { class: 'school-search-form' }) do |f| %>
+          <%= f.govuk_text_field :location, required: true, minlength: "2", label: { text: t('helpers.label.location') } %>
 
-          <%= f.search_field :location, required: true, minlength: "2" %>
-
-          <%= f.collection_select :distance,
-                Candidates::SchoolSearch.distances, :first, :last unless f.object.whitelisted_urns? %>
+          <%= f.govuk_collection_select :distance,
+                Candidates::SchoolSearch.distances, :first, :last, label: { text: t('helpers.label.distance')  } unless f.object.whitelisted_urns? %>
 
           <div class="school-search-form__submit">
             <div class="govuk-form-group">
-              <%= f.submit 'Search', name: nil, aria: { label: 'Search for schools offering school experience' } %>
+              <%= f.govuk_submit 'Search', name: nil, aria: { label: 'Search for schools offering school experience' } %>
             </div>
           </div>
-
       <% end %>
     </div>
   </div>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -32,7 +32,7 @@
 
       <div data-target="collapsible.panel">
         <%= link_to 'Skip to search results', '#search-results', class: 'govuk-skip-link', id: 'skip-to-results' %>
-        <%= form_for @search, as: '',
+        <%= govuk_form_for @search, as: '',
                      method: :get,
                      html: { class: "collapsible__content" } do |f| %>
 
@@ -42,13 +42,20 @@
           <%= f.hidden_field :latitude %>
           <%= f.hidden_field :longitude %>
 
-          <%= f.collection_check_boxes :phases, Candidates::School.phases, :first, :last %>
+          <%= f.govuk_collection_check_boxes :phases, Candidates::School.phases, :first, :last,
+            legend: { text: t("helpers.fieldset.phases") }, hint: { text: t("helpers.hint.phases") } %>
 
-          <%= f.collection_check_boxes :subjects, Candidates::School.subjects, :first, :last %>
-          <%= f.collection_check_boxes :dbs_policies, [[2, nil]], :first, :last %>
-          <%= f.check_box_fieldset :disability_confident, [:disability_confident], include_hidden: false %>
+          <%= f.govuk_collection_check_boxes :subjects, Candidates::School.subjects, :first, :last,
+            classes: %w(search-subjects-checkboxes), hint: { text: t("helpers.hint.subjects") } %>
 
-          <%= f.submit 'Update schools list', name: nil %>
+          <%= f.govuk_collection_check_boxes :dbs_policies, [[2, t("helpers.label.dbs_policies_2")]], :first, :last,
+            legend: { text: t("helpers.fieldset.dbs_policies") }, hint: { text: t("helpers.hint.dbs_policies") } %>
+
+          <%= f.govuk_check_boxes_fieldset :disability_confident, multiple: false, legend: { text: t("helpers.fieldset.disability_confident") } do %>
+            <%= f.govuk_check_box :disability_confident, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.disability_confident") } %>
+          <% end %>
+
+          <%= f.govuk_submit 'Update schools list', name: nil %>
         <% end %>
       </div>
     </div>

--- a/app/webpacker/stylesheets/school-search.scss
+++ b/app/webpacker/stylesheets/school-search.scss
@@ -80,7 +80,7 @@
   margin-bottom: govuk-spacing(4);
 }
 
-#_subjects_container .govuk-checkboxes {
+.search-subjects-checkboxes {
   height: 300px;
   overflow-y: scroll;
 }

--- a/spec/views/candidates/school_searches/new.html.erb_spec.rb
+++ b/spec/views/candidates/school_searches/new.html.erb_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "candidates/school_searches/new.html.erb", type: :view do
     expect(rendered).to have_css('label', text: 'Enter location or postcode')
     expect(rendered).to have_css('label', text: 'Select search area')
 
-    expect(rendered).to have_css("input#location[required='required']")
-    expect(rendered).to have_css('select#distance')
+    expect(rendered).to have_css("input#location-field[required='required']")
+    expect(rendered).to have_css('select#distance-field')
 
     expect(rendered).to have_button('Search')
   end
@@ -31,8 +31,8 @@ RSpec.describe "candidates/school_searches/new.html.erb", type: :view do
       expect(rendered).to have_css('label', text: 'Enter location or postcode')
       expect(rendered).not_to have_css('label', text: 'Select search area')
 
-      expect(rendered).to have_css("input#location[required='required']")
-      expect(rendered).not_to have_css('select#distance')
+      expect(rendered).to have_css("input#location-field[required='required']")
+      expect(rendered).not_to have_css('select#distance-field')
     end
   end
 end

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
     end
 
     it "shows the disability confident filter" do
-      expect(rendered).to have_css('.govuk-fieldset__heading', text: 'Disability and access needs')
+      expect(rendered).to have_css('.govuk-fieldset__legend', text: 'Disability and access needs')
       expect(rendered).to have_css '#search-filter input[name="disability_confident"]'
     end
 


### PR DESCRIPTION
### Trello card

[Trello-178](https://trello.com/c/mLbFqGrn/178-migrate-the-candidates-schoolsearches-forms)

### Context

We want to use the new GOV.UK form builder for all of the school experience forms.

### Changes proposed in this pull request

- Use GOV.UK form builder on search form
- Use GOV.UK form builder on search results page

### Guidance to review

Due to the use of `as: ''` in the form call the translations are set manually for these forms (full explanation in the commit messages).
