### PR TITLE
Update confirm attendance form to use GOV.UK form builder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'dotenv-rails', '>= 2.7.6'
 
 gem 'govuk_design_system_formbuilder', '~> 2.8'
+gem 'govuk_elements_form_builder', github: 'DFE-Digital/govuk_elements_form_builder'
 gem 'notifications-ruby-client'
 
 gem 'acts_as_list'

--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'dotenv-rails', '>= 2.7.6'
 
 gem 'govuk_design_system_formbuilder', '~> 2.8'
-gem 'govuk_elements_form_builder', github: 'DFE-Digital/govuk_elements_form_builder'
 gem 'notifications-ruby-client'
 
 gem 'acts_as_list'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,15 +14,6 @@ GIT
       get_into_teaching_api_client
 
 GIT
-  remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: 9420e3f1c9f780b9fc3a832cfdeb1e970f70a423
-  specs:
-    govuk_elements_form_builder (1.3.0)
-      govuk_elements_rails (>= 3.0.0)
-      govuk_frontend_toolkit (>= 6.0.0)
-      rails (>= 6.1.0)
-
-GIT
   remote: https://github.com/microsoft/ApplicationInsights-Ruby.git
   revision: a74292001cf12f6de957dfdcefaf8dbe415d7181
   ref: a7429200
@@ -264,12 +255,6 @@ GEM
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
-    govuk_elements_rails (3.1.3)
-      govuk_frontend_toolkit (>= 6.0.2)
-      rails (>= 4.1.0)
-      sass (>= 3.2.0)
-    govuk_frontend_toolkit (9.0.1)
-      railties (>= 3.1.0)
     hashdiff (1.0.1)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -492,11 +477,6 @@ GEM
     sanitize (6.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -633,7 +613,6 @@ DEPENDENCIES
   geocoder
   get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder (~> 2.8)
-  govuk_elements_form_builder!
   invisible_captcha (>= 2.0.0)
   json (>= 2.3.0)
   kaminari

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,15 +14,6 @@ GIT
       get_into_teaching_api_client
 
 GIT
-  remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
-  revision: 9420e3f1c9f780b9fc3a832cfdeb1e970f70a423
-  specs:
-    govuk_elements_form_builder (1.3.0)
-      govuk_elements_rails (>= 3.0.0)
-      govuk_frontend_toolkit (>= 6.0.0)
-      rails (>= 6.1.0)
-
-GIT
   remote: https://github.com/microsoft/ApplicationInsights-Ruby.git
   revision: a74292001cf12f6de957dfdcefaf8dbe415d7181
   ref: a7429200
@@ -264,12 +255,6 @@ GEM
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
-    govuk_elements_rails (3.1.3)
-      govuk_frontend_toolkit (>= 6.0.2)
-      rails (>= 4.1.0)
-      sass (>= 3.2.0)
-    govuk_frontend_toolkit (9.0.1)
-      railties (>= 3.1.0)
     hashdiff (1.0.1)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -324,10 +309,6 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
@@ -492,11 +473,6 @@ GEM
     sanitize (6.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -633,7 +609,6 @@ DEPENDENCIES
   geocoder
   get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder (~> 2.8)
-  govuk_elements_form_builder!
   invisible_captcha (>= 2.0.0)
   json (>= 2.3.0)
   kaminari

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,15 @@ GIT
       get_into_teaching_api_client
 
 GIT
+  remote: https://github.com/DFE-Digital/govuk_elements_form_builder.git
+  revision: 9420e3f1c9f780b9fc3a832cfdeb1e970f70a423
+  specs:
+    govuk_elements_form_builder (1.3.0)
+      govuk_elements_rails (>= 3.0.0)
+      govuk_frontend_toolkit (>= 6.0.0)
+      rails (>= 6.1.0)
+
+GIT
   remote: https://github.com/microsoft/ApplicationInsights-Ruby.git
   revision: a74292001cf12f6de957dfdcefaf8dbe415d7181
   ref: a7429200
@@ -255,6 +264,12 @@ GEM
       activemodel (>= 6.0)
       activesupport (>= 6.0)
       deep_merge (~> 1.2.1)
+    govuk_elements_rails (3.1.3)
+      govuk_frontend_toolkit (>= 6.0.2)
+      rails (>= 4.1.0)
+      sass (>= 3.2.0)
+    govuk_frontend_toolkit (9.0.1)
+      railties (>= 3.1.0)
     hashdiff (1.0.1)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -309,6 +324,10 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
@@ -473,6 +492,11 @@ GEM
     sanitize (6.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    sass (3.7.4)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -609,6 +633,7 @@ DEPENDENCIES
   geocoder
   get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder (~> 2.8)
+  govuk_elements_form_builder!
   invisible_captcha (>= 2.0.0)
   json (>= 2.3.0)
   kaminari

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -127,6 +127,15 @@ module ApplicationHelper
     form_for(*args, **merged, &block)
   end
 
+  def govuk_form_with(*args, **options, &block)
+    merged = options.dup
+    merged[:builder] = GOVUKDesignSystemFormBuilder::FormBuilder
+    merged[:html] ||= {}
+    merged[:html][:novalidate] = true
+
+    form_with(*args, **merged, &block)
+  end
+
 private
 
   def valid_user?(user)

--- a/app/helpers/schools/confirm_attendance_helper.rb
+++ b/app/helpers/schools/confirm_attendance_helper.rb
@@ -2,15 +2,6 @@ module Schools::ConfirmAttendanceHelper
   # NOTE: we can't use the form builder here because it wraps everything in
   # form-groups and fieldsets which affect how it's displayed in a table cell
   def confirm_attendance_radio(builder, booking_id, value, label_text)
-    tag.div(class: "govuk-radios__item") do
-      safe_join(
-        [
-          builder.radio_button(booking_id, value, class: %w[govuk-radios__input]),
-          builder.label("#{booking_id}_#{value}", class: %(govuk-label govuk-radios__label)) do
-            label_text
-          end
-        ]
-      )
-    end
+    builder.govuk_radio_button(booking_id.to_s, value, class: %w[govuk-radios__input], label: { text: label_text })
   end
 end

--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -11,9 +11,11 @@
 
 <%- if @bookings.any? %>
 
-  <%= form_with url: schools_confirm_attendance_path, method: 'put' do |f| %>
-    <%= GovukElementsErrorsHelper.error_summary @updated_attendance, 'There is a problem', '' %>
+  <%= govuk_form_for @updated_attendance, url: nil do |f| %>
+    <%= f.govuk_error_summary %>
+  <% end %>
 
+  <%= govuk_form_with url: schools_confirm_attendance_path, method: 'put' do |f| %>
     <%= pagination_bar @bookings %>
 
     <table class="govuk-table">
@@ -53,7 +55,7 @@
     <%= pagination_bar @bookings %>
 
     <div>
-      <%= f.submit 'Save and return to dashboard' %>
+      <%= f.govuk_submit 'Save and return to dashboard' %>
     </div>
 
   <% end %>

--- a/config/initializers/govuk_form_builder.rb
+++ b/config/initializers/govuk_form_builder.rb
@@ -1,0 +1,1 @@
+ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder

--- a/config/initializers/govuk_form_builder.rb
+++ b/config/initializers/govuk_form_builder.rb
@@ -1,1 +1,0 @@
-ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder

--- a/config/initializers/govuk_form_builder.rb
+++ b/config/initializers/govuk_form_builder.rb
@@ -1,1 +1,1 @@
-ActionView::Base.default_form_builder = GovukElementsFormBuilder::FormBuilder
+ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -146,4 +146,13 @@ describe ApplicationHelper, type: :helper do
       )
     end
   end
+
+  describe "#govuk_form_with" do
+    it "renders a form with GOV.UK form builder" do
+      expect(govuk_form_with(url: "http://test.com", method: "put") {}).to eq(
+        "<form novalidate=\"novalidate\" action=\"http://test.com\" accept-charset=\"UTF-8\" "\
+          "data-remote=\"true\" method=\"post\"><input type=\"hidden\" name=\"_method\" value=\"put\" /></form>",
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-470](https://trello.com/c/XC3OdLq9/470-migrate-schools-confirmattendance-form)
[Trello-469](https://trello.com/c/vfob47uo/469-remove-old-form-builder-gem)

### Context

We want to use the latest GOV.UK form builder for all of our forms.

### Changes proposed in this pull request

- Use GOV.UK form builder on confirm attendance form
- Remove old form builder gem

### Guidance to review

Testing this one locally was a pain as you need confirmed bookings that are in the past to test success (you can do this by manually modifying the date of a booking to be in the past then confirm it) and to force an error I hacked the model query scopes to allow it to show a confirmed booking in the future and tried to confirm attendance:

<img width="1184" alt="Screenshot 2022-01-11 at 09 50 59" src="https://user-images.githubusercontent.com/29867726/148921942-3ae25ad5-b99d-4b30-a1a4-97cb0d8720bb.png">

The error summary links don't jump to the correct row, but they don't currently in master either.