### PR TITLE
Update the bundler version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN yarn install && yarn cache clean
 # Install Gems removing artifacts
 COPY .ruby-version Gemfile Gemfile.lock ./
 # hadolint ignore=SC2046
-RUN gem install bundler --version='~> 2.2.17' && \
+RUN gem install bundler --version='~> 2.3.4' && \
     bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java && \
     bundle config set without 'development' && \
     bundle install --jobs=$(nproc --all) && \


### PR DESCRIPTION
### Trello card
N/A

### Context
The docker builds are complaining about using old bundler version to install gems.

### Changes proposed in this pull request
Update the bundler version in Dockerfile

### Guidance to review

