### PR TITLE
Add parking filter in the search page

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -49,7 +49,7 @@ private
   def search_params
     params.permit(
       :query, :location, :latitude, :longitude, :page, :distance, :disability_confident,
-      :max_fee, phases: [], subjects: [], dbs_policies: []
+      :max_fee, :parking, phases: [], subjects: [], dbs_policies: []
     )
   end
 

--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -130,6 +130,12 @@ module Candidates::SchoolHelper
     t('helpers.candidates.school_search.disability_confident_filter.text_html')
   end
 
+  def school_search_parking_filter_description(search)
+    return if search.parking.nil?
+
+    t('helpers.candidates.school_search.parking_filter.text_html')
+  end
+
   def cleanup_school_url(url)
     if url.blank?
       '#'

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -168,6 +168,15 @@ class Bookings::School < ApplicationRecord
     end
   }
 
+  scope :with_parking, lambda { |option|
+    if option.present?
+      joins(:profile)
+        .where('bookings_profiles.parking_provided IS ?', option)
+    else
+      all
+    end
+  }
+
   def to_param
     urn.to_s.presence
   end

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -94,6 +94,7 @@ private
       .includes([:available_placement_dates])
       .with_dbs_policies(dbs_options)
       .disability_confident(disability_confident)
+      .with_parking(parking)
   end
 
   def whitelisted_base_query

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -20,7 +20,7 @@ module Candidates
     ].freeze
 
     attr_accessor :query, :location, :latitude, :disability_confident,
-                  :longitude, :page, :analytics_tracking_uuid
+                  :longitude, :page, :analytics_tracking_uuid, :parking
     attr_reader :distance, :max_fee
 
     delegate :location_name, :has_coordinates?, :valid?, :errors, to: :school_search
@@ -125,7 +125,8 @@ module Candidates
         page: page,
         analytics_tracking_uuid: analytics_tracking_uuid,
         dbs_policies: dbs_policies,
-        disability_confident: disability_confident
+        disability_confident: disability_confident,
+        parking: parking
       )
     end
 

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -55,6 +55,10 @@
             <%= f.govuk_check_box :disability_confident, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.disability_confident") } %>
           <% end %>
 
+          <%= f.govuk_check_boxes_fieldset :parking, multiple: false, legend: { text: t("helpers.fieldset.parking") } do %>
+            <%= f.govuk_check_box :parking, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.parking") } %>
+          <% end %>
+
           <%= f.govuk_submit 'Update schools list', name: nil %>
         <% end %>
       </div>
@@ -62,7 +66,7 @@
   </aside>
 
   <section class="govuk-grid-column-two-thirds" id="search-results" aria-label="Search results">
-    <%- if @search.subjects.any? || @search.phases.any? || @search.dbs_policies.any? || @search.disability_confident.present? -%>
+    <% if @search.subjects.any? || @search.phases.any? || @search.dbs_policies.any? || @search.disability_confident.present? || @search.parking.present?%>
       <div class="school-search-filter-info">
         <div>
           <%= school_search_phase_filter_description @search %>
@@ -75,8 +79,13 @@
         <div>
           <%= school_search_dbs_policies_filter_description @search %>
         </div>
+
         <div>
           <%= school_search_disability_confident_filter_description(@search) %>
+        </div>
+
+        <div>
+          <%= school_search_parking_filter_description(@search) %>
         </div>
       </div>
     <%- end -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,6 +510,7 @@ en:
       phases: Education phases
       dbs_policies: DBS check
       disability_confident: Disability and access needs
+      parking: Parking
       fees: Fees
       subjects: Subjects
       candidates_registrations_teaching_preference:
@@ -594,6 +595,7 @@ en:
     label:
       dbs_policies_2: Only show placements that do not require a DBS check
       disability_confident: Only show Disability Confident schools
+      parking: Only show schools with parking
       schools_placement_requests_confirm_booking:
         bookings_subject_id: Confirm subject
         placement_details: Confirm experience details
@@ -867,6 +869,8 @@ en:
         subjects_filter_html: "Placement subjects: %{subject_names}"
         disability_confident_filter:
           text_html: "Disability Confident schools: <strong>Yes</strong>"
+        parking_filter:
+          text_html: "Schools with parking: <strong>Yes</strong>"
         dbs_policies_filter:
           text_html: "DBS check: %{dbs_policies_options}"
           options:

--- a/db/migrate/20220111121054_add_parking_to_bookings_school_search.rb
+++ b/db/migrate/20220111121054_add_parking_to_bookings_school_search.rb
@@ -1,0 +1,5 @@
+class AddParkingToBookingsSchoolSearch < ActiveRecord::Migration[6.1]
+  def change
+    add_column :bookings_school_searches, :parking, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_10_132724) do
+ActiveRecord::Schema.define(version: 2022_01_11_121054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 2021_12_10_132724) do
     t.uuid "analytics_tracking_uuid"
     t.integer "dbs_policies", array: true
     t.boolean "disability_confident"
+    t.boolean "parking"
   end
 
   create_table "bookings_school_types", force: :cascade do |t|

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         max_fee: '30',
         order: 'Name',
         dbs_policies: %w[1],
-        disability_confident: '1'
+        disability_confident: '1',
+        parking: '1'
       }
     end
 
@@ -30,6 +31,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       expect(assigns(:search).max_fee).to eq('30')
       expect(assigns(:search).dbs_policies).to eq([1])
       expect(assigns(:search).disability_confident).to eq('1')
+      expect(assigns(:search).parking).to eq('1')
 
       # note, this search will yield no results so the search radius will
       # automatically be expanded from 10 to the value at EXPANDED_SEARCH_RADIUS

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -271,6 +271,29 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
     end
   end
 
+  context '.school_search_parking_filter_description' do
+    context 'when the parking filter is not selected' do
+      subject do
+        double('Bookings::SchoolSearch', parking: nil)
+      end
+
+      it("should return a nil") do
+        expect(school_search_parking_filter_description(subject)).to be_nil
+      end
+    end
+
+    context 'when the parking filter is selected' do
+      subject do
+        double('Bookings::SchoolSearch', parking: '1')
+      end
+
+      it("should return yes") do
+        expect(school_search_parking_filter_description(subject)).to \
+          eq("Schools with parking: <strong>Yes</strong>")
+      end
+    end
+  end
+
   describe '#cleanup_school_url' do
     context 'with blank url' do
       subject { cleanup_school_url(' ') }

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -345,6 +345,23 @@ describe Bookings::SchoolSearch do
             expect(subject).not_to include(non_matching_school)
           end
         end
+
+        context 'Filtering on parking' do
+          before do
+            create(:bookings_profile, parking_provided: true, school: matching_school)
+            create(:bookings_profile, school: non_matching_school)
+          end
+
+          subject { Bookings::SchoolSearch.new(query: '', location: coords_in_manchester, parking: '1').results }
+
+          specify 'should return matching results' do
+            expect(subject).to include(matching_school)
+          end
+
+          specify 'should omit non-matching results' do
+            expect(subject).not_to include(non_matching_school)
+          end
+        end
       end
 
       context 'Chaining' do

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -395,6 +395,30 @@ describe Bookings::School, type: :model do
           end
         end
       end
+
+      context 'By parking' do
+        before do
+          create(:bookings_profile, parking_provided: true, school: school_a)
+          create(:bookings_profile, parking_provided: true, school: school_b)
+          create(:bookings_profile, school: school_c)
+        end
+
+        context 'when no options suplied' do
+          specify 'should return all schools' do
+            expect(subject.with_parking(nil)).to include(school_a, school_b, school_c)
+          end
+        end
+
+        context 'when true' do
+          specify 'should return all disability confident schools' do
+            expect(subject.with_parking(true)).to include(school_a, school_b)
+          end
+
+          specify 'should not return school that are not disability confident' do
+            expect(subject.with_parking(true)).not_to include(school_c)
+          end
+        end
+      end
     end
 
     context 'Availability and placement dates' do

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe Candidates::SchoolSearch do
         phases: [1, 2, 3],
         subjects: [4, 5, 6],
         dbs_policies: [2],
-        disability_confident: '1'
+        disability_confident: '1',
+        parking: '1'
       )
     end
 
@@ -24,6 +25,7 @@ RSpec.describe Candidates::SchoolSearch do
       expect(subject.subjects).to eq([4, 5, 6])
       expect(subject.dbs_policies).to eq([2])
       expect(subject.disability_confident).to eq('1')
+      expect(subject.parking).to eq('1')
     end
   end
 

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
     let(:subjects) { %w[1 3] }
     let(:dbs_policies) { %w[2] }
     let(:disability_confident) { '1' }
+    let(:parking) { '1' }
 
     before do
       allow(Candidates::School).to receive(:subjects).and_return(
@@ -70,6 +71,11 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
     it "shows the disability confident filter" do
       expect(rendered).to have_css('.govuk-fieldset__legend', text: 'Disability and access needs')
       expect(rendered).to have_css '#search-filter input[name="disability_confident"]'
+    end
+
+    it "shows the parking filter" do
+      expect(rendered).to have_css('.govuk-fieldset__legend', text: 'Parking')
+      expect(rendered).to have_css '#search-filter input[name="parking"]'
     end
 
     it "shows results" do


### PR DESCRIPTION
### Trello card
https://trello.com/c/0mlwwqVl

### Context
We want to add a filter for candidates to find schools that provide parking.

### Changes proposed in this pull request
Add a parking filter at the bottom of the filters section in the search page.

### Guidance to review
| before | After |
|-|-|
|![before](https://user-images.githubusercontent.com/951947/148972447-3f822d56-0fdc-42c3-9f81-146e8f5e89d8.png)|![after](https://user-images.githubusercontent.com/951947/148973065-836c58f7-1ded-40fd-8137-3b3433f341f9.png)|
