### PR TITLE
Change the look of the filters section

### DIFF
--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -42,22 +42,32 @@
           <%= f.hidden_field :latitude %>
           <%= f.hidden_field :longitude %>
 
-          <%= f.govuk_collection_check_boxes :phases, Candidates::School.phases, :first, :last,
-            legend: { text: t("helpers.fieldset.phases") }, hint: { text: t("helpers.hint.phases") } %>
+          <div class="filter">
+            <%= f.govuk_collection_check_boxes :phases, Candidates::School.phases, :first, :last,
+              legend: { text: t("helpers.fieldset.phases") }, hint: { text: t("helpers.hint.phases") } %>
+          </div>
 
-          <%= f.govuk_collection_check_boxes :subjects, Candidates::School.subjects, :first, :last,
-            classes: %w(search-subjects-checkboxes), hint: { text: t("helpers.hint.subjects") } %>
+          <div class="filter">
+            <%= f.govuk_collection_check_boxes :subjects, Candidates::School.subjects, :first, :last,
+              classes: %w(search-subjects-checkboxes), hint: { text: t("helpers.hint.subjects") } %>
+          </div>
 
-          <%= f.govuk_collection_check_boxes :dbs_policies, [[2, t("helpers.label.dbs_policies_2")]], :first, :last,
-            legend: { text: t("helpers.fieldset.dbs_policies") }, hint: { text: t("helpers.hint.dbs_policies") } %>
+          <div class="filter">
+            <%= f.govuk_collection_check_boxes :dbs_policies, [[2, t("helpers.label.dbs_policies_2")]], :first, :last,
+              legend: { text: t("helpers.fieldset.dbs_policies") }, hint: { text: t("helpers.hint.dbs_policies") } %>
+          </div>
 
-          <%= f.govuk_check_boxes_fieldset :disability_confident, multiple: false, legend: { text: t("helpers.fieldset.disability_confident") } do %>
-            <%= f.govuk_check_box :disability_confident, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.disability_confident") } %>
-          <% end %>
+          <div class="filter">
+            <%= f.govuk_check_boxes_fieldset :disability_confident, multiple: false, legend: { text: t("helpers.fieldset.disability_confident") } do %>
+              <%= f.govuk_check_box :disability_confident, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.disability_confident") } %>
+            <% end %>
+          </div>
 
-          <%= f.govuk_check_boxes_fieldset :parking, multiple: false, legend: { text: t("helpers.fieldset.parking") } do %>
-            <%= f.govuk_check_box :parking, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.parking") } %>
-          <% end %>
+          <div class="filter">
+            <%= f.govuk_check_boxes_fieldset :parking, multiple: false, legend: { text: t("helpers.fieldset.parking") } do %>
+              <%= f.govuk_check_box :parking, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.parking") } %>
+            <% end %>
+          </div>
 
           <%= f.govuk_submit 'Update schools list', name: nil %>
         <% end %>

--- a/app/webpacker/stylesheets/school-search.scss
+++ b/app/webpacker/stylesheets/school-search.scss
@@ -78,6 +78,22 @@
 
 .filter-list {
   margin-bottom: govuk-spacing(4);
+  background-color: govuk-colour("light-grey");
+
+  .filter {
+    border-bottom: 1px solid govuk-colour("mid-grey");
+    padding: 10px;
+    margin: 10px 0px;
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+
+  button[type=submit] {
+    margin-left: 10px;
+  }
+
 }
 
 .search-subjects-checkboxes {


### PR DESCRIPTION
### Trello card
https://trello.com/c/REYZCid4

### Context
Part of the search page redesign is to add grey background to the filters section and change the spacings a bit.

### Changes proposed in this pull request
Change the background colour and update the spacing between the filters.

### Guidance to review
|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/951947/149125234-e33bd2df-b4fa-4a15-a92b-8d6df272fc08.png)|![after](https://user-images.githubusercontent.com/951947/149125260-c6f95179-75c4-42ce-9826-ebe6735dceba.png)|
