### PR TITLE
Update the manage school privacy policy

### DIFF
--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -15,18 +15,16 @@
       </h2>
 
       <p>
-        This work is being carried out by Education Standards which is a part of
-        the Department for Education (DfE).
+        This work is being carried out by the Department for Education (DfE).
       </p>
 
       <p>
-        DfE has engaged the private companies Engine Group and Teleperformance UK
-        (TPUK) to help provide and improve the service.
+        Mentions of "us" and "we" mean DfE and "you" means anyone using this service.
       </p>
 
       <p>
         For the purpose of data protection legislation, the DfE is the data
-        controller for the personal data processed as part of the service.
+        controller for the personal data processed as part of this service.
       </p>
     </section>
 
@@ -58,9 +56,17 @@
       </p>
 
       <p>
-        As part of the service we'll use the contact information you've
-        provided to send out notifications, reminders and feedback
-        questionnaires relating to the service.
+        As part of the service we'll use the contact information you've provided
+        to send out notifications, reminders, feedback questionnaires and updates
+        relating to the service. We may also contact you to request your involvement
+        in user research to help improve the service.
+      </p>
+
+      <p>
+        We will also use collected data for security purposes to protect the
+        service - for example, parts of the IP addresses of website visitors are
+        collected to block continuous direct denial of service attacks from
+        an IP address range.
       </p>
     </section>
 
@@ -70,7 +76,7 @@
       </h2>
 
       <p>
-        In order to lawfully use your personal data, we need to meet 1 (or more)
+        In order to lawfully use your personal data, we need to meet one (or more)
         conditions in the data protection legislation. For the purpose of this
         project, your consent forms the basis of this as stated under GDPR
         Article 6 (1)(a).
@@ -92,45 +98,6 @@
         Where we need to share your personal data with others, we ensure that
         this data sharing complies with data protection legislation.
       </p>
-
-      <p>
-        We share specific types of personal data with Engine Group, who have been
-        contracted by DfE to manage the delivery of the digital service and TPUK,
-        who have been contracted by DfE to support the administration of the
-        service.
-      </p>
-
-      <h3 class="govuk-heading-s">
-        The private company Engine Group uses your data for:
-      </h3>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>
-          user research to help develop the service - where you've shared your
-          name, email address and / or phone number for this purpose
-        </li>
-
-        <li>
-          security purposes to protect the service - for example, parts of the
-          IP addresses of website visitors are collected to block continuous
-          direct denial of service attacks from an IP address range
-        </li>
-
-        <li>
-          communications purposes - to help you use and receive updates
-          about the service individual email addresses are collected
-        </li>
-      </ul>
-
-      <h3 class="govuk-heading-s">
-        The private company TPUK uses your data:
-      </h3>
-
-      <ul class="govuk-list govuk-list--bullet">
-        <li>
-          to cancel, amend and manage booking requests on your behalf
-        </li>
-      </ul>
     </section>
 
     <section>
@@ -139,9 +106,9 @@
       </h2>
 
       <p>
-        DfE, Engine Group or TPUK will only keep your personal data for as long
+        DfE will only keep your personal data for as long
         as we need it for the purposes of their work, after which point it will
-        be securely destroyed. If this is longer than 6 years your data will be
+        be securely destroyed. If this is longer than 5 years your data will be
         deleted.
       </p>
 
@@ -149,7 +116,7 @@
         Note: under Data Protection legislation, and in compliance with the
         relevant data processing conditions, personal data can be kept for
         longer periods of time when processed purely for archiving purposes in
-        the public interest, statistical purposes and historical or scientific
+        the public task, statistical purposes and historical or scientific
         research.
       </p>
     </section>
@@ -201,7 +168,7 @@
 
       <p>
         Further information about your data protection rights can be found on
-        the on the <%= link_to "Information Commissioner's Office (ICO)", "https://ico.org.uk/" %>
+        the <%= link_to "Information Commissioner's Office (ICO)", "https://ico.org.uk/" %>
         website.
       </p>
     </section>
@@ -237,7 +204,7 @@
       <p>
         We may need to update this privacy notice periodically and recommend
         you revisit this information from time to time. This version was last
-        updated on 27 June 2019.
+        updated on 12 January 2022.
       </p>
     </section>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/RnkeOZiI

### Context
The current Manage School Privacy Policy mentions that we share data with certain private companies, which is not the case anymore and needs to be updated accordingly.

### Changes proposed in this pull request
Update the policy

### Guidance to review
Use the path: `/schools_privacy_policy`
or go to Manage school experience page and click the `Privacy Policy` link at the bottom. 
