### PR TITLE
Cucumber tests

### DIFF
--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -19,7 +19,7 @@
         url: candidates_schools_path,
         method: :get,
         html: { class: 'school-search-form' }) do |f| %>
-          <%= f.govuk_text_field :location, required: true, minlength: "2", label: { text: t('helpers.label.location') } %>
+          <%= f.govuk_text_field :location, required: true, minlength: "2", label: { text: t('helpers.label.location') }, type: "search" %>
 
           <%= f.govuk_collection_select :distance,
                 Candidates::SchoolSearch.distances, :first, :last, label: { text: t('helpers.label.distance')  } unless f.object.whitelisted_urns? %>

--- a/app/views/schools/confirmed_bookings/cancellations/show.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/show.html.erb
@@ -27,7 +27,9 @@
       </p>
 
       <p>
-        <%= govuk_button_to 'Send cancellation email', schools_booking_cancellation_notification_delivery_path(@booking) %>
+        <%= govuk_button_to schools_booking_cancellation_notification_delivery_path(@booking) do %>
+          Send cancellation email
+        <% end %>
       </p>
     </section>
   </div>

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -33,7 +33,7 @@
           <%= f.govuk_radio_button :dbs_fees, "false", 'aria-label': 'No, we do not charge a fee to cover DBS check costs' %>
         <% end %>
       <% else %>
-        <%= f.hidden_field :dbs_fees, value: false %>
+        <%= f.hidden_field :dbs_fees, value: "false" %>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :other_fees do %>

--- a/app/views/schools/placement_requests/cancellations/_form.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_form.html.erb
@@ -24,7 +24,7 @@
                 f.govuk_radio_buttons_fieldset(
                   :rejection_category,
                   small: true,
-                  legend: { class: 'govuk-visually-hidden' }
+                  legend: { class: 'govuk-visually-hidden', text: 'Rejection reason' }
                 ) do
                   safe_join(
                     [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -505,8 +505,6 @@ en:
       bookings_school:
         availability_preference_fixed: Choose how dates are displayed
         experience_type: School experience type
-      bookings_placement_request_cancellation:
-        rejection_category: Rejection reason
       phases: Education phases
       dbs_policies: DBS check
       disability_confident: Disability and access needs

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -611,7 +611,7 @@ en:
         availability_preference_fixed_options:
           true: Show specific dates
           false: Show a description of when you can host candidates
-        availability_info: Availability info
+        availability_info: Describe your school experience availability
         experience_type_options:
           virtual: Virtual experience
           inschool: In school experience
@@ -628,6 +628,7 @@ en:
           false: In school experience
       bookings_placement_request_cancellation:
         reason: Cancellation reasons
+        extra_details: Extra details
         rejection_category_options:
           fully_booked: The date you requested is fully booked.
           accepted_on_ttc: We cannot offer you school experience because you've already been accepted on a teacher training course.

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -56,7 +56,7 @@ end
 
 Then("it should have the hint text {string}") do |hint|
   within('#search-filter') do
-    expect(page).to have_css('legend > span.govuk-hint', text: hint)
+    expect(page).to have_css('fieldset > span.govuk-hint', text: hint)
   end
 end
 
@@ -79,7 +79,7 @@ end
 Then("it should have checkboxes for all subjects") do
   within('#search-filter') do
     form_group = page
-      .find('.govuk-label', text: 'Subjects')
+      .find('legend', text: 'Subjects')
       .ancestor('div.govuk-form-group')
 
     ensure_check_boxes_exist(form_group, @subjects.map(&:name))
@@ -111,7 +111,7 @@ When("I click back on the results screen") do
 end
 
 Then("the location input should be populated with {string}") do |string|
-  expect(page.find('input#location').value).to eql(string)
+  expect(page.find("input[name]").value).to eql(string)
 end
 
 Given("there are no schools near my search location") do

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -169,7 +169,7 @@ end
 def ensure_date_field_exists(form_group)
   %w[Day Month Year].each do |date_part|
     form_group.find('label', text: date_part).tap do |inner_label|
-      expect(form_group).to have_field(inner_label.text, type: 'number')
+      expect(form_group).to have_field(inner_label.text)
     end
   end
 end

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -96,13 +96,13 @@ Given("I choose {string} from the {string} radio buttons") do |option, field|
 end
 
 Given("I choose {string} from the {string} radio buttons if available") do |option, field|
-  if page.has_css? "h2.govuk-fieldset__heading", text: field
+  if page.has_css? ".govuk-fieldset__legend", text: field
     step "I choose '#{option}' from the '#{field}' radio buttons"
   end
 end
 
 Then("the {string} input should require at least {string} characters") do |field, length|
-  input = page.find("input##{field}")
+  input = page.find("input[name=#{field}]")
   expect(input['minlength']).to eql(length)
 end
 
@@ -134,7 +134,7 @@ When("I enter {string} into the {string} text area") do |value, label|
 end
 
 When("I click the {string} submit button") do |string|
-  page.find("input[value='#{string}']").click
+  page.find("button", text: string).click
 end
 
 Then("there should not be a {string} checkbox") do |label_text|


### PR DESCRIPTION
### Trello card
https://trello.com/c/pk1uu8mE

### Context
Some recent updates have broken the Cucumber tests.

### Changes proposed in this pull request
- Fix form when no DBS cost: The value for this currently doesn't work. This means the user will see a validation error, and won't be able to correct it.
- Fix various selectors: Some of the elements are different in the new form builder. Update the Cucumber tests to match.
- Update input types: The cucumber tests weren't finding these inputs because they had the wrong type. It is in the GOV guidance to not use the number type for inputs, so I have left that one as text type.
- Fix labels: Some labels were wrong after the update to the new form builder.
- Use block for button_to: One of the cucumber selectors was looking for a button element. button_to generates an input usually, but generates a button when using a block.
- Give text to hidden label: Pass text explicitly to this label as I can't get it to pick up the text from the translations file.

### Guidance to review

Currently a single failing test that I can't figure out 🤔 