### PR TITLE
Reorder presence validation to be after timeliness

### DIFF
--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -17,15 +17,14 @@ module Bookings
     has_one :school_cancellation, through: :bookings_placement_request
 
     validates :date,
-      presence: true
-
-    validates :date,
       if: -> { date_changed? },
       timeliness: {
         on_or_after: -> { MIN_BOOKING_DELAY.from_now.to_date },
         before: -> { 2.years.from_now },
-        type: :date
+        type: :date,
       }
+
+    validates :date, presence: true
 
     validate on: :updating_date do
       errors.add :date, :not_changed unless date_changed?

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -71,7 +71,6 @@ end
 Then("I fill in the date field {string} with {int}-{int}-{int}") do |field, day, month, year|
   # Some of the designs call for the field name to be styled as a heading/legend
   date_field_set = page.find '.govuk-label, .govuk-fieldset__heading, .govuk-fieldset__legend', text: field
-
   within(date_field_set.ancestor('.govuk-form-group')) do
     fill_in 'Day',   with: day
     fill_in 'Month', with: month


### PR DESCRIPTION
Reorder presence validation to be after timeliness At the moment if you enter an invalid date into the edit booking date form it results in the attribute on the model being assigned `nil` (as they date cannot be represented).

If the model is them validated we end up with a `:blank` validation error in addition to an `:invalid_date` error. As `govuk_error_summary` only outputs one error per attribute we see the `:blank` one as its defined first in the model.

Instead, we can get the correct `:invalid_date` error (provided by the Timeliness gem via a shim on ActiveRecord) if we move the presence validator to be last. This way the timeliness error will take presedence.

In an ideal world we could use the `allow_blank: false` option as part of the timeliness validation call, but for some reason this just doesn't appear to behave.