### PR TITLE
Update the school description form

### DIFF
--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = 'Enter a short description of your school' -%>
+<%- self.page_title = 'School description' -%>
 
 <%= govuk_back_link javascript: true %>
 
@@ -6,38 +6,30 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_form_for description, url: schools_on_boarding_description_path, method: method do |f| %>
       <h1 class="govuk-heading-l">
-        Enter a short description of your school
+        School description
       </h1>
 
+      <p>
+        Use this section to tell candidates about your school.
+      </p>
+
+      <p class="govuk-!-margin-top-4">
+        Include details like:
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>if the school includes primary, secondary or both</li>
+          <li>the school's ethos and values</li>
+          <li>what kind of place it's like to work in</li>
+        </ul>
+      </p>
+
+      <p>
+        Do not write about the kind of school experience you offer, you'll be
+        able to add those details later.
+      </p>
+
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_area :details, rows: 10 do %>
-
-        <details id="description-example" class="govuk-details" role="group" data-module="govuk-details">
-          <summary class="govuk-details__summary" role="button" aria-label="View an example school description that could be entered to complete this step">
-            <span class="govuk-details__summary-text">View description example</span>
-          </summary>
-          <div class="govuk-details__text">
-            <p>
-              We’re a thriving community school serving a cosmopolitan community with more than 1,700 pupils.
-            </p>
-            <p>
-              Our GCSE scores are above the national average and, with multiple languages spoken at our school, we’re highly-skilled in meeting the needs of bilingual children.
-            </p>
-            <p>
-              We’re a barrier-free school and cater for pupils with movement difficulties while our work with hearing-impaired children is supported by the local authority and other agencies.
-            </p>
-            <p>
-              We also specialise in art and drama and have strong sporting connections with local community organisations.
-            </p>
-          </div>
-        </details>
-
-        <p class="govuk-hint">
-          You can skip this section by selecting continue. You can then enter
-          your description later by selecting 'Update school profile' on your
-          'Manage requests and bookings' page
-        </p>
-      <% end %>
+      <%= f.govuk_text_area :details, rows: 10, label: -> { tag.h2('Enter a description of your school') } %>
 
       <%= f.govuk_submit 'Continue' %>
       <%= f.govuk_submit 'Skip', class: 'govuk-button govuk-button--secondary' %>

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -30,7 +30,7 @@
         able to add those details later.
       </p>
 
-      <%= f.govuk_text_area :details, rows: 10, label: -> { tag.h2('Enter a description of your school') } %>
+      <%= f.govuk_text_area :details, max_words: 200, rows: 10, label: -> { tag.h2('Enter a description of your school') } %>
 
       <%= f.govuk_submit 'Continue' %>
       <%= f.govuk_submit 'Skip', class: 'govuk-button govuk-button--secondary' %>

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -33,7 +33,6 @@
       <%= f.govuk_text_area :details, max_words: 200, rows: 10, label: -> { tag.h2('Enter a description of your school') } %>
 
       <%= f.govuk_submit 'Continue' %>
-      <%= f.govuk_submit 'Skip', class: 'govuk-button govuk-button--secondary' %>
     <% end %>
   </div>
 </div>

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -5,6 +5,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_form_for description, url: schools_on_boarding_description_path, method: method do |f| %>
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-l">
         School description
       </h1>
@@ -28,7 +30,6 @@
         able to add those details later.
       </p>
 
-      <%= f.govuk_error_summary %>
       <%= f.govuk_text_area :details, rows: 10, label: -> { tag.h2('Enter a description of your school') } %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -748,8 +748,6 @@ en:
           1: 'Secondary (11 to 16 years)'
         secondary_and_college_options:
           1: 'Secondary with 16 to 18 years'
-      schools_on_boarding_description:
-        details: 'Tell us about your school. Provide a summary to help candidates select your school experience.'
       schools_on_boarding_candidate_experience_detail:
         business_dress_options:
           1: 'Business dress'

--- a/features/schools/onboarding/descriptions.feature
+++ b/features/schools/onboarding/descriptions.feature
@@ -20,10 +20,10 @@ Feature: Description
 
   Scenario: Page title
     Given I am on the 'description' page
-    Then the page title should be 'Enter a short description of your school'
+    Then the page title should be 'School description'
 
   Scenario: Completing the step with description
     Given I am on the 'Description' page
-    And I enter 'We have a race track' into the 'Tell us about your school. Provide a summary to help candidates select your school experience.' text area
+    And I enter 'We have a race track' into the 'Enter a description of your school' text area
     When I submit the form
     Then I should be on the 'Candidate experience details' page

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -118,7 +118,7 @@ end
 Given "I have completed the Description step" do
   steps %(
     Given I am on the 'Description' page
-    And I enter 'We have a race track' into the 'Tell us about your school. Provide a summary to help candidates select your school experience.' text area
+    And I enter 'We have a race track' into the 'Enter a description of your school' text area
     When I submit the form
   )
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/z3ILZDc7

### Context
We want to update the content in the school description form to help schools write better profiles. Using the complex question pattern seems like a good fit.

We also need to remove the skip as it's the only place we use it and looks unusual. We are keeping the form as optional until we do more tests though.

### Changes proposed in this pull request

- Update the content
- Move the error summary page above the `<h1>`
- Apply 200 words limit in the text area
- Remove the skip button

### Guidance to review
|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/951947/149323784-049ed0f0-12d4-409e-8031-d3c1114a9918.png)|![after](https://user-images.githubusercontent.com/951947/149323797-511c993a-83d8-4e81-bd59-882900b27e7e.png)|
