### PR TITLE
Only attempt sms mobile

### DIFF
--- a/app/notify/notify_despatchers/sms.rb
+++ b/app/notify/notify_despatchers/sms.rb
@@ -5,10 +5,19 @@ class NotifyDespatchers::Sms < NotifyDespatchers::Base
     validate_personalisation!
 
     to.each do |phone_number|
+      number = Phonelib.parse(phone_number)
+      next unless valid_mobile_number?(number)
+
       Notify::SmsJob.perform_later \
-        to: phone_number,
+        to: number.sanitized,
         template_id: template_id,
         personalisation_json: personalisation_json
     end
+  end
+
+private
+
+  def valid_mobile_number?(phone_number)
+    phone_number.valid? && phone_number.types.include?(:mobile)
   end
 end

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     master_id { nil }
     merged { false }
     email { "email@address.com" }
-    telephone { "111111111" }
+    telephone { "07777777777" }
     address_line1 { "3 Main Street" }
     address_line2 { "Botchergate" }
     address_line3 { "" }

--- a/spec/notify/notify_despatchers/notify_spec.rb
+++ b/spec/notify/notify_despatchers/notify_spec.rb
@@ -194,6 +194,19 @@ describe NotifyDespatchers::Sms do
   context "when in non-production environments" do
     before { allow(Feature).to receive(:active?).with(:sms) { false } }
 
+    let :notification do
+      subject.new to: recipients, name: 'Test User'
+    end
+
+    it "does not despatch SMS" do
+      perform_enqueued_jobs do
+        notification.despatch_later!
+      end
+
+      expect(NotifyService.instance).not_to have_received(notify_method)
+    end
+  end
+
     it "does not despatch SMS" do
       expect(NotifyService.instance).not_to have_received(notify_method)
     end

--- a/spec/notify/notify_despatchers/notify_spec.rb
+++ b/spec/notify/notify_despatchers/notify_spec.rb
@@ -10,10 +10,6 @@ shared_examples "notify_client" do
   describe 'custom notify_client' do
     describe '#despatch_later!' do
       context 'with valid personalisation' do
-        let :notification do
-          subject.new to: recipients, name: 'Test User'
-        end
-
         before do
           perform_enqueued_jobs do
             notification.despatch_later!
@@ -164,6 +160,7 @@ describe NotifyDespatchers::Email do
       }
     end
   end
+  let(:notification) { subject.new to: recipients, name: 'Test User' }
 
   subject { StubEmailNotification }
   include_examples "notify_client"
@@ -185,18 +182,16 @@ describe NotifyDespatchers::Sms do
       }
     end
   end
+  let(:notification) { subject.new to: recipients, name: 'Test User' }
 
   before { allow(Feature).to receive(:active?).with(:sms) { true } }
 
   subject { StubSmsNotification }
+
   include_examples "notify_client"
 
   context "when in non-production environments" do
     before { allow(Feature).to receive(:active?).with(:sms) { false } }
-
-    let :notification do
-      subject.new to: recipients, name: 'Test User'
-    end
 
     it "does not despatch SMS" do
       perform_enqueued_jobs do
@@ -207,8 +202,36 @@ describe NotifyDespatchers::Sms do
     end
   end
 
-    it "does not despatch SMS" do
-      expect(NotifyService.instance).not_to have_received(notify_method)
+  context "when there are non-mobile numbers" do
+    let(:valid_recipients) { %w[07777777778 07777777779] }
+    let(:invalid_recipients) { %w[12345678910] }
+    let(:valid_landline) { %w[03700002288] }
+    let(:recipients) { valid_recipients + invalid_recipients + valid_landline }
+
+    it "only despatches to valid mobile numbers" do
+      perform_enqueued_jobs do
+        notification.despatch_later!
+      end
+
+      expect(NotifyService.instance).to have_received(notify_method).twice
+    end
+  end
+
+  context "when there is a number that can be sanitised" do
+    let(:valid_recipients) { %w[07777777778 07777777779] }
+    let(:invalid_recipients) { %w[07777777774.] }
+    let(:recipients) { valid_recipients + invalid_recipients }
+
+    let(:expected_recipients) { %w[07777777778 07777777779 07777777774] }
+
+    it "sanitizes invalid numbers" do
+      perform_enqueued_jobs do
+        notification.despatch_later!
+      end
+
+      expected_recipients.each do |phone_number|
+        expect(NotifyService.instance).to have_received(notify_method).with(a_hash_including(phone_number: phone_number))
+      end
     end
   end
 end


### PR DESCRIPTION
### Trello card
N/A

### Context
We have seen a couple of production errors from GOV Notify, where we are attempting to send a SMS to an invalid phone number, or a non-mobile phone number. Check whether numbers are valid mobile numbers before despatching.

### Changes proposed in this pull request
- Only despatch SMS to valid mobile numbers. Also, sanitise numbers because we saw one the other day with a full stop (something like `07777777777.`)
- Fix test: Noticed that this test would have always passed. Make sure it only passes when the correct code is in place.

### Guidance to review

