### PR TITLE
Add ability to open/close date a number of days before it starts

### DIFF
--- a/app/controllers/schools/placement_dates/configurations_controller.rb
+++ b/app/controllers/schools/placement_dates/configurations_controller.rb
@@ -24,6 +24,7 @@ module Schools
         if @configuration.subject_specific?
           new_schools_placement_date_subject_selection_path @placement_date
         else
+          @placement_date.publish
           auto_enable_school
           schools_placement_dates_path
         end

--- a/app/controllers/schools/placement_dates/subject_selections_controller.rb
+++ b/app/controllers/schools/placement_dates/subject_selections_controller.rb
@@ -11,6 +11,7 @@ module Schools
         @subject_selection = SubjectSelection.new subject_selection_params
 
         if @subject_selection.save @placement_date
+          @placement_date.publish
           auto_enable_school
           redirect_to schools_placement_dates_path
         else

--- a/app/forms/schools/placement_dates/close_confirmation_form.rb
+++ b/app/forms/schools/placement_dates/close_confirmation_form.rb
@@ -1,0 +1,10 @@
+module Schools
+  module PlacementDates
+    class CloseConfirmationForm
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attribute :confirmed, default: true
+    end
+  end
+end

--- a/app/forms/schools/placement_dates/configuration_form.rb
+++ b/app/forms/schools/placement_dates/configuration_form.rb
@@ -58,7 +58,6 @@ module Schools
         else
           placement_date.subject_specific = false
           placement_date.subject_ids = []
-          placement_date.published_at = DateTime.now
         end
       end
     end

--- a/app/forms/schools/placement_dates/subject_selection.rb
+++ b/app/forms/schools/placement_dates/subject_selection.rb
@@ -22,7 +22,6 @@ module Schools
         placement_date.tap do |pd|
           pd.subject_specific = true
           pd.subject_ids = subject_ids
-          pd.published_at = DateTime.now
 
           pd.save!
         end

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -1,54 +1,70 @@
 module Bookings
   class PlacementDate < ApplicationRecord
     belongs_to :bookings_school,
-      class_name: 'Bookings::School',
-      inverse_of: :bookings_placement_dates,
-      foreign_key: 'bookings_school_id'
+               class_name: 'Bookings::School',
+               inverse_of: :bookings_placement_dates,
+               foreign_key: 'bookings_school_id'
 
     has_many :placement_requests,
-      class_name: 'Bookings::PlacementRequest',
-      inverse_of: :placement_date,
-      foreign_key: :bookings_placement_date_id,
-      dependent: :restrict_with_exception
+             class_name: 'Bookings::PlacementRequest',
+             inverse_of: :placement_date,
+             foreign_key: :bookings_placement_date_id,
+             dependent: :restrict_with_exception
 
     has_many :placement_date_subjects,
-      class_name: 'Bookings::PlacementDateSubject',
-      inverse_of: :bookings_placement_date,
-      foreign_key: :bookings_placement_date_id,
-      dependent: :destroy
+             class_name: 'Bookings::PlacementDateSubject',
+             inverse_of: :bookings_placement_date,
+             foreign_key: :bookings_placement_date_id,
+             dependent: :destroy
 
     has_many :subjects,
-      class_name: 'Bookings::Subject',
-      through: :placement_date_subjects,
-      source: :bookings_subject
+             class_name: 'Bookings::Subject',
+             through: :placement_date_subjects,
+             source: :bookings_subject
 
     accepts_nested_attributes_for :subjects, allow_destroy: true
 
     validates :bookings_school, presence: true
     validates :duration,
-      presence: true,
-      numericality: {
-        greater_than_or_equal_to: 1,
-        less_than: 100
-      }
+              presence: true,
+              numericality: {
+                greater_than_or_equal_to: 1,
+                less_than: 100
+              }
+
+    validates :start_availability_offset,
+              presence: true,
+              numericality: {
+                greater_than_or_equal_to: 1,
+                less_than: 100,
+              }
+
+    validates :end_availability_offset,
+              presence: true,
+              numericality: {
+                greater_than_or_equal_to: 0,
+                less_than: 100
+              }
 
     validates :date, presence: true
     validates :date,
-      timeliness: {
-        on_or_after: -> { Booking::MIN_BOOKING_DELAY.from_now.to_date },
-        before: -> { 2.years.from_now },
-        type: :date
-      },
-      if: -> { date.present? },
-      on: :create
+              timeliness: {
+                on_or_after: -> { Booking::MIN_BOOKING_DELAY.from_now.to_date },
+                before: -> { 2.years.from_now },
+                type: :date
+              },
+              if: -> { date.present? },
+              on: :create
 
     validates :virtual, inclusion: [true, false]
+
+    validate :start_offset_greater_than_end_offset
 
     # users manually selecting this only happens when schools are both primary
     # and secondary, otherwise it's automatically set in the controller
     validates :supports_subjects,
-      inclusion: [true, false],
-      if: -> { bookings_school&.has_primary_and_secondary_phases? }
+              inclusion: [true, false],
+              if: -> { bookings_school&.has_primary_and_secondary_phases? }
 
     with_options if: :published? do
       validates :max_bookings_count, numericality: { greater_than: 0, allow_nil: true }
@@ -60,11 +76,16 @@ module Bookings
       where arel_table[:date].gteq Bookings::Booking::MIN_BOOKING_DELAY.from_now.to_date
     }
 
-    scope :in_date_order, -> { order(date: 'asc') }
     scope :active, -> { where(active: true) }
-    scope :inactive, -> { where(active: false) }
 
-    scope :available, -> { published.active.bookable_date.in_date_order }
+    scope :inside_availability_window, lambda {
+      where("date - end_availability_offset > ?", Date.today)
+        .where("date - start_availability_offset <= ?", Date.today)
+    }
+
+    scope :in_date_order, -> { order(date: 'asc') }
+
+    scope :available, -> { published.active.bookable_date.inside_availability_window.in_date_order }
     scope :published, -> { where.not published_at: nil }
 
     # 'supporting subjects' are dates belonging to phases where
@@ -98,8 +119,37 @@ module Bookings
       published_at.present?
     end
 
+    def available?
+      return false unless active
+
+      inside_availability_window?
+    end
+
     def inschool?
       !virtual?
+    end
+
+    def publish
+      self.active = true
+      self.published_at = DateTime.now
+
+      save!
+    end
+
+  private
+
+    def inside_availability_window?
+      availability_start_date = date - start_availability_offset
+      availability_end_date = date - end_availability_offset
+      (availability_start_date.past? || availability_start_date.today?) && availability_end_date.future?
+    end
+
+    def start_offset_greater_than_end_offset
+      return if start_availability_offset.nil? || end_availability_offset.nil?
+
+      if start_availability_offset <= end_availability_offset
+        errors.add(:start_availability_offset, "Must be greater than the number of days before the event that the event closes to candidates")
+      end
     end
   end
 end

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -148,7 +148,7 @@ module Bookings
       return if start_availability_offset.nil? || end_availability_offset.nil?
 
       if start_availability_offset <= end_availability_offset
-        errors.add(:start_availability_offset, "Must be greater than the number of days before the event that the event closes to candidates")
+        errors.add(:start_availability_offset, "The publish date must be before the closing date")
       end
     end
   end

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -36,14 +36,14 @@ module Bookings
               presence: true,
               numericality: {
                 greater_than_or_equal_to: 1,
-                less_than: 100,
+                less_than: 181,
               }
 
     validates :end_availability_offset,
               presence: true,
               numericality: {
                 greater_than_or_equal_to: 0,
-                less_than: 100
+                less_than: 101
               }
 
     validates :date, presence: true

--- a/app/views/schools/placement_dates/close_confirmation.html.erb
+++ b/app/views/schools/placement_dates/close_confirmation.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= form_for @confirmation, url: schools_placement_date_close_path(@placement_date.id, confirmed: :confirmed) do |f| %>
-        <%= f.govuk_radio_buttons_fieldset :confirmed, legend: { text: "Are your sure you want to close #{@placement_date.date.to_formatted_s(:govuk)}?", class: "govuk-heading-l" } do %>
+        <%= f.govuk_radio_buttons_fieldset :confirmed, legend: { text: "Are your sure you want to close the placement on #{@placement_date.date.to_formatted_s(:govuk)}?", class: "govuk-heading-l" } do %>
           <%= f.govuk_radio_button :confirmed, true, label: { text: "Yes" } %>
           <%= f.govuk_radio_button :confirmed, false, label: { text: "No" } %>
         <% end %>

--- a/app/views/schools/placement_dates/close_confirmation.html.erb
+++ b/app/views/schools/placement_dates/close_confirmation.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-main-wrapper">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= form_for @confirmation, url: schools_placement_date_close_path(@placement_date.id, confirmed: :confirmed) do |f| %>
+        <%= f.govuk_radio_buttons_fieldset :confirmed, legend: { text: "Are your sure you want to close #{@placement_date.date.to_formatted_s(:govuk)}?", class: "govuk-heading-l" } do %>
+          <%= f.govuk_radio_button :confirmed, true, label: { text: "Yes" } %>
+          <%= f.govuk_radio_button :confirmed, false, label: { text: "No" } %>
+        <% end %>
+
+        <%= f.govuk_submit 'Continue' %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -21,16 +21,14 @@
 
   <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m govuk-!-margin-0' }  %>
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      <%= f.govuk_check_boxes_fieldset :active, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :active, 1, 0, multiple: false, link_errors: true %>
-      <% end %>
-    </fieldset>
-  </div>
+  <%= f.govuk_number_field :end_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
+  <%= f.govuk_number_field :start_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
 
   <%= f.govuk_submit 'Continue' %>
 <%- end -%>
+
+
+<%= link_to "Close placement date", schools_placement_date_close_path(@placement_date.id) if @placement_date.available? %>
 
 <% unless Feature.instance.active? :subject_specific_dates %>
 <p class="govuk-inset-text">

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -21,8 +21,8 @@
 
   <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m govuk-!-margin-0' }  %>
 
-  <%= f.govuk_number_field :end_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
   <%= f.govuk_number_field :start_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
+  <%= f.govuk_number_field :end_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
 
   <%= f.govuk_submit 'Continue' %>
 <%- end -%>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -42,8 +42,8 @@
             </td>
 
             <td class="govuk-table__cell status">
-              <strong class="govuk-tag <%= placement_date_display_class(placement_date.active) %>">
-                <%= placement_date_display_status(placement_date.active) %>
+              <strong class="govuk-tag <%= placement_date_display_class(placement_date.available?) %>">
+                <%= placement_date_display_status(placement_date.available?) %>
               </strong>
             </td>
 

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -15,6 +15,8 @@
   <%= f.govuk_error_summary %>
   <%= f.govuk_date_field :date, heading: true %>
   <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m' } %>
+  <%= f.govuk_number_field :end_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
+  <%= f.govuk_number_field :start_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
   <%= f.govuk_radio_buttons_fieldset :virtual do %>
     <%= f.govuk_radio_button :virtual, true, link_errors: true %>
     <%= f.govuk_radio_button :virtual, false, label: { text: t("helpers.label.bookings_placement_date.virtual_options.false") }, hint: nil %>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -15,8 +15,8 @@
   <%= f.govuk_error_summary %>
   <%= f.govuk_date_field :date, heading: true %>
   <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m' } %>
-  <%= f.govuk_number_field :end_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
   <%= f.govuk_number_field :start_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
+  <%= f.govuk_number_field :end_availability_offset, width: 3, required: true, label: { class: 'govuk-heading-m' }, suffix_text: 'days before the event' %>
   <%= f.govuk_radio_buttons_fieldset :virtual do %>
     <%= f.govuk_radio_button :virtual, true, link_errors: true %>
     <%= f.govuk_radio_button :virtual, false, label: { text: t("helpers.label.bookings_placement_date.virtual_options.false") }, hint: nil %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -465,6 +465,14 @@ en:
             virtual:
               blank: Please choose either virtual or in school
               inclusion: Please choose either virtual or in school
+            end_availability_offset:
+              blank: Enter a number of days
+              greater_than_or_equal_to: Must not be a negative number
+              less_than: Must be 100 days or less
+            start_availability_offset:
+              blank: Enter a number of days
+              greater_than_or_equal_to: Must be at least 1 day
+              less_than: Must be less than 100
         bookings/booking:
           attributes:
             supports_subjects:
@@ -555,6 +563,8 @@ en:
       bookings_booking:
         duration: Enter number of days.
       bookings_placement_date:
+        end_availability_offset: You'll need enough time to process requests before the placement starts
+        start_availability_offset: We recommend publishing dates no more than 60 days in advance.
         date: For example, 01 09 2020.
         duration: Enter number of days.
         virtual: Does this school experience take place in school or via the internet
@@ -622,6 +632,8 @@ en:
           both: Both virtual and in school experiences
       bookings_placement_date:
         duration: How long will it last?
+        end_availability_offset: When do you want to close this date to candidates?
+        start_availability_offset: When do you want to publish this date?
         active_options:
           1: Make this date available to candidates?
         supports_subjects_options:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -468,11 +468,11 @@ en:
             end_availability_offset:
               blank: Enter a number of days
               greater_than_or_equal_to: Must not be a negative number
-              less_than: Must be 100 days or less
+              less_than: Must be 100 days or fewer
             start_availability_offset:
               blank: Enter a number of days
               greater_than_or_equal_to: Must be at least 1 day
-              less_than: Must be 180 days or less
+              less_than: Must be 180 days or fewer
         bookings/booking:
           attributes:
             supports_subjects:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -472,7 +472,7 @@ en:
             start_availability_offset:
               blank: Enter a number of days
               greater_than_or_equal_to: Must be at least 1 day
-              less_than: Must be less than 100
+              less_than: Must be 180 days or less
         bookings/booking:
           attributes:
             supports_subjects:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,8 @@ Rails.application.routes.draw do
         resource :configuration, only: %i[new create], controller: 'placement_dates/configurations'
         resource :subject_selection, only: %i[new create], controller: 'placement_dates/subject_selections'
       end
+      post "/close", action: "close"
+      get "/close", action: "close_confirmation"
     end
 
     namespace :errors do

--- a/db/migrate/20220119115856_add_availability_offsets_to_bookings_placement_dates.rb
+++ b/db/migrate/20220119115856_add_availability_offsets_to_bookings_placement_dates.rb
@@ -1,0 +1,6 @@
+class AddAvailabilityOffsetsToBookingsPlacementDates < ActiveRecord::Migration[6.1]
+  def change
+    add_column :bookings_placement_dates, :end_availability_offset, :integer, default: 0, null: false
+    add_column :bookings_placement_dates, :start_availability_offset, :integer, default: 60, null: false
+  end
+end

--- a/db/migrate/20220125180747_set_start_availability_offset_to_maximum_for_existing_dates.rb
+++ b/db/migrate/20220125180747_set_start_availability_offset_to_maximum_for_existing_dates.rb
@@ -1,0 +1,7 @@
+class SetStartAvailabilityOffsetToMaximumForExistingDates < ActiveRecord::Migration[6.1]
+  def up
+    Bookings::PlacementDate.update_all(start_availability_offset: 180)
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_17_152044) do
+ActiveRecord::Schema.define(version: 2022_01_19_115856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
@@ -79,6 +79,8 @@ ActiveRecord::Schema.define(version: 2022_01_17_152044) do
     t.boolean "subject_specific", default: false, null: false
     t.boolean "supports_subjects"
     t.boolean "virtual", null: false
+    t.integer "end_availability_offset", default: 0, null: false
+    t.integer "start_availability_offset", default: 60, null: false
     t.index ["bookings_school_id"], name: "index_bookings_placement_dates_on_bookings_school_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_19_115856) do
+ActiveRecord::Schema.define(version: 2022_01_25_180747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"

--- a/features/schools/placement_dates/edit.feature
+++ b/features/schools/placement_dates/edit.feature
@@ -16,7 +16,8 @@ Feature: Editing placement dates
         Then I should see a form with the following fields:
             | Label                  | Type   |
             | How long will it last? | number |
-        And there should be a 'Make this date available to candidates?' checkbox
+            | When do you want to close this date to candidates? | number |
+            | When do you want to publish this date? | number |
         And the current start date should be present
 
     Scenario: Filling in and submitting the form
@@ -30,16 +31,17 @@ Feature: Editing placement dates
     @smoke_test
     Scenario: Activating a placement date
         Given I am on the edit page for my 'inactive' placement
-        When I check the 'Make this date available to candidates?' checkbox
         And I submit the form
         Then I should be on the new configuration page for this date
+        And I submit the form
         Given I am on the 'placement dates' page
         Then my placement should have been 'activated'
 
     Scenario: Deactivating a placement date
         Given I am on the edit page for my 'active' placement
-        When I uncheck the 'Make this date available to candidates?' checkbox
-        And I submit the form
-        Then I should be on the new configuration page for this date
+        And I click the 'Close placement date' link
+        Then I should be on the Are you sure you want to close this date page
+        Then 'Yes' radio button should be selected
+        When I submit the form
         Given I am on the 'placement dates' page
         Then my placement should have been 'deactivated'

--- a/features/schools/placement_dates/new.feature
+++ b/features/schools/placement_dates/new.feature
@@ -17,6 +17,8 @@ Feature: Creating new placement dates
             | Label                  | Type   |
             | Enter start date       | date   |
             | How long will it last? | number |
+            | When do you want to close this date to candidates? | number |
+            | When do you want to publish this date? | number |
 
     Scenario: Preventing invalid dates from being added
         Given I am on the 'new placement date' page

--- a/features/step_definitions/schools/placement_dates/edit_steps.rb
+++ b/features/step_definitions/schools/placement_dates/edit_steps.rb
@@ -23,6 +23,10 @@ Given("I am on the edit page for my {string} placement") do |state|
   expect(page.current_path).to eql(path)
 end
 
+When("I click the 'Close placement date' link") do
+  page.find("a", text: "Close placement date").click
+end
+
 Then("my placement should have been {string}") do |operation|
   description = {
     'deactivated' => 'Closed',

--- a/features/step_definitions/schools/placement_dates/new_steps.rb
+++ b/features/step_definitions/schools/placement_dates/new_steps.rb
@@ -25,3 +25,7 @@ end
 Then "I should be on the new configuration page for this date" do
   expect(page.current_path).to eq path_for 'new configuration', placement_date_id: Bookings::PlacementDate.last.id
 end
+
+Then "I should be on the Are you sure you want to close this date page" do
+  expect(page.current_path).to eq schools_placement_date_close_path(placement_date_id: Bookings::PlacementDate.last.id)
+end

--- a/spec/controllers/schools/placement_dates/configurations_controller_spec.rb
+++ b/spec/controllers/schools/placement_dates/configurations_controller_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementDates::ConfigurationsController, type: :request do
+  include ActiveSupport::Testing::TimeHelpers
   include_context "logged in DfE user"
 
   let! :school do
@@ -40,6 +41,8 @@ describe Schools::PlacementDates::ConfigurationsController, type: :request do
     end
 
     before do
+      freeze_time
+
       post "/schools/placement_dates/#{placement_date.id}/configuration",
         params: params
     end
@@ -111,6 +114,11 @@ describe Schools::PlacementDates::ConfigurationsController, type: :request do
 
         it 'redirects to the dashboard' do
           expect(response).to redirect_to schools_placement_dates_path
+        end
+
+        it 'publishes the date' do
+          expect(placement_date.reload.active).to be true
+          expect(placement_date.reload.published_at).to eq DateTime.now
         end
       end
     end

--- a/spec/controllers/schools/placement_dates/subject_selections_controller_spec.rb
+++ b/spec/controllers/schools/placement_dates/subject_selections_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require Rails.root.join("spec", "controllers", "schools", "session_context")
 
 describe Schools::PlacementDates::SubjectSelectionsController, type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   let! :school do
     create \
       :bookings_school,
@@ -42,6 +44,8 @@ describe Schools::PlacementDates::SubjectSelectionsController, type: :request do
     end
 
     before do
+      freeze_time
+
       post "/schools/placement_dates/#{placement_date.id}/subject_selection",
         params: params
 
@@ -66,6 +70,11 @@ describe Schools::PlacementDates::SubjectSelectionsController, type: :request do
       it 'sets the subjects' do
         expect(placement_date).to be_subject_specific
         expect(placement_date.subjects).to match_array school.subjects.first(2)
+      end
+
+      it 'publishes the date' do
+        expect(placement_date.active).to be true
+        expect(placement_date.published_at).to eq DateTime.now
       end
 
       it 'redirects to placement dates index' do

--- a/spec/controllers/schools/placement_dates_controller_spec.rb
+++ b/spec/controllers/schools/placement_dates_controller_spec.rb
@@ -117,4 +117,30 @@ describe Schools::PlacementDatesController, type: :request do
       end
     end
   end
+
+  context '#close' do
+    let(:placement_date) { create :bookings_placement_date, :active, bookings_school: school }
+
+    context 'when confirmed' do
+      let(:params) { { schools_placement_dates_close_confirmation_form: { confirmed: true } } }
+
+      it 'closes the date and redirects to the index page' do
+        post schools_placement_date_close_path(placement_date.id), params: params
+
+        expect(placement_date.reload.active).to be false
+        expect(response).to redirect_to schools_placement_dates_path
+      end
+    end
+
+    context 'when not confirmed' do
+      let(:params) { { schools_placement_dates_close_confirmation_form: { confirmed: false } } }
+
+      it 'does not close the date and redirects to the index page' do
+        post schools_placement_date_close_path(placement_date.id), params: params
+
+        expect(placement_date.reload.active).to be true
+        expect(response).to redirect_to schools_placement_dates_path
+      end
+    end
+  end
 end

--- a/spec/forms/schools/placement_dates/configuration_form_spec.rb
+++ b/spec/forms/schools/placement_dates/configuration_form_spec.rb
@@ -5,12 +5,6 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
     create :bookings_school, :with_subjects, subject_count: 3
   end
 
-  let! :stubbed_time do
-    DateTime.now
-  end
-
-  before { allow(DateTime).to receive(:now) { stubbed_time } }
-
   context '.new_from_date' do
     subject { described_class.new_from_date placement_date }
 
@@ -86,10 +80,6 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
           it 'sets subject_specific' do
             expect(placement_date).not_to be_subject_specific
           end
-
-          it 'sets published_at' do
-            expect(placement_date.published_at).to eq stubbed_time
-          end
         end
 
         context 'when doesnt support subjects' do
@@ -111,10 +101,6 @@ describe Schools::PlacementDates::ConfigurationForm, type: :model do
 
           it 'empties subject_ids' do
             expect(placement_date.subjects).to be_empty
-          end
-
-          it 'sets published_at' do
-            expect(placement_date).to be_published
           end
         end
 

--- a/spec/forms/schools/placement_dates/subject_selection_spec.rb
+++ b/spec/forms/schools/placement_dates/subject_selection_spec.rb
@@ -5,12 +5,6 @@ describe Schools::PlacementDates::SubjectSelection, type: :model do
     create :bookings_school, :with_subjects, subject_count: 3
   end
 
-  let! :stubbed_time do
-    DateTime.now
-  end
-
-  before { allow(DateTime).to receive(:now) { stubbed_time } }
-
   context 'validations' do
     it { is_expected.to validate_presence_of :subject_ids }
   end
@@ -86,10 +80,6 @@ describe Schools::PlacementDates::SubjectSelection, type: :model do
 
       it 'updates the placement_date subjects to the selected_subjects' do
         expect(placement_date.subjects).to eq subjects
-      end
-
-      it 'updates published_at' do
-        expect(placement_date.published_at).to eq stubbed_time
       end
     end
   end

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -95,7 +95,7 @@ describe Bookings::PlacementDate, type: :model do
         expect(subject).to(
           validate_numericality_of(:start_availability_offset)
             .is_greater_than_or_equal_to(1)
-            .is_less_than(100)
+            .is_less_than(181)
         )
       end
       it { expect(subject).to validate_presence_of(:start_availability_offset) }
@@ -112,7 +112,7 @@ describe Bookings::PlacementDate, type: :model do
         expect(subject).to(
           validate_numericality_of(:end_availability_offset)
             .is_greater_than_or_equal_to(0)
-            .is_less_than(100)
+            .is_less_than(101)
         )
       end
       it { expect(subject).to validate_presence_of(:end_availability_offset) }

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Bookings::PlacementDate, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
   let! :school do
     create :bookings_school, :with_subjects, subject_count: 3
   end
@@ -15,6 +17,8 @@ describe Bookings::PlacementDate, type: :model do
     it { is_expected.to have_db_column(:published_at).of_type(:datetime) }
     it { is_expected.to have_db_column(:subject_specific).of_type(:boolean).with_options(default: false, null: false) }
     it { is_expected.to have_db_column(:supports_subjects).of_type(:boolean) }
+    it { is_expected.to have_db_column(:start_availability_offset).of_type(:integer).with_options(default: 60, null: false) }
+    it { is_expected.to have_db_column(:end_availability_offset).of_type(:integer).with_options(default: 0, null: false) }
   end
 
   describe 'Validation' do
@@ -84,6 +88,34 @@ describe Bookings::PlacementDate, type: :model do
         )
       end
       it { expect(subject).to validate_presence_of(:duration) }
+    end
+
+    context '#start_availability_offset' do
+      specify do
+        expect(subject).to(
+          validate_numericality_of(:start_availability_offset)
+            .is_greater_than_or_equal_to(1)
+            .is_less_than(100)
+        )
+      end
+      it { expect(subject).to validate_presence_of(:start_availability_offset) }
+
+      it "is greater than #end_availability_offset" do
+        subject.end_availability_offset = 1
+        is_expected.to allow_value(2).for :start_availability_offset
+        is_expected.to_not allow_values(0, 1).for :start_availability_offset
+      end
+    end
+
+    context '#end_availability_offset' do
+      specify do
+        expect(subject).to(
+          validate_numericality_of(:end_availability_offset)
+            .is_greater_than_or_equal_to(0)
+            .is_less_than(100)
+        )
+      end
+      it { expect(subject).to validate_presence_of(:end_availability_offset) }
     end
 
     context '#virtual' do
@@ -175,35 +207,65 @@ describe Bookings::PlacementDate, type: :model do
     end
 
     context '.active' do
-      let!(:active) { create(:bookings_placement_date, active: true) }
-      let!(:inactive) { create(:bookings_placement_date, active: false) }
+      subject { date.active }
 
-      specify 'should return active placement dates' do
-        expect(described_class.active).to include(active)
+      context "when active is false" do
+        let!(:date) { create(:bookings_placement_date, active: false) }
+
+        it { is_expected.to be false }
       end
 
-      specify 'should not return inactive placement dates' do
-        expect(described_class.active).not_to include(inactive)
+      context "when active is true" do
+        let!(:date) { create(:bookings_placement_date, active: true) }
+
+        it { is_expected.to be true }
       end
     end
 
-    context '.inactive' do
-      let!(:active) { create(:bookings_placement_date, active: true) }
-      let!(:inactive) { create(:bookings_placement_date, active: false) }
+    context ".inside_availability_window" do
+      subject { described_class.inside_availability_window }
 
-      specify 'should return inactive placement dates' do
-        expect(described_class.inactive).to include(inactive)
+      it 'includes placements that have not yet closed' do
+        travel_to Date.new(2022, 1, 8)
+
+        is_expected.to include(create(:bookings_placement_date, date: Date.new(2022, 1, 10), end_availability_offset: 1))
       end
 
-      specify 'should not return active placement dates' do
-        expect(described_class.inactive).not_to include(active)
+      it 'does not include placements that closed today' do
+        travel_to Date.new(2022, 1, 9)
+
+        is_expected.to_not include(create(:bookings_placement_date, date: Date.new(2022, 1, 10), end_availability_offset: 1))
+      end
+
+      it 'does not include placements closed to candidates in the past' do
+        travel_to Date.new(2022, 1, 10)
+
+        is_expected.to_not include(create(:bookings_placement_date, date: Date.new(2022, 1, 20), end_availability_offset: 15))
+      end
+
+      it 'includes placements that opened today' do
+        travel_to Date.new(2022, 1, 8)
+
+        is_expected.to include(create(:bookings_placement_date, date: Date.new(2022, 1, 9), start_availability_offset: 1))
+      end
+
+      it 'does not include placements that open tomorrow' do
+        travel_to Date.new(2022, 1, 8)
+
+        is_expected.to_not include(create(:bookings_placement_date, date: Date.new(2022, 1, 10), start_availability_offset: 1))
+      end
+
+      it 'includes placements that opened in the past' do
+        travel_to Date.new(2022, 1, 10)
+
+        is_expected.to include(create(:bookings_placement_date, date: Date.new(2022, 1, 20), start_availability_offset: 20))
       end
     end
 
     context '.available' do
       after { described_class.available }
-      specify 'should combine the future, active, published, and in_date_order scopes' do
-        expect(described_class).to receive_message_chain(:published, :active, :bookable_date, :in_date_order)
+      specify 'should combine the future, active, published, open_to_candidates, and in_date_order scopes' do
+        expect(described_class).to receive_message_chain(:published, :active, :bookable_date, :inside_availability_window, :in_date_order)
       end
     end
 
@@ -214,6 +276,26 @@ describe Bookings::PlacementDate, type: :model do
       specify 'should return only the published placement_dates' do
         expect(described_class.published).to match_array [published]
       end
+    end
+  end
+
+  context 'publish' do
+    subject { create(:bookings_placement_date) }
+
+    before do
+      subject.active = false
+      subject.published_at = nil
+      freeze_time
+
+      subject.publish
+    end
+
+    it 'updates #active to true' do
+      expect(subject.active).to be true
+    end
+
+    it 'sets #published_at to the current time' do
+      expect(subject.published_at).to eq DateTime.now
     end
   end
 
@@ -249,6 +331,66 @@ describe Bookings::PlacementDate, type: :model do
 
       it 'returns false' do
         expect(subject.published?).to be false
+      end
+    end
+  end
+
+  context "available?" do
+    context "when not active" do
+      before { subject.active = false }
+
+      it 'returns false' do
+        expect(subject.available?).to be false
+      end
+    end
+
+    context "when active" do
+      it 'includes placements that have not yet closed' do
+        travel_to Date.new(2022, 1, 8)
+        subject.end_availability_offset = 1
+        subject.date = Date.new(2022, 1, 10)
+
+        expect(subject.available?).to be true
+      end
+
+      it 'does not include placements that closed today' do
+        travel_to Date.new(2022, 1, 9)
+        subject.end_availability_offset = 1
+        subject.date = Date.new(2022, 1, 10)
+
+        expect(subject.available?).to be false
+      end
+
+      it 'does not include placements closed to candidates in the past' do
+        travel_to Date.new(2022, 1, 10)
+        subject.end_availability_offset = 15
+        subject.date = Date.new(2022, 1, 20)
+
+        expect(subject.available?).to be false
+      end
+
+      it 'includes placements that opened today' do
+        travel_to Date.new(2022, 1, 8)
+        subject.start_availability_offset = 1
+        subject.date = Date.new(2022, 1, 9)
+
+        expect(subject.available?).to be true
+      end
+
+      it 'does not include placements that open tomorrow' do
+        travel_to Date.new(2022, 1, 8)
+        subject.start_availability_offset = 1
+        subject.date = Date.new(2022, 1, 10)
+
+        expect(subject.available?).to be false
+      end
+
+      it 'includes placements that opened in the past' do
+        travel_to Date.new(2022, 1, 8)
+        subject.start_availability_offset = 20
+        subject.date = Date.new(2022, 1, 20)
+
+        expect(subject.available?).to be true
       end
     end
   end


### PR DESCRIPTION
### Trello card
https://trello.com/c/1cQIAhsL
https://trello.com/c/9vuYRoqd

### Context
We are moving towards a [new manage dates design](https://get-school-experience-prototype.london.cloudapps.digital/manage-dates-mvp/). 

Part of this is to have two new fields which will set an availability window in which the day will be available to applicants - open date x number of days before & close date x number of days before.

Another part of this is to remove the active/inactive checkbox. Now, dates will become active when published, and can be made inactive by following a link in each date page.

![image](https://user-images.githubusercontent.com/47089130/150961638-7e9b58de-1dd9-4df0-af56-76352f9f9c76.png)
When a date is active, it can be closed through this link:
![image](https://user-images.githubusercontent.com/47089130/150961811-619f915b-da3d-4c7c-851e-186f7da01d0e.png)


### Changes proposed in this pull request
- Add ability to close date a number of days before it starts
- Add ability to open a date a number of days before it starts
- Change active/not active checkbox to a close button/link
- All current dates will be given a default start offset of 180 days: The default start offset is 60 days. However, there are a number of dates in the system that don't start for a greater period than this. Therefore, if we apply the default, a large number of active dates will become inactive. Add migration to update all current dates to the maximum allowed offset - 180 days (prod database shows no active dates further than 180 days away, so no dates will be affected). All new dates will have the default value of 60 days.
### Guidance to review