### PR TITLE
Remove form view helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -118,24 +118,6 @@ module ApplicationHelper
     end
   end
 
-  def govuk_form_for(*args, **options, &block)
-    merged = options.dup
-    merged[:builder] = GOVUKDesignSystemFormBuilder::FormBuilder
-    merged[:html] ||= {}
-    merged[:html][:novalidate] = true
-
-    form_for(*args, **merged, &block)
-  end
-
-  def govuk_form_with(*args, **options, &block)
-    merged = options.dup
-    merged[:builder] = GOVUKDesignSystemFormBuilder::FormBuilder
-    merged[:html] ||= {}
-    merged[:html][:novalidate] = true
-
-    form_with(*args, **merged, &block)
-  end
-
 private
 
   def valid_user?(user)

--- a/app/views/candidates/placement_requests/cancellations/_new_booking.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_new_booking.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Cancel booking</h1>
-      <%= govuk_form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
+      <%= form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
         <%= f.govuk_error_summary %>
 
         <p>

--- a/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Cancel request</h1>
-      <%= govuk_form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
+      <%= form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
         <%= f.govuk_error_summary %>
 
       <p>

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -1,7 +1,7 @@
 <% self.page_title = 'Check your answers' %>
 <%= govuk_back_link %>
 <div class="govuk-grid-row" id="application-preview">
-  <%= govuk_form_for @privacy_policy,
+  <%= form_for @privacy_policy,
         url: candidates_school_registrations_confirmation_email_path,
         data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
   <div class="govuk-grid-column-full">

--- a/app/views/candidates/registrations/background_checks/_form.html.erb
+++ b/app/views/candidates/registrations/background_checks/_form.html.erb
@@ -20,7 +20,7 @@
       </strong>
     </p>
 
-    <%= govuk_form_for background_check, url: candidates_school_registrations_background_check_path do |f| %>
+    <%= form_for background_check, url: candidates_school_registrations_background_check_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <% # force the params to submit if the user has not selected an option %>

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -24,7 +24,7 @@
           If a school accepts your request, the school experience service will send you text message alerts about your booking.
         </p>
 
-        <%= govuk_form_for contact_information, url: candidates_school_registrations_contact_information_path do |f| %>
+        <%= form_for contact_information, url: candidates_school_registrations_contact_information_path do |f| %>
           <%= f.govuk_error_summary %>
 
           <%= f.govuk_phone_field :phone, autocomplete: 'on' %>

--- a/app/views/candidates/registrations/educations/_form.html.erb
+++ b/app/views/candidates/registrations/educations/_form.html.erb
@@ -5,7 +5,7 @@
   The following will be used to help schools offer you school experience.
 </p>
 
-<%= govuk_form_for education, url: candidates_school_registrations_education_path, data: { controller: 'education-form' } do |f| %>
+<%= form_for education, url: candidates_school_registrations_education_path, data: { controller: 'education-form' } do |f| %>
   <%= f.govuk_error_summary %>
 
   <section id="education-degree-stage-container" data-education-form-target="degreeStagesContainer">

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -19,7 +19,7 @@
         Get Into Teaching offers help and advice about becoming a teacher.
         </p>
 
-        <%= govuk_form_for personal_information,
+        <%= form_for personal_information,
               url: candidates_school_registrations_personal_information_path,
               data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
 

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Request school experience</h1>
 
-    <%= govuk_form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>
+    <%= form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <%- unless @school.availability_preference_fixed? %>

--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -27,7 +27,7 @@
       <li><%= @email_address %></li>
     </ul>
 
-    <%= govuk_form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>
+    <%= form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :email %>

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Choose a date</h1>
-    <%= govuk_form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
+    <%= form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :date_and_subject_ids %>

--- a/app/views/candidates/registrations/teaching_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/teaching_preferences/_form.html.erb
@@ -1,7 +1,7 @@
 <% self.page_title = 'Which of the following best describes how you feel about teaching?' %>
 <%= govuk_back_link %>
 <div id="teaching-preference">
-  <%= govuk_form_for teaching_preference, url: candidates_school_registrations_teaching_preference_path, data: { controller: 'subject-preference-form' } do |f| %>
+  <%= form_for teaching_preference, url: candidates_school_registrations_teaching_preference_path, data: { controller: 'subject-preference-form' } do |f| %>
     <%= f.govuk_error_summary %>
 
     <%= f.govuk_collection_radio_buttons :teaching_stage, f.object.available_teaching_stages, :to_s, :to_s %>

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-one-half">
     <div id="search-form">
 
-      <%= govuk_form_for(@search,
+      <%= form_for(@search,
         as: '',
         url: candidates_schools_path,
         method: :get,

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -9,7 +9,7 @@
 
 <div class="govuk-grid-row">
   <section id="search-bar" class="govuk-grid-column-full">
-    <%= govuk_form_for @search, as: '', url: candidates_schools_path, method: :get do |f| %>
+    <%= form_for @search, as: '', url: candidates_schools_path, method: :get do |f| %>
       <%= f.govuk_text_field :location, label: { text: "School location", class: "govuk-visually-hidden" }, width: 'full', placeholder: 'Location or postcode' %>
 
       <%= f.govuk_select :distance, label: { text: 'Search radius' } do
@@ -32,7 +32,7 @@
 
       <div data-target="collapsible.panel">
         <%= link_to 'Skip to search results', '#search-results', class: 'govuk-skip-link', id: 'skip-to-results' %>
-        <%= govuk_form_for @search, as: '',
+        <%= form_for @search, as: '',
                      method: :get,
                      html: { class: "collapsible__content" } do |f| %>
 

--- a/app/views/candidates/sessions/create.html.erb
+++ b/app/views/candidates/sessions/create.html.erb
@@ -14,7 +14,7 @@
       <li><%= @verification_code.email %></li>
     </ul>
 
-    <%= govuk_form_for @verification_code, url: candidates_signin_code_path, method: :put do |f| %>
+    <%= form_for @verification_code, url: candidates_signin_code_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :firstname %>

--- a/app/views/candidates/sessions/new.html.erb
+++ b/app/views/candidates/sessions/new.html.erb
@@ -10,7 +10,7 @@
       you can sign in with.
     </p>
 
-    <%= govuk_form_for @candidates_session, url: candidates_signin_path, html: {novalidate: true} do |f| %>
+    <%= form_for @candidates_session, url: candidates_signin_path, html: {novalidate: true} do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_email_field :email, autocomplete: 'on', class: 'govuk-input govuk-input--width-30' %>

--- a/app/views/cookie_preferences/edit.html.erb
+++ b/app/views/cookie_preferences/edit.html.erb
@@ -25,7 +25,7 @@
           for us to use.
         </p>
 
-        <%= govuk_form_for cookie_preferences do |f| %>
+        <%= form_for cookie_preferences do |f| %>
           <%= f.govuk_error_summary %>
 
           <%= f.govuk_radio_buttons_fieldset :analytics do |fieldset| %>

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Give feedback on this service</h1>
-    <%= govuk_form_for feedback do |f| %>
+    <%= form_for feedback do |f| %>
       <%= f.govuk_error_summary %>
       <p>
         Help us improve the school experience service.

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for @current_school, url: schools_availability_info_path, method: :patch do |f| %>
+    <%= form_for @current_school, url: schools_availability_info_path, method: :patch do |f| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
           <%= f.govuk_text_area :availability_info, rows: 7, label: { class: 'govuk-heading-l' } do %>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for @current_school, url: schools_availability_preference_path, method: 'patch' do |f| %>
+    <%= form_for @current_school, url: schools_availability_preference_path, method: 'patch' do |f| %>
       <%= f.govuk_error_summary f.object %>
       <%= f.govuk_radio_buttons_fieldset :availability_preference_fixed do %>
 

--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <% if Schools::ChangeSchool.allow_school_change_in_app? %>
       <% if @schools.any? %>
-        <%= govuk_form_for @change_school, url: schools_change_path, method: :post do |f| %>
+        <%= form_for @change_school, url: schools_change_path, method: :post do |f| %>
           <%= f.govuk_radio_buttons_fieldset :change_to_urn, legend: { tag: "h1", size: "l" } do %>
             <% @schools.each do |school| %>
               <%= f.govuk_radio_button :change_to_urn, school.urn, label: -> do %>

--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -11,11 +11,11 @@
 
 <%- if @bookings.any? %>
 
-  <%= govuk_form_for @updated_attendance, url: nil do |f| %>
+  <%= form_for @updated_attendance, url: nil do |f| %>
     <%= f.govuk_error_summary %>
   <% end %>
 
-  <%= govuk_form_with url: schools_confirm_attendance_path, method: 'put' do |f| %>
+  <%= form_with url: schools_confirm_attendance_path, method: 'put' do |f| %>
     <%= pagination_bar @bookings %>
 
     <table class="govuk-table">

--- a/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
@@ -1,7 +1,7 @@
 <%- self.page_title = "Review and send cancellation email to candidate" %>
 <%= govuk_back_link schools_booking_path(@booking) %>
 
-<%= govuk_form_for cancellation, url: schools_booking_cancellation_path do |f| %>
+<%= form_for cancellation, url: schools_booking_cancellation_path do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">

--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -16,7 +16,7 @@
       booking date.
     </p>
 
-    <%= govuk_form_for @booking, url: schools_booking_date_path(@booking), method: 'patch' do |f| %>
+    <%= form_for @booking, url: schools_booking_date_path(@booking), method: 'patch' do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_date_field :date, heading: true %>

--- a/app/views/schools/csv_exports/_form.html.erb
+++ b/app/views/schools/csv_exports/_form.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_form_for form, url: schools_csv_export_path do |f| %>
+<%= form_for form, url: schools_csv_export_path do |f| %>
   <%= f.govuk_error_summary %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">

--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -8,7 +8,7 @@
       <%= title %>
     </h1>
 
-    <%= govuk_form_for model, url: submission_path do |f| %>
+    <%= form_for model, url: submission_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_number_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.9, label: { class: 'govuk-heading-m' }, prefix_text: '£' %>

--- a/app/views/schools/on_boarding/access_needs_details/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_details/_form.html.erb
@@ -3,7 +3,7 @@
 <%= govuk_back_link javascript: true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for access_needs_detail, url: schools_on_boarding_access_needs_detail_path, method: method do |f| %>
+    <%= form_for access_needs_detail, url: schools_on_boarding_access_needs_detail_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_text_area :description, rows: 9, label: { class: 'govuk-heading-l' } do %>
         <p>

--- a/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for access_needs_policy, url: schools_on_boarding_access_needs_policy_path, method: method do |f| %>
+    <%= form_for access_needs_policy, url: schools_on_boarding_access_needs_policy_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.govuk_radio_buttons_fieldset :has_access_needs_policy, legend: { tag: "h1", size: "l" } do %>
         <p class="govuk-hint">

--- a/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
@@ -3,7 +3,7 @@
 <%= govuk_back_link javascript: true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for access_needs_support, url: schools_on_boarding_access_needs_support_path, method: method do |f| %>
+    <%= form_for access_needs_support, url: schools_on_boarding_access_needs_support_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.hidden_field :supports_access_needs, value: nil %>
 

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -7,7 +7,7 @@
     <h1 class="govuk-heading-l">
       Enter school experience admin contact details
     </h1>
-    <%= govuk_form_for admin_contact, url: url, method: method do |f| %>
+    <%= form_for admin_contact, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
       <p>

--- a/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_details/_form.html.erb
@@ -11,7 +11,7 @@
       These details will help candidates select a school experience.
     </p>
 
-    <%= govuk_form_for candidate_experience_detail, url: url, method: method do |f| %>
+    <%= form_for candidate_experience_detail, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :business_dress_1 %>
 
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/schools/on_boarding/candidate_requirements_choices/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_choices/_form.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_back_link javascript: true %>
 
-    <%= govuk_form_for candidate_requirements_choice, url: schools_on_boarding_candidate_requirements_choice_path, method: method do |f|%>
+    <%= form_for candidate_requirements_choice, url: schools_on_boarding_candidate_requirements_choice_path, method: method do |f|%>
       <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :has_requirements, value: nil %>

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -8,7 +8,7 @@
       What requirements do you have?
     </h1>
 
-    <%= govuk_form_for candidate_requirements_selection, url: schools_on_boarding_candidate_requirements_selection_path, method: method do |f| %>
+    <%= form_for candidate_requirements_selection, url: schools_on_boarding_candidate_requirements_selection_path, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :on_teacher_training_course_1 %>
 
       <p>

--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -8,7 +8,7 @@
       DBS check costs
     </h1>
 
-    <%= govuk_form_for @dbs_fee, url: schools_on_boarding_dbs_fee_path do |f| %>
+    <%= form_for @dbs_fee, url: schools_on_boarding_dbs_fee_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_number_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.9, label: { class: 'govuk-heading-m' }, prefix_text: '£' %>

--- a/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
@@ -16,7 +16,7 @@
       You'll be given a chance to check and change the details you enter.
     </p>
 
-    <%= govuk_form_for dbs_requirement, url: url, method: method do |f| %>
+    <%= form_for dbs_requirement, url: url, method: method do |f| %>
       <%= f.govuk_radio_buttons_fieldset :dbs_policy_conditions do %>
         <%= f.govuk_error_summary %>
 

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for description, url: schools_on_boarding_description_path, method: method do |f| %>
+    <%= form_for description, url: schools_on_boarding_description_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/app/views/schools/on_boarding/disability_confidents/_form.html.erb
+++ b/app/views/schools/on_boarding/disability_confidents/_form.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for disability_confident, url: schools_on_boarding_disability_confident_path, method: method do |f| %>
+    <%= form_for disability_confident, url: schools_on_boarding_disability_confident_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.hidden_field :is_disability_confident, value: nil %>
       <%= f.govuk_radio_buttons_fieldset :is_disability_confident, legend: { tag: "h1", size: "l" } do %>

--- a/app/views/schools/on_boarding/experience_outlines/_form.html.erb
+++ b/app/views/schools/on_boarding/experience_outlines/_form.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for experience_outline, url: url, method: method do |f| %>
+    <%= form_for experience_outline, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -8,7 +8,7 @@
       Do you charge fees to cover any of the following?
     </h1>
 
-    <%= govuk_form_for fees, url: url, method: method do |f| %>
+    <%= form_for fees, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
       <p>

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -7,7 +7,7 @@
     <h1 class="govuk-heading-l">
       Which key stages do you offer experience with?
     </h1>
-    <%= govuk_form_for key_stage_list, url: url, method: method do |f| %>
+    <%= form_for key_stage_list, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :early_years_1 %>
 
       <p>

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -8,7 +8,7 @@
       Which school phases do you offer experience with?
     </h1>
 
-    <%= govuk_form_for phases_list, url: url, method: method do |f| %>
+    <%= form_for phases_list, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :primary_1 %>
 
       <p>

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -21,7 +21,7 @@
       </strong>
     </div>
 
-    <%= govuk_form_for @confirmation, url: schools_on_boarding_confirmation_path do |f| %>
+    <%= form_for @confirmation, url: schools_on_boarding_confirmation_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h2 class="govuk-heading-m">School details</h2>

--- a/app/views/schools/on_boarding/subjects/_form.html.erb
+++ b/app/views/schools/on_boarding/subjects/_form.html.erb
@@ -7,7 +7,7 @@
     <h1 class="govuk-heading-l">
       Select school experience subjects
     </h1>
-    <%= govuk_form_for subject_list, url: schools_on_boarding_subjects_path, method: method do |f| %>
+    <%= form_for subject_list, url: schools_on_boarding_subjects_path, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :subject_ids_1 %>
       <p>
         Tell us which subjects you offer for secondary school experience and

--- a/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
+++ b/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
@@ -8,7 +8,7 @@
       Teacher training details
     </h1>
 
-    <%= govuk_form_for teacher_training, url: url, method: method do |f| %>
+    <%= form_for teacher_training, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :provides_teacher_training do %>

--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for @configuration, method: :post, url: schools_placement_date_configuration_path(@placement_date) do |f| %>
+    <%= form_for @configuration, method: :post, url: schools_placement_date_configuration_path(@placement_date) do |f| %>
       <%= f.govuk_error_summary %>
 
       <% if Feature.instance.active? :capped_bookings %>

--- a/app/views/schools/placement_dates/edit.html.erb
+++ b/app/views/schools/placement_dates/edit.html.erb
@@ -10,7 +10,7 @@
 </p>
 
 
-<%= govuk_form_for @placement_date, url: schools_placement_date_path(@placement_date), method: :put do |f| %>
+<%= form_for @placement_date, url: schools_placement_date_path(@placement_date), method: :put do |f| %>
 
   <div>
     <h2 class="govuk-heading-m">Start date</h2>

--- a/app/views/schools/placement_dates/new.html.erb
+++ b/app/views/schools/placement_dates/new.html.erb
@@ -11,7 +11,7 @@
   at your school.
 </p>
 
-<%= govuk_form_for @placement_date, url: schools_placement_dates_path, method: :post do |f| %>
+<%= form_for @placement_date, url: schools_placement_dates_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_date_field :date, heading: true %>
   <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m' } %>

--- a/app/views/schools/placement_dates/subject_selections/new.html.erb
+++ b/app/views/schools/placement_dates/subject_selections/new.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for @subject_selection, method: :post, url: schools_placement_date_subject_selection_path(@placement_date) do |f| %>
+    <%= form_for @subject_selection, method: :post, url: schools_placement_date_subject_selection_path(@placement_date) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_collection_check_boxes :subject_ids, @placement_date.bookings_school.subjects, :id, :name, legend: { tag: "h1", size: "l" } %>

--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -97,7 +97,7 @@
     <div>
       <% if @placement_request.fixed_date_is_bookable? && @last_booking_found %>
         <%# contact details are present and school has fixed dates, allow for move on to the email preview%>
-        <%= govuk_form_for @booking, url: schools_placement_request_acceptance_make_changes_path, method: 'post' do |f| %>
+        <%= form_for @booking, url: schools_placement_request_acceptance_make_changes_path, method: 'post' do |f| %>
           <%= f.hidden_field :contact_name %>
           <%= f.hidden_field :contact_number %>
           <%= f.hidden_field :contact_email %>

--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -8,7 +8,7 @@
       Confirm the booking for <%= @placement_request.candidate_name %> at <%= @placement_request.school.name %>
     </h1>
 
-    <%= govuk_form_for @booking, url: schools_placement_request_acceptance_make_changes_path, method: 'post' do |f| %>
+    <%= form_for @booking, url: schools_placement_request_acceptance_make_changes_path, method: 'post' do |f| %>
       <%= f.govuk_error_summary %>
       <div>
 

--- a/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
+++ b/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
@@ -12,7 +12,7 @@
       to confirm their booking.
     </p>
 
-    <%= govuk_form_for @booking, url: schools_placement_request_acceptance_preview_confirmation_email_path(@placement_request.id) do |f| %>
+    <%= form_for @booking, url: schools_placement_request_acceptance_preview_confirmation_email_path(@placement_request.id) do |f| %>
       <%= f.govuk_error_summary %>
       <div class="email-preview">
         <p>Dear <%= @placement_request.candidate_name %>,</p>

--- a/app/views/schools/placement_requests/cancellations/_form.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= govuk_back_link schools_placement_request_path(@cancellation.placement_request) %>
 
-<%= govuk_form_for cancellation, url: schools_placement_request_cancellation_path do |f| %>
+<%= form_for cancellation, url: schools_placement_request_cancellation_path do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">

--- a/app/views/schools/placement_requests/reject/new.html.erb
+++ b/app/views/schools/placement_requests/reject/new.html.erb
@@ -16,7 +16,7 @@
       know why their request has been turned down.
     </p>
 
-    <%= govuk_form_for @reject_reason, url: schools_placement_request_reject_path, method: :post do |f| %>
+    <%= form_for @reject_reason, url: schools_placement_request_reject_path, method: :post do |f| %>
       <%= f.govuk_text_area :reason, 'Reasons for rejecting the request' %>
       <%= f.govuk_submit "Reject request" %>
     <% end %>

--- a/app/views/schools/toggle_enabled/edit.html.erb
+++ b/app/views/schools/toggle_enabled/edit.html.erb
@@ -1,6 +1,6 @@
 <% self.page_title = "Toggle requests" %>
 
-<%= govuk_form_for @current_school, url: schools_enabled_path, method: 'patch' do |f| %>
+<%= form_for @current_school, url: schools_enabled_path, method: 'patch' do |f| %>
   <%= f.govuk_radio_buttons_fieldset(:enabled) do %>
     <%= f.govuk_radio_button :enabled, true, link_errors: true, label: { text: "Turn profile on to allow requests" } %>
     <%= f.govuk_radio_button :enabled, false, label: { text: "Turn profile off" }, hint: nil %>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -137,22 +137,4 @@ describe ApplicationHelper, type: :helper do
       end
     end
   end
-
-  describe "#govuk_form_for" do
-    it "renders a form with GOV.UK form builder" do
-      expect(govuk_form_for(StubModel.new, url: "http://test.com") {}).to eq(
-        "<form class=\"new_stub_model\" id=\"new_stub_model\" novalidate=\"novalidate\" "\
-        "action=\"http://test.com\" accept-charset=\"UTF-8\" method=\"post\"></form>",
-      )
-    end
-  end
-
-  describe "#govuk_form_with" do
-    it "renders a form with GOV.UK form builder" do
-      expect(govuk_form_with(url: "http://test.com", method: "put") {}).to eq(
-        "<form novalidate=\"novalidate\" action=\"http://test.com\" accept-charset=\"UTF-8\" "\
-          "data-remote=\"true\" method=\"post\"><input type=\"hidden\" name=\"_method\" value=\"put\" /></form>",
-      )
-    end
-  end
 end


### PR DESCRIPTION
[Trello-471](https://trello.com/c/T9KpHJ3V/471-remove-govukformfor-with-helpers)

Now that we only have one form builder in the application we no longer need to be explicit around which we are using and can default to `form_for/with`, which is configured to go to the `GOVUKDesignSystemFormBuilder` globally.
