### PR TITLE
Refactor outstanding task counters for consistency

### DIFF
--- a/app/controllers/schools/dashboards_controller.rb
+++ b/app/controllers/schools/dashboards_controller.rb
@@ -5,28 +5,8 @@ module Schools
     def show
       @school = current_school
 
-      @requests_requiring_attention = current_school
-        .placement_requests
-        .requiring_attention
-        .count
-
-      @bookings_requiring_attention = current_school
-        .bookings
-        .with_unviewed_candidate_cancellation
-        .count
-
-      @candidate_attendances = current_school
-        .bookings
-        .previous
-        .not_cancelled
-        .accepted
-        .attendance_unlogged
-        .count
-
-      @withdrawn_requests = current_school
-        .placement_requests
-        .withdrawn_but_unviewed
-        .count
+      summary = OutstandingTasks.new([current_school.urn]).summarize
+      @outstanding_tasks = summary[current_school.urn]
 
       set_latest_service_update
 

--- a/app/models/bookings/placement_request.rb
+++ b/app/models/bookings/placement_request.rb
@@ -101,17 +101,6 @@ module Bookings
         .where(school_cancellations_bookings_placement_requests: { id: nil })
     }
 
-    scope :requiring_attention_including_attendance, lambda {
-      excluding_old_expired_requests
-        .left_joins(:booking)
-        .where("bookings_bookings.id IS NULL OR (bookings_bookings.accepted_at IS NOT NULL AND bookings_bookings.date < ? AND bookings_bookings.attended IS NULL)", Time.zone.today)
-        .left_joins(:candidate_cancellation)
-        .merge(Cancellation.unviewed)
-        .merge(Cancellation.sent.or(Cancellation.where(id: nil)))
-        .left_joins(:school_cancellation)
-        .where(school_cancellations_bookings_placement_requests: { id: nil })
-    }
-
     scope :withdrawn, lambda {
       without_booking
         .joins(:candidate_cancellation)

--- a/app/models/schools/change_school.rb
+++ b/app/models/schools/change_school.rb
@@ -67,12 +67,9 @@ module Schools
     end
 
     def school_task_counts
-      @school_task_counts ||= Bookings::PlacementRequest \
-        .joins(:school)
-        .where(bookings_schools: { urn: organisation_urns })
-        .requiring_attention_including_attendance
-        .group('bookings_schools.urn')
-        .count(:id)
+      @school_task_counts = Schools::OutstandingTasks.new(organisation_urns)
+        .summarize
+        .transform_values { |h| h.values.sum }
     end
   end
 end

--- a/app/models/schools/outstanding_tasks.rb
+++ b/app/models/schools/outstanding_tasks.rb
@@ -1,0 +1,72 @@
+class Schools::OutstandingTasks
+  attr_reader :school_urns
+
+  def initialize(school_urns)
+    @school_urns = school_urns
+  end
+
+  def summarize
+    [
+      requests_requiring_attention,
+      unviewed_withdrawn_requests,
+      upcoming_bookings,
+      bookings_pending_attendance_confirmation
+    ].reduce(&:deep_merge!)
+  end
+
+  private
+
+  def requests_requiring_attention
+    query = schools
+      .joins(:placement_requests)
+      .merge(Bookings::PlacementRequest.requiring_attention)
+
+    keyed_total(query, :requests_requiring_attention)
+  end
+
+  def unviewed_withdrawn_requests
+    query = schools
+      .joins(:placement_requests)
+      .merge(Bookings::PlacementRequest.withdrawn_but_unviewed.reorder(nil))
+
+      keyed_total(query, :unviewed_withdrawn_requests)
+  end
+
+  def upcoming_bookings
+    query = schools
+      .joins(:bookings)
+      .merge(Bookings::Booking.with_unviewed_candidate_cancellation)
+
+      keyed_total(query, :upcoming_bookings)
+  end
+
+  def bookings_pending_attendance_confirmation
+    query = schools
+      .joins(:bookings)
+      .merge(Bookings::Booking.previous)
+      .merge(Bookings::Booking.not_cancelled)
+      .merge(Bookings::Booking.accepted)
+      .merge(Bookings::Booking.attendance_unlogged)
+
+      keyed_total(query, :bookings_pending_attendance_confirmation)
+  end
+
+  def schools
+    Bookings::School.where(urn: school_urns)
+  end
+
+  def keyed_total(query, key)
+    query
+      .group('bookings_schools.urn')
+      .count(:id)
+      .reduce(zero_hash(key)) do |hash, (urn, count)|
+        hash.tap { |h| h[urn] = { key => count } }
+      end
+  end
+
+  def zero_hash(key)
+    school_urns.reduce({}) do |hash, urn|
+      hash.tap { |h| h[urn] = Hash.new(0) }
+    end
+  end
+end

--- a/app/models/schools/outstanding_tasks.rb
+++ b/app/models/schools/outstanding_tasks.rb
@@ -14,12 +14,13 @@ class Schools::OutstandingTasks
     ].reduce(&:deep_merge!)
   end
 
-  private
+private
 
   def requests_requiring_attention
     query = schools
       .joins(:placement_requests)
       .merge(Bookings::PlacementRequest.requiring_attention)
+      .merge(Bookings::PlacementRequest.unprocessed)
 
     keyed_total(query, :requests_requiring_attention)
   end
@@ -29,7 +30,7 @@ class Schools::OutstandingTasks
       .joins(:placement_requests)
       .merge(Bookings::PlacementRequest.withdrawn_but_unviewed.reorder(nil))
 
-      keyed_total(query, :unviewed_withdrawn_requests)
+    keyed_total(query, :unviewed_withdrawn_requests)
   end
 
   def upcoming_bookings
@@ -37,7 +38,7 @@ class Schools::OutstandingTasks
       .joins(:bookings)
       .merge(Bookings::Booking.with_unviewed_candidate_cancellation)
 
-      keyed_total(query, :upcoming_bookings)
+    keyed_total(query, :upcoming_bookings)
   end
 
   def bookings_pending_attendance_confirmation
@@ -48,7 +49,7 @@ class Schools::OutstandingTasks
       .merge(Bookings::Booking.accepted)
       .merge(Bookings::Booking.attendance_unlogged)
 
-      keyed_total(query, :bookings_pending_attendance_confirmation)
+    keyed_total(query, :bookings_pending_attendance_confirmation)
   end
 
   def schools
@@ -64,7 +65,7 @@ class Schools::OutstandingTasks
       end
   end
 
-  def zero_hash(key)
+  def zero_hash(_key)
     school_urns.reduce({}) do |hash, urn|
       hash.tap { |h| h[urn] = Hash.new(0) }
     end

--- a/app/views/schools/dashboards/_history_and_support.html.erb
+++ b/app/views/schools/dashboards/_history_and_support.html.erb
@@ -6,7 +6,7 @@
       <ul class="govuk-list">
         <li>
           <%= link_to "Withdrawn requests", schools_withdrawn_requests_path  %>
-          <%= numbered_circle(@withdrawn_requests, id: 'withdrawn-requests-counter', aria_label: 'requests withdrawn by candidate') %>
+          <%= numbered_circle(@outstanding_tasks[:unviewed_withdrawn_requests], id: 'withdrawn-requests-counter', aria_label: 'requests withdrawn by candidate') %>
         </li>
         <li>
           <%= link_to "Rejected requests", schools_rejected_requests_path %>

--- a/app/views/schools/dashboards/_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_requests_and_bookings.html.erb
@@ -7,7 +7,7 @@
       <ul class="govuk-list">
         <li>
           <%= link_to "Manage requests", schools_placement_requests_path %>
-          <%= numbered_circle(@requests_requiring_attention, id: 'new-requests-counter', aria_label: 'new placement requests') %>
+          <%= numbered_circle(@outstanding_tasks[:requests_requiring_attention], id: 'new-requests-counter', aria_label: 'new placement requests') %>
         </li>
       </ul>
     </div>
@@ -21,11 +21,11 @@
       <ul class="govuk-list">
         <li>
           <%= link_to "Manage upcoming bookings", schools_bookings_path  %>
-          <%= numbered_circle(@bookings_requiring_attention, id: 'new-bookings-counter', aria_label: 'new upcoming bookings') %>
+          <%= numbered_circle(@outstanding_tasks[:upcoming_bookings], id: 'new-bookings-counter', aria_label: 'new upcoming bookings') %>
         </li>
         <li>
           <%= link_to "Confirm booking attendance", schools_confirm_attendance_path  %>
-          <%= numbered_circle(@candidate_attendances, id: 'confirm-attendance-counter', aria_label: 'attendances to confirm') %>
+          <%= numbered_circle(@outstanding_tasks[:bookings_pending_attendance_confirmation], id: 'confirm-attendance-counter', aria_label: 'attendances to confirm') %>
           <p class="govuk-hint">Confirm if candidates have attended their school experience</p>
         </li>
       </ul>

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -218,33 +218,6 @@ describe Bookings::PlacementRequest, type: :model do
       it { is_expected.not_to include request_with_school_cancellation }
       it { is_expected.not_to include other_schools_request }
     end
-
-    context '.requiring_attention_including_attendance' do
-      let! :request_with_past_booking_without_attendance do
-        create :placement_request, :booked, school: school do |pr|
-          pr.booking.update_columns date: Date.yesterday
-        end
-      end
-
-      let! :request_with_past_booking_with_attendance do
-        create :placement_request, :booked, school: school do |pr|
-          pr.booking.update_columns \
-            date: Date.yesterday,
-            attended: false
-        end
-      end
-
-      subject { school.placement_requests.requiring_attention_including_attendance }
-
-      it { is_expected.to     include request_pending_decision }
-      it { is_expected.to     include request_with_unviewed_candidate_cancellation }
-      it { is_expected.not_to include request_with_viewed_candidate_cancellation }
-      it { is_expected.not_to include request_with_booking }
-      it { is_expected.not_to include request_with_school_cancellation }
-      it { is_expected.not_to include other_schools_request }
-      it { is_expected.to     include request_with_past_booking_without_attendance }
-      it { is_expected.not_to include request_with_past_booking_with_attendance }
-    end
   end
 
   context '.create_from_registration_session' do

--- a/spec/models/schools/outstanding_tasks_spec.rb
+++ b/spec/models/schools/outstanding_tasks_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+describe Schools::OutstandingTasks do
+  let(:school) { create :bookings_school, :with_subjects }
+  let(:other_school) { create :bookings_school, :with_subjects }
+
+  describe "#summarize" do
+    let(:summary) { described_class.new([school.urn, other_school.urn]).summarize }
+
+    context "requests_requiring_attention" do
+      subject { compact_summary(:requests_requiring_attention) }
+
+      it { is_expected.to eq({ school.urn => 0, other_school.urn => 0 }) }
+
+      context "when there are requests requiring attention" do
+        before do
+          create(:placement_request, school: school)
+          create(:placement_request, :cancelled, school: school)
+        end
+
+        it { is_expected.to eq({ school.urn => 2, other_school.urn => 0 }) }
+
+        context "when there are also requests not requiring attention" do
+          before do
+            create(:placement_request, :booked, school: school)
+          end
+
+          it { is_expected.to eq({ school.urn => 2, other_school.urn => 0 }) }
+        end
+
+        context "when there are also other school requests requiring attention" do
+          before { create(:placement_request, school: other_school) }
+
+          it { is_expected.to eq({ school.urn => 2, other_school.urn => 1 }) }
+        end
+      end
+    end
+
+    context "unviewed_withdrawn_requests" do
+      subject { compact_summary(:unviewed_withdrawn_requests) }
+
+      it { is_expected.to eq({ school.urn => 0, other_school.urn => 0 }) }
+
+      context "when there are unviewed, withdrawn placement requests" do
+        before { create(:placement_request, :cancelled, school: school) }
+
+        it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
+
+        context "when there are also viewed, withdrawn placement requests" do
+          before do
+            create(:placement_request, :cancelled, school: school).tap do |pr|
+              pr.candidate_cancellation.viewed!
+            end
+          end
+
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
+        end
+
+        context "when there are also other schools with unviewed, withdrawn placement requests" do
+          before { create(:placement_request, :cancelled, school: other_school) }
+
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 1 }) }
+        end
+      end
+    end
+
+    context "upcoming_bookings" do
+      subject { compact_summary(:upcoming_bookings) }
+
+      it { is_expected.to eq({ school.urn => 0, other_school.urn => 0 }) }
+
+      context "when there are bookings requiring attention" do
+        before { create(:bookings_booking, :cancelled_by_candidate, bookings_school: school) }
+
+        it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
+
+        context "when there are also bookings not requiring attention" do
+          before do
+            create(:placement_request, :booked, school: school)
+            create(:bookings_booking, :with_viewed_candidate_cancellation, bookings_school: school)
+            create(:bookings_booking, :cancelled_by_school, bookings_school: school)
+          end
+
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
+        end
+
+        context "when there are also other schools with bookings requiring attention" do
+          before { create(:bookings_booking, :cancelled_by_candidate, bookings_school: other_school) }
+
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 1 }) }
+        end
+      end
+    end
+
+    context "bookings_pending_attendance_confirmation" do
+      subject { compact_summary(:bookings_pending_attendance_confirmation) }
+
+      it { is_expected.to eq({ school.urn => 0, other_school.urn => 0 }) }
+
+      context "when there are bookings pending attendance confirmation" do
+        before do
+          create(:placement_request, :booked, school: school) do |pr|
+            pr.booking.update_columns date: Date.yesterday
+          end
+        end
+
+        it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
+
+        context "when there are also bookings not pending attendance confirmation" do
+          before do
+            create(:placement_request, :booked, school: school) do |pr|
+              pr.booking.update_columns date: Date.yesterday, attended: false
+            end
+          end
+
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
+        end
+
+        context "when there are also other schools with bookings pending attendance confirmation" do
+          before do
+            create(:placement_request, :booked, school: other_school) do |pr|
+              pr.booking.update_columns date: Date.yesterday
+            end
+          end
+
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 1 }) }
+        end
+      end
+    end
+  end
+
+  def compact_summary(key)
+    summary.transform_values { |v| v[key] }
+  end
+end

--- a/spec/models/schools/outstanding_tasks_spec.rb
+++ b/spec/models/schools/outstanding_tasks_spec.rb
@@ -15,23 +15,23 @@ describe Schools::OutstandingTasks do
       context "when there are requests requiring attention" do
         before do
           create(:placement_request, school: school)
-          create(:placement_request, :cancelled, school: school)
         end
 
-        it { is_expected.to eq({ school.urn => 2, other_school.urn => 0 }) }
+        it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
 
         context "when there are also requests not requiring attention" do
           before do
             create(:placement_request, :booked, school: school)
+            create(:placement_request, :cancelled, school: school)
           end
 
-          it { is_expected.to eq({ school.urn => 2, other_school.urn => 0 }) }
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 0 }) }
         end
 
         context "when there are also other school requests requiring attention" do
           before { create(:placement_request, school: other_school) }
 
-          it { is_expected.to eq({ school.urn => 2, other_school.urn => 1 }) }
+          it { is_expected.to eq({ school.urn => 1, other_school.urn => 1 }) }
         end
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-433](https://trello.com/c/4nJ2DJiv/433-investigate-bug-with-notification-bubbles-not-adding-up)

### Context

We show outstanding task counts in several places on the dashboard and a running total on the switch school page. At the moment, the running total doesn't always add up to the total displayed on the dashboard, which is confusing to users. We also see a phantom badge appearing over "Manage requests" - when navigating to that section there is no corresponding request to action.

### Changes proposed in this pull request

- Exclude processed requests from those requiring attention

Resolve an issue where a bade was displaying against placement requests but there were no requests in the list when you navigate to it, as they had been cancelled (i.e. processed).


- Add Bookings::OutstandingTasks to easily summarise by school

At the moment we calculate the outstanding tasks for schools in different places, using different methods. This has resulted in the badges on the dashboard not adding up to the total that is displayed on the school switcher page.

Extract the logic from the dashboard and encapsulate in a new class that we can call and use in both scenarios.

The current scope for the school switcher page is more optimal than this solution, but its impossible to try and reconcile the
logic with the dashboard as it is. This will perform individual requests that can then be totalled; I don't imagine the
efficiency difference will be an issue and this will be far easier to maintain and debug.

In my testing I occasionally got badges showing on the dashboard when there were no corresponding bookings/requests on the detail page. I think there is overlap between `requests_requiring_attention` and `unviewed_withdrawn_requests`
at the moment, but that will be addressed in a later PR/commit. For now the aim is to keep it consistent with what the dashboard is displaying.

- Use OutstandingTasks in DashboardController

Replace custom calls to specific scopes with the `OutstandingTasks` asbtraction.

- Update ChangeSchool to use OutstandingTask

By using the `OutstandingTask` model we are bringing it inline with how the dashboard calculates outstanding tasks.

### Guidance to review
