### PR TITLE
Make dates GOV.UK format throughout

### DIFF
--- a/config/initializers/date_format.rb
+++ b/config/initializers/date_format.rb
@@ -1,4 +1,4 @@
 # Standard GOVUK date format, use via `Date.tomorrow.to_formatted_s(:govuk)`
 # https://design-system.service.gov.uk/components/date-input/
-Date::DATE_FORMATS[:govuk] = "%d %B %Y"
+Date::DATE_FORMATS[:govuk] = "%-d %B %Y"
 Date::DATE_FORMATS[:gitis] = "%d/%m/%Y"

--- a/features/schools/attendances/index.feature
+++ b/features/schools/attendances/index.feature
@@ -25,11 +25,11 @@ Feature: Viewing historical attendances
         Given there are some bookings with attendance recorded
         When I am on the 'attendances' page
         Then the 'attendances' table should have the following values:
-			| Heading    | Value             |
-            | Name       | Matthew Richards  |
-            | Subject    | Biology           |
-            | Date       | \d{2}\s\w+\s\d{4} |
-            | Attended   | Did not attend    |
+			| Heading    | Value                |
+            | Name       | Matthew Richards     |
+            | Subject    | Biology              |
+            | Date       | \d{1,2}\s\w+\s\d{4}  |
+            | Attended   | Did not attend       |
 
     Scenario: No attendance records
         Given there are no bookings with attendance recorded

--- a/features/schools/cancelled_bookings/show.feature
+++ b/features/schools/cancelled_bookings/show.feature
@@ -41,7 +41,7 @@ Feature: Viewing a cancelled booking
             | Heading          | Value                                                                  |
             | Subject          | Biology                                                                |
             | DBS certificate  | Yes - Candidate says they have DBS certificate \(not verified by DfE\) |
-            | Request received | \d{2}\s\w+\s\d{4}                                                      |
+            | Request received | \d{1,2}\s\w+\s\d{4}                                                      |
         And the future booking date should be listed
 
     @smoke_test
@@ -67,6 +67,6 @@ Feature: Viewing a cancelled booking
         Given there is a cancelled booking
         When I am viewing my chosen cancelled booking
         Then I should see a 'Cancellation details' section with the following values:
-            | Heading              | Value             |
-            | Cancellation reason  | MyText            |
-            | Cancellation sent at | \d{2}\s\w+\s\d{4} |
+            | Heading              | Value                  |
+            | Cancellation reason  | MyText                 |
+            | Cancellation sent at | \d{1,2}\s\w+\s\d{4}    |

--- a/features/schools/confirmed_bookings/show.feature
+++ b/features/schools/confirmed_bookings/show.feature
@@ -42,7 +42,7 @@ Feature: Viewing a booking
             | Heading          | Value                                                                  |
             | Subject          | Biology                                                                |
             | DBS certificate  | Yes - Candidate says they have DBS certificate \(not verified by DfE\) |
-            | Request received | \d{2}\s\w+\s\d{4}                                                      |
+            | Request received | \d{1,2}\s\w+\s\d{4}                                                      |
         And the future booking date should be listed
 
     @smoke_test
@@ -68,15 +68,15 @@ Feature: Viewing a booking
         Given there is a booking cancelled by the candidate
         When I am viewing my chosen booking
         Then I should see a 'Cancellation details' section with the following values:
-            | Heading              | Value             |
-            | Cancellation reason  | MyText            |
-            | Cancellation sent at | \d{2}\s\w+\s\d{4} |
+            | Heading              | Value              |
+            | Cancellation reason  | MyText             |
+            | Cancellation sent at | \d{1,2}\s\w+\s\d{4}|
 
     @smoke_test
     Scenario: School Cancellation details
         Given there is a booking cancelled by the school
         When I am viewing my chosen booking
         Then I should see a 'Cancellation details' section with the following values:
-            | Heading              | Value             |
-            | Cancellation reason  | MyText            |
-            | Cancellation sent at | \d{2}\s\w+\s\d{4} |
+            | Heading              | Value              |
+            | Cancellation reason  | MyText             |
+            | Cancellation sent at | \d{1,2}\s\w+\s\d{4}|

--- a/features/schools/previous_bookings/show.feature
+++ b/features/schools/previous_bookings/show.feature
@@ -42,7 +42,7 @@ Feature: Viewing a previous booking
             | Heading          | Value                                                                  |
             | Subject          | Biology                                                                |
             | DBS certificate  | Yes - Candidate says they have DBS certificate \(not verified by DfE\) |
-            | Request received | \d{2}\s\w+\s\d{4}                                                      |
+            | Request received | \d{1,2}\s\w+\s\d{4}                                                      |
         And the future booking date should be listed
 
     @smoke_test
@@ -68,6 +68,6 @@ Feature: Viewing a previous booking
         Given there is a cancelled previous booking
         When I am viewing my chosen previous booking
         Then I should see a 'Cancellation details' section with the following values:
-            | Heading              | Value             |
-            | Cancellation reason  | MyText            |
-            | Cancellation sent at | \d{2}\s\w+\s\d{4} |
+            | Heading              | Value               |
+            | Cancellation reason  | MyText              |
+            | Cancellation sent at | \d{1,2}\s\w+\s\d{4} |

--- a/features/step_definitions/candidates/registrations/application_preview_steps.rb
+++ b/features/step_definitions/candidates/registrations/application_preview_steps.rb
@@ -28,7 +28,7 @@ end
 Given("I have filled in my subject and date information successfully") do
   within(
     page
-      .find('dt', text: @wanted_bookings_placement_date.date.strftime("%d %B %Y"))
+      .find('dt', text: @wanted_bookings_placement_date.date.to_formatted_s(:govuk))
       .sibling('dd')
   ) do
     choose("All subjects (1 day)")

--- a/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
+++ b/features/step_definitions/candidates/registrations/subject_and_date_information_steps.rb
@@ -19,7 +19,7 @@ Then("I should see the list of primary placement dates") do
   @primary_dates.each do |pd|
     expect(page).to have_css(
       'label',
-      text: "#{pd.date.strftime('%d %B %Y')} (#{pd.duration} day)"
+      text: "#{pd.date.to_formatted_s(:govuk)} (#{pd.duration} day)"
     )
   end
 end
@@ -35,7 +35,7 @@ end
 
 Then("I should see the list of secondary placement dates") do
   @secondary_dates.each do |sd|
-    expect(page).to have_css('dt', text: sd.date.strftime('%d %B %Y'))
+    expect(page).to have_css('dt', text: sd.date.to_formatted_s(:govuk))
 
     sd.subjects.each do |subject|
       expect(page).to have_css('label', text: subject.name)

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -277,7 +277,7 @@ end
 
 Then("I should see the following list of available dates and subjects:") do |table|
   table.hashes.each do |row|
-    formatted_date = row['Weeks from now'].to_i.weeks.from_now.strftime('%d %B %Y')
+    formatted_date = row['Weeks from now'].to_i.weeks.from_now.to_date.to_formatted_s(:govuk)
 
     list_item = page.find('dt', text: formatted_date).ancestor('.govuk-summary-list__row').find('dd')
 

--- a/features/step_definitions/schools/bookings_steps.rb
+++ b/features/step_definitions/schools/bookings_steps.rb
@@ -1,5 +1,5 @@
 Given("the scheduled booking date is in the future") do
-  @scheduled_booking_date = 1.week.from_now.strftime("%d %B %Y")
+  @scheduled_booking_date = 1.week.from_now.to_formatted_s(:govuk)
 end
 
 Given("there are some bookings") do
@@ -15,7 +15,7 @@ Given("there is a booking cancelled by the candidate") do
     :cancelled_by_candidate,
     bookings_school: @school,
     bookings_subject: @school.subjects.last,
-    date: 1.week.from_now.strftime("%d %B %Y")
+    date: 1.week.from_now.to_formatted_s(:govuk)
 
   @booking_id = @booking.id
 end
@@ -25,7 +25,7 @@ Given("there is a booking cancelled by the school") do
     :cancelled_by_school,
     bookings_school: @school,
     bookings_subject: @school.subjects.last,
-    date: 1.week.from_now.strftime("%d %B %Y")
+    date: 1.week.from_now.to_formatted_s(:govuk)
 
   @booking_id = @booking.id
 end
@@ -43,7 +43,7 @@ And("there is/are {int} booking/bookings") do |count|
       :with_existing_subject,
       :accepted,
       bookings_school: @school,
-      date: index.week.from_now.strftime("%d %B %Y")
+      date: index.week.from_now.to_formatted_s(:govuk)
     )
   end
   @booking = @bookings.first

--- a/features/step_definitions/schools/confirm_attendance_steps.rb
+++ b/features/step_definitions/schools/confirm_attendance_steps.rb
@@ -18,7 +18,7 @@ Then("the correct data should be present in each row") do
 
   within("table > tbody > tr[data-booking-id='#{@first_booking.id}']") do
     expect(page).to have_content(contact.full_name)
-    expect(page).to have_content(@first_booking.date.strftime('%d %B %Y'))
+    expect(page).to have_content(@first_booking.date.to_formatted_s(:govuk))
     expect(page).to have_content(@first_booking.bookings_subject.name)
   end
 end

--- a/features/step_definitions/schools/placement_dates/edit_steps.rb
+++ b/features/step_definitions/schools/placement_dates/edit_steps.rb
@@ -35,5 +35,5 @@ Then("my placement should have been {string}") do |operation|
 end
 
 Then("the current start date should be present") do
-  expect(page).to have_css('.placement-start-date', text: @placement_date.date.strftime('%d %B %Y'))
+  expect(page).to have_css('.placement-start-date', text: @placement_date.date.to_formatted_s(:govuk))
 end

--- a/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
+++ b/features/step_definitions/schools/placement_requests/confirm_booking_steps.rb
@@ -60,7 +60,7 @@ Then("the original date should be listed on the page") do
   # this makes sense so the user can refer back to it if they've made changes
   expect(page).to have_css(
     'dd.availability-requested-date',
-    text: @placement_date.date.strftime("%d %B %Y")
+    text: @placement_date.date.to_formatted_s(:govuk)
   )
 end
 

--- a/features/step_definitions/schools/previous_bookings_steps.rb
+++ b/features/step_definitions/schools/previous_bookings_steps.rb
@@ -49,7 +49,7 @@ When("I am viewing my chosen previous booking") do
 end
 
 Given("the scheduled booking date is in the past") do
-  @scheduled_booking_date = 1.week.ago.strftime("%d %B %Y")
+  @scheduled_booking_date = 1.week.ago.to_formatted_s(:govuk)
 end
 
 Given("there is a cancelled previous booking") do

--- a/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
+++ b/spec/controllers/schools/confirmed_bookings/date_controller_spec.rb
@@ -102,7 +102,7 @@ describe Schools::ConfirmedBookings::DateController, type: :request do
           booking.candidate_name,
           booking,
           candidates_cancel_url(booking.token),
-          old_date.strftime("%d %B %Y")
+          old_date.to_formatted_s(:govuk)
         )
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-458](https://trello.com/c/CUa33w7D/458-remove-the-leading-zero-in-gse-dates)

### Context

In a lot of areas at the moment we use the `%d %B %Y` date format, however GOV.UK recommend omitting the leading 0 for dates such as these.

Update all references to use the `%-d %B %Y` format.

### Changes proposed in this pull request

- Make dates GOV.UK format throughout

### Guidance to review

