### PR TITLE
Add secondary subject to the CSV export

### DIFF
--- a/app/models/schools/csv_export.rb
+++ b/app/models/schools/csv_export.rb
@@ -6,15 +6,16 @@ module Schools
     MAX_IDS_IN_CRM_REQ = 50
     BATCH_SIZE = 300
 
-    HEADER = %w[
-      Id
-      Name
-      Email
-      Date
-      Duration
-      Subject
-      Status
-      Attendance
+    HEADER = [
+      "Id",
+      "Name",
+      "Email",
+      "Date",
+      "Duration",
+      "Subject",
+      "Second Subject",
+      "Status",
+      "Attendance"
     ].freeze
 
     attr_reader :school

--- a/app/models/schools/csv_export_row.rb
+++ b/app/models/schools/csv_export_row.rb
@@ -17,6 +17,7 @@ module Schools
         date,
         duration,
         subject,
+        second_subject,
         status,
         attendance
       ]
@@ -46,6 +47,10 @@ module Schools
       else
         request.subject&.name || request.subject_first_choice
       end
+    end
+
+    def second_subject
+      request.subject_second_choice
     end
 
     def attendance

--- a/spec/models/schools/csv_export_row_spec.rb
+++ b/spec/models/schools/csv_export_row_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Schools::CsvExportRow do
         it { is_expected.to include "Date" => pr.placement_date.date.to_formatted_s(:govuk) }
         it { is_expected.to include "Duration" => pr.placement_date.duration }
         it { is_expected.to include "Subject" => pr.subject_first_choice }
+        it { is_expected.to include "Second Subject" => pr.subject_second_choice }
         it { is_expected.to include "Status" => "New" }
         it { is_expected.to include "Attendance" => nil }
 
@@ -46,6 +47,7 @@ RSpec.describe Schools::CsvExportRow do
         it { is_expected.to include "Date" => nil }
         it { is_expected.to include "Duration" => nil }
         it { is_expected.to include "Subject" => pr.subject_first_choice }
+        it { is_expected.to include "Second Subject" => pr.subject_second_choice }
         it { is_expected.to include "Status" => "New" }
         it { is_expected.to include "Attendance" => nil }
       end
@@ -60,6 +62,7 @@ RSpec.describe Schools::CsvExportRow do
       it { is_expected.to include "Date" => pr.booking.date.to_formatted_s(:govuk) }
       it { is_expected.to include "Duration" => pr.booking.duration }
       it { is_expected.to include "Subject" => pr.booking.bookings_subject.name }
+      it { is_expected.to include "Second Subject" => pr.subject_second_choice }
       it { is_expected.to include "Status" => "Booked" }
       it { is_expected.to include "Attendance" => nil }
 

--- a/spec/models/schools/csv_export_spec.rb
+++ b/spec/models/schools/csv_export_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Schools::CsvExport do
 
       it "should contain a header row" do
         is_expected.to eql \
-          %w[Id Name Email Date Duration Subject Status Attendance]
+          ["Id", "Name", "Email", "Date", "Duration", "Subject", "Second Subject", "Status", "Attendance"]
       end
     end
 


### PR DESCRIPTION
### Trello card

[Trello-450](https://trello.com/c/igQuecRO/450-add-second-subject-to-csv-export-function)

### Context

As part of the request process, candidates can select 2 subject preferences. We only have one of these as a field int he CSV export, we should add this as a parameter on the CSV export to be helpful for some schools.

### Changes proposed in this pull request

- Add secondary subject to the CSV export

### Guidance to review

It looks like for the primary subject the `Booking` subject takes precedence over the `PlacementRequest`, however we only have the `PlacementRequest` as a reference to the secondary subject so we just directly retrieve it from there.
