### PR TITLE
Update the content in the dashboard profile and preview pages

### DIFF
--- a/app/presenters/schools/on_boarding/preview_presenter.rb
+++ b/app/presenters/schools/on_boarding/preview_presenter.rb
@@ -14,6 +14,14 @@ module Schools
         end
       end
 
+      def warning
+        if school.private_beta?
+          "To save your changes, go back and select 'Publish changes'."
+        else
+          "To set up your profile, go back and select 'Accept and set up profile'."
+        end
+      end
+
     private
 
       def candidate_school_presenter

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -258,6 +258,22 @@ module Schools
         @school_profile.flexible_dates?
       end
 
+      def page_heading
+        if @school.private_beta?
+          'School profile'
+        else
+          'Check your answers before setting up your profile'
+        end
+      end
+
+      def publish_warning
+        if @school.private_beta?
+          "To save your changes, select 'Publish changes' at the bottom of the page."
+        else
+          "To set up your profile, select the checkbox at the bottom of the page and select 'Accept and set up profile'."
+        end
+      end
+
     private
 
       def candidate_requirements

--- a/app/views/schools/on_boarding/previews/show.html.erb
+++ b/app/views/schools/on_boarding/previews/show.html.erb
@@ -9,14 +9,14 @@
 %>
 
 <h1 class="govuk-heading-l govuk-!-margin-top-4">
-  Preview your school experience profile
+  School profile preview
 </h1>
 
 <div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-    Any changes are not yet published. To publish your changes, go back and press 'Accept and set up profile'
+    <%= @presenter.warning %>
   </strong>
 </div>
 

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -10,14 +10,14 @@
 <div class="govuk-grid-row" id="school-onboarding-profile">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      Check your answers before setting up your school experience profile
+      <%= @profile.page_heading %>
     </h1>
 
     <div class="govuk-warning-text">
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive">Warning</span>
-        Any changes are not yet published. To publish changes, press 'Accept and set up profile' at the bottom of the page.
+        <%= @profile.publish_warning %>
       </strong>
     </div>
 

--- a/spec/presenters/schools/on_boarding/preview_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/preview_presenter_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe Schools::OnBoarding::PreviewPresenter do
+  subject { described_class.new profile }
+
+  let! :school do
+    FactoryBot.create :bookings_school, :full_address, urn: 123_456
+  end
+
+  context '#warning' do
+    let :profile do
+      FactoryBot.create :school_profile, bookings_school: school
+    end
+
+    context 'when school is onboarded' do
+      let(:school) do
+        FactoryBot.create :bookings_school, :onboarded, :full_address, urn: 123_456
+      end
+
+      it 'returns publich warning' do
+        expect(subject.warning).to eq "To save your changes, go back and select 'Publish changes'."
+      end
+    end
+
+    context 'when school is not onboarded' do
+      it 'returns profile set up warning' do
+        expect(subject.warning).to eq "To set up your profile, go back and select 'Accept and set up profile'."
+      end
+    end
+  end
+end

--- a/spec/presenters/schools/on_boarding/preview_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/preview_presenter_spec.rb
@@ -4,20 +4,20 @@ describe Schools::OnBoarding::PreviewPresenter do
   subject { described_class.new profile }
 
   let! :school do
-    FactoryBot.create :bookings_school, :full_address, urn: 123_456
+    create :bookings_school, :full_address, urn: 123_456
   end
 
   context '#warning' do
     let :profile do
-      FactoryBot.create :school_profile, bookings_school: school
+      create :school_profile, bookings_school: school
     end
 
     context 'when school is onboarded' do
       let(:school) do
-        FactoryBot.create :bookings_school, :onboarded, :full_address, urn: 123_456
+        create :bookings_school, :onboarded, :full_address, urn: 123_456
       end
 
-      it 'returns publich warning' do
+      it 'returns publish warning' do
         expect(subject.warning).to eq "To save your changes, go back and select 'Publish changes'."
       end
     end

--- a/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
@@ -417,4 +417,48 @@ describe Schools::OnBoarding::SchoolProfilePresenter do
       expect(subject.admin_contact_phone).to eq '+441234567890'
     end
   end
+
+  context '#page_heading' do
+    let :profile do
+      FactoryBot.create :school_profile, bookings_school: school
+    end
+
+    context 'when school is onboarded' do
+      let(:school) do
+        FactoryBot.create :bookings_school, :onboarded, :full_address, urn: 123_456
+      end
+
+      it 'returns School profile' do
+        expect(subject.page_heading).to eq 'School profile'
+      end
+    end
+
+    context 'when school is not onboarded' do
+      it 'returns School profile' do
+        expect(subject.page_heading).to eq 'Check your answers before setting up your profile'
+      end
+    end
+  end
+
+  context '#publish_warning' do
+    let :profile do
+      FactoryBot.create :school_profile, bookings_school: school
+    end
+
+    context 'when school is onboarded' do
+      let(:school) do
+        FactoryBot.create :bookings_school, :onboarded, :full_address, urn: 123_456
+      end
+
+      it 'returns School profile' do
+        expect(subject.publish_warning).to eq "To save your changes, select 'Publish changes' at the bottom of the page."
+      end
+    end
+
+    context 'when school is not onboarded' do
+      it 'returns School profile' do
+        expect(subject.publish_warning).to eq "To set up your profile, select the checkbox at the bottom of the page and select 'Accept and set up profile'."
+      end
+    end
+  end
 end

--- a/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
+++ b/spec/presenters/schools/on_boarding/school_profile_presenter_spec.rb
@@ -428,13 +428,13 @@ describe Schools::OnBoarding::SchoolProfilePresenter do
         FactoryBot.create :bookings_school, :onboarded, :full_address, urn: 123_456
       end
 
-      it 'returns School profile' do
+      it 'returns "School profile"' do
         expect(subject.page_heading).to eq 'School profile'
       end
     end
 
     context 'when school is not onboarded' do
-      it 'returns School profile' do
+      it 'returns "Check your answers"' do
         expect(subject.page_heading).to eq 'Check your answers before setting up your profile'
       end
     end
@@ -450,13 +450,13 @@ describe Schools::OnBoarding::SchoolProfilePresenter do
         FactoryBot.create :bookings_school, :onboarded, :full_address, urn: 123_456
       end
 
-      it 'returns School profile' do
+      it 'returns "Publish changes"' do
         expect(subject.publish_warning).to eq "To save your changes, select 'Publish changes' at the bottom of the page."
       end
     end
 
     context 'when school is not onboarded' do
-      it 'returns School profile' do
+      it 'returns "Accept and set up profile"' do
         expect(subject.publish_warning).to eq "To set up your profile, select the checkbox at the bottom of the page and select 'Accept and set up profile'."
       end
     end


### PR DESCRIPTION
### Trello card
https://trello.com/c/9yokR1Ac

### Context
The content on review and preview profile pages currently only makes sense in the context of the onboarding journey. It needs to display different content when a school is simply updating their profile.

### Changes proposed in this pull request
- Update the content
- Use the SchoolProfile and Preview presenters to deal with the conditional logic

### Guidance to review

