### PR TITLE
Remove accordion GA event

### DIFF
--- a/app/webpacker/analytics/log_accordion_toggle.js
+++ b/app/webpacker/analytics/log_accordion_toggle.js
@@ -1,7 +1,0 @@
-import { sendGAEvent } from 'analytics/send_ga_event';
-
-const logAccordionToggle = (name, section, state) => {
-  sendGAEvent(name, section, state);
-};
-
-export { logAccordionToggle };

--- a/app/webpacker/analytics/send_ga_event.js
+++ b/app/webpacker/analytics/send_ga_event.js
@@ -1,7 +1,0 @@
-const sendGAEvent = (action, label, value) => {
-    if (window.ga) {
-        window.ga('send', 'event', action, label, value);
-    };
-};
-
-export { sendGAEvent };

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -3,54 +3,14 @@ require.context('../images', true);
 
 import "../stylesheets/application.scss";
 
-import { initAll, Accordion } from "govuk-frontend";
+import { initAll } from "govuk-frontend";
 initAll();
 
 import "@stimulus/polyfills";
 import "custom-event-polyfill";
 import { Application } from "stimulus";
 import { definitionsFromContext } from "stimulus/webpack-helpers";
-import { logAccordionToggle } from 'analytics/log_accordion_toggle';
-
-// Various top level code sets analytics so add global helper
-import { CookiePreferences } from 'cookie_preferences' ;
-global.cookie_allowed = CookiePreferences.allowed ;
 
 const application = Application.start();
 const context = require.context("controllers", true, /.js$/);
 application.load(definitionsFromContext(context));
-
-Accordion.prototype.originalSetExpanded = Accordion.prototype.setExpanded;
-Accordion.prototype.setExpanded = function (expanded, $section) {
-  // the name of the accordion as it will be categorised in GA
-  const eventName = this.$module.attributes.id;
-
-  // the button inserted by the accordion plugin that replaces the
-  // provided span and takes its descriptive ID
-  const sectionName = $section.querySelector('.govuk-accordion__section-content').id;
-
-  if (eventName && sectionName) {
-    const accordionExpanded = new CustomEvent('accordionToggle', {
-      bubbles: true,
-      detail: {
-        name: eventName.value,
-        section: sectionName,
-        expanded: expanded
-      }
-    });
-
-    $section.dispatchEvent(accordionExpanded);
-  }
-
-  this.originalSetExpanded(expanded, $section);
-};
-
-// attach the listener to the outer accordion to catch messages bubbling
-// up from its segments
-if (CookiePreferences.allowed('analytics')) {
-  document.querySelectorAll('.govuk-accordion').forEach((accordion) => {
-    accordion.addEventListener('accordionToggle', (e) => {
-      logAccordionToggle(e.detail.name, e.detail.section, e.detail.expanded ? 'open' : 'closed');
-    });
-  });
-}


### PR DESCRIPTION
### Trello card

[Trello-487](https://trello.com/c/X8EQIm8R/487-dev-add-gtm-tracking-capability-to-the-website-and-also-update-the-cookies-preference-and-policy-page-to-inform-users-that-gtm-i)

### Context

We don't appear to use this event and to avoid migrating it to the new GTM container I'm pulling it out.

### Changes proposed in this pull request

- Remove accordion GA event

### Guidance to review

Also removes globally set `cookie_allowed` variable which doesn't appear to be referenced.

These are the only two pages that appear to have accordions on them:

https://review-school-experience-2242.london.cloudapps.digital/dfe_signin_help
https://review-school-experience-2242.london.cloudapps.digital/help_and_support_access_needs