### PR TITLE
Extend school search

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -12,6 +12,8 @@ class Candidates::SchoolsController < ApplicationController
 
     return render 'candidates/school_searches/new' unless @search.valid?
 
+    @other_region = @search.other_region
+
     if @search.results.empty? && !@search.whitelisted_urns?
       @expanded_search_radius = true
       @search = Candidates::SchoolSearch.new(search_params.merge(distance: EXPANDED_SEARCH_RADIUS))

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -141,7 +141,7 @@ private
     )&.first
 
     if empty_geocoder_result?(result)
-      Rails.logger.info("No Geocoder results found in #{REGION} for #{formatted_request} (user entered: #{location})")
+      Rails.logger.info("No Geocoder results found for #{formatted_request} (user entered: #{location})")
       return
     end
 

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -1,13 +1,14 @@
 require 'geocoding_request'
 
 class Bookings::SchoolSearch < ApplicationRecord
-  attr_reader :location_name
+  attr_reader :location_name, :other_region
 
   validates :location, length: { minimum: 2 }, allow_nil: false, if: -> { location.is_a?(String) }
 
   # Despite this being an England-only service, we want to search the whole of the UK
   # so that we can return results to users who are near the border.
   REGION = 'United Kingdom'.freeze
+  OTHER_UK_REGIONS = ['Northern Ireland', 'Scotland', 'Wales'].freeze
   GEOCODER_PARAMS = { maxRes: 1 }.freeze
   PER_PAGE = 15
 
@@ -149,10 +150,18 @@ private
 
     # this better work
     @location_name = result.try(:name) || result.address_components.first.fetch('long_name', location)
+
+    @other_region = find_other_regions(result)
+
     extract_coords(
       latitude: result.latitude,
       longitude: result.longitude
     )
+  end
+
+  def find_other_regions(result)
+    address_components = result.address_components.map(&:values).flatten
+    OTHER_UK_REGIONS.find { |region| address_components.include?(region) }
   end
 
   def empty_geocoder_result?(result)

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -5,7 +5,9 @@ class Bookings::SchoolSearch < ApplicationRecord
 
   validates :location, length: { minimum: 2 }, allow_nil: false, if: -> { location.is_a?(String) }
 
-  REGION = 'England'.freeze
+  # Despite this being an England-only service, we want to search the whole of the UK
+  # so that we can return results to users who are near the border.
+  REGION = 'United Kingdom'.freeze
   GEOCODER_PARAMS = { maxRes: 1 }.freeze
   PER_PAGE = 15
 

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -23,7 +23,7 @@ module Candidates
                   :longitude, :page, :parking
     attr_reader :distance, :max_fee
 
-    delegate :location_name, :has_coordinates?, :valid?, :errors, to: :school_search
+    delegate :location_name, :other_region, :has_coordinates?, :valid?, :errors, to: :school_search
     delegate :whitelisted_urns, :whitelisted_urns?, to: Bookings::SchoolSearch
 
     class << self

--- a/app/views/candidates/schools/_england_only_service.html.erb
+++ b/app/views/candidates/schools/_england_only_service.html.erb
@@ -1,0 +1,17 @@
+<h2 class="govuk-heading-m">
+  This service is for schools in England
+</h2>
+
+<% case @other_region when "Scotland" %>
+  <p class="govuk-body">
+    <%= link_to 'Learn more about teacher training in Scotland', 'https://teachinscotland.scot/' %>
+  </p>
+<% when "Wales" %>
+  <p class="govuk-body">
+    <%= link_to 'Learn more about teacher training in Wales', 'https://educators.wales/teachers' %>
+  </p>
+<% when "Northern Ireland" %>
+  <p class="govuk-body">
+    <%= link_to 'Learn more about teacher training in Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland' %>
+  </p>
+<% end %>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -87,11 +87,13 @@
       <%= paginate @search.results %>
     </div>
 
-    <hr/>
+    <% if @search.results.size > 1 %>
+      <hr/>
 
-    <p>Sorted by distance</p>
+      <p>Sorted by distance</p>
 
-    <hr/>
+      <hr/>
+    <% end %>
 
     <ul id="results">
       <%= render 'expanded_search', search: @search if @expanded_search_radius %>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -89,14 +89,17 @@
 
     <% if @search.results.size > 1 %>
       <hr/>
-
       <p>Sorted by distance</p>
-
       <hr/>
     <% end %>
 
+
     <ul id="results">
-      <%= render 'expanded_search', search: @search if @expanded_search_radius %>
+      <% if @expanded_search_radius && @other_region.present? && @search.results.none? %>
+        <%= render 'england_only_service' %>
+      <% elsif @expanded_search_radius %>
+        <%= render 'expanded_search', search: @search %>
+      <% end %>
 
       <% @search.results.each_with_index do |school, _| %>
         <li data-school-urn="<%= school.urn %>">

--- a/features/candidates/schools/search/results/no_results.feature
+++ b/features/candidates/schools/search/results/no_results.feature
@@ -8,3 +8,9 @@ Feature: Schools search page contents
         When I search for schools within 5 miles
         Then the results page should include a warning that no results were found
         And there should be a link to Get into teaching
+
+    Scenario: No results in expanded area and search outside England
+        Given there are no schools in or around my search location
+        And my search is outside of England
+        When I search for schools within 5 miles
+        Then there should be a message and link to get more information about teacher training

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -115,7 +115,12 @@ Then("the location input should be populated with {string}") do |string|
 end
 
 Given("there are no schools near my search location") do
-  # do nothing, my location is Bury, Greater Manchester
+  # Do nothing
+end
+
+Given("my search is outside of England") do
+  geocoder_result = [Geocoder::Result::Test.new('latitude' => 53.596, 'longitude' => -2.29, 'name' => 'Cardiff, UK', "address_components" => ["long_name" => "Wales"])]
+  allow(Geocoder).to receive(:search).and_return(geocoder_result)
 end
 
 Given("there are some schools just outside it") do
@@ -156,4 +161,9 @@ Then("there should be a link to Get into teaching") do
   within('#results li.expanded-search-radius') do
     expect(page).to have_link("Get into teaching", href: 'https://getintoteaching.education.gov.uk/get-school-experience')
   end
+end
+
+Then("there should be a message and link to get more information about teacher training") do
+  expect(page).to have_css('h2', text: 'This service is for schools in England')
+  expect(page).to have_link("Learn more about teacher training in Wales", href: 'https://educators.wales/teachers')
 end

--- a/lib/servertest/geocoder.rb
+++ b/lib/servertest/geocoder.rb
@@ -1,6 +1,6 @@
 module Geocoder
   def self.search(*_args)
     # A point in Bury, Greater Manchester
-    [Geocoder::Result::Test.new('latitude' => 53.596, 'longitude' => -2.29, 'name' => 'Manchester, UK')]
+    [Geocoder::Result::Test.new('latitude' => 53.596, 'longitude' => -2.29, 'name' => 'Manchester, UK', "address_components" => ["long_name" => "England"])]
   end
 end

--- a/spec/helpers/candidates/results_helper_spec.rb
+++ b/spec/helpers/candidates/results_helper_spec.rb
@@ -5,8 +5,8 @@ describe Candidates::ResultsHelper, type: :helper do
 
   let(:geocoder_manchester_search_result) do
     [
-      Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK'),
-      Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229, name: 'Manchester, UK')
+      Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK', address_components: [long_name: "England"]),
+      Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229, name: 'Manchester, UK', address_components: [long_name: "England"])
     ]
   end
   let(:search) { Candidates::SchoolSearch.new(location: 'Manchester') }

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -33,19 +33,19 @@ describe Bookings::SchoolSearch do
       end
     end
 
-    context 'Limiting to England' do
-      specify 'region should be England' do
-        expect(described_class::REGION).to eql('England')
+    context 'Limiting to United Kingdom' do
+      specify 'region should be United Kingdom' do
+        expect(described_class::REGION).to eql('United Kingdom')
       end
 
-      context "when a result with name 'England' is returned" do
+      context "when a result with name 'United Kingdom' is returned" do
         before do
           allow(Geocoder).to receive(:search).and_return(
             [
               Geocoder::Result::Test.new(
                 "latitude" => 53.488,
                 "longitude" => -2.242,
-                name: 'England'
+                name: 'United Kingdom'
               )
             ]
           )
@@ -55,11 +55,11 @@ describe Bookings::SchoolSearch do
 
         specify "should append the region to the Geocoder query" do
           expect(Geocoder).to receive(:search)
-            .with('Mumbai, England', params: described_class::GEOCODER_PARAMS)
+            .with('Mumbai, United Kingdom', params: described_class::GEOCODER_PARAMS)
         end
 
         specify 'should return an empty result' do
-          expect(Rails.logger).to receive(:info).with("No Geocoder results found in England for Mumbai, England (user entered: Mumbai)")
+          expect(Rails.logger).to receive(:info).with("No Geocoder results found in United Kingdom for Mumbai, United Kingdom (user entered: Mumbai)")
         end
       end
     end

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -59,7 +59,7 @@ describe Bookings::SchoolSearch do
         end
 
         specify 'should return an empty result' do
-          expect(Rails.logger).to receive(:info).with("No Geocoder results found in United Kingdom for Mumbai, United Kingdom (user entered: Mumbai)")
+          expect(Rails.logger).to receive(:info).with("No Geocoder results found for Mumbai, United Kingdom (user entered: Mumbai)")
         end
       end
     end

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -9,8 +9,8 @@ describe Bookings::SchoolSearch do
 
   let(:geocoder_manchester_search_result) do
     [
-      Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK'),
-      Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229, name: 'Manchester, UK')
+      Geocoder::Result::Test.new("latitude" => 53.488, "longitude" => -2.242, name: 'Manchester, UK', address_components: [long_name: "England"]),
+      Geocoder::Result::Test.new("latitude" => 53.476, "longitude" => -2.229, name: 'Manchester, UK', address_components: [long_name: "England"])
     ]
   end
 
@@ -45,7 +45,8 @@ describe Bookings::SchoolSearch do
               Geocoder::Result::Test.new(
                 "latitude" => 53.488,
                 "longitude" => -2.242,
-                name: 'United Kingdom'
+                name: 'United Kingdom',
+                "address_components" => ["long_name" => "England"]
               )
             ]
           )
@@ -501,6 +502,50 @@ describe Bookings::SchoolSearch do
           expect(subject.max_fee).to eql(max_fee)
           expect(subject.location).to eql(location)
         end
+      end
+    end
+  end
+
+  describe "#other_region" do
+    subject { Bookings::SchoolSearch.new(location: "Test") }
+
+    let(:scotland_search_result) do
+      [
+        Geocoder::Result::Test.new("address_components" => [{ "long_name" => "Scotland", "short_name" => "Scotland", "types" => %w[administrative_area_level_1 political] }], "latitude" => 53.488, "longitude" => -2.242)
+      ]
+    end
+    let(:wales_search_result) do
+      [
+        Geocoder::Result::Test.new("address_components" => [{ "long_name" => "Wales", "short_name" => "Wales", "types" => %w[administrative_area_level_1 political] }], "latitude" => 53.488, "longitude" => -2.242)
+      ]
+    end
+    let(:northern_ireland_search_result) do
+      [
+        Geocoder::Result::Test.new("address_components" => [{ "long_name" => "Northern Ireland", "short_name" => "Northern Ireland", "types" => %w[administrative_area_level_1 political] }], "latitude" => 53.488, "longitude" => -2.242)
+      ]
+    end
+
+    context "when search result includes Scotland" do
+      before { allow(Geocoder).to receive(:search).and_return(scotland_search_result) }
+
+      it "returns Scotland" do
+        expect(subject.other_region).to eq "Scotland"
+      end
+    end
+
+    context "when search result includes Wales" do
+      before { allow(Geocoder).to receive(:search).and_return(wales_search_result) }
+
+      it "returns Scotland" do
+        expect(subject.other_region).to eq "Wales"
+      end
+    end
+
+    context "when search result includes Northern Ireland" do
+      before { allow(Geocoder).to receive(:search).and_return(northern_ireland_search_result) }
+
+      it "returns Scotland" do
+        expect(subject.other_region).to eq "Northern Ireland"
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,7 @@ RSpec.configure do |config|
   # Prevent unintended API access from Geocoder
   config.before :each do
     allow(Geocoder).to receive(:search).and_return([
-      Geocoder::Result::Test.new(name: 'Bury', latitude: 53.4794892, longitude: -2.2451148)
+      Geocoder::Result::Test.new(name: 'Bury', latitude: 53.4794892, longitude: -2.2451148, address_components: [long_name: "England"])
     ])
 
     # Clean up memoized subjects so they can be mocked per test

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
   context "sorted by distance tag" do
     before do
       @search = Candidates::SchoolSearch.new
+      @facet_tags = FacetTagsPresenter.new(@search.applied_filters)
       allow(@search).to receive(:results).and_return(Kaminari.paginate_array(schools).page(1))
 
       render
@@ -129,6 +130,51 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
 
       it "shows when more than one result" do
         expect(rendered).to_not have_css 'p', text: 'Sorted by distance'
+      end
+    end
+  end
+
+  context "when no results and expanded search" do
+    shared_examples "a non-England search" do
+      before do
+        @search = Candidates::SchoolSearch.new
+        @facet_tags = FacetTagsPresenter.new(@search.applied_filters)
+
+        assign(:other_region, region)
+        assign(:expanded_search_radius, true)
+
+        render
+      end
+
+      it "show a message and link to get more information about teacher training" do
+        expect(rendered).to have_css('h2', text: 'This service is for schools in England')
+        expect(rendered).to have_link(link_text, href: href)
+      end
+    end
+
+    context "when other region search" do
+      context "when search result is Wales" do
+        let(:region) { "Wales" }
+        let(:link_text) { 'Learn more about teacher training in Wales' }
+        let(:href) { 'https://educators.wales/teachers' }
+
+        it_behaves_like "a non-England search"
+      end
+
+      context "when search result is Scotland" do
+        let(:region) { "Scotland" }
+        let(:link_text) { 'Learn more about teacher training in Scotland' }
+        let(:href) { 'https://teachinscotland.scot/' }
+
+        it_behaves_like "a non-England search"
+      end
+
+      context "when search result is Northern Ireland" do
+        let(:region) { "Northern Ireland" }
+        let(:link_text) { 'Learn more about teacher training in Northern Ireland' }
+        let(:href) { 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland' }
+
+        it_behaves_like "a non-England search"
       end
     end
   end

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -107,4 +107,29 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
       end
     end
   end
+
+  context "sorted by distance tag" do
+    before do
+      @search = Candidates::SchoolSearch.new
+      allow(@search).to receive(:results).and_return(Kaminari.paginate_array(schools).page(1))
+
+      render
+    end
+
+    context "when more than one result is returned" do
+      let(:schools) { [build(:bookings_school), build(:bookings_school)] }
+
+      it "shows when more than one result" do
+        expect(rendered).to have_css 'p', text: 'Sorted by distance'
+      end
+    end
+
+    context "when less than two results are returned" do
+      let(:schools) { [build(:bookings_school)] }
+
+      it "shows when more than one result" do
+        expect(rendered).to_not have_css 'p', text: 'Sorted by distance'
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/T7AwPYtZ

### Changes proposed in this pull request
1. Use United Kingdom as the search region instead of England: The search region is currently set to England because School Experience is an England-only service. However, when somebody search for a non-England area/address (e.g., Edinburgh), we receive a null result (because 'Edinburgh, England' can't be interpreted by Google Geocoding) and don't log out region and district. Additionally, if they are close to the border and within their chosen radius of any events, the null result means that we won't show these to the user. Update the region to United Kingdom so that we no longer get null results.
2. Update the logger message so it makes more sense.
3. Only show "Sorted by distance" when there are two or more results: It doesn't make sense to show this unless there are multiple results, and it makes the search look messy.
4. Show targeted messages when no results from searches outside England: We want to show a message telling users that this is an England-only service, along with a link to a country specific teacher training resource. Check the address component of the Geocoding result to see if the search was in Northern Ireland, Scotland, or Wales, and display the link and message if there are no results (there could be some results if the search is near to the border).

### Guidance to review
Some searches to try in the review app:
1. Tenby 👈 Wales message
2. Edinburgh 👈 Scotland message
3. Belfast 👈 Northern Ireland message
4. Cardiff 👈  Unchanged because it's within 50 miles of a school, and it was not returning a null result despite not being in England.
4. Denbighshire 👈  Compare to staging. This returns a null result when `Denbighshire, England` (staging), but correct result when `Denbighshire, United Kingdom` (this review app). It is within 50 miles of a school, so we see some results where previously we wouldn't.

Note: It seems that Google is able to interpret most of our searches anyway. It returns the correct location for `Cardiff, England`, `Dumfries, England`, `LL114UA, England`, `Maes Carafanau Llanbenwch Caravan Park, England` etc. The exceptions seem to be `Edinburgh, England`, and `Denbighshire, England` which it doesn't like.