### PR TITLE
Send page view to GTM on search

### DIFF
--- a/app/webpacker/controllers/search_controller.js
+++ b/app/webpacker/controllers/search_controller.js
@@ -63,6 +63,8 @@ export default class extends Controller {
     this.executeSearch(url)
 
     history.replaceState({}, document.title, url)
+
+    this.sendPageView(url)
   }
 
   executeSearch(url) {
@@ -83,6 +85,13 @@ export default class extends Controller {
 
         this.loadingTarget.classList.remove('active')
       })
+  }
+
+  sendPageView(url) {
+    if (window.gtag) {
+      window.gtag('set', 'page_path', url);
+      window.gtag('event', 'page_view');
+    }
   }
 
   updateInterface() {

--- a/spec/javascript/controllers/search_controller_spec.js
+++ b/spec/javascript/controllers/search_controller_spec.js
@@ -35,6 +35,10 @@ describe('SearchController', () => {
     global.history.replaceState = jest.fn()
   }
 
+  const mockGtag = () => {
+    window.gtag = jest.fn();
+  };
+
   const setBody = () => {
     document.body.innerHTML = `
       <div data-controller="search" data-search-results-id-value="search-results" data-search-form-id-value="form">
@@ -87,6 +91,7 @@ describe('SearchController', () => {
       mockFetch()
       mockHistory()
       setBody()
+      mockGtag()
     })
 
     it('hides the search button', () => {
@@ -126,6 +131,11 @@ describe('SearchController', () => {
 
       it('updates the page history', () => {
         expect(history.replaceState).toHaveBeenCalledWith({}, document.title, '/path?checkbox1=1&checkbox2=2&checkbox3=3')
+      })
+
+      it('sends a page view to gtag', () => {
+        expect(window.gtag).toHaveBeenCalledWith('set', 'page_path', '/path?checkbox1=1&checkbox2=2&checkbox3=3');
+        expect(window.gtag).toHaveBeenCalledWith('event', 'page_view');
       })
     })
 


### PR DESCRIPTION
As the search no longer reloads the page we are not registering the change as a page view in GTM.

Send a page view event to GTM when the search is executed.