### PR TITLE
Pre-check all subjects for new placement dates

### DIFF
--- a/app/controllers/schools/placement_dates/subject_selections_controller.rb
+++ b/app/controllers/schools/placement_dates/subject_selections_controller.rb
@@ -5,6 +5,10 @@ module Schools
 
       def new
         @subject_selection = SubjectSelection.new_from_date @placement_date
+
+        if @subject_selection.subject_ids.empty?
+          @subject_selection.subject_ids = current_school.subjects.pluck(:id)
+        end
       end
 
       def create

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -407,6 +407,11 @@ en:
             subjects:
               blank: 'Select which subjects are available for this date'
 
+        schools/placement_dates/subject_selection:
+          attributes:
+            subject_ids:
+              blank: Select which subjects are available for this date
+
         schools/placement_requests/add_more_details:
           attributes:
             contact_name:
@@ -554,6 +559,8 @@ en:
     hint:
       schools_placement_requests_confirm_booking:
         placement_details: You can add extra experience details
+      schools_placement_dates_subject_selection:
+        subject_ids_html: This list is based on the <a href="/schools/on_boarding/subjects/new" target="_blank">subjects selected on your profile</a>, uncheck all that do not apply
       bookings_school:
         enabled: |
           Turning your profile off will stop your school from appearing in searches.

--- a/features/schools/placement_dates/subject_selection.feature
+++ b/features/schools/placement_dates/subject_selection.feature
@@ -14,12 +14,17 @@ Feature: Selecting subjects for a placement date
     Scenario: Page title
         Then the page's main heading should be 'Select school experience subjects'
 
-    Scenario: Selecting nothing
+    Scenario: De-selecting all subjects
+        Given I uncheck the 'Maths' checkbox
+        And I uncheck the 'Physics' checkbox
+        And I uncheck the 'Biology' checkbox
         When I submit the form
         Then I should see a validation error message
 
     Scenario: Selecting some subjects
         Given I check 'Maths'
+        And I uncheck the 'Physics' checkbox
+        And I uncheck the 'Biology' checkbox
         When I submit the form
         Then I should be on the 'placement dates' page
         And my date should be listed
@@ -28,3 +33,5 @@ Feature: Selecting subjects for a placement date
         Given I have previously selected 'Biology'
         When I try to edit the subjects for my newly-created placement date
         Then the 'Biology' checkbox should be checked
+        And the 'Maths' checkbox should not be checked
+        And the 'Physics' checkbox should not be checked

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -26,7 +26,8 @@ Given "the placement date is subject specific" do
 end
 
 Given "I have previously selected {string}" do |subject_name|
-  # pick biology from the subjects list and continue
+  all("input[type='checkbox']").each { |checkbox| checkbox.set(false) }
+
   check(subject_name)
   click_button('Continue')
 
@@ -42,6 +43,10 @@ end
 
 Then("the {string} checkbox should be checked") do |subject_name|
   expect(get_input(page, subject_name)).to be_checked
+end
+
+Then("the {string} checkbox should not be checked") do |subject_name|
+  expect(get_input(page, subject_name)).not_to be_checked
 end
 
 Then "the page's main heading should be the date I just entered" do


### PR DESCRIPTION
### Trello card

[Trello-441](https://trello.com/c/Dfrl4vGz/441-dev-prefill-the-add-dates-subject-list-to-match-the-schools-subject-list)

### Context

When a new placement date is created the user is prompted to check all subjects that apply for the given date. A school can have many subjects and checking them all is time consuming/an annoyance.

Instead, we want to pre-check all the subjects and let the user uncheck those that don't apply.

### Changes proposed in this pull request

- Pre-check all subjects for new placement dates

### Guidance to review

To check this you can manage placement dates and add a new date with specific subjects; ensure all the subjects are checked. Go back and edit the placement date and then make sure the old selections are retained.

Also adds a missing error message translation and additional hint text for the field.