### PR TITLE
Handle unknown countries in candidate school search

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -12,7 +12,7 @@ class Candidates::SchoolsController < ApplicationController
 
     return render 'candidates/school_searches/new' unless @search.valid?
 
-    @other_region = @search.other_region
+    @country = @search.country
 
     if @search.results.empty? && !@search.whitelisted_urns?
       @expanded_search_radius = true

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -1,14 +1,14 @@
 require 'geocoding_request'
+require 'geocoding_response_country'
 
 class Bookings::SchoolSearch < ApplicationRecord
-  attr_reader :location_name, :other_region
+  attr_reader :location_name, :country
 
   validates :location, length: { minimum: 2 }, allow_nil: false, if: -> { location.is_a?(String) }
 
   # Despite this being an England-only service, we want to search the whole of the UK
   # so that we can return results to users who are near the border.
   REGION = 'United Kingdom'.freeze
-  OTHER_UK_REGIONS = ['Northern Ireland', 'Scotland', 'Wales'].freeze
   GEOCODER_PARAMS = { maxRes: 1 }.freeze
   PER_PAGE = 15
 
@@ -151,17 +151,12 @@ private
     # this better work
     @location_name = result.try(:name) || result.address_components.first.fetch('long_name', location)
 
-    @other_region = find_other_regions(result)
+    @country = GeocodingResponseCountry.new(result)
 
     extract_coords(
       latitude: result.latitude,
       longitude: result.longitude
     )
-  end
-
-  def find_other_regions(result)
-    address_components = result.address_components.map(&:values).flatten
-    OTHER_UK_REGIONS.find { |region| address_components.include?(region) }
   end
 
   def empty_geocoder_result?(result)

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -23,7 +23,7 @@ module Candidates
                   :longitude, :page, :parking
     attr_reader :distance, :max_fee
 
-    delegate :location_name, :other_region, :has_coordinates?, :valid?, :errors, to: :school_search
+    delegate :location_name, :country, :has_coordinates?, :valid?, :errors, to: :school_search
     delegate :whitelisted_urns, :whitelisted_urns?, to: Bookings::SchoolSearch
 
     class << self

--- a/app/views/candidates/schools/_england_only_service.html.erb
+++ b/app/views/candidates/schools/_england_only_service.html.erb
@@ -2,7 +2,7 @@
   This service is for schools in England
 </h2>
 
-<% case @other_region when "Scotland" %>
+<% case @country.name when "Scotland" %>
   <p class="govuk-body">
     <%= link_to 'Learn more about teacher training in Scotland', 'https://teachinscotland.scot/' %>
   </p>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -93,9 +93,8 @@
       <hr/>
     <% end %>
 
-
     <ul id="results">
-      <% if @expanded_search_radius && @other_region.present? && @search.results.none? %>
+      <% if @expanded_search_radius && @country&.not_serviced? && @search.results.none? %>
         <%= render 'england_only_service' %>
       <% elsif @expanded_search_radius %>
         <%= render 'expanded_search', search: @search %>

--- a/lib/geocoding_response_country.rb
+++ b/lib/geocoding_response_country.rb
@@ -1,0 +1,32 @@
+# We can retrieve country from the Geocoding response. However, it tends to return
+# 'United Kingdom', whereas we are interested in the actual country (England, Scotland,
+# Northern Ireland, Wales). Therefore, we need to actively search the result for countries.
+# The country mostly comes through on the key 'administrative_area_level_1', but this
+# doesn't seem to be consistent.
+class GeocodingResponseCountry
+  ENGLAND = "England".freeze
+  COUNTRIES_NOT_SERVICED = ["Northern Ireland", "Scotland", "Wales"].freeze
+
+  attr_reader :name
+
+  def initialize(geocoding_response)
+    @geocoding_response = geocoding_response
+
+    @name = find_country_name(@geocoding_response)
+  end
+
+  def not_serviced?
+    name != ENGLAND
+  end
+
+private
+
+  def find_country_name(response)
+    address_components = response.address_components.map(&:values).flatten
+    all_countries.find { |region| address_components.include?(region) }
+  end
+
+  def all_countries
+    COUNTRIES_NOT_SERVICED + [ENGLAND]
+  end
+end

--- a/spec/lib/geocoding_response_country_spec.rb
+++ b/spec/lib/geocoding_response_country_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+require 'geocoding_response_country'
+
+RSpec.describe GeocodingResponseCountry do
+  describe "#name" do
+    shared_examples "a known country" do |country|
+      let(:response) { Geocoder::Result::Test.new(address_components: [long_name: country]) }
+
+      subject do
+        described_class.new(response).name
+      end
+
+      it "returns '#{country}'" do
+        expect(subject).to eq country
+      end
+    end
+
+    context "when Scotland" do
+      it_behaves_like "a known country", "Scotland"
+    end
+
+    context "when Wales" do
+      it_behaves_like "a known country", "Wales"
+    end
+
+    context "when Northern Ireland" do
+      it_behaves_like "a known country", "Northern Ireland"
+    end
+
+    context "when England" do
+      it_behaves_like "a known country", "England"
+    end
+
+    context "when unknown country" do
+      let(:canada_response) { Geocoder::Result::Test.new(address_components: [long_name: "Canada"]) }
+
+      subject do
+        described_class.new(canada_response).name
+      end
+
+      it "returns nil" do
+        expect(subject).to be nil
+      end
+    end
+  end
+
+  describe "#not_serviced?" do
+    shared_examples "a country that is not serviced" do |country|
+      let(:response) { Geocoder::Result::Test.new(address_components: [long_name: country]) }
+
+      subject do
+        described_class.new(response).not_serviced?
+      end
+
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+
+    context "when Scotland" do
+      it_behaves_like "a country that is not serviced", "Scotland"
+    end
+
+    context "when Wales" do
+      it_behaves_like "a country that is not serviced", "Wales"
+    end
+
+    context "when Northern Ireland" do
+      it_behaves_like "a country that is not serviced", "Northern Ireland"
+    end
+
+    context "when unknown country" do
+      it_behaves_like "a country that is not serviced", "Canada"
+    end
+
+    context "when England" do
+      let(:response) { Geocoder::Result::Test.new(address_components: [long_name: "England"]) }
+
+      subject do
+        described_class.new(response).not_serviced?
+      end
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+end

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -506,7 +506,7 @@ describe Bookings::SchoolSearch do
     end
   end
 
-  describe "#other_region" do
+  describe "#country" do
     subject { Bookings::SchoolSearch.new(location: "Test") }
 
     let(:scotland_search_result) do
@@ -529,7 +529,7 @@ describe Bookings::SchoolSearch do
       before { allow(Geocoder).to receive(:search).and_return(scotland_search_result) }
 
       it "returns Scotland" do
-        expect(subject.other_region).to eq "Scotland"
+        expect(subject.country.name).to eq "Scotland"
       end
     end
 
@@ -537,7 +537,7 @@ describe Bookings::SchoolSearch do
       before { allow(Geocoder).to receive(:search).and_return(wales_search_result) }
 
       it "returns Scotland" do
-        expect(subject.other_region).to eq "Wales"
+        expect(subject.country.name).to eq "Wales"
       end
     end
 
@@ -545,7 +545,7 @@ describe Bookings::SchoolSearch do
       before { allow(Geocoder).to receive(:search).and_return(northern_ireland_search_result) }
 
       it "returns Scotland" do
-        expect(subject.other_region).to eq "Northern Ireland"
+        expect(subject.country.name).to eq "Northern Ireland"
       end
     end
   end

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -140,7 +140,9 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
         @search = Candidates::SchoolSearch.new
         @facet_tags = FacetTagsPresenter.new(@search.applied_filters)
 
-        assign(:other_region, region)
+        geocoding_response = Geocoder::Result::Test.new(address_components: [long_name: country])
+        country = GeocodingResponseCountry.new(geocoding_response)
+        assign(:country, country)
         assign(:expanded_search_radius, true)
 
         render
@@ -154,7 +156,7 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
 
     context "when other region search" do
       context "when search result is Wales" do
-        let(:region) { "Wales" }
+        let(:country) { "Wales" }
         let(:link_text) { 'Learn more about teacher training in Wales' }
         let(:href) { 'https://educators.wales/teachers' }
 
@@ -162,7 +164,7 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
       end
 
       context "when search result is Scotland" do
-        let(:region) { "Scotland" }
+        let(:country) { "Scotland" }
         let(:link_text) { 'Learn more about teacher training in Scotland' }
         let(:href) { 'https://teachinscotland.scot/' }
 
@@ -170,11 +172,29 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
       end
 
       context "when search result is Northern Ireland" do
-        let(:region) { "Northern Ireland" }
+        let(:country) { "Northern Ireland" }
         let(:link_text) { 'Learn more about teacher training in Northern Ireland' }
         let(:href) { 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland' }
 
         it_behaves_like "a non-England search"
+      end
+
+      context "when search result is unknown" do
+        let(:country) { "Canada" }
+
+        it "shows a message" do
+          @search = Candidates::SchoolSearch.new
+          @facet_tags = FacetTagsPresenter.new(@search.applied_filters)
+
+          geocoding_response = Geocoder::Result::Test.new(address_components: [long_name: country])
+          country = GeocodingResponseCountry.new(geocoding_response)
+          assign(:country, country)
+          assign(:expanded_search_radius, true)
+
+          render
+
+          expect(rendered).to have_css('h2', text: 'This service is for schools in England')
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
We can retrieve country from the Geocoding response. However, it tends to return 'United Kingdom', whereas we are interested in the actual country (England, Scotland, Northern Ireland, Wales). Therefore, we need to actively search the result for countries. The country mostly comes through on the key 'administrative_area_level_1', but this doesn't seem to be consistent.

### Changes proposed in this pull request
Move the country logic into its own class, and handle unknown countries (i.e., countries that we don't actively search for)

### Guidance to review

