### PR TITLE
Remove redundant cookie

### DIFF
--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -85,20 +85,6 @@
               </td>
             </tr>
 
-            <% if google_analytics_enabled? %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                <strong>_gat</strong>
-              </td>
-              <td class="govuk-table__cell">
-                Used to manage the rate at which page view requests are made
-              </td>
-              <td class="govuk-table__cell govuk-table__cell--numeric">
-                1 minute
-              </td>
-            </tr>
-            <% end %>
-
             <% if gtm_enabled? %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">


### PR DESCRIPTION
The GA code has been removed so this cookie won't drop; the method also no longer exists and is causing an exception.
