### PR TITLE
Set the is_virtual_experince correctly

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
@@ -50,8 +50,11 @@ module Schools
 
         def set_is_virtual_experience
           @is_virtual_experience =
-            current_school.experience_type == 'virtual' ||
-            @placement_request.placement_date&.virtual?
+            if @placement_request.placement_date
+              @placement_request.placement_date&.virtual?
+            else
+              current_school.experience_type == 'virtual'
+            end
         end
 
         def send_virtual_confirmation(booking)


### PR DESCRIPTION
### Trello card
N/A

### Context
Currently if the school changes from virtual flex to fixed dates, the set_is_virtual_experience will return true for in-school fixed dates.

### Changes proposed in this pull request
Check if a placement_date exists which ensures the request is for a fixed date

### Guidance to review

