### PR TITLE
Candidate booking feedback

### DIFF
--- a/app/controllers/candidates/booking_feedbacks_controller.rb
+++ b/app/controllers/candidates/booking_feedbacks_controller.rb
@@ -1,0 +1,53 @@
+module Candidates
+  class BookingFeedbacksController < ApplicationController
+    before_action :ensure_booking_attended, :ensure_feedback_not_provided, except: [:show]
+
+    def new
+      @feedback = Candidates::BookingFeedback.new
+    end
+
+    def create
+      @feedback = Candidates::BookingFeedback.new(
+        feedback_params.merge(booking: placement_request.booking)
+      )
+
+      if @feedback.save
+        redirect_to(@feedback)
+      else
+        render :new
+      end
+    end
+
+    def show; end
+
+  private
+
+    def ensure_booking_attended
+      render :booking_not_attended unless booking&.attended?
+    end
+
+    def ensure_feedback_not_provided
+      render :feedback_already_provided if booking&.candidate_feedback.present?
+    end
+
+    def feedback_params
+      params.require(:candidates_booking_feedback).permit(
+        :gave_realistic_impression,
+        :covered_subject_of_interest,
+        :influenced_decision,
+        :intends_to_apply,
+        :effect_on_decision
+      )
+    end
+
+    def placement_request
+      @placement_request ||= Bookings::PlacementRequest.find_by!(
+        token: params[:booking_token]
+      )
+    end
+
+    def booking
+      placement_request.booking
+    end
+  end
+end

--- a/app/controllers/candidates/booking_feedbacks_controller.rb
+++ b/app/controllers/candidates/booking_feedbacks_controller.rb
@@ -8,7 +8,7 @@ module Candidates
 
     def create
       @feedback = Candidates::BookingFeedback.new(
-        feedback_params.merge(booking: placement_request.booking)
+        feedback_params.merge(booking: booking)
       )
 
       if @feedback.save

--- a/app/controllers/schools/confirm_attendance_controller.rb
+++ b/app/controllers/schools/confirm_attendance_controller.rb
@@ -40,9 +40,9 @@ module Schools
         .not_cancelled
         .accepted
         .eager_load(
-          :bookings_placement_request,
+          { bookings_placement_request: :placement_date },
           :bookings_subject,
-          :bookings_school
+          :bookings_school,
         )
         .order(date: 'desc')
     end
@@ -60,6 +60,8 @@ module Schools
     def build_updated_attendance
       bookings = unlogged_bookings.where(id: bookings_params.keys) \
         .includes(bookings_placement_request: %i[candidate candidate_cancellation school_cancellation])
+
+      assign_gitis_contacts(bookings)
 
       @updated_attendance = Schools::Attendance.new(bookings: bookings, bookings_params: bookings_params)
     end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -16,6 +16,12 @@ module Bookings
     has_one :candidate_cancellation, through: :bookings_placement_request
     has_one :school_cancellation, through: :bookings_placement_request
 
+    has_one :candidate_feedback,
+      class_name: "Candidates::BookingFeedback",
+      foreign_key: :bookings_booking_id,
+      inverse_of: :booking,
+      dependent: :destroy
+
     validates :date,
       if: -> { date_changed? },
       timeliness: {

--- a/app/models/candidates/booking_feedback.rb
+++ b/app/models/candidates/booking_feedback.rb
@@ -1,0 +1,19 @@
+class Candidates::BookingFeedback < ApplicationRecord
+  enum effect_on_decision: {
+    negatively: 0,
+    positively: 1,
+    unaffected: 2,
+  }
+
+  belongs_to :booking,
+    class_name: "Bookings::Booking",
+    foreign_key: :bookings_booking_id
+
+  validates :bookings_booking_id, uniqueness: true
+
+  validates :gave_realistic_impression, inclusion: [true, false]
+  validates :covered_subject_of_interest, inclusion: [true, false]
+  validates :influenced_decision, inclusion: [true, false]
+  validates :intends_to_apply, inclusion: [true, false]
+  validates :effect_on_decision, presence: true
+end

--- a/app/notify/notify_email/candidate_booking_feedback.189569bd-3115-43e0-8396-be14480a5f2d.md
+++ b/app/notify/notify_email/candidate_booking_feedback.189569bd-3115-43e0-8396-be14480a5f2d.md
@@ -1,0 +1,11 @@
+Dear ((candidate_name)),
+
+((school_name)) have confirmed your attendance at your school experience booking on ((placement_schedule)).
+
+# Give us feedback
+
+We would love to find out more about your experiences using the service. You can give feedback here:
+
+((feedback_url))
+
+Get school experience service

--- a/app/notify/notify_email/candidate_booking_feedback_request.rb
+++ b/app/notify/notify_email/candidate_booking_feedback_request.rb
@@ -1,0 +1,56 @@
+class NotifyEmail::CandidateBookingFeedbackRequest < NotifyDespatchers::Email
+  include Rails.application.routes.url_helpers
+
+  attr_accessor :candidate_name,
+    :school_name,
+    :placement_schedule,
+    :feedback_url
+
+  def initialize(
+    to:,
+    candidate_name:,
+    school_name:,
+    placement_schedule:,
+    feedback_url:
+  )
+    self.candidate_name = candidate_name
+    self.school_name = school_name
+    self.placement_schedule = placement_schedule
+    self.feedback_url = feedback_url
+
+    super(to: to)
+  end
+
+  def self.from_booking(booking)
+    new(
+      to: booking.candidate_email,
+      candidate_name: booking.candidate_name,
+      school_name: booking.bookings_school.name,
+      placement_schedule: booking.placement_start_date_with_duration,
+      feedback_url: generate_feedback_url(booking),
+    )
+  end
+
+  def self.generate_feedback_url(booking)
+    url_helpers = Rails.application.routes.url_helpers
+    url_helpers.new_candidates_booking_feedback_url(
+      booking.token,
+      host: Rails.configuration.x.base_url
+    )
+  end
+
+protected
+
+  def template_id
+    "189569bd-3115-43e0-8396-be14480a5f2d"
+  end
+
+  def personalisation
+    {
+      school_name: school_name,
+      candidate_name: candidate_name,
+      placement_schedule: placement_schedule,
+      feedback_url: feedback_url
+    }
+  end
+end

--- a/app/views/candidates/booking_feedbacks/_form.html.erb
+++ b/app/views/candidates/booking_feedbacks/_form.html.erb
@@ -1,0 +1,40 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Give feedback on your experience</h1>
+    <%= form_for(feedback, url: candidates_booking_feedback_path(params[:booking_token])) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <p>
+        Help us improve the school experience service.
+      </p>
+
+      <%= f.govuk_radio_buttons_fieldset :gave_realistic_impression do %>
+        <%= f.govuk_radio_button :gave_realistic_impression, "true", link_errors: true %>
+        <%= f.govuk_radio_button :gave_realistic_impression, "false" %>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset :covered_subject_of_interest do %>
+        <%= f.govuk_radio_button :covered_subject_of_interest, "true", link_errors: true %>
+        <%= f.govuk_radio_button :covered_subject_of_interest, "false" %>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset :influenced_decision do %>
+        <%= f.govuk_radio_button :influenced_decision, "true", link_errors: true %>
+        <%= f.govuk_radio_button :influenced_decision, "false" %>
+      <% end %>
+
+      <%= f.govuk_collection_radio_buttons :effect_on_decision,
+        f.object.class.effect_on_decisions,
+        :first,
+        nil
+      %>
+
+      <%= f.govuk_radio_buttons_fieldset :intends_to_apply do %>
+        <%= f.govuk_radio_button :intends_to_apply, "true", link_errors: true %>
+        <%= f.govuk_radio_button :intends_to_apply, "false" %>
+      <% end %>
+
+      <%= f.govuk_submit "Submit feedback" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidates/booking_feedbacks/booking_not_attended.html.erb
+++ b/app/views/candidates/booking_feedbacks/booking_not_attended.html.erb
@@ -1,0 +1,5 @@
+<% self.page_title = "Booking not yet attended" %>
+
+<h1>Booking not yet attended</h1>
+
+<p>You can only leave feedback once you have attended the school exeprience.</p>

--- a/app/views/candidates/booking_feedbacks/feedback_already_provided.html.erb
+++ b/app/views/candidates/booking_feedbacks/feedback_already_provided.html.erb
@@ -1,0 +1,5 @@
+<% self.page_title = "Feedback already provided" %>
+
+<h1>Feedback already provided</h1>
+
+<p>You have already provided feedback for the school experience.</p>

--- a/app/views/candidates/booking_feedbacks/new.html.erb
+++ b/app/views/candidates/booking_feedbacks/new.html.erb
@@ -1,0 +1,3 @@
+<% self.page_title = "Give feedback on your experience" %>
+
+<%= render partial: "candidates/booking_feedbacks/form", locals: { feedback: @feedback } %>

--- a/app/views/candidates/booking_feedbacks/show.html.erb
+++ b/app/views/candidates/booking_feedbacks/show.html.erb
@@ -1,0 +1,21 @@
+<% self.page_title = "Experience feedback sent" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Thank you for your feedback.
+      </h1>
+    </div>
+    <h2 class="govuk-heading-m">
+      View and request more school experience
+    </h2>
+    <p>
+      <% if Rails.application.config.x.phase >= 5  %>
+        <%= link_to "Your requests and bookings", candidates_dashboard_path %>
+      <% else %>
+        <%= link_to "Find more school experience", candidates_root_path %>
+      <% end %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,6 +510,18 @@ en:
               invalid: Enter a valid contact telephone number
             candidate_instructions:
               blank: Enter some instructions for the candidate
+        candidates/booking_feedback:
+          attributes:
+            gave_realistic_impression:
+              inclusion: Select yes if you gained a realistic impression of school life
+            covered_subject_of_interest:
+              inclusion: Select yes if you got to see how schools teach your subject of interest
+            influenced_decision:
+              inclusion: Select yes if the experience helped you decide to apply for teacher training
+            intends_to_apply:
+              inclusion: Select yes if you intend to apply for teacher training
+            effect_on_decision:
+              blank: Select how your experience has affected your decision to apply for teacher training
         candidates/feedback:
           <<: *feedback_errors
         schools/feedback:
@@ -712,6 +724,23 @@ en:
         email: Email address
       candidates_verification_code:
         code: Enter your verification code here
+      candidates_booking_feedback:
+        gave_realistic_impression_options:
+          true: "Yes"
+          false: "No"
+        covered_subject_of_interest_options:
+          true: "Yes"
+          false: "No"
+        influenced_decision_options:
+          true: "Yes"
+          false: "No"
+        intends_to_apply_options:
+          true: "Yes"
+          false: "No"
+        effect_on_decision_options:
+          negatively: Negatively
+          positively: Positively
+          unaffected: It has not affected my decision
       cookie_preference:
         analytics_options:
           true: "On"
@@ -924,6 +953,12 @@ en:
         has_dbs_check: Do you have a DBS certificate?
       candidates_registrations_privacy_policy:
         acceptance: Send your school experience request
+      candidates_booking_feedback:
+        gave_realistic_impression: Do you feel you gained a realistic impression of school life?
+        covered_subject_of_interest: Did you get to see how schools teach your subject of interest?
+        influenced_decision: Has your experience helped you decide whether or not to apply for teacher training?
+        intends_to_apply: Do you want to apply for teacher training?
+        effect_on_decision: How has your experience affected your decision to apply for teacher training?
       bookings_school:
         enabled: Turn profile on or off
         availability_preference_fixed: Choose how dates are displayed

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,10 @@ Rails.application.routes.draw do
       resource :cancellation, only: %i[new create show], controller: 'placement_requests/cancellations'
     end
 
+    resources :bookings, only: [], param: :token do
+      resource :feedback, only: %i[new create show], controller: "booking_feedbacks"
+    end
+
     if Rails.application.config.x.phase >= 5
       get 'signin', to: 'sessions#new'
       post 'signin', to: 'sessions#create'

--- a/db/migrate/20220202103752_create_candidates_booking_feedbacks.rb
+++ b/db/migrate/20220202103752_create_candidates_booking_feedbacks.rb
@@ -1,0 +1,15 @@
+class CreateCandidatesBookingFeedbacks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :candidates_booking_feedbacks do |t|
+      t.belongs_to :bookings_booking, foreign_key: true, index: { unique: true }
+
+      t.boolean :gave_realistic_impression
+      t.boolean :covered_subject_of_interest
+      t.boolean :influenced_decision
+      t.boolean :intends_to_apply
+      t.integer :effect_on_decision
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_25_180747) do
+ActiveRecord::Schema.define(version: 2022_02_02_103752) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "address_standardizer"
   enable_extension "plpgsql"
   enable_extension "postgis"
 
@@ -268,6 +267,18 @@ ActiveRecord::Schema.define(version: 2022_01_25_180747) do
     t.index ["name"], name: "index_bookings_subjects_on_name", unique: true
   end
 
+  create_table "candidates_booking_feedbacks", force: :cascade do |t|
+    t.bigint "bookings_booking_id"
+    t.boolean "gave_realistic_impression"
+    t.boolean "covered_subject_of_interest"
+    t.boolean "influenced_decision"
+    t.boolean "intends_to_apply"
+    t.integer "effect_on_decision"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["bookings_booking_id"], name: "index_candidates_booking_feedbacks_on_bookings_booking_id", unique: true
+  end
+
   create_table "candidates_session_tokens", force: :cascade do |t|
     t.string "token", null: false
     t.bigint "candidate_id", null: false
@@ -431,6 +442,7 @@ ActiveRecord::Schema.define(version: 2022_01_25_180747) do
   add_foreign_key "bookings_schools_phases", "bookings_schools"
   add_foreign_key "bookings_schools_subjects", "bookings_schools"
   add_foreign_key "bookings_schools_subjects", "bookings_subjects"
+  add_foreign_key "candidates_booking_feedbacks", "bookings_bookings"
   add_foreign_key "candidates_session_tokens", "bookings_candidates", column: "candidate_id"
   add_foreign_key "events", "bookings_candidates"
   add_foreign_key "events", "bookings_schools"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,6 +13,7 @@
 ActiveRecord::Schema.define(version: 2022_02_02_103752) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "address_standardizer"
   enable_extension "plpgsql"
   enable_extension "postgis"
 

--- a/features/candidates/booking_feedback.feature
+++ b/features/candidates/booking_feedback.feature
@@ -1,0 +1,47 @@
+Feature: Feedback
+    So I can help improve the experience offered by schools
+    As a candidate
+    I want to be able to leave my feedback
+
+  Background:
+    Given I have an attended booking
+
+    Scenario: Page contents
+      When I visit the booking feedback link
+      Then I should see radio buttons for 'Do you feel you gained a realistic impression of school life?' with the following options:
+          | Yes |
+          | No  |
+
+        And I should see radio buttons for 'Did you get to see how schools teach your subject of interest?' with the following options:
+          | Yes |
+          | No  |
+
+        And I should see radio buttons for 'Has your experience helped you decide whether or not to apply for teacher training?' with the following options:
+          | Yes |
+          | No  |
+
+        And I should see radio buttons for 'How has your experience affected your decision to apply for teacher training?' with the following options:
+          | Positively                      |
+          | Negatively                      |
+          | It has not affected my decision |
+
+        And I should see radio buttons for 'Do you want to apply for teacher training?' with the following options:
+          | Yes |
+          | No  |
+
+    Scenario: Submitting feedback with an error
+      When I visit the booking feedback link
+      And I choose 'Yes' from the 'Do you feel you gained a realistic impression of school life?' radio buttons
+      And I choose 'No' from the 'Did you get to see how schools teach your subject of interest?' radio buttons
+      When I click the 'Submit feedback' button
+      Then I should see an error
+
+    Scenario: Completing the form successfully
+      When I visit the booking feedback link
+      And I choose 'Yes' from the 'Do you feel you gained a realistic impression of school life?' radio buttons
+      And I choose 'No' from the 'Did you get to see how schools teach your subject of interest?' radio buttons
+      And I choose 'Yes' from the 'Has your experience helped you decide whether or not to apply for teacher training?' radio buttons
+      And I choose 'Positively' from the 'How has your experience affected your decision to apply for teacher training?' radio buttons
+      And I choose 'No' from the 'Do you want to apply for teacher training?' radio buttons
+      When I click the 'Submit feedback' button
+      Then I should see the text 'Thank you for your feedback.'

--- a/features/schools/confirm_attendance.feature
+++ b/features/schools/confirm_attendance.feature
@@ -7,6 +7,7 @@ Feature: Confirming candidate attendance
         Given I am logged in as a DfE user
         And the school offers 'Biology, Maths'
         And my school is fully-onboarded
+        And I can receive feedback request emails
 
     Scenario: When there are no bookings
         Given there are no bookings
@@ -41,6 +42,7 @@ Feature: Confirming candidate attendance
         And I click the 'Save and return to dashboard' submit button
         Then I should be on the 'schools dashboard' page
         And the booking should be marked as attended
+        And a feedback request email should have been sent to the candidate
 
     Scenario: Setting a booking as not attended
         Given there are some bookings that were scheduled last week
@@ -49,6 +51,7 @@ Feature: Confirming candidate attendance
         And I click the 'Save and return to dashboard' submit button
         Then I should be on the 'schools dashboard' page
         And the booking should be marked as not attended
+        And no feedback request emails have been sent
 
     Scenario: Only selected records are updated
         Given I have set a booking to be attended

--- a/features/step_definitions/candidates/bookings/feedback_steps.rb
+++ b/features/step_definitions/candidates/bookings/feedback_steps.rb
@@ -1,0 +1,8 @@
+Given "I have an attended booking" do
+  placement_request = FactoryBot.create(:placement_request, :with_attended_booking)
+  @booking = placement_request.booking
+end
+
+When "I visit the booking feedback link" do
+  visit new_candidates_booking_feedback_path(@booking.token)
+end

--- a/features/step_definitions/schools/confirm_attendance_steps.rb
+++ b/features/step_definitions/schools/confirm_attendance_steps.rb
@@ -37,6 +37,25 @@ Then("the booking should be marked as not attended") do
   expect(@bookings.first.reload.attended).to be(false)
 end
 
+Given("I can receive feedback request emails") do
+  @feedback_request_double = instance_double(
+    NotifyEmail::CandidateBookingFeedbackRequest, despatch_later!: true
+  )
+
+  allow(NotifyEmail::CandidateBookingFeedbackRequest).to \
+    receive(:from_booking) { @feedback_request_double }
+end
+
+Then("a feedback request email should have been sent to the candidate") do
+  expect(NotifyEmail::CandidateBookingFeedbackRequest).to \
+    have_received(:from_booking).with(@bookings.first)
+end
+
+Then("no feedback request emails have been sent") do
+  expect(NotifyEmail::CandidateBookingFeedbackRequest).not_to \
+    have_received(:from_booking)
+end
+
 Given("I have set a booking to be attended") do
   steps %(
     Given there are some bookings that were scheduled last week

--- a/features/support/database_cleaner.rb
+++ b/features/support/database_cleaner.rb
@@ -3,6 +3,7 @@ require 'database_cleaner/prevent_disabling_referential_integrity'
 truncation_options = { except: %w[schema_migrations spatial_ref_sys] }
 deletion_options = {
   only: %w[
+    candidates_booking_feedbacks
     events
     schools_school_profiles
     bookings_placement_request_cancellations

--- a/spec/controllers/candidates/booking_feedbacks_controller_spec.rb
+++ b/spec/controllers/candidates/booking_feedbacks_controller_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+shared_examples "invalid requests" do
+  context "when the token is incorrect" do
+    let(:token) { "incorrect" }
+
+    it { expect { perform_request }.to raise_error(ActiveRecord::RecordNotFound) }
+  end
+
+  context "when there is no booking" do
+    let(:placement_request) { create(:placement_request) }
+
+    it { is_expected.to render_template(:booking_not_attended) }
+  end
+
+  context "when the booking has not yet been attended" do
+    let(:placement_request) { create(:placement_request, :with_incomplete_booking) }
+
+    it { is_expected.to render_template(:booking_not_attended) }
+  end
+
+  context "when feedback has already been left" do
+    before { create(:candidates_booking_feedback, booking: booking) }
+
+    it { is_expected.to render_template(:feedback_already_provided) }
+  end
+end
+
+describe Candidates::BookingFeedbacksController, type: :request do
+  let(:placement_request) { create(:placement_request, :with_attended_booking) }
+  let(:booking) { placement_request.booking }
+  let(:token) { placement_request.token }
+
+  describe "#new" do
+    include_context "invalid requests"
+
+    subject(:perform_request) do
+      get new_candidates_booking_feedback_path(token)
+      response
+    end
+
+    it { is_expected.to render_template(:new) }
+  end
+
+  describe "#create" do
+    include_context "invalid requests"
+
+    let(:attributes) { attributes_for(:candidates_booking_feedback) }
+    let(:params) { { candidates_booking_feedback: attributes } }
+    let(:created_feedback) { Candidates::BookingFeedback.last }
+
+    subject(:perform_request) do
+      post candidates_booking_feedback_path(token, params: params)
+      response
+    end
+
+    it { is_expected.to redirect_to(created_feedback) }
+    it { expect { perform_request }.to change { Candidates::BookingFeedback.count }.by(1) }
+
+    it "creates feedback associated to the booking" do
+      perform_request
+      expect(created_feedback).to have_attributes(attributes.merge(booking: booking))
+    end
+
+    context "when the request is invalid" do
+      before { attributes[:gave_realistic_impression] = nil }
+
+      it { is_expected.to render_template(:new) }
+    end
+  end
+
+  describe "#show" do
+    subject do
+      get candidates_booking_feedback_path(token)
+      response
+    end
+
+    it { is_expected.to render_template(:show) }
+  end
+end

--- a/spec/controllers/schools/confirm_attendance_controller_spec.rb
+++ b/spec/controllers/schools/confirm_attendance_controller_spec.rb
@@ -24,6 +24,18 @@ describe Schools::ConfirmAttendanceController, type: :request do
 
       allow(school_experience).to \
         receive(:write_to_gitis_contact)
+
+      ids = [
+        unattended.candidate.gitis_uuid,
+        attended.candidate.gitis_uuid,
+      ]
+      allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+        receive(:get_schools_experience_sign_ups).with(ids) do
+          [
+            build(:api_schools_experience_sign_up),
+            build(:api_schools_experience_sign_up)
+          ]
+        end
     end
 
     let!(:attended) do

--- a/spec/factories/candidates/booking_feedbacks.rb
+++ b/spec/factories/candidates/booking_feedbacks.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :candidates_booking_feedback, class: "Candidates::BookingFeedback" do
+    association :booking, factory: :bookings_booking
+
+    gave_realistic_impression { false }
+    covered_subject_of_interest { false }
+    influenced_decision { false }
+    intends_to_apply { false }
+    effect_on_decision { "positively" }
+  end
+end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -160,6 +160,13 @@ describe Bookings::Booking do
     it { is_expected.to belong_to(:bookings_school) }
     it { is_expected.to have_one(:candidate_cancellation).through(:bookings_placement_request) }
     it { is_expected.to have_one(:school_cancellation).through(:bookings_placement_request) }
+    it do
+      is_expected.to have_one(:candidate_feedback)
+        .class_name("Candidates::BookingFeedback")
+        .with_foreign_key(:bookings_booking_id)
+        .inverse_of(:booking)
+        .dependent(:destroy)
+    end
   end
 
   describe 'Delegation' do

--- a/spec/models/candidates/booking_feedback_spec.rb
+++ b/spec/models/candidates/booking_feedback_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe Candidates::BookingFeedback, type: :model do
+  it do
+    is_expected.to belong_to(:booking)
+      .class_name("Bookings::Booking")
+      .with_foreign_key("bookings_booking_id")
+  end
+
+  it do
+    is_expected.to define_enum_for(:effect_on_decision)
+      .with_values(%i[negatively positively unaffected])
+  end
+
+  describe "validations" do
+    %i[
+      gave_realistic_impression
+      covered_subject_of_interest
+      influenced_decision
+      intends_to_apply
+    ].each do |attribute|
+      it { is_expected.to allow_values(true, false).for(attribute) }
+      it { is_expected.not_to allow_value(nil).for(attribute) }
+    end
+
+    it { is_expected.to validate_presence_of(:effect_on_decision) }
+
+    it do
+      subject.booking = create(:bookings_booking)
+      is_expected.to validate_uniqueness_of(:bookings_booking_id)
+    end
+  end
+end

--- a/spec/notify/notify_email/candidate_booking_feedback_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_feedback_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe NotifyEmail::CandidateBookingFeedbackRequest do
+  it_should_behave_like "email template", "189569bd-3115-43e0-8396-be14480a5f2d",
+    school_name: "Springfield Elementary",
+    candidate_name: "Kearney Zzyzwicz",
+    placement_schedule: "2022-03-04 for 3 days",
+    feedback_url: "https://example.com/candiates/bookings/abc-123/feedback/new"
+
+  describe ".from_booking" do
+    let(:booking) { create(:bookings_booking) }
+    let(:candidate) { booking.bookings_placement_request.candidate }
+
+    before do
+      candidate.gitis_contact = build(:api_schools_experience_sign_up_with_name)
+      candidate.gitis_uuid = candidate.gitis_contact.candidate_id
+    end
+
+    subject { described_class.from_booking(booking) }
+
+    context "correctly assigning attributes" do
+      it "candidate_name is correctly-assigned" do
+        expect(subject.candidate_name).to eql(booking.candidate_name)
+      end
+
+      it "school_name is correctly-assigned" do
+        expect(subject.school_name).to eql(booking.bookings_school.name)
+      end
+
+      it "placement_schedule is correctly-assigned" do
+        expect(subject.placement_schedule).to eql(booking.placement_start_date_with_duration)
+      end
+
+      it "feedback_url is correctly-assigned" do
+        expect(subject.feedback_url).to eql(
+          "https://some-host/candidates/bookings/#{booking.token}/feedback/new"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-264](https://trello.com/c/35VTFD2c/264-dev-create-a-post-experience-survey-experience-for-those-who-are-confirmed-attendees-of-school-experience)

### Context

When a candidate has attended a school experience booking we want to obtain feedback so that we can improve the service.

### Changes proposed in this pull request

- Add model to capture candidate booking feedback

When a candidate has attended a placement we want to ask them for feedback about their experience.

Add `Candidates::BookingFeedback` model to capture feedback from users.

- Accept feedback for attended bookings

Allow candidates to submit feedback for bookings they have attended.

We use the secure token on the `PlacementRequest` to allow a candidate to submit feedback.

Candidates can only submit feedback on bookings that they have attended. Feedback can only be submitted once.

- Send feedback request emails on confirmation of attendance

When a school indicates that a candidate has attended a school experience booking we want to issue an email that requests feedback.

Add `CandidateBookingFeedbackRequest` to queue an email to the candidate.

Update `School::Attendance` to issue feedback requests for attended bookings.

Update `ConfirmAttendanceController` to load the `gitis_contact` for bookings prior to processing the attendance; we need the contact information present so that we can access the candidate's email.

### Guidance to review

Best reviewed by-commit.

To trigger the feedback request you need to sign up for a placement, accept it as the school and then move its `date` into the past - you can do this via the Rails console locally in Cloud Foundry:

```
cf ssh review-school-experience-2261
export PATH=${PATH}:/usr/local/bin
cd /app
./bin/rails c
Bookings::Booking.last.update_attribute(:date, Date.yesterday)
```

You can then mark it as attended and you should receive the feedback email as the candidate.

Initially I went down the path of implementing the mechanism to send the feedback request in the `Booking` model in an `after_save` hook. This proved a bit of a nightmare, whilst it was easy enough to implement it breaks a bunch of tests related to creating attended bookings as the mocked `booking` never had an associated `candidate` with contact information present. 

To avoid this I opted to move the logic into the `Attendance` model, which still makes sense but is less robust IMO. I think we could clean up the logic around how contact information is loaded from the API; currently it mostly happens in the controllers and occasionally in services, but it means the state has to be assumed in classes further down the chain (like in models). I would opt to refactor this so the `Candidate` model is responsible for loading its contact information from the API at the time its accessed, which would massively reduce the complexity around this process and clean up a bunch of repeating logic in various controllers/services.

| Form  |  Form (errors)  |  Success |  Not attended  | Already provided  |  Email |
|---|---|---|---|---|---|
| ![screencapture-localhost-3000-candidates-bookings-CsTPUhXrALjwX8phvXwF26Dk-feedback-new-2022-02-04-10_41_57](https://user-images.githubusercontent.com/29867726/152515491-4af1c9ed-e62e-4598-9965-3f9998816dff.png)  | ![screencapture-localhost-3000-candidates-bookings-CsTPUhXrALjwX8phvXwF26Dk-feedback-2022-02-04-10_41_31](https://user-images.githubusercontent.com/29867726/152515438-fd6b075e-70e2-4fda-8a2f-de9504d55ccb.png)  |  ![screencapture-localhost-3000-candidates-bookings-CsTPUhXrALjwX8phvXwF26Dk-feedback-2022-02-04-10_40_07](https://user-images.githubusercontent.com/29867726/152515210-1f08599b-0856-4f1d-9902-e7bccccbe3c0.png) |   ![screencapture-localhost-3000-candidates-bookings-CsTPUhXrALjwX8phvXwF26Dk-feedback-new-2022-02-04-10_38_53](https://user-images.githubusercontent.com/29867726/152515039-a26b25bd-161a-4458-9b50-8184d1c9ac58.png) |  ![screencapture-localhost-3000-candidates-bookings-CsTPUhXrALjwX8phvXwF26Dk-feedback-new-2022-02-04-10_39_30](https://user-images.githubusercontent.com/29867726/152515120-d18800e4-667f-4a38-b1bc-40b314a02b6d.png) | <img width="817" alt="Screenshot 2022-02-04 at 10 52 22" src="https://user-images.githubusercontent.com/29867726/152516778-8352869e-4d85-47d8-b127-69b88af6f252.png"> |