### PR TITLE
Fix education phase seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ end
 
 # Phases
 YAML.load_file(Rails.root.join('db', 'data', 'phases.yml')).each do |edubase_id, name|
-  Bookings::Phase.create(name: name, edubase_id: edubase_id)
+  Bookings::Phase.create(name: name, edubase_id: edubase_id, supports_subjects: name != "Primary (4 to 11)")
 end
 
 # School types


### PR DESCRIPTION
When we seed the education phases they all default to `supports_subjects: true` - this means we can never add a placement date for a primary education phase (the control is never displayed to the user).

We seem to have manually fixed this in the production/staging database, however when reseeding locally its an issue.

Fix by ensuring `supports_subjects` is `false` for the primary education phase.

| Before      | After |
| ----------- | ----------- |
| <img width="825" alt="Screenshot 2022-02-10 at 10 04 33" src="https://user-images.githubusercontent.com/29867726/153384337-50bc46da-ae9c-485f-a632-5a02cb122abd.png">      | <img width="773" alt="Screenshot 2022-02-10 at 10 04 45" src="https://user-images.githubusercontent.com/29867726/153384364-d64e2d10-a9ee-43c0-8f43-f6a55074b825.png">       |
