### PR TITLE
Experience type for flex dates

### DIFF
--- a/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/make_changes_controller.rb
@@ -37,7 +37,8 @@ module Schools
             :bookings_subject_id,
             :contact_name,
             :contact_number,
-            :contact_email
+            :contact_email,
+            :experience_type
           )
         end
       end

--- a/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
+++ b/app/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller.rb
@@ -5,7 +5,6 @@ module Schools
         include Acceptance
 
         before_action :set_placement_request_and_fetch_gitis_contact
-        before_action :set_is_virtual_experience
 
         def edit
           @booking = @placement_request.booking
@@ -34,7 +33,7 @@ module Schools
         end
 
         def candidate_booking_notifications(booking)
-          if @is_virtual_experience
+          if @booking.virtual_experience?
             send_virtual_confirmation(booking)
           else
             send_inschool_confirmation(booking)
@@ -46,15 +45,6 @@ module Schools
             dates_requested: booking.date.to_formatted_s(:govuk),
             cancellation_url: candidates_cancel_url(booking.token),
           ).despatch_later!
-        end
-
-        def set_is_virtual_experience
-          @is_virtual_experience =
-            if @placement_request.placement_date
-              @placement_request.placement_date&.virtual?
-            else
-              current_school.experience_type == 'virtual'
-            end
         end
 
         def send_virtual_confirmation(booking)

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -192,5 +192,9 @@ module Bookings
     def editable_date?
       in_future? && !cancelled?
     end
+
+    def virtual_experience?
+      experience_type == 'virtual'
+    end
   end
 end

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -36,6 +36,8 @@ module Bookings
       errors.add :date, :not_changed unless date_changed?
     end
 
+    validates :experience_type, presence: true
+
     validates :bookings_placement_request, presence: true
     validates :bookings_placement_request_id, presence: true
     validates :bookings_subject, presence: true
@@ -117,6 +119,7 @@ module Bookings
                placement_request.fixed_date
              end
       duration = placement_request.placement_date&.duration || DEFAULT_DURATION
+      experience_type = placement_request.experience_type unless placement_request.unclear_experience_type?
 
       new(
         bookings_school: placement_request.school,
@@ -124,7 +127,8 @@ module Bookings
         date: date,
         bookings_subject_id: placement_request.requested_subject.id,
         placement_details: placement_request.school.placement_info,
-        duration: duration
+        duration: duration,
+        experience_type: experience_type
       )
     end
 

--- a/app/models/bookings/booking.rb
+++ b/app/models/bookings/booking.rb
@@ -36,7 +36,9 @@ module Bookings
       errors.add :date, :not_changed unless date_changed?
     end
 
-    validates :experience_type, presence: true
+    validates :experience_type,
+      presence: true,
+      inclusion: { in: PlacementRequest::EXPERIENCE_TYPES }
 
     validates :bookings_placement_request, presence: true
     validates :bookings_placement_request_id, presence: true

--- a/app/models/bookings/placement_date.rb
+++ b/app/models/bookings/placement_date.rb
@@ -136,6 +136,12 @@ module Bookings
       save!
     end
 
+    def experience_type
+      return 'virtual' if virtual?
+
+      'inschool'
+    end
+
   private
 
     def inside_availability_window?

--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -49,6 +49,14 @@
           <%= f.govuk_number_field :duration, width: 3, required: true, label: { class: 'govuk-heading-m' } %>
         <% end %>
         <%= f.govuk_collection_select :bookings_subject_id, @subjects, :id, :name, label: { class: 'govuk-heading-m' } %>
+
+        <% if @placement_request.unclear_experience_type? %>
+          <div class="govuk-radios govuk-radios--inline">
+            <%= f.govuk_collection_radio_buttons :experience_type, Bookings::PlacementRequest::EXPERIENCE_TYPES, :to_s %>
+          </div>
+        <% else %>
+          <%= f.hidden_field :experience_type, value: @placement_request.experience_type %>
+        <% end %>
       </div>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
+++ b/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
@@ -19,7 +19,7 @@
 
         <p><%= @placement_request.school.name %> have confirmed your school experience booking.</p>
 
-        <% if @is_virtual_experience %>
+        <% if @booking.virtual_experience? %>
           <%= render partial: 'virtual_sections', locals: { form: f } %>
         <% else %>
           <%= render partial: 'in_school_sections', locals: { form: f } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -511,7 +511,7 @@ en:
             candidate_instructions:
               blank: Enter some instructions for the candidate
             experience_type:
-              blank: Select if it is an In school or Virtual experience
+              blank: Select if it is an in school or virtual experience
         candidates/booking_feedback:
           attributes:
             gave_realistic_impression:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -510,6 +510,8 @@ en:
               invalid: Enter a valid contact telephone number
             candidate_instructions:
               blank: Enter some instructions for the candidate
+            experience_type:
+              blank: Select if it is an In school or Virtual experience
         candidates/booking_feedback:
           attributes:
             gave_realistic_impression:
@@ -694,6 +696,9 @@ en:
         contact_email: Email address
         candidate_instructions: Other instructions
         bookings_subject_id: Subject
+        experience_type_options:
+          inschool: In school
+          virtual: Virtual
       candidates_registrations_contact_information:
         building: "Building and street"
         phone: "UK telephone number"
@@ -1002,6 +1007,7 @@ en:
         change_to_urn: Select your school
       bookings_booking:
         date: Booking date
+        experience_type: Experience type
 
   views:
     pagination:

--- a/db/migrate/20220203124105_add_experience_type_to_requests_and_bookings_tables.rb
+++ b/db/migrate/20220203124105_add_experience_type_to_requests_and_bookings_tables.rb
@@ -13,7 +13,7 @@ class AddExperienceTypeToRequestsAndBookingsTables < ActiveRecord::Migration[6.1
 
   def migrate_data
     Bookings::PlacementRequest.find_each(batch_size: 100) do |pr|
-      experience_type = pr.resolve_experience_type.downcase.delete(' ')
+      experience_type = pr.resolve_experience_type
 
       pr.update_attribute('experience_type', experience_type)
     end

--- a/db/migrate/20220203124105_add_experience_type_to_requests_and_bookings_tables.rb
+++ b/db/migrate/20220203124105_add_experience_type_to_requests_and_bookings_tables.rb
@@ -1,0 +1,28 @@
+class AddExperienceTypeToRequestsAndBookingsTables < ActiveRecord::Migration[6.1]
+  def up
+    add_column :bookings_placement_requests, :experience_type, :string
+    add_column :bookings_bookings, :experience_type, :string
+
+    migrate_data
+  end
+
+  def down
+    remove_column :bookings_placement_requests, :experience_type
+    remove_column :bookings_bookings, :experience_type
+  end
+
+  def migrate_data
+    Bookings::PlacementRequest.find_each(batch_size: 100) do |pr|
+      experience_type = pr.resolve_experience_type.downcase.delete(' ')
+
+      pr.update_attribute('experience_type', experience_type)
+    end
+
+    # Skip the half finished booking records, as the Schools
+    # will be asked to choose the experience type for these
+    # ones when completing the acceptance form.
+    Bookings::Booking.where('accepted_at IS NOT NULL').find_each(batch_size: 100) do |b|
+      b.update(experience_type: b.bookings_placement_request.experience_type)
+    end
+  end
+end

--- a/db/migrate/20220203124105_add_experience_type_to_requests_and_bookings_tables.rb
+++ b/db/migrate/20220203124105_add_experience_type_to_requests_and_bookings_tables.rb
@@ -15,7 +15,9 @@ class AddExperienceTypeToRequestsAndBookingsTables < ActiveRecord::Migration[6.1
     Bookings::PlacementRequest.find_each(batch_size: 100) do |pr|
       experience_type = pr.resolve_experience_type
 
+      # rubocop:disable Rails/SkipsModelValidations
       pr.update_attribute('experience_type', experience_type)
+      # rubocop:enable Rails/SkipsModelValidations
     end
 
     # Skip the half finished booking records, as the Schools

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_02_103752) do
+ActiveRecord::Schema.define(version: 2022_02_03_124105) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2022_02_02_103752) do
     t.integer "duration", default: 1, null: false
     t.datetime "accepted_at"
     t.boolean "attended"
+    t.string "experience_type"
     t.index ["bookings_placement_request_id"], name: "index_bookings_bookings_on_bookings_placement_request_id", unique: true
     t.index ["bookings_school_id"], name: "index_bookings_bookings_on_bookings_school_id"
     t.index ["bookings_subject_id"], name: "index_bookings_bookings_on_bookings_subject_id"
@@ -119,6 +120,7 @@ ActiveRecord::Schema.define(version: 2022_02_02_103752) do
     t.bigint "candidate_id"
     t.bigint "bookings_subject_id"
     t.datetime "under_consideration_at"
+    t.string "experience_type"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
     t.index ["bookings_school_id"], name: "index_bookings_placement_requests_on_bookings_school_id"
     t.index ["bookings_subject_id"], name: "index_bookings_placement_requests_on_bookings_subject_id"

--- a/features/schools/placement_requests/acceptance/confirming_a_request_with_a_future_date.feature
+++ b/features/schools/placement_requests/acceptance/confirming_a_request_with_a_future_date.feature
@@ -7,7 +7,7 @@ Feature: Confirming a request with a future date
         Given I am logged in as a DfE user
         And the school has subjects
         And the school has fixed dates
-        And there is a new placement request with a future date
+        And there is a new in-school placement request with a future date
 
     Scenario: Page content: when the school has no prior bookings
         Given I am on the 'confirm booking' page for the placement request

--- a/features/schools/placement_requests/acceptance/confirming_flex_requests_with_unclear_experience_type.feature
+++ b/features/schools/placement_requests/acceptance/confirming_flex_requests_with_unclear_experience_type.feature
@@ -1,0 +1,38 @@
+Feature: Confirming a flex request when experience type is  unclear
+    So I can quickly set the experience type and accept a placement request
+    As a school administrator
+    I want to be able to choose the experience type and accept a booking in one step
+
+    Background:
+        Given I am logged in as a DfE user
+        And the school has subjects
+        And my school has flexible dates
+        And there is a new placement request
+
+    Scenario: Accepting a flexible booking with experience type 'both'
+        Given I am on the 'confirm booking' page for the placement request
+        When I click the 'Continue' button
+        Then I should see a form with the following fields:
+            | Label                  | Type   | Options             |
+            | Booking date           | date   |                     |
+            | Experience type        | radio  | In school, Virtual  |
+
+    Scenario: Displaying experience type validation error when the request experience type 'both'
+        Given I am on the 'make changes' page for the placement request
+        And I enter a future date in the 'Booking date' date field
+        When I submit the form
+        Then I should see the validation error 'Select if it is an In school or Virtual experience'
+
+    @smoke_test
+    Scenario: Updating and submitting a flexible booking with experience type 'both'
+        Given I am on the 'make changes' page for the placement request
+        And I enter a future date in the 'Booking date' date field
+        And I select 'Biology' from the 'Subject' select box
+        And I choose 'Virtual' from the 'Experience type' radio buttons
+        And I have entered the following details into the form:
+            | Name             | Joey Test     |
+            | Telephone number | 01234 456 421 |
+            | Email address    | test@test.org |
+        When I submit the form
+        Then I should be on the 'preview confirmation email' page for the placement request
+        And the booking details should have been saved

--- a/features/schools/placement_requests/acceptance/confirming_flex_requests_with_unclear_experience_type.feature
+++ b/features/schools/placement_requests/acceptance/confirming_flex_requests_with_unclear_experience_type.feature
@@ -21,7 +21,7 @@ Feature: Confirming a flex request when experience type is  unclear
         Given I am on the 'make changes' page for the placement request
         And I enter a future date in the 'Booking date' date field
         When I submit the form
-        Then I should see the validation error 'Select if it is an In school or Virtual experience'
+        Then I should see the validation error 'Select if it is an in school or virtual experience'
 
     @smoke_test
     Scenario: Updating and submitting a flexible booking with experience type 'both'

--- a/features/schools/placement_requests/acceptance/sending_details_to_candidate.feature
+++ b/features/schools/placement_requests/acceptance/sending_details_to_candidate.feature
@@ -10,7 +10,7 @@ Feature: Previewing candidate emails
         And there is a new placement request with a future date
 
     Scenario: Page contents for in-school experience
-        Given I have progressed to the 'preview confirmation email' page for the placement request
+        Given I have progressed to the 'preview confirmation email' page for the 'inschool' placement request
         Then I should see an email preview that has the following sections:
             | Date and time                     |
             | Location                          |
@@ -22,7 +22,7 @@ Feature: Previewing candidate emails
 
     Scenario: Page contents for virtual experience
         Given there is a new virtual placement request with a future date
-        And I have progressed to the 'preview confirmation email' page for the placement request
+        And I have progressed to the 'preview confirmation email' page for the 'virtual' placement request
         Then I should see an email preview that has the following sections:
             | Date and time                     |
             | Location                          |
@@ -32,7 +32,7 @@ Feature: Previewing candidate emails
 
     @smoke_test
     Scenario: Actually confirming a placement request
-        Given I have progressed to the 'preview confirmation email' page for the placement request
+        Given I have progressed to the 'preview confirmation email' page for the 'inschool' placement request
         And I enter 'Come to the main reception' into the 'Other instructions' text area
         When I click the 'Send confirmation email' button
         Then I should be on the 'email sent' page for the placement request
@@ -40,7 +40,7 @@ Feature: Previewing candidate emails
         And I should be on the 'email sent' page for the placement request
 
     Scenario: Failing to send a placement request
-        Given I have progressed to the 'preview confirmation email' page for the placement request
+        Given I have progressed to the 'preview confirmation email' page for the 'inschool' placement request
         And I enter nothing into the 'Extra instructions for the candidate' text area
         When I click the 'Send confirmation email' button
         Then I should see an error

--- a/features/step_definitions/schools/placement_requests/accept_steps.rb
+++ b/features/step_definitions/schools/placement_requests/accept_steps.rb
@@ -23,9 +23,15 @@ Given("there is a new placement request with a future date") do
   @placement_request = FactoryBot.create(:bookings_placement_request, school: @school, placement_date: placement_date)
 end
 
+Given("there is a new in-school placement request with a future date") do
+  @profile = FactoryBot.create(:bookings_profile, school: @school)
+  placement_date = FactoryBot.create(:bookings_placement_date, bookings_school: @school)
+  @placement_request = FactoryBot.create(:placement_request, :inschool, school: @school, placement_date: placement_date)
+end
+
 Given("there is a new virtual placement request with a future date") do
   placement_date = FactoryBot.create(:bookings_placement_date, bookings_school: @school, virtual: true)
-  @placement_request = FactoryBot.create(:bookings_placement_request, school: @school, placement_date: placement_date)
+  @placement_request = FactoryBot.create(:placement_request, :virtual, school: @school, placement_date: placement_date)
 end
 
 Given("there is a new placement request with a past date") do

--- a/features/step_definitions/schools/placement_requests/accept_steps.rb
+++ b/features/step_definitions/schools/placement_requests/accept_steps.rb
@@ -20,7 +20,7 @@ end
 Given("there is a new placement request with a future date") do
   @profile = FactoryBot.create(:bookings_profile, school: @school)
   placement_date = FactoryBot.create(:bookings_placement_date, bookings_school: @school)
-  @placement_request = FactoryBot.create(:bookings_placement_request, school: @school, placement_date: placement_date)
+  @placement_request = FactoryBot.create(:placement_request, :inschool, school: @school, placement_date: placement_date)
 end
 
 Given("there is a new in-school placement request with a future date") do
@@ -37,7 +37,7 @@ end
 Given("there is a new placement request with a past date") do
   @profile = FactoryBot.create(:bookings_profile, school: @school)
   placement_date = FactoryBot.create(:bookings_placement_date, :in_the_past, bookings_school: @school)
-  @placement_request = FactoryBot.create(:bookings_placement_request, school: @school, placement_date: placement_date)
+  @placement_request = FactoryBot.create(:placement_request, :inschool, school: @school, placement_date: placement_date)
 end
 
 When("I am on the {string} screen for that placement request") do |string|

--- a/features/step_definitions/schools/placement_requests/preview_confirmation_email_steps.rb
+++ b/features/step_definitions/schools/placement_requests/preview_confirmation_email_steps.rb
@@ -13,8 +13,10 @@ Then("the placement request should be accepted") do
   expect(@placement_request.reload.booking.accepted_at).not_to be_nil
 end
 
-Given("I have progressed to the {string} page for the placement request") do |string|
-  @booking = FactoryBot.create(:bookings_booking, bookings_placement_request: @placement_request)
+Given("I have progressed to the {string} page for the {string} placement request") do |string, experience_type|
+  @booking = FactoryBot.create(:bookings_booking,
+    experience_type: experience_type,
+    bookings_placement_request: @placement_request)
   path = path_for(string, placement_request: @placement_request)
   visit(path)
   expect(page.current_path).to eql(path)

--- a/spec/controllers/schools/placement_requests/acceptance/make_changes_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/make_changes_controller_spec.rb
@@ -29,6 +29,7 @@ describe Schools::PlacementRequests::Acceptance::MakeChangesController, type: :r
     let(:contact_number) { "01234 456 678" }
     let(:contact_email) { "edna.krabappel@springfield.edu" }
     let(:location) { "Reception" }
+    let(:experience_type) { "inschool" }
 
     context 'with valid params' do
       let(:params) do
@@ -38,7 +39,8 @@ describe Schools::PlacementRequests::Acceptance::MakeChangesController, type: :r
             bookings_subject_id: bookings_subject.id,
             contact_name: contact_name,
             contact_number: contact_number,
-            contact_email: contact_email
+            contact_email: contact_email,
+            experience_type: experience_type
           }
         }
       end
@@ -51,6 +53,7 @@ describe Schools::PlacementRequests::Acceptance::MakeChangesController, type: :r
         expect(subject.contact_name).to eql(contact_name)
         expect(subject.contact_number).to eql(contact_number)
         expect(subject.contact_email).to eql(contact_email)
+        expect(subject.experience_type).to eql(experience_type)
       end
     end
 
@@ -63,7 +66,8 @@ describe Schools::PlacementRequests::Acceptance::MakeChangesController, type: :r
             bookings_subject_id: bookings_subject.id,
             contact_name: contact_name,
             contact_number: contact_number,
-            contact_email: contact_email
+            contact_email: contact_email,
+            experience_type: experience_type
           }
         }
       end

--- a/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/acceptance/preview_confirmation_email_controller_spec.rb
@@ -72,7 +72,22 @@ describe Schools::PlacementRequests::Acceptance::PreviewConfirmationEmailControl
 
     context 'when virtual experience' do
       let!(:virtual_experience) { create(:bookings_placement_date, virtual: true) }
-      let!(:pr) { create(:bookings_placement_request, school: @current_user_school, placement_date: virtual_experience) }
+      let!(:pr) { create(:placement_request, :virtual, school: @current_user_school, placement_date: virtual_experience) }
+      let!(:booking) do
+        create(
+          :bookings_booking,
+          bookings_school: @current_user_school,
+          experience_type: 'virtual',
+          bookings_placement_request: pr,
+          date: 3.weeks.from_now,
+          placement_details: "an amazing experience",
+          contact_name: 'Gary Chalmers',
+          contact_email: 'gary.chalmers@springfield.edu',
+          contact_number: '01234 456 678',
+          location: 'Near the assembly hall',
+          candidate_instructions: 'Please come to the main reception'
+        )
+      end
 
       specify 'should send a candidate booking confirmation notification virtual experience email' do
         allow(NotifyEmail::CandidateVirtualExperienceBookingConfirmation).to(

--- a/spec/factories/bookings/bookings_factory.rb
+++ b/spec/factories/bookings/bookings_factory.rb
@@ -9,8 +9,13 @@ FactoryBot.define do
     contact_name { 'William MacDougal' }
     contact_email { 'gcw@springfield.edu' }
     contact_number { '01234 456 245' }
+    experience_type { 'inschool' }
 
     date { 2.months.from_now }
+
+    trait :virtual_experience do
+      experience_type { 'virtual' }
+    end
 
     trait :accepted do
       candidate_instructions { 'Report to reception on arrival' }

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
     degree_stage_explaination { nil }
     degree_subject { "Not applicable" }
     teaching_stage { "I’m very sure and think I’ll apply" }
+    experience_type { 'both' }
 
     # FIXME: change this to cancelled_by_candidate
     trait :cancelled do
@@ -125,6 +126,14 @@ FactoryBot.define do
     trait :with_a_fixed_date_in_the_past do
       availability { nil }
       association :placement_date, :in_the_past, factory: :bookings_placement_date
+    end
+
+    trait :virtual do
+      experience_type { 'virtual' }
+    end
+
+    trait :inschool do
+      experience_type { 'inschool' }
     end
   end
 end

--- a/spec/factories/bookings/placement_requests_factory.rb
+++ b/spec/factories/bookings/placement_requests_factory.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
     has_dbs_check { true }
     availability { "Every second Thursday" }
     association :school, factory: :bookings_school
+    experience_type { "both" }
     urn { 123_456 }
 
     trait(:with_a_fixed_date) do

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -108,5 +108,20 @@ FactoryBot.define do
     trait :with_school_profile do
       association :school_profile, factory: %i[school_profile completed]
     end
+
+    trait :flex_virtual do
+      experience_type { 'virtual' }
+      availability_preference_fixed { false }
+    end
+
+    trait :flex_inschool do
+      experience_type { 'inschool' }
+      availability_preference_fixed { false }
+    end
+
+    trait :flex_both do
+      experience_type { 'both' }
+      availability_preference_fixed { false }
+    end
   end
 end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -53,7 +53,7 @@ describe Bookings::Booking do
     it { is_expected.to validate_presence_of(:duration) }
     it { is_expected.to validate_numericality_of(:duration).is_greater_than 0 }
     it { is_expected.to validate_presence_of(:experience_type) }
-    it { is_expected.to validate_inclusion_of(:experience_type).in_array( %w[inschool virtual]) }
+    it { is_expected.to validate_inclusion_of(:experience_type).in_array(%w[inschool virtual]) }
 
     it { is_expected.to validate_presence_of(:contact_name).on(:create) }
     it { is_expected.to validate_presence_of(:contact_number).on(:create) }

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -559,4 +559,24 @@ describe Bookings::Booking do
       end
     end
   end
+
+  describe '#virtual_experience?' do
+    subject { described_class.new(experience_type: experience_type) }
+
+    context 'when experience type is virtual' do
+      let(:experience_type) { 'virtual' }
+
+      it 'returns true' do
+        expect(subject.virtual_experience?).to be true
+      end
+    end
+
+    context 'when experience type is not virtual' do
+      let(:experience_type) { 'inschool' }
+
+      it 'returns false' do
+        expect(subject.virtual_experience?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -53,6 +53,7 @@ describe Bookings::Booking do
     it { is_expected.to validate_presence_of(:duration) }
     it { is_expected.to validate_numericality_of(:duration).is_greater_than 0 }
     it { is_expected.to validate_presence_of(:experience_type) }
+    it { is_expected.to validate_inclusion_of(:experience_type).in_array( %w[inschool virtual]) }
 
     it { is_expected.to validate_presence_of(:contact_name).on(:create) }
     it { is_expected.to validate_presence_of(:contact_number).on(:create) }

--- a/spec/models/bookings/booking_spec.rb
+++ b/spec/models/bookings/booking_spec.rb
@@ -39,6 +39,11 @@ describe Bookings::Booking do
         .of_type(:integer)
         .with_options(default: 1, null: false)
     end
+
+    it do
+      is_expected.to have_db_column(:experience_type)
+        .of_type(:string)
+    end
   end
 
   describe 'Validation' do
@@ -47,6 +52,7 @@ describe Bookings::Booking do
     it { is_expected.to validate_presence_of(:bookings_school) }
     it { is_expected.to validate_presence_of(:duration) }
     it { is_expected.to validate_numericality_of(:duration).is_greater_than 0 }
+    it { is_expected.to validate_presence_of(:experience_type) }
 
     it { is_expected.to validate_presence_of(:contact_name).on(:create) }
     it { is_expected.to validate_presence_of(:contact_number).on(:create) }
@@ -500,6 +506,23 @@ describe Bookings::Booking do
     specify { expect(described_class).to respond_to(:from_placement_request) }
     let(:placement_request) { create(:bookings_placement_request, placement_date: placement_date) }
     subject { described_class.from_placement_request(placement_request) }
+
+    context 'when experience type is vaguely specified' do
+      let(:placement_request) { create(:placement_request, experience_type: 'both') }
+
+      specify 'should not set the experience type' do
+        expect(subject.experience_type).to be_nil
+      end
+    end
+
+    context 'when experience type is clearly specified' do
+      let(:school) { build(:bookings_school, experience_type: 'inschool') }
+      let(:placement_request) { create(:placement_request, :inschool, school: school) }
+
+      specify 'should set the experience type' do
+        expect(subject.experience_type).to eql(placement_request.experience_type)
+      end
+    end
 
     context 'when there is no placement date' do
       let(:placement_request) { create(:bookings_placement_request) }

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -394,4 +394,22 @@ describe Bookings::PlacementDate, type: :model do
       end
     end
   end
+
+  describe "#experience_type" do
+    context "when it's a Virtual date" do
+      subject { create(:bookings_placement_date, :virtual) }
+
+      it "returns 'Virtual'" do
+        expect(subject.experience_type).to eq('Virtual')
+      end
+    end
+
+    context "when it's an Inschool date" do
+      subject { create(:bookings_placement_date) }
+
+      it "returns 'In school'" do
+        expect(subject.experience_type).to eq('In school')
+      end
+    end
+  end
 end

--- a/spec/models/bookings/placement_date_spec.rb
+++ b/spec/models/bookings/placement_date_spec.rb
@@ -399,16 +399,16 @@ describe Bookings::PlacementDate, type: :model do
     context "when it's a Virtual date" do
       subject { create(:bookings_placement_date, :virtual) }
 
-      it "returns 'Virtual'" do
-        expect(subject.experience_type).to eq('Virtual')
+      it "returns 'virtual'" do
+        expect(subject.experience_type).to eq('virtual')
       end
     end
 
     context "when it's an Inschool date" do
       subject { create(:bookings_placement_date) }
 
-      it "returns 'In school'" do
-        expect(subject.experience_type).to eq('In school')
+      it "returns 'inschool'" do
+        expect(subject.experience_type).to eq('inschool')
       end
     end
   end

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -25,7 +25,7 @@ describe Bookings::PlacementRequest, type: :model do
   describe 'Constants' do
     describe 'EXPERIENCE_TYPES' do
       it 'returns an array of strings' do
-        expect(described_class::EXPERIENCE_TYPES).to eq ['inschool', 'virtual']
+        expect(described_class::EXPERIENCE_TYPES).to eq %w[inschool virtual]
       end
     end
   end
@@ -263,7 +263,7 @@ describe Bookings::PlacementRequest, type: :model do
       end
 
       it 'creates the placement request' do
-        expect {subject}.to change { described_class.count }.by 1
+        expect { subject }.to change { described_class.count }.by 1
       end
 
       it 'saves the experience type' do

--- a/spec/models/bookings/placement_request_spec.rb
+++ b/spec/models/bookings/placement_request_spec.rb
@@ -22,6 +22,14 @@ describe Bookings::PlacementRequest, type: :model do
 
   it { is_expected.to have_secure_token }
 
+  describe 'Constants' do
+    describe 'EXPERIENCE_TYPES' do
+      it 'returns an array of strings' do
+        expect(described_class::EXPERIENCE_TYPES).to eq ['inschool', 'virtual']
+      end
+    end
+  end
+
   describe 'candidate requirement' do
     it { is_expected.to validate_presence_of :candidate }
 
@@ -249,11 +257,17 @@ describe Bookings::PlacementRequest, type: :model do
         FactoryBot.build :registration_session
       end
 
+      subject do
+        candidate.placement_requests.create_from_registration_session! \
+          registration_session
+      end
+
       it 'creates the placement request' do
-        expect {
-          candidate.placement_requests.create_from_registration_session! \
-            registration_session
-        }.to change { described_class.count }.by 1
+        expect {subject}.to change { described_class.count }.by 1
+      end
+
+      it 'saves the experience type' do
+        expect(subject.experience_type).not_to be_nil
       end
     end
 
@@ -942,6 +956,86 @@ describe Bookings::PlacementRequest, type: :model do
     context 'with flexible' do
       let(:pr) { build(:placement_request) }
       it { is_expected.to be false }
+    end
+  end
+
+  describe '#resolve_experience_type' do
+    context 'when it is a flex date' do
+      it 'returns the experience type of the school' do
+        expect(subject.resolve_experience_type).to eq subject.school.experience_type
+      end
+    end
+
+    context 'when it is a fixed date' do
+      subject { build :placement_request, :with_a_fixed_date }
+
+      it 'returns the experience type of the placement date' do
+        expect(subject.resolve_experience_type).to eq subject.placement_date.experience_type
+      end
+    end
+  end
+
+  describe '#flex_date?' do
+    context 'without a placement date' do
+      it "returns true" do
+        expect(subject.flex_date?).to be true
+      end
+    end
+
+    context 'with a placement date' do
+      subject { build :placement_request, :with_a_fixed_date }
+
+      it "returns false" do
+        expect(subject.flex_date?).to be false
+      end
+    end
+  end
+
+  describe '#unclear_experience_type?' do
+    context 'when it is a flex date' do
+      context 'when experience is virtual' do
+        let(:school) { build :bookings_school, :flex_virtual }
+        subject { build :placement_request, :virtual, school: school }
+
+        it 'returns false' do
+          expect(subject.unclear_experience_type?).to be false
+        end
+      end
+
+      context 'when experience is in school' do
+        let(:school) { build :bookings_school, :flex_inschool }
+        subject { build :placement_request, :inschool, school: school }
+
+        it 'returns false' do
+          expect(subject.unclear_experience_type?).to be false
+        end
+      end
+
+      context 'when the experience is both' do
+        let(:school) { build :bookings_school, :flex_both }
+        subject { build :placement_request, school: school }
+
+        it 'returns true' do
+          expect(subject.unclear_experience_type?).to be true
+        end
+      end
+
+      context 'when the school and placement request experience types are different' do
+        let(:school) { build :bookings_school, :flex_both }
+        subject { build :placement_request, :virtual, school: school }
+
+        it 'returns true' do
+          expect(subject.unclear_experience_type?).to be true
+        end
+      end
+    end
+
+    context 'when it is a fixed date' do
+      subject { build :placement_request, :with_a_fixed_date }
+
+      it 'returns false' do
+        expect(subject.unclear_experience_type?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/NzhZrsbg

### Context
We need to reliably know whether a candidate is requesting and having an In school or Virtual experience when schools offer flexible dates.

We currently store the school experience type, but can be unclear, meaning either the school offers both types or the school experience type is shifted while there are pending requests and bookings.

### Changes proposed in this pull request
- Add the experience type column in the PlacementRequest model

This allows to always know what experience type the candidate requested, but also to determine if the school experience type has shifted since a placement request was created.

- Add the experience type column in the Bookings model 

This allows to know what experience type the candidate is actually going to have, so to display content relevant to In school or Virtual experiences. Also use to make more accurate reports.

- Migrate all current placement request and booking records

Update all placement requests and bookings to avoid creating data inconsistency issues in reports and in pending requests/bookings. The migration will be in batches of 100 to avoid running out of memory.

Finally, had to skip the placement requests validations due to data inconsistencies which are irrelevant to the experience type.

- Update PlacementRequest.create_from_registration_session to store the experience type based on the the school experience type

The experience type will be inherited from the school record when the request is created.

- Update the Booking.from_placement_request to try to store the booking experience type based on the the placement request experience type

The experience type will be inherited from the placement request record unless it's unclear, in which case user input will be required.

- Update the booking make changes page to ask schools to choose the experience type when it can't be determined by the system

Require user input when the placement request experience type is unclear

- Add #experience_type in the PlacementDate model

To simulate the experience type from the school, placement request and booking model. 

- Refactor the preview_confirmation_email_controller to use the booking experience type to decide which email should preview and send

### Guidance to review
Nothing should change visually regarding the fixed dates.

Flex dates:
1. When the experience type is clear, nothing should change visually. Both placement request and booking models should have the same experience type with the School's experience type. Also, the booking confirmation email should display the virtual content for 'Virtual' experiences and the in school content for 'In school' experiences. Finally, confirm the correct email has been received when creating the booking.

2. When the experience type is unclear, the experience type radio buttons should be displayed when accepting a request. The booking should then have the chosen experience type and based on that, it should display the equivalent content in the the preview email. Also confirm the correct email has been received when creating the booking.
