### PR TITLE
Error messages search

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -5,12 +5,10 @@ class Candidates::SchoolsController < ApplicationController
   before_action :redirect_if_deactivated
 
   def index
-    return redirect_to new_candidates_school_search_path unless location_present?
-
     @search = Candidates::SchoolSearch.new(search_params)
-    @facet_tags = FacetTagsPresenter.new(@search.applied_filters)
+    render 'candidates/school_searches/new' and return unless @search.valid? && location_present?
 
-    return render 'candidates/school_searches/new' unless @search.valid?
+    @facet_tags = FacetTagsPresenter.new(@search.applied_filters)
 
     @country = @search.country
 

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -4,7 +4,7 @@ require 'geocoding_response_country'
 class Bookings::SchoolSearch < ApplicationRecord
   attr_reader :location_name, :country
 
-  validates :location, length: { minimum: 2 }, allow_nil: false, if: -> { location.is_a?(String) }
+  validates :location, presence: true, length: { minimum: 2 }, if: -> { location.is_a?(String) }
 
   # Despite this being an England-only service, we want to search the whole of the UK
   # so that we can return results to users who are near the border.

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -21,7 +21,7 @@
         html: { class: 'school-search-form' },
         data: { controller: :autocomplete, "autocomplete-target": "wrapper", "autocomplete-api-key-value": Rails.application.config.x.google_maps_key }) do |f| %>
 
-        <%= f.govuk_text_field :location, required: true, minlength: "2", label: { text: t('helpers.label.location') }, type: "search",
+        <%= f.govuk_text_field :location, label: { text: t('helpers.label.location') }, type: "search",
                                  data: { "autocomplete-target": "nonJsInput" } %>
 
         <label for="location-field" data-autocomplete-target="autocompleteInputLabel" class="govuk-label govuk-visually-hidden"><%= t('helpers.label.location') %></label>

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -24,7 +24,7 @@
                            "autocomplete-api-key-value": Rails.application.config.x.google_maps_key,
                            "autocomplete-error-value": @search.errors[:location].first }) do |f| %>
 
-        <%= f.govuk_text_field :location, label: { text: t('helpers.label.location') }, type: "search",
+        <%= f.govuk_text_field :location, required: true, minlength: "2", label: { text: t('helpers.label.location') }, type: "search",
                                data: { "autocomplete-target": "nonJsInput" } %>
 
         <div class="govuk-form-group" data-autocomplete-target="locationFormGroup">

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -15,26 +15,31 @@
     <div id="search-form">
 
       <%= form_for(@search,
-        as: '',
-        url: candidates_schools_path,
-        method: :get,
-        html: { class: 'school-search-form' },
-        data: { controller: :autocomplete, "autocomplete-target": "wrapper", "autocomplete-api-key-value": Rails.application.config.x.google_maps_key }) do |f| %>
+                   as: '',
+                   url: candidates_schools_path,
+                   method: :get,
+                   html: { class: 'school-search-form' },
+                   data: { controller: :autocomplete,
+                           "autocomplete-target": "wrapper",
+                           "autocomplete-api-key-value": Rails.application.config.x.google_maps_key,
+                           "autocomplete-error-value": @search.errors[:location].first }) do |f| %>
 
         <%= f.govuk_text_field :location, label: { text: t('helpers.label.location') }, type: "search",
-                                 data: { "autocomplete-target": "nonJsInput" } %>
+                               data: { "autocomplete-target": "nonJsInput" } %>
 
-        <label for="location-field" data-autocomplete-target="autocompleteInputLabel" class="govuk-label govuk-visually-hidden"><%= t('helpers.label.location') %></label>
-        <div id="location-autocomplete" data-autocomplete-target="autocompleteWrapper" class="govuk-body"></div>
+        <div class="govuk-form-group" data-autocomplete-target="locationFormGroup">
+          <label for="location-field" data-autocomplete-target="autocompleteInputLabel" class="govuk-label govuk-visually-hidden"><%= t('helpers.label.location') %></label>
+          <div id="location-autocomplete" data-autocomplete-target="autocompleteWrapper" class="govuk-body"></div>
+        </div>
 
-          <%= f.govuk_collection_select :distance,
-                Candidates::SchoolSearch.distances, :first, :last, label: { text: t('helpers.label.distance')  } unless f.object.whitelisted_urns? %>
+        <%= f.govuk_collection_select :distance,
+                                      Candidates::SchoolSearch.distances, :first, :last, label: { text: t('helpers.label.distance') } unless f.object.whitelisted_urns? %>
 
-          <div class="school-search-form__submit">
-            <div class="govuk-form-group">
-              <%= f.govuk_submit 'Search', name: nil, aria: { label: 'Search for schools offering school experience' } %>
-            </div>
+        <div class="school-search-form__submit">
+          <div class="govuk-form-group">
+            <%= f.govuk_submit 'Search', name: nil, aria: { label: 'Search for schools offering school experience' } %>
           </div>
+        </div>
       <% end %>
     </div>
   </div>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -14,7 +14,7 @@
       <%= f.govuk_text_field :location, width: 'full', label: { text: t('helpers.label.location') },
                              data: { "autocomplete-target": "nonJsInput" }%>
 
-      <div class="govuk-form-group">
+      <div class="govuk-form-group" data-autocomplete-target="locationFormGroup">
         <label for="location-field" data-autocomplete-target="autocompleteInputLabel" class="govuk-label govuk-visually-hidden"><%= t('helpers.label.location_short') %></label>
         <div id="location-autocomplete" data-autocomplete-target="autocompleteWrapper"></div>
       </div>

--- a/app/webpacker/controllers/autocomplete_controller.js
+++ b/app/webpacker/controllers/autocomplete_controller.js
@@ -10,10 +10,12 @@ export default class extends Controller {
     "autocompleteWrapper",
     "autocompleteInputLabel",
     "wrapper",
+    "locationFormGroup",
   ];
 
   static values = {
     apiKey: String,
+    error: String,
   };
 
   async connect() {
@@ -22,11 +24,32 @@ export default class extends Controller {
     this.#initialiseAutoComplete();
     this.#removeNonJsInput();
     this.#showAutoCompleteLabel();
+    this.#showErrorMessage();
 
     this.#setWrapperVisibility(true);
 
     await this.#loadScript();
     this.#initialiseService();
+  }
+
+  #showErrorMessage() {
+    if (this.errorValue === "") return;
+
+    this.locationFormGroupTarget.classList.add("govuk-form-group--error");
+
+    const errorMessage = document.createElement("span");
+    errorMessage.textContent = this.errorValue;
+    errorMessage.classList.add("govuk-error-message");
+
+    const hiddenErrorMessage = document.createElement("span");
+    hiddenErrorMessage.textContent = "Error:";
+    hiddenErrorMessage.classList.add("govuk-visually-hidden");
+    errorMessage.prepend(hiddenErrorMessage);
+
+    this.locationFormGroupTarget.insertBefore(
+      errorMessage,
+      document.getElementById(this.autocompleteWrapperTarget.id)
+    );
   }
 
   #findPredictions = (query, populateResults) => {

--- a/app/webpacker/controllers/autocomplete_controller.js
+++ b/app/webpacker/controllers/autocomplete_controller.js
@@ -20,7 +20,6 @@ export default class extends Controller {
     this.#setWrapperVisibility(false);
 
     this.#initialiseAutoComplete();
-    this.#applyGovStyling();
     this.#removeNonJsInput();
     this.#showAutoCompleteLabel();
 
@@ -96,13 +95,5 @@ export default class extends Controller {
     // To reduce any shift as the page loads, hide the section on initialisation (which
     // maintains the space), then show it when loaded.
     this.wrapperTarget.style.visibility = visible ? "" : "hidden";
-  }
-
-  #applyGovStyling() {
-    const autocompleteInput =
-      this.autocompleteWrapperTarget.childNodes[0].getElementsByTagName(
-        "input"
-      )[0];
-    autocompleteInput.classList.add("govuk-input");
   }
 }

--- a/app/webpacker/controllers/autocomplete_controller.js
+++ b/app/webpacker/controllers/autocomplete_controller.js
@@ -19,19 +19,19 @@ export default class extends Controller {
   async connect() {
     this.#setWrapperVisibility(false);
 
-    await this.#loadScript();
-
-    this.#initialiseService();
     this.#initialiseAutoComplete();
     this.#applyGovStyling();
     this.#removeNonJsInput();
     this.#showAutoCompleteLabel();
 
     this.#setWrapperVisibility(true);
+
+    await this.#loadScript();
+    this.#initialiseService();
   }
 
   #findPredictions = (query, populateResults) => {
-    this.#autocompleteService.getPlacePredictions(
+    this.#autocompleteService?.getPlacePredictions(
       {
         input: query,
         sessionToken: this.#sessionToken,

--- a/app/webpacker/stylesheets/school-search.scss
+++ b/app/webpacker/stylesheets/school-search.scss
@@ -185,3 +185,9 @@
     }
   }
 }
+
+[data-controller*="autocomplete"] {
+  input {
+    @extend .govuk-input;
+  }
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -459,6 +459,7 @@ en:
           attributes:
             location:
               too_short: Must be at least 2 characters
+              blank : Enter a location or postcode
         bookings/school:
           attributes:
             availability_preference_fixed:

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -19,43 +19,45 @@ RSpec.describe Candidates::SchoolsController, type: :request do
       }
     end
 
-    before { get candidates_schools_path(query_params) }
+    context "with search params" do
+      before { get candidates_schools_path(query_params) }
 
-    it "assigns params to search model" do
-      expect(assigns(:search).query).to eq('Something')
-      expect(assigns(:search).location).to eq('Manchester')
-      expect(assigns(:search).latitude).to eq('53.481')
-      expect(assigns(:search).longitude).to eq('-2.241')
-      expect(assigns(:search).phases).to eq([1])
-      expect(assigns(:search).subjects).to eq([2, 3])
-      expect(assigns(:search).max_fee).to eq('30')
-      expect(assigns(:search).dbs_policies).to eq([1])
-      expect(assigns(:search).disability_confident).to eq('1')
-      expect(assigns(:search).parking).to eq('1')
+      it "assigns params to search model" do
+        expect(assigns(:search).query).to eq('Something')
+        expect(assigns(:search).location).to eq('Manchester')
+        expect(assigns(:search).latitude).to eq('53.481')
+        expect(assigns(:search).longitude).to eq('-2.241')
+        expect(assigns(:search).phases).to eq([1])
+        expect(assigns(:search).subjects).to eq([2, 3])
+        expect(assigns(:search).max_fee).to eq('30')
+        expect(assigns(:search).dbs_policies).to eq([1])
+        expect(assigns(:search).disability_confident).to eq('1')
+        expect(assigns(:search).parking).to eq('1')
 
-      # note, this search will yield no results so the search radius will
-      # automatically be expanded from 10 to the value at EXPANDED_SEARCH_RADIUS
-      expect(assigns(:search).distance).to eq(Candidates::SchoolsController::EXPANDED_SEARCH_RADIUS)
-    end
-
-    context 'when location and coordinates are blank' do
-      let(:query_params) do
-        {
-          query: 'Something',
-          location: '',
-          latitude: '',
-          longitude: '',
-          distance: '10',
-          phases: %w[1],
-          subjects: %w[2 3],
-          max_fee: '30',
-          order: 'Name',
-          dbs_policies: %w[1]
-        }
+        # note, this search will yield no results so the search radius will
+        # automatically be expanded from 10 to the value at EXPANDED_SEARCH_RADIUS
+        expect(assigns(:search).distance).to eq(Candidates::SchoolsController::EXPANDED_SEARCH_RADIUS)
       end
 
-      it 'redirects to the search page' do
-        expect(subject).to redirect_to(new_candidates_school_search_path)
+      context 'when location and coordinates are blank' do
+        let(:query_params) do
+          {
+            query: 'Something',
+            location: '',
+            latitude: '',
+            longitude: '',
+            distance: '10',
+            phases: %w[1],
+            subjects: %w[2 3],
+            max_fee: '30',
+            order: 'Name',
+            dbs_policies: %w[1]
+          }
+        end
+
+        it 'renders the search page' do
+          expect(subject).to render_template :new
+        end
       end
 
       context 'when coordinates are blank and location is present' do
@@ -76,6 +78,16 @@ RSpec.describe Candidates::SchoolsController, type: :request do
         before { get candidates_schools_path(query_params_with_coordinates) }
 
         specify { expect(response).to have_http_status(:success) }
+      end
+    end
+
+    context "when search is invalid" do
+      before do
+        allow_any_instance_of(Candidates::SchoolSearch).to receive(:valid?).and_return false
+      end
+
+      it "renders the search page" do
+        expect(get(candidates_schools_path(query_params))).to render_template :new
       end
     end
   end

--- a/spec/javascript/controllers/autocomplete_controller_spec.js
+++ b/spec/javascript/controllers/autocomplete_controller_spec.js
@@ -38,12 +38,6 @@ describe("SearchController", () => {
       ).toHaveBeenCalledTimes(1);
     });
 
-    it("applies GOV.UK styling to the autocomplete input", () => {
-      expect(document.getElementsByTagName("input")[0].classList).toContain(
-        "govuk-input"
-      );
-    });
-
     it("removes the non-JavaScript input", () => {
       expect(
         document.querySelector('[data-autocomplete-target="nonJsInput"]')

--- a/spec/javascript/controllers/autocomplete_controller_spec.js
+++ b/spec/javascript/controllers/autocomplete_controller_spec.js
@@ -8,13 +8,15 @@ describe("SearchController", () => {
   });
 
   beforeEach(() => {
-    setBody();
     clearHead();
-
     setupGoogleMock();
   });
 
   describe("connecting", () => {
+    beforeEach(() => {
+      setBody();
+    });
+
     it("shows the section (after hiding it, to reduce content shift)", () => {
       const wrapper = document.getElementsByTagName("form")[0];
 
@@ -53,7 +55,30 @@ describe("SearchController", () => {
     });
   });
 
-  const setBody = () => {
+  describe("errors", () => {
+    beforeEach(() => {
+      setBody(true);
+    });
+
+    it("shows an GOV.UK error message", () => {
+      const locationFormGroup = document.querySelector(
+        '[data-autocomplete-target="locationFormGroup"]'
+      );
+
+      expect(locationFormGroup.classList).toContain("govuk-form-group--error");
+
+      const errorMessage = locationFormGroup.getElementsByTagName("span")[0];
+      const hiddenErrorMessage = errorMessage.getElementsByTagName("span")[0];
+
+      expect(errorMessage.textContent).toEqual(
+        "Error:Must be at least 2 characters"
+      );
+      expect(errorMessage.classList).toContain("govuk-error-message");
+      expect(hiddenErrorMessage.classList).toContain("govuk-visually-hidden");
+    });
+  });
+
+  const setBody = (errors = false) => {
     document.body.innerHTML = `
       <form class="school-search-form" id="new_" novalidate="novalidate" data-controller="autocomplete" data-autocomplete-target="wrapper" data-autocomplete-api-key-value="KEY" action="/candidates/schools" accept-charset="UTF-8" method="get">
         <div class="govuk-form-group">
@@ -61,8 +86,10 @@ describe("SearchController", () => {
           <input id="location-field" class="govuk-input" required="required" minlength="2" type="search" data-autocomplete-target="nonJsInput" name="location">
         </div>
 
-        <label for="location-autocomplete" data-autocomplete-target="autocompleteInputLabel" class="govuk-label govuk-visually-hidden">Enter location or postcode</label>
-        <div id="location-autocomplete" data-autocomplete-target="autocompleteWrapper" class="govuk-body"></div>
+        <div class="govuk-form-group" data-autocomplete-target="locationFormGroup">
+          <label for="location-autocomplete" data-autocomplete-target="autocompleteInputLabel" class="govuk-label govuk-visually-hidden">Enter location or postcode</label>
+          <div id="location-autocomplete" data-autocomplete-target="autocompleteWrapper" class="govuk-body"></div>
+        </div>
 
         <div class="school-search-form__submit">
           <div class="govuk-form-group">
@@ -71,6 +98,14 @@ describe("SearchController", () => {
         </div>
       </form>
     `;
+
+    if (errors) {
+      const form = document.body.getElementsByTagName("form")[0];
+      form.setAttribute(
+        "data-autocomplete-error-value",
+        "Must be at least 2 characters"
+      );
+    }
   };
 
   const setupGoogleMock = () => {

--- a/spec/javascript/controllers/autocomplete_controller_spec.js
+++ b/spec/javascript/controllers/autocomplete_controller_spec.js
@@ -2,23 +2,21 @@ import { Application } from "stimulus";
 import AutocompleteController from "autocomplete_controller.js";
 
 describe("SearchController", () => {
-  beforeEach(async () => {
-    setupGoogleMock();
-
+  beforeAll(() => {
     const application = Application.start();
     application.register("autocomplete", AutocompleteController);
+  });
 
+  beforeEach(() => {
     setBody();
     clearHead();
+
+    setupGoogleMock();
   });
 
   describe("connecting", () => {
-    it("hides then shows the section to reduce content shift", async () => {
+    it("shows the section (after hiding it, to reduce content shift)", () => {
       const wrapper = document.getElementsByTagName("form")[0];
-
-      expect(wrapper.style.visibility).toEqual("hidden");
-
-      await mockGoogleScriptLoading();
 
       expect(wrapper.style.visibility).toEqual("");
     });
@@ -40,35 +38,19 @@ describe("SearchController", () => {
       ).toHaveBeenCalledTimes(1);
     });
 
-    it("applies GOV.UK styling to the autocomplete input", async () => {
-      await mockGoogleScriptLoading();
-
+    it("applies GOV.UK styling to the autocomplete input", () => {
       expect(document.getElementsByTagName("input")[0].classList).toContain(
         "govuk-input"
       );
     });
 
-    it("removes the non-JavaScript input", async () => {
-      expect(
-        document.querySelector('[data-autocomplete-target="nonJsInput"]')
-      ).toBeTruthy();
-
-      await mockGoogleScriptLoading();
-
+    it("removes the non-JavaScript input", () => {
       expect(
         document.querySelector('[data-autocomplete-target="nonJsInput"]')
       ).toBeFalsy();
     });
 
-    it("shows the autocomplete label", async () => {
-      expect(
-        document.querySelector(
-          '[data-autocomplete-target="autocompleteInputLabel"]'
-        ).classList
-      ).toContain("govuk-visually-hidden");
-
-      await mockGoogleScriptLoading();
-
+    it("shows the autocomplete label", () => {
       expect(
         document.querySelector(
           '[data-autocomplete-target="autocompleteInputLabel"]'

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Candidates::SchoolSearch do
+  describe "validation" do
+    describe "#location" do
+      it { is_expected.not_to allow_values("", "a").for :location }
+      it { is_expected.to allow_value("aaa").for :location }
+    end
+  end
+
   context '.new' do
     subject do
       described_class.new(


### PR DESCRIPTION
### Trello card
https://trello.com/c/Tc6IYa96

### Context
The search page is not displaying any validation errors, instead it submit the data to the search results page and then it gets redirected back to the search page.

### Changes proposed in this pull request
1. Reduce time before search input loads: Sometimes, there is a very brief flash of blankness while the autocomplete loads. Swap the order of loading, so that the input is shown before the Google script is loaded.
2. Apply GOV.UK styling to accessible autocomplete in CSS: I was previously applying the styling in JavaScript, but the accessible autocomplete was reloading when its state changed, so was losing the class.Sass comes with an @extend rule, so use that instead.
3. Make sure validation errors are shown when user doesn't enter a value: Currently, when a user doesn't enter a search value, they are redirected back to the `new` page, but not shown a validation error. Check `valid?` and `location_present?` in the same line to make sure validation is shown properly.
4. Show error messages when JavaScript enabled: We want to show error messages on the location search when JavaScript is enabled. I have previously done this as a Rails partial, but it was easier to do it here in the Stimulus controller. 
5. Make sure blank message shows if search is blank: Currently, the search shows the too_short message when the search is blank. Update it so that it shows the correct message.

### Guidance to review
This still send you back to the `new` search page if there is an error (which is what the ticket says to do). It looks weird if we show the error on the `index` page.

