### PR TITLE
Add option to run Capybara tests in headed mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,15 @@ If you have plenty of cpu cores, it faster to run tests with parallel_tests
 1. Create the databases - `bundle exec rake parallel:create`
 2. Copy the schema over from the main database - `bundle exec rake parallel:prepare`
 3. Run RSpecs - `bundle exec rake parallel:spec`
-3. Run Cucumber features - `bundle exec rake parallel:features`
+4. Run Cucumber features - `bundle exec rake parallel:features`
+
+### Feature tests in headed mode
+
+To run feature tests in a headed configuration for easier troubleshooting, add an `.env.test.local` file to the root of the project with the following environment variable:
+
+```
+SELENIUM_CHROME_DRIVER=true
+```
 
 ### Common issues running tests
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -51,11 +51,9 @@ ActionController::Base.allow_rescue = false
 
 # Browser configuration
 
-driver = :selenium_chrome_headless
-
 Capybara.server = :puma, { Silent: true }
 
-Capybara.register_driver driver do |app|
+Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
 
   options.add_argument("--headless")
@@ -63,7 +61,16 @@ Capybara.register_driver driver do |app|
   options.add_argument("--disable-dev-shm-usage")
   options.add_argument("--window-size=1400,1400")
 
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [options])
 end
 
-Capybara.javascript_driver = driver
+if ENV['SELENIUM_CHROME_DRIVER']
+  Capybara.configure do |config|
+    config.default_driver = :selenium_chrome
+    config.javascript_driver = :selenium_chrome
+  end
+else
+  Capybara.configure do |config|
+    config.javascript_driver = :headless_chrome
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/wvVsEM0g

### Changes proposed in this pull request
For easier troubleshooting, we want to be able to run Capybara tests in headed mode.

Add an environment variable `SELENIUM_CHROME_DRIVER` which will configure Capybara to use the default `selenium_chrome` config. 

Because `.env.local` doesn't override the `test` environment, `SELENIUM_CHROME_DRIVER` will need to be set in `.env.test.local`.

This also removes the deprecated `options` parameter for driver initialisation.