### PR TITLE
Various title/heading updates

### DIFF
--- a/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
@@ -1,4 +1,4 @@
-<% self.page_title = 'Cancel placement request' %>
+<% self.page_title = 'Cancel request' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_school.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_show_placement_request_cancelled_by_school.html.erb
@@ -1,4 +1,4 @@
-<% self.page_title = 'Rejected placement request' %>
+<% self.page_title = 'Request declined' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -1,4 +1,4 @@
-<% self.page_title = 'Request a school experience date' %>
+<% self.page_title = 'Choose a school experience date' %>
 <%= govuk_back_link javascript: true %>
 
 <div class="govuk-grid-row" id="placement-preference">

--- a/app/views/candidates/registrations/teaching_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/teaching_preferences/_form.html.erb
@@ -4,7 +4,7 @@
   <%= form_for teaching_preference, url: candidates_school_registrations_teaching_preference_path, data: { controller: 'subject-preference-form' } do |f| %>
     <%= f.govuk_error_summary %>
 
-    <%= f.govuk_collection_radio_buttons :teaching_stage, f.object.available_teaching_stages, :to_s, :to_s %>
+    <%= f.govuk_collection_radio_buttons :teaching_stage, f.object.available_teaching_stages, :to_s, :to_s, { legend: { tag: "h1" } } %>
 
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">

--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -1,4 +1,4 @@
-<% self.page_title = 'Privacy policy - Schools' %>
+<% self.page_title = 'Privacy policy for Manage school experience' %>
 
 <%= govuk_back_link %>
 

--- a/app/views/schools/archived_placement_requests/index.html.erb
+++ b/app/views/schools/archived_placement_requests/index.html.erb
@@ -1,5 +1,5 @@
 <%
-  self.page_title = "Archived placement requests"
+  self.page_title = "Archived requests"
 
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = "Describe when you’ll host school experience candidates" %>
+<%- self.page_title = "Describe your school experience availability" %>
 
 <%= govuk_back_link edit_schools_availability_preference_path %>
 
@@ -7,7 +7,7 @@
     <%= form_for @current_school, url: schools_availability_info_path, method: :patch do |f| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <%= f.govuk_text_area :availability_info, rows: 7, label: { class: 'govuk-heading-l' } do %>
+          <%= f.govuk_text_area :availability_info, rows: 7, label: { tag: 'h1', size: 'l' } do %>
             <p>
               Outline when you offer in school or virtual school experiences at
               your school.

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @current_school, url: schools_availability_preference_path, method: 'patch' do |f| %>
       <%= f.govuk_error_summary f.object %>
-      <%= f.govuk_radio_buttons_fieldset :availability_preference_fixed do %>
+      <%= f.govuk_radio_buttons_fieldset :availability_preference_fixed, { legend: { tag: 'h1' } } do %>
 
         <%= f.hidden_field :availability_preference_fixed %>
 

--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -1,4 +1,4 @@
-<% self.page_title = "Manage requests and bookings at #{@current_school.name}" %>
+<% self.page_title = "School dashboard" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/schools/errors/auth_failed/show.html.erb
+++ b/app/views/schools/errors/auth_failed/show.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = "Error - Auth failed" -%>
+<%- self.page_title = "Error - there was a problem signing you in" -%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/errors/inaccessible_school/show.html.erb
+++ b/app/views/schools/errors/inaccessible_school/show.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = "Error - Inaccessible school" -%>
+<%- self.page_title = "Error - you do not have access to this school" -%>
 
 <%= govuk_back_link %>
 

--- a/app/views/schools/errors/insufficient_privileges/show.html.erb
+++ b/app/views/schools/errors/insufficient_privileges/show.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = "Error - Insufficient privileges" -%>
+<%- self.page_title = "Error - request school experience access" -%>
 
 <%= govuk_back_link %>
 

--- a/app/views/schools/on_boarding/access_needs_details/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_details/_form.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for access_needs_detail, url: schools_on_boarding_access_needs_detail_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_area :description, rows: 9, label: { class: 'govuk-heading-l' } do %>
+      <%= f.govuk_text_area :description, rows: 9, label: { tag: "h1" } do %>
         <p>
           Edit and add to the following suggested wording so we can add it to your school profile.
         </p>

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = 'Confirm number of primary key stages' -%>
+<%- self.page_title = 'Which key stages do you offer experience with?' -%>
 
 <%= govuk_back_link javascript: true %>
 

--- a/app/views/schools/on_boarding/previews/show.html.erb
+++ b/app/views/schools/on_boarding/previews/show.html.erb
@@ -1,5 +1,5 @@
 <%
-  self.page_title = @school.name
+  self.page_title = "School profile review"
 
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,

--- a/app/views/schools/placement_requests/index.html.erb
+++ b/app/views/schools/placement_requests/index.html.erb
@@ -1,5 +1,5 @@
 <%
-  self.page_title = "All placement requests"
+  self.page_title = "Manage requests"
 
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,

--- a/features/schools/availability_information/edit.feature
+++ b/features/schools/availability_information/edit.feature
@@ -10,7 +10,7 @@ Feature: Editing availability info
 
     Scenario: Page title
         Given I am on the 'availability information' page
-        Then the page title should be 'Describe when you’ll host school experience candidates'
+        Then the page title should be 'Describe your school experience availability'
 
     Scenario: Page contents
         Given I am on the 'availability information' page

--- a/features/schools/placement_requests/index.feature
+++ b/features/schools/placement_requests/index.feature
@@ -10,7 +10,7 @@ Feature: Viewing all placement requests
 
     Scenario: Page title
         Given I am on the 'placement requests' page
-        Then the page title should be 'All placement requests'
+        Then the page title should be 'Manage requests'
 
     Scenario: List presence
         Given there are some placement requests


### PR DESCRIPTION
### Trello card

[Trello-519](https://trello.com/c/p4aJJgZX/519-update-page-titles-so-they-match-their-page-headings)

### Context

Update a number of page titles to match new versions as per a spreadsheet provided in the Trello card.

Update some form labels/legends that should be `<h1>` tags.

### Changes proposed in this pull request

- Various title/headings updates

### Guidance to review

