### PR TITLE
Add booking reminder email for virtual experiences

### DIFF
--- a/app/notify/notify_email/candidate_booking_reminder_virtual_experience_updated_jan22.be4eb8b2-3abd-4882-8719-e6812975110a.md
+++ b/app/notify/notify_email/candidate_booking_reminder_virtual_experience_updated_jan22.be4eb8b2-3abd-4882-8719-e6812975110a.md
@@ -1,0 +1,32 @@
+Dear ((candidate_name)),
+
+It’s ((time_until_booking)) until your placement at ((school_name)).
+
+#Date and time
+Date: ((placement_schedule))
+Start and finish times: ((school_start_time)) to ((school_finish_time))
+
+#Location
+Online (virtual experience)
+
+#Instructions
+((candidate_instructions))
+
+#Subject
+((subject_name))
+
+#Who to contact
+For questions about your experience, use the following contact details:
+
+Name: ((school_teacher_name))
+Email: ((school_teacher_email))
+Telephone number: ((school_teacher_telephone))
+
+To change your booking, contact the school experience administrator:
+
+Email: ((school_admin_email))
+Telephone number: ((school_admin_telephone))
+
+#Cancelling your booking
+Use the following link to cancel your booking:
+((cancellation_url))

--- a/app/notify/notify_email/candidate_virtual_experience_booking_reminder.rb
+++ b/app/notify/notify_email/candidate_virtual_experience_booking_reminder.rb
@@ -1,0 +1,97 @@
+class NotifyEmail::CandidateVirtualExperienceBookingReminder < NotifyDespatchers::Email
+  attr_accessor :school_name,
+    :time_until_booking,
+    :candidate_name,
+    :placement_schedule,
+    :school_start_time,
+    :school_finish_time,
+    :school_admin_email,
+    :school_admin_telephone,
+    :school_teacher_name,
+    :school_teacher_email,
+    :school_teacher_telephone,
+    :candidate_instructions,
+    :subject_name,
+    :cancellation_url
+
+  def initialize(
+    to:,
+    school_name:,
+    time_until_booking:,
+    candidate_name:,
+    placement_schedule:,
+    school_start_time:,
+    school_finish_time:,
+    school_admin_email:,
+    school_admin_telephone:,
+    school_teacher_name:,
+    school_teacher_email:,
+    school_teacher_telephone:,
+    candidate_instructions:,
+    subject_name:,
+    cancellation_url:
+  )
+    self.school_name = school_name
+    self.time_until_booking = time_until_booking
+    self.candidate_name = candidate_name
+    self.placement_schedule = placement_schedule
+    self.school_start_time = school_start_time
+    self.school_finish_time = school_finish_time
+    self.school_admin_email = school_admin_email
+    self.school_admin_telephone = school_admin_telephone
+    self.school_teacher_name = school_teacher_name
+    self.school_teacher_email = school_teacher_email
+    self.school_teacher_telephone = school_teacher_telephone
+    self.candidate_instructions = candidate_instructions
+    self.subject_name = subject_name
+    self.cancellation_url = cancellation_url
+
+    super(to: to)
+  end
+
+  def self.from_booking(to, time_until_booking, booking, candidates_cancel_url)
+    school = booking.bookings_school
+    profile = school.profile
+
+    new(
+      to: to,
+      school_name: school.name,
+      time_until_booking: time_until_booking,
+      candidate_name: booking.candidate_name,
+      placement_schedule: booking.placement_start_date_with_duration,
+      school_start_time: profile.start_time,
+      school_finish_time: profile.end_time,
+      school_admin_email: profile.admin_contact_email,
+      school_admin_telephone: profile.admin_contact_phone,
+      school_teacher_name: booking.contact_name,
+      school_teacher_email: booking.contact_email,
+      school_teacher_telephone: booking.contact_number,
+      candidate_instructions: booking.candidate_instructions,
+      subject_name: booking.bookings_subject.name,
+      cancellation_url: candidates_cancel_url
+    )
+  end
+
+  def template_id
+    'be4eb8b2-3abd-4882-8719-e6812975110a'
+  end
+
+  def personalisation
+    {
+      school_name: school_name,
+      time_until_booking: time_until_booking,
+      candidate_name: candidate_name,
+      placement_schedule: placement_schedule,
+      school_start_time: school_start_time,
+      school_finish_time: school_finish_time,
+      school_admin_email: school_admin_email,
+      school_admin_telephone: school_admin_telephone,
+      school_teacher_name: school_teacher_name,
+      school_teacher_email: school_teacher_email,
+      school_teacher_telephone: school_teacher_telephone,
+      candidate_instructions: candidate_instructions,
+      subject_name: subject_name,
+      cancellation_url: cancellation_url
+    }
+  end
+end

--- a/app/services/bookings/reminder.rb
+++ b/app/services/bookings/reminder.rb
@@ -20,7 +20,24 @@ class Bookings::Reminder
 private
 
   def despatch_reminder_email
+    if @booking.virtual_experience?
+      virtual_reminder
+    else
+      in_school_reminder
+    end
+  end
+
+  def in_school_reminder
     NotifyEmail::CandidateBookingReminder.from_booking(
+      @booking.candidate_email,
+      @time_until_booking,
+      @booking,
+      candidates_cancel_url(@booking.token)
+    ).despatch_later!
+  end
+
+  def virtual_reminder
+    NotifyEmail::CandidateVirtualExperienceBookingReminder.from_booking(
       @booking.candidate_email,
       @time_until_booking,
       @booking,

--- a/spec/notify/notify_email/candidate_virtual_experience_booking_reminder_spec.rb
+++ b/spec/notify/notify_email/candidate_virtual_experience_booking_reminder_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+describe NotifyEmail::CandidateVirtualExperienceBookingReminder do
+  it_should_behave_like "email template", "be4eb8b2-3abd-4882-8719-e6812975110a",
+    time_until_booking: "2 weeks",
+    school_name: "Springfield Elementary",
+    candidate_name: "Kearney Zzyzwicz",
+    placement_schedule: "2022-03-04 for 3 days",
+    school_start_time: "08:40",
+    school_finish_time: "15:30",
+    school_admin_email: "sskinner@example.com",
+    school_admin_telephone: "01234 123 1234",
+    school_teacher_name: "Edna Krabappel",
+    school_teacher_email: "ednak@example.com",
+    school_teacher_telephone: "01234 234 1245",
+    candidate_instructions: "Please report to reception on arrival",
+    subject_name: 'Biology',
+    cancellation_url: "#{Rails.configuration.x.base_url}/candiates/cancel/abc-123"
+
+  describe ".from_booking" do
+    before do
+      stub_const(
+        'Notify::API_KEY',
+        ["somekey", SecureRandom.uuid, SecureRandom.uuid].join("-")
+      )
+    end
+
+    specify { expect(described_class).to respond_to(:from_booking) }
+
+    let(:time_until_booking) { "2 weeks" }
+    let!(:school) { create(:bookings_school) }
+    let!(:profile) { create(:bookings_profile, school: school) }
+    let(:to) { "morris.szyslak@moes.net" }
+    let(:candidate_name) { "morris.szyslak" }
+
+    let!(:pr) { create(:bookings_placement_request, school: school) }
+    let!(:booking) do
+      create(
+        :bookings_booking,
+        bookings_school: school,
+        bookings_placement_request: pr
+      )
+    end
+
+    before do
+      allow(booking).to receive(:candidate_name).and_return(candidate_name)
+    end
+
+    let!(:cancellation_url) { "#{Rails.configuration.x.base_url}/candidates/cancel/#{booking.token}" }
+
+    subject { described_class.from_booking(to, time_until_booking, booking, cancellation_url) }
+
+    it { is_expected.to be_a(described_class) }
+
+    context 'correctly assigning attributes' do
+      specify 'time_until_booking is correctly assigned' do
+        expect(subject.time_until_booking).to eql(time_until_booking)
+      end
+
+      specify 'candidate_name is correctly-assigned' do
+        expect(subject.candidate_name).to eql(candidate_name)
+      end
+
+      specify 'placement_schedule is correctly-assigned' do
+        expect(subject.placement_schedule).to eql(booking.placement_start_date_with_duration)
+      end
+
+      specify 'school_start_time is correctly-assigned' do
+        expect(subject.school_start_time).to eql(profile.start_time)
+      end
+
+      specify 'school_end_time is correctly-assigned' do
+        expect(subject.school_finish_time).to eql(profile.end_time)
+      end
+
+      specify 'school_admin_email is correctly-assigned' do
+        expect(subject.school_admin_email).to eql(profile.admin_contact_email)
+      end
+
+      specify 'school_admin_telephone is correctly-assigned' do
+        expect(subject.school_admin_telephone).to eql(profile.admin_contact_phone)
+      end
+
+      specify 'school_teacher_name is correctly-assigned' do
+        expect(subject.school_teacher_name).to eql(booking.contact_name)
+      end
+
+      specify 'school_teacher_email is correctly-assigned' do
+        expect(subject.school_teacher_email).to eql(booking.contact_email)
+      end
+
+      specify 'school_teacher_telephone is correctly-assigned' do
+        expect(subject.school_teacher_telephone).to eql(booking.contact_number)
+      end
+
+      specify 'subject_name is correctly-assigned' do
+        expect(subject.subject_name).to eql(booking.bookings_subject.name)
+      end
+
+      specify 'candidate_instructions is correctly-assigned' do
+        expect(subject.candidate_instructions).to eql(booking.candidate_instructions)
+      end
+
+      specify 'cancellation_url is correctly-assigned' do
+        expect(subject.cancellation_url).to eql(cancellation_url)
+      end
+    end
+  end
+end

--- a/spec/services/bookings/reminder_spec.rb
+++ b/spec/services/bookings/reminder_spec.rb
@@ -21,5 +21,25 @@ describe Bookings::Reminder, type: :request do
 
       expect { subject.deliver }.to change { enqueued_jobs.size }.by(2)
     end
+
+    context "when it's an in school experience" do
+      it "despatches the in school reminder email" do
+        expect_any_instance_of(NotifyEmail::CandidateBookingReminder).to \
+          receive(:despatch_later!)
+
+        subject.deliver
+      end
+    end
+
+    context "when it's a virtual experience" do
+      let(:booking) { create(:bookings_booking, :accepted, :virtual_experience, bookings_school: school, date: 3.weeks.from_now) }
+
+      it "despatches the virtual reminder email" do
+        expect_any_instance_of(NotifyEmail::CandidateVirtualExperienceBookingReminder).to \
+          receive(:despatch_later!)
+
+        subject.deliver
+      end
+    end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/nzVAo0EK

### Context
The current content of the booking email reminder is not very suitable for virtual experiences. 

We want to keep sending the current reminder for in school experiences only, and create a new email reminder for virtual experiences.

### Changes proposed in this pull request
- Add the notify class for the virtual experiences email reminder
- Update the `Bookings::Reminder#despatch_reminder_email` to send the proper reminder based on the booking's experience type

### Guidance to review
1. Accept/Create a 'virtual' and 'in school' booking that will take place tomorrow
2. Trigger the reminder job
3. Confirm the correct email was sent for both bookings
