### PR TITLE
Expose various metrics to Prometheus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,14 @@ gem 'rails_semantic_logger'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+# Metrics
+gem 'yabeda-rails'
+gem 'yabeda-delayed_job'
+gem 'yabeda-prometheus'
+gem 'yabeda-puma-plugin'
+gem 'yabeda-http_requests'
+gem 'yabeda-gc'
+
 gem 'dotenv-rails', '>= 2.7.6'
 
 gem 'govuk_design_system_formbuilder', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,10 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_attr (0.15.4)
+      actionpack (>= 3.0.2, < 7.1)
+      activemodel (>= 3.0.2, < 7.1)
+      activesupport (>= 3.0.2, < 7.1)
     activejob (6.1.4.6)
       activesupport (= 6.1.4.6)
       globalid (>= 0.3.6)
@@ -96,6 +100,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.1.0)
     amazing_print (1.4.0)
+    anyway_config (2.2.3)
+      ruby-next-core (>= 0.14.0)
     ast (2.4.2)
     attr_required (1.0.1)
     bindata (2.4.10)
@@ -192,6 +198,7 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    dry-initializer (3.1.1)
     erubi (1.10.0)
     et-orbi (1.2.6)
       tzinfo
@@ -326,6 +333,7 @@ GEM
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     phonelib (0.6.55)
+    prometheus-client (2.1.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -461,6 +469,7 @@ GEM
       rubocop (~> 1.19)
     ruby-graphviz (1.2.5)
       rexml
+    ruby-next-core (0.14.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -495,6 +504,9 @@ GEM
       rack (~> 2.2)
       rack-protection (= 2.1.0)
       tilt (~> 2.0)
+    sniffer (0.4.0)
+      active_attr (>= 0.10.2)
+      anyway_config (>= 1.0)
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -555,6 +567,29 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yabeda (0.11.0)
+      anyway_config (>= 1.0, < 3)
+      concurrent-ruby
+      dry-initializer
+    yabeda-delayed_job (0.1.0)
+      delayed_job
+      yabeda
+    yabeda-gc (0.1.1)
+      yabeda (~> 0.6)
+    yabeda-http_requests (0.2.0)
+      sniffer
+      yabeda
+    yabeda-prometheus (0.8.0)
+      prometheus-client (>= 0.10, < 3.0)
+      rack
+      yabeda (~> 0.10)
+    yabeda-puma-plugin (0.6.0)
+      json
+      puma
+      yabeda (~> 0.5)
+    yabeda-rails (0.7.2)
+      rails
+      yabeda (~> 0.8)
     zeitwerk (2.5.4)
 
 PLATFORMS
@@ -632,6 +667,12 @@ DEPENDENCIES
   web-console (>= 4.1.0)
   webmock
   webpacker (~> 5.4)
+  yabeda-delayed_job
+  yabeda-gc
+  yabeda-http_requests
+  yabeda-prometheus
+  yabeda-puma-plugin
+  yabeda-rails
 
 RUBY VERSION
    ruby 2.7.5p203

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -2,4 +2,7 @@
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'delayed/command'
+
+::Yabeda::Prometheus::Exporter.start_metrics_server!
+
 Delayed::Command.new(ARGV).daemonize

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -1,0 +1,10 @@
+if ENV.key?("VCAP_APPLICATION")
+  vcap_config = JSON.parse(ENV["VCAP_APPLICATION"])
+
+  Yabeda.configure do
+    default_tag :app, vcap_config["name"]
+    default_tag :app_instance, ENV["CF_INSTANCE_INDEX"]
+    default_tag :organisation, vcap_config["organization_name"]
+    default_tag :space, vcap_config["space_name"]
+  end
+end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -54,3 +54,7 @@ if Rails.env.development?
 else
   port listen_port
 end
+
+# Metrics
+activate_control_app
+plugin :yabeda

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
+  mount Yabeda::Prometheus::Exporter => '/metrics'
+
   get '/healthcheck.txt', to: 'healthchecks#show', as: :healthcheck
   get '/healthcheck', to: 'healthchecks#show', as: :healthcheck_json
   get '/deployment.txt', to: 'healthchecks#deployment', as: :deployment


### PR DESCRIPTION
### Trello card

[Trello-86](https://trello.com/c/y0JoDoIC/86-investigate-add-metrics-endpoint-to-se-for-gathering-any-information-by-prometheus)

### Context

We want to to expose application metrics to Prometheus via a /metrics endpoint.

The Yabeda library and associated gems make this straight forward, giving us metrics for:

- DelayedJob
- Rails internals
- Puma
- Garbage collection
- HTTP requests

### Changes proposed in this pull request

- Expose various metrics to Prometheus

### Guidance to review

[Metrics endpoint](https://review-school-experience-2303.london.cloudapps.digital/metrics)

We still need to setup a Prometheus instance to scrape it and then a dashboard in Grafana.