### PR TITLE
Add network policies to allow monitoring

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -80,6 +80,10 @@ resource "cloudfoundry_app" "delayed_jobs" {
     }
   }
 
+  routes {
+    route = cloudfoundry_route.route_delayed_internal.id
+  }
+
   dynamic "routes" {
     for_each = cloudfoundry_route.route_delayed
     content {

--- a/terraform/paas/dev.env.tfvars
+++ b/terraform/paas/dev.env.tfvars
@@ -1,4 +1,6 @@
 paas_space                = "get-into-teaching"
+paas_monitoring_space     = "get-into-teaching"
+paas_monitoring_app       = "prometheus-dev-get-into-teaching"
 paas_database_common_name = "school-experience-dev-pg-common-svc"
 paas_redis_1_name         = "school-experience-dev-redis-svc"
 paas_application_name     = "school-experience-app-dev"

--- a/terraform/paas/network.tf
+++ b/terraform/paas/network.tf
@@ -1,0 +1,45 @@
+data "cloudfoundry_app" "prometheus" {
+    name_or_id = var.paas_monitoring_app
+    space      = data.cloudfoundry_space.monitoring.id
+}
+
+data "cloudfoundry_app" "monitor_delayed" {
+
+  count      = length( cloudfoundry_app.delayed_jobs ) == 0 ? 0 : 1
+
+  name_or_id = cloudfoundry_app.delayed_jobs[0].id
+  space      = data.cloudfoundry_space.space.id
+
+  depends_on = [cloudfoundry_app.delayed_jobs ]
+}
+
+
+data "cloudfoundry_app" "monitor_apps" {
+
+  name_or_id = cloudfoundry_app.application.id
+  space      = data.cloudfoundry_space.space.id
+
+  depends_on = [ cloudfoundry_app.application ]
+}
+
+
+resource "cloudfoundry_network_policy" "monitoring-policy-app" {
+
+    policy {
+        source_app = data.cloudfoundry_app.prometheus.id
+        destination_app = data.cloudfoundry_app.monitor_apps.id
+        port = "3000"
+        protocol = "tcp"
+    }
+}
+
+resource "cloudfoundry_network_policy" "monitoring-policy-del" {
+
+    count      = length( data.cloudfoundry_app.monitor_delayed  ) == 0 ? 0 : 1
+    policy {
+        source_app = data.cloudfoundry_app.prometheus.id
+        destination_app = data.cloudfoundry_app.monitor_delayed[0].id
+        port = "3000"
+        protocol = "tcp"
+    }
+}

--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -1,4 +1,6 @@
 paas_space                = "get-into-teaching-production"
+paas_monitoring_space     = "get-into-teaching-monitoring"
+paas_monitoring_app       = "prometheus-prod-get-into-teaching"
 paas_database_common_name = "school-experience-prod-pg-common-svc"
 paas_redis_1_name         = "school-experience-prod-redis-svc"
 paas_application_name     = "school-experience-app-production"

--- a/terraform/paas/review.env.tfvars
+++ b/terraform/paas/review.env.tfvars
@@ -1,4 +1,6 @@
 paas_space                = "get-into-teaching"
+paas_monitoring_space     = "get-into-teaching"
+paas_monitoring_app       = "prometheus-dev-get-into-teaching"
 paas_database_common_name = "school-experience-dev-pg-common-svc"
 paas_redis_1_name         = "school-experience-dev-redis-svc"
 application_environment   = "dfe-school-experience-review"

--- a/terraform/paas/route.tf
+++ b/terraform/paas/route.tf
@@ -17,6 +17,12 @@ resource "cloudfoundry_route" "route_internal" {
   space    = data.cloudfoundry_space.space.id
 }
 
+resource "cloudfoundry_route" "route_delayed_internal" {
+  domain   = data.cloudfoundry_domain.internal.id
+  hostname = "${var.paas_application_name}-delayed-internal"
+  space    = data.cloudfoundry_space.space.id
+}
+
 resource "cloudfoundry_route" "route_delayed" {
   count    = var.delayed_jobs
   domain   = data.cloudfoundry_domain.internal.id

--- a/terraform/paas/space.tf
+++ b/terraform/paas/space.tf
@@ -3,3 +3,7 @@ data "cloudfoundry_space" "space" {
   org_name = var.paas_org_name
 }
 
+data "cloudfoundry_space" "monitoring" {
+  name     = var.paas_monitoring_space
+  org_name = var.paas_org_name
+}

--- a/terraform/paas/staging.env.tfvars
+++ b/terraform/paas/staging.env.tfvars
@@ -1,4 +1,6 @@
 paas_space                = "get-into-teaching-test"
+paas_monitoring_space     = "get-into-teaching-monitoring"
+paas_monitoring_app       = "prometheus-prod-get-into-teaching"
 paas_database_common_name = "school-experience-staging-pg-common-svc"
 paas_redis_1_name         = "school-experience-staging-redis-svc"
 paas_application_name     = "school-experience-app-staging"

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -60,6 +60,14 @@ variable "paas_space" {
   default = "sandbox"
 }
 
+variable "paas_monitoring_space" {
+  default = "sandbox"
+}
+
+variable "paas_monitoring_app" {
+  default = ""
+}
+
 variable "environment" {
   default = "sb"
 }


### PR DESCRIPTION
## Issue
School experience did not have any metrics, now that a metrics endpoint has been created at port 3000 this needs to be consumed by Prometheus using an internal network route.

## Steps
1. Create an internal network route for the Application and the Delayed_Jobs Application
2. Adding networking policies to allow Prometheus to access the metrics,

for example:

|source |                            destination |                               protocol|   ports  | destination space  | destination org| 
|-------|----------------------------|---------------------------|--------|-------------------|-----------------|
|prometheus-dev-get-into-teaching |  school-experience-app-dev      |            tcp     |   3000   | get-into-teaching |   dfe|
|prometheus-dev-get-into-teaching |  school-experience-app-dev-delayed_job   |   tcp   |     3000   | get-into-teaching |  dfe|

The complexity here is that the route must persist after a deployment, which sometimes we found it could disappear 
