### PR TITLE
Add booking date change email for virtual experiences

### DIFF
--- a/app/controllers/schools/confirmed_bookings/date_controller.rb
+++ b/app/controllers/schools/confirmed_bookings/date_controller.rb
@@ -31,7 +31,25 @@ module Schools
     private
 
       def date_changed_email(booking, old_date)
+        if booking.virtual_experience?
+          virtual_email(booking, old_date)
+        else
+          in_school_email(booking, old_date)
+        end
+      end
+
+      def in_school_email(booking, old_date)
         NotifyEmail::CandidateBookingDateChanged.from_booking(
+          booking.candidate_email,
+          booking.candidate_name,
+          booking,
+          candidates_cancel_url(booking.token),
+          old_date.to_formatted_s(:govuk)
+        )
+      end
+
+      def virtual_email(booking, old_date)
+        NotifyEmail::CandidateVirtualExperienceBookingDateChanged.from_booking(
           booking.candidate_email,
           booking.candidate_name,
           booking,

--- a/app/notify/notify_email/candidate_virtual_experience_booking_date_changed.rb
+++ b/app/notify/notify_email/candidate_virtual_experience_booking_date_changed.rb
@@ -1,0 +1,100 @@
+class NotifyEmail::CandidateVirtualExperienceBookingDateChanged < NotifyDespatchers::Email
+  attr_accessor :school_name,
+    :candidate_name,
+    :placement_schedule,
+    :school_start_time,
+    :school_finish_time,
+    :school_admin_email,
+    :school_admin_telephone,
+    :school_teacher_name,
+    :school_teacher_email,
+    :school_teacher_telephone,
+    :candidate_instructions,
+    :cancellation_url,
+    :new_date,
+    :old_date
+
+  def initialize(
+    to:,
+    school_name:,
+    candidate_name:,
+    placement_schedule:,
+    school_start_time:,
+    school_finish_time:,
+    school_admin_email:,
+    school_admin_telephone:,
+    school_teacher_name:,
+    school_teacher_email:,
+    school_teacher_telephone:,
+    candidate_instructions:,
+    cancellation_url:,
+    new_date:,
+    old_date:
+  )
+
+    self.school_name = school_name
+    self.candidate_name = candidate_name
+    self.placement_schedule = placement_schedule
+    self.school_start_time = school_start_time
+    self.school_finish_time = school_finish_time
+    self.school_admin_email = school_admin_email
+    self.school_admin_telephone = school_admin_telephone
+    self.school_teacher_name = school_teacher_name
+    self.school_teacher_email = school_teacher_email
+    self.school_teacher_telephone = school_teacher_telephone
+    self.candidate_instructions = candidate_instructions
+    self.cancellation_url = cancellation_url
+    self.new_date = new_date
+    self.old_date = old_date
+
+    super(to: to)
+  end
+
+  def self.from_booking(to, candidate_name, booking, cancellation_url, old_date)
+    school = booking.bookings_school
+    profile = school.profile
+
+    new(
+      to: to,
+      school_name: school.name,
+      candidate_name: candidate_name,
+      placement_schedule: booking.placement_start_date_with_duration,
+      school_start_time: profile.start_time,
+      school_finish_time: profile.end_time,
+      school_admin_email: profile.admin_contact_email,
+      school_admin_telephone: profile.admin_contact_phone,
+      school_teacher_name: booking.contact_name,
+      school_teacher_email: booking.contact_email,
+      school_teacher_telephone: booking.contact_number,
+      candidate_instructions: booking.candidate_instructions,
+      cancellation_url: cancellation_url,
+      new_date: booking.date.to_formatted_s(:govuk),
+      old_date: old_date
+    )
+  end
+
+private
+
+  def template_id
+    '50a32920-fa3a-4294-b013-a6472e230cf8'
+  end
+
+  def personalisation
+    {
+      school_name: school_name,
+      candidate_name: candidate_name,
+      placement_schedule: placement_schedule,
+      school_start_time: school_start_time,
+      school_finish_time: school_finish_time,
+      school_admin_email: school_admin_email,
+      school_admin_telephone: school_admin_telephone,
+      school_teacher_name: school_teacher_name,
+      school_teacher_email: school_teacher_email,
+      school_teacher_telephone: school_teacher_telephone,
+      candidate_instructions: candidate_instructions,
+      cancellation_url: cancellation_url,
+      new_date: new_date,
+      old_date: old_date
+    }
+  end
+end

--- a/app/notify/notify_email/datechange_virtualexperience_updated_jan22.50a32920-fa3a-4294-b013-a6472e230cf8.md
+++ b/app/notify/notify_email/datechange_virtualexperience_updated_jan22.50a32920-fa3a-4294-b013-a6472e230cf8.md
@@ -1,0 +1,28 @@
+Dear ((candidate_name)),
+
+^ ((school_name)) has moved your school experience date from ((old_date)) to ((new_date))
+
+# New date and time
+Date: ((placement_schedule))
+Start and finish times: ((school_start_time)) to ((school_finish_time))
+
+# Instructions
+((candidate_instructions))
+
+# If you cannot make the new date
+Contact the school experience administrator using the following details.
+
+Email address: ((school_admin_email))
+UK telephone number: ((school_admin_telephone))
+
+#If you have questions about your school experience
+Use the following contact details for questions about your school experience.
+
+Name: ((school_teacher_name))
+Email address: ((school_teacher_email))
+UK telephone number: ((school_teacher_telephone))
+
+# Cancelling your booking
+Use the following link to cancel your booking:
+
+((cancellation_url))

--- a/spec/notify/notify_email/candidate_virtual_experience_booking_date_changed_spec.rb
+++ b/spec/notify/notify_email/candidate_virtual_experience_booking_date_changed_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+describe NotifyEmail::CandidateVirtualExperienceBookingDateChanged do
+  it_should_behave_like "email template", "50a32920-fa3a-4294-b013-a6472e230cf8",
+    school_name: "Springfield Elementary",
+    candidate_name: "Kearney Zzyzwicz",
+    placement_schedule: "2022-03-04 for 3 days",
+    school_start_time: "08:40",
+    school_finish_time: "15:30",
+    school_admin_email: "sskinner@example.com",
+    school_admin_telephone: "01234 123 1234",
+    school_teacher_name: "Edna Krabappel",
+    school_teacher_email: "ednak@example.com",
+    school_teacher_telephone: "01234 234 1245",
+    candidate_instructions: "Please report to reception on arrival",
+    cancellation_url: 'https://example.com/candiates/cancel/abc-123',
+    old_date: '24 July 2019',
+    new_date: '28 July 2019'
+
+  describe ".from_booking" do
+    before do
+      stub_const(
+        'Notify::API_KEY',
+        ["somekey", SecureRandom.uuid, SecureRandom.uuid].join("-")
+      )
+    end
+
+    specify { expect(described_class).to respond_to(:from_booking) }
+
+    let!(:school) { create(:bookings_school, urn: 11_048) }
+    let!(:profile) { create(:bookings_profile, school: school) }
+    let(:to) { "morris.szyslak@example.com" }
+    let(:candidate_name) { "morris.szyslak" }
+    let(:old_date) { '09 October 2019' }
+
+    let!(:pr) { create(:bookings_placement_request, school: school) }
+    let!(:booking) do
+      create :bookings_booking, :accepted, bookings_placement_request: pr
+    end
+
+    let!(:cancellation_url) { "https://example.com/candidates/cancel/#{booking.token}" }
+
+    subject { described_class.from_booking(to, candidate_name, booking, cancellation_url, old_date) }
+
+    it { is_expected.to be_a(described_class) }
+
+    context 'correctly assigning attributes' do
+      specify 'candidate_name is correctly-assigned' do
+        expect(subject.candidate_name).to eql(candidate_name)
+      end
+
+      specify 'placement_schedule is correctly-assigned' do
+        expect(subject.placement_schedule).to eql(booking.placement_start_date_with_duration)
+      end
+
+      specify 'school_start_time is correctly-assigned' do
+        expect(subject.school_start_time).to eql(profile.start_time)
+      end
+
+      specify 'school_end_time is correctly-assigned' do
+        expect(subject.school_finish_time).to eql(profile.end_time)
+      end
+
+      specify 'school_admin_email is correctly-assigned' do
+        expect(subject.school_admin_email).to eql(profile.admin_contact_email)
+      end
+
+      specify 'school_admin_telephone is correctly-assigned' do
+        expect(subject.school_admin_telephone).to eql(profile.admin_contact_phone)
+      end
+
+      specify 'school_teacher_name is correctly-assigned' do
+        expect(subject.school_teacher_name).to eql(booking.contact_name)
+      end
+
+      specify 'school_teacher_email is correctly-assigned' do
+        expect(subject.school_teacher_email).to eql(booking.contact_email)
+      end
+
+      specify 'school_teacher_telephone is correctly-assigned' do
+        expect(subject.school_teacher_telephone).to eql(booking.contact_number)
+      end
+
+      specify 'candidate_instructions' do
+        expect(subject.candidate_instructions).to eql(booking.candidate_instructions)
+      end
+
+      specify 'cancellation_url is correctly-assigned' do
+        expect(subject.cancellation_url).to eql(cancellation_url)
+      end
+
+      specify 'old_date is correctly-assigned' do
+        expect(subject.old_date).to eql(old_date)
+      end
+
+      specify 'new_date is correctly-assigned' do
+        expect(subject.new_date).to eql(booking.date.to_formatted_s(:govuk))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Trello card
https://trello.com/c/nzVAo0EK

### Context
Currently we send the same email for in school and virtual experiences when the booking date is changed, however the content of the email is tailored for in school experiences.

We want to send more suitable content for virtual experiences.

### Changes proposed in this pull request
- Add the notify class for the virtual experiences booking date change email
- Update the ConfirmedBookings::DateController to send the correct email based on the booking's experience type

### Guidance to review
- Change the booking date of an in school experience and check you received the email with the in school content
- Change the booking date of a virtual experience and check you received the email with the virtual content

