### PR TITLE
Rename private_beta? to onboarded?

### DIFF
--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -29,7 +29,7 @@ class Candidates::SchoolsController < ApplicationController
 
     @school.increment!(:views)
 
-    if @school.private_beta?
+    if @school.onboarded?
       @presenter = Candidates::SchoolPresenter.new(@school, @school.profile)
     else
       @available_dates = @school.bookings_placement_dates.available

--- a/app/controllers/schools/base_controller.rb
+++ b/app/controllers/schools/base_controller.rb
@@ -52,7 +52,7 @@ module Schools
     end
 
     def ensure_onboarded
-      unless @current_school.private_beta?
+      unless @current_school.onboarded?
         Rails.logger.warn(sprintf("%<school_name>s tried to access %<page>s before completing profile", school_name: @current_school.name, page: request.path))
 
         redirect_to schools_dashboard_path

--- a/app/controllers/schools/on_boarding/on_boardings_controller.rb
+++ b/app/controllers/schools/on_boarding/on_boardings_controller.rb
@@ -22,7 +22,7 @@ module Schools
       end
 
       def continue(school_profile)
-        if current_school.private_beta? && school_profile.completed?
+        if current_school.onboarded? && school_profile.completed?
           Bookings::ProfilePublisher.new(current_school, school_profile).update!
           flash.notice = "Your profile has been saved and published."
         end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -181,7 +181,7 @@ class Bookings::School < ApplicationRecord
     urn.to_s.presence
   end
 
-  def private_beta?
+  def onboarded?
     profile.present?
   end
 

--- a/app/presenters/schools/on_boarding/preview_presenter.rb
+++ b/app/presenters/schools/on_boarding/preview_presenter.rb
@@ -15,7 +15,7 @@ module Schools
       end
 
       def warning
-        unless school.private_beta?
+        unless school.onboarded?
           "To set up your profile, go back and select 'Accept and set up profile'."
         end
       end

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -259,7 +259,7 @@ module Schools
       end
 
       def page_heading
-        if @school.private_beta?
+        if @school.onboarded?
           'School profile'
         else
           'Check your answers before setting up your profile'
@@ -267,7 +267,7 @@ module Schools
       end
 
       def publish_warning
-        unless @school.private_beta?
+        unless @school.onboarded?
           "To set up your profile, select the checkbox at the bottom of the page and select 'Accept and set up profile'."
         end
       end

--- a/app/views/candidates/schools/_phase1.html.erb
+++ b/app/views/candidates/schools/_phase1.html.erb
@@ -105,7 +105,7 @@
         </dd>
       </div>
 
-      <%- if @school.private_beta? && !@school.availability_preference_fixed? -%>
+      <%- if @school.onboarded? && !@school.availability_preference_fixed? -%>
       <div id="school-availability-info" class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           Placement availability

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -4,7 +4,7 @@ Find out more about a career in teaching, experience days and how to apply." %>
 
 <%= govuk_back_link javascript: true %>
 
-<% if !@school.private_beta? %>
+<% if !@school.onboarded? %>
   <div class="govuk-inset-text">
     This school has not yet joined the Get school experience service.
     <%= link_to 'Search for schools offering school experience', new_candidates_school_search_path %>.

--- a/app/views/schools/dashboards/_help_and_support.html.erb
+++ b/app/views/schools/dashboards/_help_and_support.html.erb
@@ -1,4 +1,4 @@
-<div class="<%= @current_school.private_beta? ? 'govuk-grid-column-one-half' : 'govuk-grid-column-full' %>">
+<div class="<%= @current_school.onboarded? ? 'govuk-grid-column-one-half' : 'govuk-grid-column-full' %>">
   <div id="help-and-support" class="panel govuk-!-margin-bottom-5">
     <h2 class="govuk-heading-m">Help and support</h2>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/schools/dashboards/show.html.erb
+++ b/app/views/schools/dashboards/show.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div id="dashboard">
-      <% unless @current_school.private_beta? %>
+      <% unless @current_school.onboarded? %>
         <%= render partial: 'update_your_school_profile' %>
       <% end %>
 
@@ -33,7 +33,7 @@
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <% if @current_school.private_beta? %>
+      <% if @current_school.onboarded? %>
         <%= render 'profile_status' %>
 
         <%= render 'service_update_notice' if @latest_service_update && !@viewed_latest_service_update %>

--- a/app/views/schools/on_boarding/previews/show.html.erb
+++ b/app/views/schools/on_boarding/previews/show.html.erb
@@ -5,7 +5,7 @@
     @current_school.name => schools_dashboard_path,
     'School profile' => schools_on_boarding_profile_path,
     'Preview' => nil
-  } if @current_school.private_beta?
+  } if @current_school.onboarded?
 %>
 
 <h1 class="govuk-heading-l govuk-!-margin-top-4">

--- a/app/views/schools/on_boarding/profiles/show.html.erb
+++ b/app/views/schools/on_boarding/profiles/show.html.erb
@@ -1,10 +1,10 @@
-<%- self.page_title = @current_school.private_beta? ? 'School profile' : 'Check your answers before setting up your school experience profile' -%>
+<%- self.page_title = @current_school.onboarded? ? 'School profile' : 'Check your answers before setting up your school experience profile' -%>
 
 <%
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,
     'School profile' => nil
-  } if @current_school.private_beta?
+  } if @current_school.onboarded?
 %>
 
 <div class="govuk-grid-row" id="school-onboarding-profile">
@@ -84,7 +84,7 @@
         <% end %>
       </dl>
 
-      <% unless @current_school.private_beta? %>
+      <% unless @current_school.onboarded? %>
         <div class="govuk-form-group">
           <%= f.govuk_check_boxes_fieldset :acceptance, multiple: false do %>
             <%= f.govuk_check_box :acceptance, 1, 0, multiple: false, link_errors: true, label: { text: "By checking this box and setting up your school experience profile you’re confirming, to the best of your knowledge:" } %>

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -542,15 +542,15 @@ describe Bookings::School, type: :model do
       end
     end
 
-    describe '#private_beta?' do
+    describe '#onboarded?' do
       context 'without profile' do
         subject { create(:bookings_school) }
-        it { is_expected.not_to be_private_beta }
+        it { is_expected.not_to be_onboarded }
       end
 
       context 'with profile' do
         subject { create(:bookings_profile).school }
-        it { is_expected.to be_private_beta }
+        it { is_expected.to be_onboarded }
       end
     end
 


### PR DESCRIPTION
### Trello card

[Trello-357](https://trello.com/c/oWgZGJYD/357-dev-spike-the-usage-of-identifying-schools-via-if-schoolprivatebeta-and-whether-we-can-remove-it)

### Context

We are currently using the term `private_beta?` to indicate if a school has completed their onboarding journey and setup a profile. We don't use this terminology any more and it's not very clear; renaming it to `onboarded?` makes more sense.

### Changes proposed in this pull request

- Rename private_beta? to onboarded?

### Guidance to review

I chose `onboarded?` as we seem to use that terminology internally and elsewhere in the application; another option I thought about was `profile_complete?` but we already have a `complete?` method on `profile` and it felt a bit close. `profile_present?` also didn't feel quite right as the profile is only created once its been fully filled in.