### PR TITLE
Fix the placement details placeholder for the date change email

### DIFF
--- a/app/notify/notify_email/candidate_booking_date_changed.rb
+++ b/app/notify/notify_email/candidate_booking_date_changed.rb
@@ -55,7 +55,7 @@ class NotifyEmail::CandidateBookingDateChanged < NotifyDespatchers::Email
     self.school_teacher_name = school_teacher_name
     self.school_teacher_email = school_teacher_email
     self.school_teacher_telephone = school_teacher_telephone
-    self.placement_details = placement_details
+    self.placement_details = placement_details.to_s
     self.candidate_instructions = candidate_instructions
     self.subject_name = subject_name
     self.cancellation_url = cancellation_url

--- a/spec/notify/notify_email/candidate_booking_date_changed_spec.rb
+++ b/spec/notify/notify_email/candidate_booking_date_changed_spec.rb
@@ -33,7 +33,8 @@ describe NotifyEmail::CandidateBookingDateChanged do
     specify { expect(described_class).to respond_to(:from_booking) }
 
     let!(:school) { create(:bookings_school, urn: 11_048) }
-    let!(:profile) { create(:bookings_profile, school: school) }
+    let!(:profile) { create(:bookings_profile, experience_details: experience_details, school: school) }
+    let(:experience_details) { 'some info' }
     let(:to) { "morris.szyslak@moes.net" }
     let(:candidate_name) { "morris.szyslak" }
     let(:old_date) { '09 October 2019' }
@@ -131,6 +132,14 @@ describe NotifyEmail::CandidateBookingDateChanged do
 
       specify 'new_date is correctly-assigned' do
         expect(subject.new_date).to eql(booking.date.to_formatted_s(:govuk))
+      end
+    end
+
+    context 'when school has not provided any experience details' do
+      let(:experience_details) { nil }
+
+      specify 'placement details is set to an empty string' do
+        expect(subject.placement_details).to eql ""
       end
     end
   end


### PR DESCRIPTION
### Trello card
https://trello.com/c/T2Ua6myz

### Context
Schools can choose to provide experience details in their profile, but it's optional. However the date change email is using this field and it fails when the experience details is not provided (`nil` value).

The email should not fail when schools don't provide the experience details.

### Changes proposed in this pull request
- Convert the placement_details argument to string when instantiating the email

### Guidance to review
1. Edit the experience details in the school profile, set it to none and save the profile.
2. Change the date of a flex date booking and ensure no exceptions are raised
3. Check you've received the change date email