### PR TITLE
Don't force SSL in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,7 +42,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = false
 
   # Logging
   config.log_level = :info
@@ -126,8 +126,6 @@ Rails.application.configure do
     expire_after: 1.hour # Sets explicit TTL for Session Redis keys
 
   config.active_job.queue_adapter = :delayed_job
-
-  config.force_ssl = true
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 


### PR DESCRIPTION
> ⚠️ WIP - needs thorough testing

We need to scrape the metrics from Prometheus via http internally, but at the moment the app rejects non-ssl requests. Disabling this will allow us to scrape it and we will redirect http -> https elsewhere anyway.
