### PR TITLE
Allow http connections to /metrics endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,12 +36,12 @@ gem 'rails_semantic_logger'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 # Metrics
-gem 'yabeda-rails'
 gem 'yabeda-delayed_job'
+gem 'yabeda-gc'
+gem 'yabeda-http_requests'
 gem 'yabeda-prometheus'
 gem 'yabeda-puma-plugin'
-gem 'yabeda-http_requests'
-gem 'yabeda-gc'
+gem 'yabeda-rails'
 
 gem 'dotenv-rails', '>= 2.7.6'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,6 +128,11 @@ Rails.application.configure do
   config.active_job.queue_adapter = :delayed_job
 
   config.force_ssl = true
+  config.ssl_options = {
+    redirect: {
+      exclude: ->(request) { request.path.start_with?("/metrics") }
+    }
+  }
 
   Rails.application.routes.default_url_options = { protocol: 'https' }
 


### PR DESCRIPTION
When we setup Prometheus we call the app internally (bypassing the load-balancer), however we can only do this over HTTP and not HTTPS. To allow `/metrics` to be called over HTTP we can exclude it from the forced SSL checks.

I haven't made this change to development as we seem to force SSL via Puma so it won't work locally.
