### PR TITLE
Use ./bin/delayed_jobs instead of rake task

### DIFF
--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [[ ${MODE} == "FRONTEND" ]] ; then
           bundle exec rails server
 elif [[ ${MODE} == "BACKGROUND" ]] ; then
 	  echo Running Background Jobs
-          bundle exec rake jobs:work
+          PORT=3000 ./bin/delayed_job run
 elif [[ ${MODE} == "RUBOCOP" ]] ; then
 	  echo Running Rubocop
 	  bundle exec rubocop app config lib features spec --format json --out=/app/out/rubocop-result.json


### PR DESCRIPTION
The rake task `rake jobs:work` doesn't hit the `delayed_job` bin file, which starts the Prometheus metrics server on the worker using webrick.

Change from the rake task to call `./bin/delayed_job`. We start it on port 3000 so that we can use the already-exposed port in Docker; we're not running Rails so there shouldn't be a conflict.