### PR TITLE
Revert "Use ./bin/delayed_jobs instead of rake task"

### DIFF
--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -95,7 +95,7 @@ if [[ ${MODE} == "FRONTEND" ]] ; then
           bundle exec rails server
 elif [[ ${MODE} == "BACKGROUND" ]] ; then
 	  echo Running Background Jobs
-          PORT=3000 ./bin/delayed_job run
+          bundle exec rake jobs:work
 elif [[ ${MODE} == "RUBOCOP" ]] ; then
 	  echo Running Rubocop
 	  bundle exec rubocop app config lib features spec --format json --out=/app/out/rubocop-result.json


### PR DESCRIPTION
Reverts DFE-Digital/schools-experience#2317 - jobs don't appear to be running, reverting to investigate