### PR TITLE
Remove gitis_uuid

### DIFF
--- a/app/models/bookings/subject.rb
+++ b/app/models/bookings/subject.rb
@@ -1,6 +1,4 @@
 class Bookings::Subject < ApplicationRecord
-  self.ignored_columns = [:gitis_uuid]
-
   validates :name,
     presence: true,
     length: { minimum: 2, maximum: 64 },

--- a/db/migrate/20220304152958_remove_gitis_uuid_from_bookings_subject.rb
+++ b/db/migrate/20220304152958_remove_gitis_uuid_from_bookings_subject.rb
@@ -1,0 +1,5 @@
+class RemoveGitisUuidFromBookingsSubject < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :bookings_subjects, :gitis_uuid, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_01_170459) do
+ActiveRecord::Schema.define(version: 2022_03_04_152958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
@@ -262,10 +262,8 @@ ActiveRecord::Schema.define(version: 2022_03_01_170459) do
     t.string "name", limit: 64, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.uuid "gitis_uuid"
     t.boolean "hidden", default: false
     t.boolean "secondary_subject", default: true, null: false
-    t.index ["gitis_uuid"], name: "index_bookings_subjects_on_gitis_uuid", unique: true
     t.index ["hidden"], name: "index_bookings_subjects_on_hidden"
     t.index ["name"], name: "index_bookings_subjects_on_name", unique: true
   end


### PR DESCRIPTION
> ⚠️ 🕙  Wait until 04/03/22 to merge

### Trello card
https://trello.com/c/qYsZJIbR

### Context
We ignored gitis_uuid to catch any left over references, but it can now be safely removed.

