### PR TITLE
Search results

### DIFF
--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -177,6 +177,8 @@ class Bookings::School < ApplicationRecord
     end
   }
 
+  scope :onboarded, -> { joins(:profile) }
+
   def to_param
     urn.to_s.presence
   end

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -91,6 +91,7 @@ private
       .that_provide(subjects)
       .at_phases(phases)
       .costing_upto(max_fee)
+      .onboarded
       .enabled
       .with_availability
       .distinct

--- a/features/step_definitions/candidates/schools/pagination_steps.rb
+++ b/features/step_definitions/candidates/schools/pagination_steps.rb
@@ -1,5 +1,7 @@
 Given("there are {int} schools in {string}") do |count, town|
-  FactoryBot.create_list(:bookings_school, count, name: town)
+  schools = FactoryBot.create_list(:bookings_school, count, name: town)
+  onboard_schools(schools)
+
   expect(Bookings::School.count).to eql(count)
 end
 

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -4,7 +4,7 @@ Given("the phases {string} and {string} exist") do |phase_one, phase_two|
 end
 
 Given("there are some schools with a range of fees containing the word {string}") do |string|
-  {
+  schools = {
     "Grammar School" => {
       phases: [@phase_two],
       fee: 30
@@ -26,6 +26,8 @@ Given("there are some schools with a range of fees containing the word {string}"
       fee: attributes[:fee]
     )
   end
+
+  onboard_schools(schools)
 end
 
 Given("I have searched for {string} and am on the results page") do |string|
@@ -124,7 +126,8 @@ Given("my search is outside of England") do
 end
 
 Given("there are some schools just outside it") do
-  FactoryBot.create_list(:bookings_school, 2, coordinates: Bookings::School::GEOFACTORY.point(-2.421, 53.624))
+  schools = FactoryBot.create_list(:bookings_school, 2, coordinates: Bookings::School::GEOFACTORY.point(-2.421, 53.624))
+  onboard_schools(schools)
 end
 
 When("I search for schools within {int} miles") do |int|

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -16,6 +16,8 @@ Given("there there are schools with the following attributes:") do |table|
     )
   end
 
+  onboard_schools(@schools)
+
   expect(Bookings::School.count).to eql(table.rows.length)
 end
 

--- a/features/support/feature_helper.rb
+++ b/features/support/feature_helper.rb
@@ -3,3 +3,9 @@ def delay_page_load
     sleep Integer(ENV.fetch('CUC_PAGE_DELAY', 0))
   end
 end
+
+def onboard_schools(schools)
+  schools.each do |s|
+    FactoryBot.create(:bookings_profile, school: s)
+  end
+end

--- a/spec/helpers/candidates/results_helper_spec.rb
+++ b/spec/helpers/candidates/results_helper_spec.rb
@@ -23,12 +23,12 @@ describe Candidates::ResultsHelper, type: :helper do
     end
 
     context 'When there fewer than one page of results' do
-      let!(:schools) { create_list(:bookings_school, 5, coordinates: point_in_manchester) }
+      let!(:schools) { create_list(:bookings_school, 5, :onboarded, coordinates: point_in_manchester) }
       specify { expect(subject).to eql('Displaying all 5 results') }
     end
 
     context 'When there are more than one page of results' do
-      let!(:schools) { create_list(:bookings_school, 18, coordinates: point_in_manchester) }
+      let!(:schools) { create_list(:bookings_school, 18, :onboarded, coordinates: point_in_manchester) }
       specify { expect(subject).to eql("Showing 1–15 of 18 results") }
     end
   end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -508,6 +508,21 @@ describe Bookings::School, type: :model do
         end
       end
     end
+
+    context 'Onboarded' do
+      let!(:onboarded_school) { create(:bookings_school, :onboarded) }
+      let!(:non_onboarded_school) { create(:bookings_school) }
+
+      it { is_expected.to respond_to(:onboarded) }
+
+      specify 'should return onboarded schools' do
+        expect(subject.onboarded).to include(onboarded_school)
+      end
+
+      specify 'should not return non-enabled schools' do
+        expect(subject.onboarded).not_to include(non_onboarded_school)
+      end
+    end
   end
 
   describe 'Methods' do


### PR DESCRIPTION
### Trello card
https://trello.com/c/n6kwbkSI

### Context
Non-onboarded schools are included in the search results, which are not useful to the candidates. 

We want to display only onboarded schools with availability.

### Changes proposed in this pull request
- Add the `onboarded` scope in the schools model
- Scope the search results to return only onboarded schools

### Guidance to review

