### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -95,7 +95,8 @@ if [[ ${MODE} == "FRONTEND" ]] ; then
           bundle exec rails server
 elif [[ ${MODE} == "BACKGROUND" ]] ; then
 	  echo Running Background Jobs
-          PORT=3000 ./bin/delayed_job run
+          export PORT=3000 
+          ./bin/delayed_job run
 elif [[ ${MODE} == "RUBOCOP" ]] ; then
 	  echo Running Rubocop
 	  bundle exec rubocop app config lib features spec --format json --out=/app/out/rubocop-result.json


### PR DESCRIPTION
I think the bash shell is interacting differently inside the docker image. so
`PORT=3000 ./bin/delayed_job run`
is probably better ran as
```
export PORT=3000
./bin/delayed_job run
```
