### PR TITLE
Run metrics from separate bin file

### DIFF
--- a/bin/metrics
+++ b/bin/metrics
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
-require 'delayed/command'
 
-Delayed::Command.new(ARGV).daemonize
+thread = ::Yabeda::Prometheus::Exporter.start_metrics_server!
+
+thread.join

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -97,7 +97,7 @@ elif [[ ${MODE} == "BACKGROUND" ]] ; then
 	  echo Waiting one minute
 	  sleep 60
 	  echo Running Background Jobs
-          bundle exec ./bin/delayed_job run
+          ./bin/delayed_job start && PORT=3000 ./bin/metrics
 elif [[ ${MODE} == "RUBOCOP" ]] ; then
 	  echo Running Rubocop
 	  bundle exec rubocop app config lib features spec --format json --out=/app/out/rubocop-result.json


### PR DESCRIPTION
If we start `delayed_job` with `start` instead of `run` it will demonize the process and continue execution. We can then start the metrics instance, which spins up a new thread so we need to hold the session by joining the thread thats spawned.

I've tested the jobs still run in the dev environment (by pausing the dev worker and spinning up a new one with this change).