### PR TITLE
Temporarily disable Yabeda

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  mount Yabeda::Prometheus::Exporter => '/metrics'
+  # TODO: disable as we are leaking PII from the delayed jobs metrics
+  # mount Yabeda::Prometheus::Exporter => '/metrics'
 
   get '/healthcheck.txt', to: 'healthchecks#show', as: :healthcheck
   get '/healthcheck', to: 'healthchecks#show', as: :healthcheck_json


### PR DESCRIPTION
We are leaking PII into our metrics instance as the payload of delayed jobs are being logged as labels.
