### PR TITLE
Order change schools by outsanding tasks, then alphabetically

### DIFF
--- a/app/models/schools/change_school.rb
+++ b/app/models/schools/change_school.rb
@@ -37,7 +37,9 @@ module Schools
     end
 
     def available_schools
-      Bookings::School.ordered_by_name.where(urn: organisation_urns)
+      Bookings::School.where(urn: organisation_urns).sort_by do |school|
+        [-task_count_for_urn(school.urn), school.name]
+      end
     end
 
     def school_uuid
@@ -67,7 +69,7 @@ module Schools
     end
 
     def school_task_counts
-      @school_task_counts = Schools::OutstandingTasks.new(organisation_urns)
+      @school_task_counts ||= Schools::OutstandingTasks.new(organisation_urns)
         .summarize
         .transform_values { |h| h.values.sum }
     end

--- a/spec/models/schools/change_school_spec.rb
+++ b/spec/models/schools/change_school_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe Schools::ChangeSchool, type: :model do
   subject { change_school }
 
-  let(:first_school) { create(:bookings_school) }
-  let(:second_school) { create(:bookings_school) }
+  let(:first_school) { create(:bookings_school, name: "B school") }
+  let(:second_school) { create(:bookings_school, name: "A school") }
   let(:user_uuid) { SecureRandom.uuid }
   let(:user) { Struct.new(:sub).new(user_uuid) }
   let(:change_to_urn) { nil }
@@ -43,9 +43,22 @@ describe Schools::ChangeSchool, type: :model do
   end
 
   describe '#available_schools' do
-    it 'should only return schools which we have in our system' do
-      is_expected.to have_attributes \
-        available_schools: match_array([first_school, second_school])
+    subject { change_school.available_schools }
+
+    it 'only returns schools which we have in our system' do
+      is_expected.to contain_exactly(first_school, second_school)
+    end
+
+    it 'returns schools in alphabetical order' do
+      is_expected.to eq([second_school, first_school])
+    end
+
+    context 'when a school has outstanding tasks' do
+      before { create :placement_request, school: first_school }
+
+      it 'returns schools with the most outstanding tasks first' do
+        is_expected.to eq([first_school, second_school])
+      end
     end
   end
 


### PR DESCRIPTION
### Trello card

[Trello-540](https://trello.com/c/JZNdk7DU/540-can-we-order-the-change-school-page-by-number-of-notifications-then-those-with-zero-alphabetically)

### Context

We want to show the schools with the most outstanding tasks at the top of the list, then the remaining schools in alphabetical order.

### Changes proposed in this pull request

- Order change schools by outstanding tasks, then alphabetically

### Guidance to review

| Before      | After |
| ----------- | ----------- |
|   <img width="398" alt="Screenshot 2022-02-28 at 09 11 00" src="https://user-images.githubusercontent.com/29867726/155955731-a7f4acbe-ed42-4f2e-9b90-f73ade407b80.png">    | <img width="403" alt="Screenshot 2022-02-28 at 09 10 25" src="https://user-images.githubusercontent.com/29867726/155955645-fea0264c-ee5d-4cb7-9116-27d32c5135f6.png">       |
