### PR TITLE
Run yabeda metrics server in delayed job process

### DIFF
--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -3,4 +3,10 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
 require 'delayed/command'
 
+require 'yabeda/delayed_job'
+
 Delayed::Command.new(ARGV).daemonize
+
+thread = ::Yabeda::Prometheus::Exporter.start_metrics_server!
+
+thread.join

--- a/bin/metrics
+++ b/bin/metrics
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
-
-thread = ::Yabeda::Prometheus::Exporter.start_metrics_server!
-
-thread.join

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -97,7 +97,7 @@ elif [[ ${MODE} == "BACKGROUND" ]] ; then
 	  echo Waiting one minute
 	  sleep 60
 	  echo Running Background Jobs
-          ./bin/delayed_job start && PORT=3000 ./bin/metrics
+    PORT=3000 ./bin/delayed_job start
 elif [[ ${MODE} == "RUBOCOP" ]] ; then
 	  echo Running Rubocop
 	  bundle exec rubocop app config lib features spec --format json --out=/app/out/rubocop-result.json


### PR DESCRIPTION
Running the metrics in a separate process causes it not to return any metrics because it can't access the same memory; we have to spawn the metrics server from the delayed job process. The only way I can get this working is to run delayed jobs in a background process, then boot the webrick instance and join the thread to keep the session open.
