### PR TITLE
Add a scheduled status for placement dates

### DIFF
--- a/app/helpers/schools/placement_dates_helper.rb
+++ b/app/helpers/schools/placement_dates_helper.rb
@@ -1,14 +1,16 @@
 module Schools::PlacementDatesHelper
-  def placement_date_display_status(val)
-    val ? "Open" : "Closed"
+  def placement_date_status_tag(placement_date)
+    if placement_date.available?
+      tag.strong "Open", class: "govuk-tag govuk-tag--available"
+    elsif placement_date.active
+      tag.strong "Scheduled", class: "govuk-tag govuk-tag--yellow"
+    else
+      tag.strong "Closed", class: "govuk-tag govuk-tag--taken"
+    end
   end
 
   def availability_status_display_status(val)
     val ? "fixed dates" : "flexible dates"
-  end
-
-  def placement_date_display_class(val)
-    val ? "govuk-tag--available" : "govuk-tag--taken"
   end
 
   def show_subject_support_option(school)

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -46,9 +46,7 @@
             </td>
 
             <td class="govuk-table__cell status">
-              <strong class="govuk-tag <%= placement_date_display_class(placement_date.available?) %>">
-                <%= placement_date_display_status(placement_date.available?) %>
-              </strong>
+              <%= placement_date_status_tag(placement_date) %>
             </td>
 
             <td class="govuk-table__cell">

--- a/spec/factories/bookings/placement_dates.rb
+++ b/spec/factories/bookings/placement_dates.rb
@@ -36,5 +36,9 @@ FactoryBot.define do
     trait :not_supporting_subjects do
       supports_subjects { false }
     end
+
+    trait :outside_availability_window do
+      start_availability_offset { 1 }
+    end
   end
 end

--- a/spec/helpers/schools/placement_dates_helper_spec.rb
+++ b/spec/helpers/schools/placement_dates_helper_spec.rb
@@ -1,6 +1,28 @@
 require 'rails_helper'
 
 describe Schools::PlacementDatesHelper, type: 'helper' do
+  describe '#placement_date_status_tag' do
+    subject { placement_date_status_tag(placement_date) }
+
+    context "when placement date is available (inside availability window)" do
+      let(:placement_date) { create(:bookings_placement_date, :active) }
+
+      it { is_expected.to have_css "strong", text: "Open", class: "govuk-tag govuk-tag--available" }
+    end
+
+    context "when placement date is active but not available" do
+      let(:placement_date) { create(:bookings_placement_date, :active, :outside_availability_window) }
+
+      it { is_expected.to have_css "strong", text: "Scheduled", class: "govuk-tag govuk-tag--yellow" }
+    end
+
+    context "when placement date is inactive" do
+      let(:placement_date) { create(:bookings_placement_date, :inactive) }
+
+      it { is_expected.to have_css "strong", text: "Closed", class: "govuk-tag govuk-tag--taken" }
+    end
+  end
+
   describe '#placement_date_subject_description' do
     subject { placement_date_subject_description(pd) }
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/BORWNkYX

### Context
Currently, dates are displayed as "Closed" when they are scheduled to be published. 

Add a new scheduled status to help to alleviate any confusion when they are in this state.

### Changes proposed in this pull request
- Add a scheduled status for placement dates

### Guidance to review
Do the colours look okay? 

<img width="1020" alt="image" src="https://user-images.githubusercontent.com/47089130/158163094-88e876d6-de67-4348-8981-3f7bc46a58cb.png">

