### PR TITLE
Use Google API loader library for Places Autocomplete

### DIFF
--- a/app/webpacker/controllers/autocomplete_controller.js
+++ b/app/webpacker/controllers/autocomplete_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from "stimulus";
+import { Loader } from "@googlemaps/js-api-loader";
 import accessibleAutocomplete from "accessible-autocomplete";
 
 export default class extends Controller {
@@ -27,9 +28,7 @@ export default class extends Controller {
     this.#showErrorMessage();
 
     this.#setWrapperVisibility(true);
-
-    await this.#loadScript();
-    this.#initialiseService();
+    await this.#initialiseService();
   }
 
   #showErrorMessage() {
@@ -84,16 +83,14 @@ export default class extends Controller {
       .remove();
   }
 
-  async #loadScript() {
-    return new Promise((resolve) => {
-      const script = document.createElement("script");
-      script.src = `https://maps.googleapis.com/maps/api/js?key=${this.apiKeyValue}&libraries=places`;
-      script.onload = resolve;
-      document.head.append(script);
+  async #initialiseService() {
+    const loader = new Loader({
+      apiKey: this.apiKeyValue,
+      libraries: ["places"],
     });
-  }
 
-  #initialiseService() {
+    const google = await loader.load();
+
     this.#sessionToken = new google.maps.places.AutocompleteSessionToken();
     this.#autocompleteService = new google.maps.places.AutocompleteService();
   }

--- a/spec/javascript/controllers/autocomplete_controller_spec.js
+++ b/spec/javascript/controllers/autocomplete_controller_spec.js
@@ -23,23 +23,6 @@ describe("SearchController", () => {
       expect(wrapper.style.visibility).toEqual("");
     });
 
-    it("inserts the Google Places API script", () => {
-      expect(document.head.getElementsByTagName("script")[0].src).toEqual(
-        "https://maps.googleapis.com/maps/api/js?key=KEY&libraries=places"
-      );
-    });
-
-    it("initialises the autocomplete service", async () => {
-      await mockGoogleScriptLoading();
-
-      expect(
-        global.window.google.maps.places.AutocompleteService
-      ).toHaveBeenCalledTimes(1);
-      expect(
-        global.window.google.maps.places.AutocompleteSessionToken
-      ).toHaveBeenCalledTimes(1);
-    });
-
     it("removes the non-JavaScript input", () => {
       expect(
         document.querySelector('[data-autocomplete-target="nonJsInput"]')
@@ -126,13 +109,6 @@ describe("SearchController", () => {
         },
       },
     };
-  };
-
-  const mockGoogleScriptLoading = async () => {
-    const googlePlacesScript = document.head.getElementsByTagName("script")[0];
-    googlePlacesScript.dispatchEvent(new Event("load"));
-
-    await new Promise(process.nextTick);
   };
 
   const clearHead = () => {


### PR DESCRIPTION
### Trello card

### Context
Currently, we are dynamically adding the Google Places script to ensure that the order of loading is correct.

I forgot about the Google API loader library, which can be used for this instead and simplifies things a bit.

