### PR TITLE
Enable candidate dashboard in staging

### DIFF
--- a/feature-flags.json
+++ b/feature-flags.json
@@ -32,7 +32,7 @@
       "name": "candidates_dashboard",
       "description": "Allows candidates to sign in to a dashboard",
       "enabled_for": {
-        "environments": ["development", "test", "servertest"]
+        "environments": ["development", "test", "servertest", "staging"]
       }
     }
   ]


### PR DESCRIPTION
### Trello card

N/A

### Context
 Enabling this in staging so the PM can have a full review.

