### PR TITLE
Switch to DirectFileStore for Prometheus metrics

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,9 +15,22 @@ require "action_view/railtie"
 # require "sprockets/railtie"
 require "rails/test_unit/railtie"
 
+require "prometheus/client/data_stores/direct_file_store"
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+
+# Setup Prometheus store
+PROMETHEUS_DIR = "/tmp/prometheus".freeze
+
+# Needs to clear before initializing.
+Dir["#{PROMETHEUS_DIR}/*.bin"].each do |file_path|
+  File.unlink(file_path)
+end
+
+file_store = Prometheus::Client::DataStores::DirectFileStore.new(dir: PROMETHEUS_DIR)
+Prometheus::Client.config.data_store = file_store
 
 module SchoolExperience
   class Application < Rails::Application

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -53,7 +53,7 @@ variable "application_memory" {
 }
 
 variable "application_disk" {
-  default = "1536"
+  default = "2048"
 }
 
 variable "paas_space" {


### PR DESCRIPTION
### Trello card

[Trello-86](https://trello.com/c/y0JoDoIC/86-investigate-add-metrics-endpoint-to-se-for-gathering-any-information-by-prometheus)

### Context

The Prometheus metrics work fine in the main application, but not all of the DelayedJob metrics are working. 

Whilst we run the metrics server and `DelayedJob` command in the same process, under the hood `daemonize` ends up forking a new process which means the default Prometheus store is not going to work.

Currently the only alternative is to use a `DirectFileStore` which works across forked processes. Sidekiq doesn't have this issue because you can run the metrics server on each Sidekiq server, but I can't find a way of doing the equivalent with DelayedJob (it doesn't have a hook for configuring a server in the pool).

Increases the disk quota as we'll be writing metrics to disk; we were sitting at ~75% disk usage so this should give us plent of headroom.

### Changes proposed in this pull request

- Switch to DirectFileStore for Prometheus metrics

### Guidance to review

I've manually checked this works in review by booting a delayed-job worker for my review app and ssh'ing on the curling the metrics endpoint.

When we used the `DirectFileStore` in GiT we noticed the CPU usage steadily increase until it maxed out; we're going to have to monitor this to see if its still a problem. We can monitor the CPU [here](https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=get-into-teaching-production&var-Applications=All&viewPanel=4) and disk usage [here](https://grafana-prod-get-into-teaching.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=get-into-teaching-production&var-Applications=All&viewPanel=10).

Relevant docs on Prometheus client built-in stores: https://github.com/prometheus/client_ruby#built-in-stores