### PR TITLE
Reduce DelayedJob sleep_delay

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,4 +1,4 @@
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.max_run_time = 5.minutes
-Delayed::Worker.sleep_delay = 15
+Delayed::Worker.sleep_delay = 5
 Delayed::Worker.max_attempts = 1


### PR DESCRIPTION
The `sleep_delay` is currently 15 seconds, which means it can take up to 30 seconds for a queued job to be picked up and processed; this is fairly noticeable with the registration confirmation emails.

Reducing this time will make the jobs execute more promptly and isn't going to have an impact on resource consumption (each time a worker checks it'll query the database, but GSE sits fairly idle most of the time anyway so we have plenty of capacity).