### PR TITLE
Deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem 'delayed_cron_job'
 gem 'delayed_job_active_record'
 gem 'delayed_job_web'
 
+gem "connection_pool"
 gem "redis", "~> 4.6"
 
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     choice (0.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -618,6 +619,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.36.0)
   capybara-screenshot
+  connection_pool
   cucumber-rails (>= 2.4.0)
   daemons
   database_cleaner

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -30,7 +30,7 @@ class PagesController < ApplicationController
   end
 
   def robots
-    render "robots.txt", layout: false
+    render("robots", formats: :txt, layout: false)
   end
 
   def sitemap; end

--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -16,7 +16,7 @@ class Healthcheck
   def test_redis
     return nil unless ENV["REDIS_URL"]
 
-    Redis.current.ping == "PONG"
+    REDIS.ping == "PONG"
   rescue RuntimeError, Errno::ETIMEDOUT
     false
   end

--- a/app/services/candidates/registrations/registration_store.rb
+++ b/app/services/candidates/registrations/registration_store.rb
@@ -14,7 +14,7 @@ module Candidates
 
         # Note this is using the same connection as was created during boot
         # so no need for reconnection params here
-        @redis = Redis.current
+        @redis = REDIS
       end
 
       def store!(registration_session)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -48,7 +48,7 @@ module Rack
   end
 
   # Redirect to custom response for throttled requests
-  Rack::Attack.throttled_response = lambda do |_env|
+  Rack::Attack.throttled_responder = lambda do |_env|
     [301, { "Location" => '/429' }, []]
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,13 +1,15 @@
 # Test the Redis connection on boot
 if ENV['SKIP_REDIS'].blank?
-  Redis.current = Redis.new(
-    db: (Rails.env.test? ? ENV['TEST_ENV_NUMBER'].presence : nil),
-    connect_timeout: 20, # Default is 5s but logic is we're better being slower booting than failing to boot
-    tcp_keepalive: 60, # Turn keep alive on, ping after 40 seconds, try twice, 10 seconds apart, before giving up - then fall through to reconnect attemp
-    reconnect_attempts: 1 # Allow for connection failure since Azure networking to Redis is showing some unreliability
-  )
+  REDIS = ConnectionPool::Wrapper.new(size: 5, timeout: 3) do
+    Redis.new(
+      db: (Rails.env.test? ? ENV['TEST_ENV_NUMBER'].presence : nil),
+      connect_timeout: 20, # Default is 5s but logic is we're better being slower booting than failing to boot
+      tcp_keepalive: 60, # Turn keep alive on, ping after 40 seconds, try twice, 10 seconds apart, before giving up - then fall through to reconnect attemp
+      reconnect_attempts: 1 # Allow for connection failure since Azure networking to Redis is showing some unreliability
+    )
+  end
 
-  unless Redis.current.ping == "PONG"
+  unless REDIS.ping == "PONG"
     raise "Could not connect to Redis"
   end
 end

--- a/spec/controllers/healthchecks_controller_spec.rb
+++ b/spec/controllers/healthchecks_controller_spec.rb
@@ -20,8 +20,7 @@ describe HealthchecksController, type: :request do
 
     allow(ENV).to receive(:[]).with("REDIS_URL").and_return \
       "redis://localhost:6379/1"
-    allow(Redis).to \
-      receive(:current).and_return double(Redis, ping: "PONG")
+    allow(REDIS).to receive(:ping) { "PONG" }
 
     allow(ApplicationRecord).to \
       receive(:connected?).and_return(true)
@@ -40,7 +39,7 @@ describe HealthchecksController, type: :request do
 
     context 'with unhealthy Cache' do
       before do
-        allow(Redis.current).to receive(:ping) { raise Redis::TimeoutError }
+        allow(REDIS).to receive(:ping) { raise Redis::TimeoutError }
 
         get healthcheck_path
       end
@@ -199,7 +198,7 @@ describe HealthchecksController, type: :request do
 
     context 'with unhealthy Cache' do
       before do
-        allow(Redis.current).to receive(:ping) { raise Redis::TimeoutError }
+        allow(REDIS).to receive(:ping) { raise Redis::TimeoutError }
 
         get api_health_path
       end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -39,7 +39,7 @@ describe PagesController, type: :request do
 
     it { expect(response).to have_http_status(:success) }
     it { expect(response.headers['X-Robots-Tag']).to eq('all') }
-    it { expect(response).to render_template 'robots.txt' }
+    it { expect(response).to render_template("robots", formats: :txt, layout: false) }
   end
 
   describe '#sitemap' do

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Healthcheck do
 
     context "with working connection" do
       before do
-        allow(Redis).to receive(:current).and_return double(Redis, ping: "PONG")
+        allow(REDIS).to receive(:ping).and_return("PONG")
       end
 
       it { is_expected.to be true }
@@ -86,7 +86,7 @@ RSpec.describe Healthcheck do
     context "with broken connection" do
       it "returns false" do
         [Errno::ETIMEDOUT, Redis::CannotConnectError].each do |error|
-          allow(Redis).to receive(:current).and_raise error
+          allow(REDIS).to receive(:ping).and_raise error
           expect(subject).to be false
         end
       end
@@ -94,7 +94,7 @@ RSpec.describe Healthcheck do
 
     context 'with non functional redis' do
       before do
-        allow(Redis.current).to receive(:ping) { raise Redis::TimeoutError }
+        allow(REDIS).to receive(:ping) { raise Redis::TimeoutError }
       end
 
       it { is_expected.to be false }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,7 +88,7 @@ RSpec.configure do |config|
   end
 
   config.after :suite do
-    Redis.current.keys("test:*").each { |k| Redis.current.del k }
+    REDIS.keys("test:*").each { |k| REDIS.del k }
   end
 end
 

--- a/spec/services/candidates/registrations/registration_store_spec.rb
+++ b/spec/services/candidates/registrations/registration_store_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe Candidates::Registrations::RegistrationStore do
   let :redis do
-    Redis.current
+    REDIS
   end
 
   let :session do


### PR DESCRIPTION
### Trello card
https://trello.com/c/w6kbXWGZ

### Context
We have some deprecation warnings that need fixing

### Changes proposed in this pull request
- Replace deprecated RackAttack method
- Fix deprecation warning for rendering templates with a dot
- Fix deprecation warning from using Redis.current: Using a single connection to Redis is now discouraged because it can lead to blocking. The recommended fix is to enable connection pooling. Wrap the existing connection using the connection_pool gem.

### Guidance to review

