### PR TITLE
Update the content in Unprocessable entity page

### DIFF
--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,11 +1,7 @@
 <main class="govuk-main-wrapper" id="main-content" role="main">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">The change you attempted was rejected</h1>
-
-      <p class="govuk-body">
-        Maybe you tried to change something you didn't have access to.
-      </p>
+      <h1 class="govuk-heading-xl">We were unable to process this request</h1>
 
       <p class="govuk-body">
         If you continue to encounter this problem, contact the Organise School

--- a/features/errors/unprocessable_entity.feature
+++ b/features/errors/unprocessable_entity.feature
@@ -5,6 +5,5 @@ Feature: Unprocessable entity error page
 
     Scenario: The page contents
         Given I am on the 'unprocessable_entity' error page
-        Then the page's main header should be 'The change you attempted was rejected'
-        And there should be some useful hints on why I might be here
+        Then the page's main header should be 'We were unable to process this request'
         And there should be an email address for support

--- a/features/step_definitions/errors/error_page_steps.rb
+++ b/features/step_definitions/errors/error_page_steps.rb
@@ -24,10 +24,6 @@ Then("there should be some useful hints on entering the correct URL") do
   end
 end
 
-Then("there should be some useful hints on why I might be here") do
-  expect(page).to have_content("Maybe you tried to change something you didn't have access to")
-end
-
 Then("there should be some text explaining technical difficulties") do
   expect(page).to have_content("We are currently experiencing technical difficulties")
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/6ZukkTBr

### Context
We display a hint in the unprocessable entity error page for what may have gone wrong, which can be misleading for the users.

We want to keep the error more generic and have the user contact the support if it issue persists.

### Changes proposed in this pull request
- Update the heading
- Remove the hint

### Guidance to review
|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/951947/158431558-c93957db-5734-472e-bd27-5a224a0555d5.png)|![after](https://user-images.githubusercontent.com/951947/158431585-b18e4085-cbce-4b98-b41a-ddd44ee59db3.png)|