### PR TITLE
Change all expired to grey

### DIFF
--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -8,7 +8,7 @@ module Schools::PlacementRequestsHelper
 
       css_class = if placement_request.cancelled?
                     'govuk-tag govuk-tag--red'
-                  elsif status == 'Flagged' 
+                  elsif status == 'Flagged'
                     'govuk-tag govuk-tag--yellow'
                   elsif placement_request.expired?
                     'govuk-tag govuk-tag--grey'

--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -8,8 +8,10 @@ module Schools::PlacementRequestsHelper
 
       css_class = if placement_request.cancelled?
                     'govuk-tag govuk-tag--red'
-                  elsif status == 'Flagged' || placement_request.expired?
+                  elsif status == 'Flagged' 
                     'govuk-tag govuk-tag--yellow'
+                  elsif placement_request.expired?
+                    'govuk-tag govuk-tag--grey'
                   elsif status == 'Under consideration'
                     'govuk-tag govuk-tag--blue'
                   else

--- a/app/presenters/candidates/placement_presenter.rb
+++ b/app/presenters/candidates/placement_presenter.rb
@@ -31,7 +31,7 @@ module Candidates
         'Withdrawn' => 'govuk-tag--orange',
         'Candidate cancellation' => 'govuk-tag--orange',
         'School cancellation' => 'govuk-tag--orange',
-        'Expired' => 'govuk-tag--yellow',
+        'Expired' => 'govuk-tag--grey',
         'Not attended' => 'govuk-tag--yellow',
         'Rejected' => 'govuk-tag--red',
         'Booked' => 'govuk-tag--blue',


### PR DESCRIPTION
### Trello card

### Context

More conversions to grey for all cases of 'expired' (this PR works across a couple of placement/request pages), toning down the colour usage.

### Changes proposed in this pull request

### Guidance to review

