### PR TITLE
Update the facet tag font to GDS Transport

### DIFF
--- a/app/webpacker/stylesheets/facet-tags.scss
+++ b/app/webpacker/stylesheets/facet-tags.scss
@@ -44,6 +44,7 @@
         height: 100%;
         padding: 8px;
         border-radius: 5px;
+        font-family: "GDS Transport",arial,sans-serif;
         font-size: 1rem;
         line-height: 1.25;
         background-color: transparent;


### PR DESCRIPTION
### Trello card
https://trello.com/c/ldqbOeig

### Context
The font of the 'x' on our facet tags is set to Arial, which also affects its vertical alignment. 

### Changes proposed in this pull request
- Update the font of the facet tag to "GDS Transport"

### Guidance to review

