### PR TITLE
Use div element for the sorting info

### DIFF
--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -95,7 +95,7 @@
 
     <% if @search.results.size > 1 %>
       <hr/>
-      <p>Sorted by distance</p>
+      <div>Sorted by distance</div>
       <hr/>
     <% end %>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/NAuPfTD3

### Context
The font size in the sorting info is a bit bigger comparing the sibling elements in the search results section.

We want to be the same.

### Changes proposed in this pull request
- Put the sorting info inside a div element
It will inherit the font size from the search-results and match the font size of its sibling elements

### Guidance to review

