### PR TITLE
Make the search results more compact

### DIFF
--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -109,8 +109,10 @@
       <% @search.results.each_with_index do |school, _| %>
         <li data-school-urn="<%= school.urn %>">
           <article class="school-result">
-            <h2 class="govuk-heading-l">
-              <%= school.name %>
+            <h2 class="govuk-heading-s">
+              <%= link_to school.name,
+                          candidates_school_path(school),
+                          aria: { 'label': "View school details for #{school.name}" } %>
               <%- if school.respond_to? :distance -%>
             <span class="govuk-caption-m distance">
               <%= pluralize Conversions::Distance::Metres::ToMiles.convert(school.distance), 'mile' %>
@@ -125,10 +127,6 @@
               <%= summary_row 'Subjects', format_school_subjects(school), nil, show_action: false %>
               <%= summary_row 'Experience type', format_school_placement_locations(school), nil, show_action: false %>
             </dl>
-
-            <%= govuk_link_to 'View school details',
-                              candidates_school_path(school),
-                              aria: { 'label': "View school details for #{school.name}" } %>
           </article>
         </li>
       <% end %>


### PR DESCRIPTION
### Trello card
https://trello.com/c/jxqmx1it

### Context
This is a try to reducing the size of the search results page

### Changes proposed in this pull request
- Resize the school name and link it to the school profile
- Remove the View school details button

### Guidance to review
Still exploring this idea, so the sole purpose of this PR for now is to spin up a review app.