### PR TITLE
Add counts to search filters

### DIFF
--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -45,6 +45,53 @@ class Bookings::SchoolSearch < ApplicationRecord
       .per(PER_PAGE)
   end
 
+  def phase_count(phase_id)
+    @phase_count ||= base_query(include_distance: false)
+      .unscope(where: { bookings_schools_phases: :bookings_phase_id })
+      .joins(:bookings_schools_phases)
+      .group("bookings_schools_phases.bookings_phase_id")
+      .count
+
+    @phase_count[phase_id] || 0
+  end
+
+  def subject_count(subject_id)
+    @subject_count ||= base_query(include_distance: false)
+      .unscope(where: { bookings_schools_subjects: :bookings_subject_id })
+      .joins(:bookings_schools_subjects)
+      .group("bookings_schools_subjects.bookings_subject_id")
+      .count
+
+    @subject_count[subject_id] || 0
+  end
+
+  def dbs_not_required_count
+    @dbs_count ||= base_query(include_distance: false)
+      .unscope(where: { bookings_profiles: :dbs_policy_conditions })
+      .group("bookings_profiles.dbs_policy_conditions")
+      .count
+
+    @dbs_count.slice("notrequired", "inschool").values.sum || 0
+  end
+
+  def disability_confident_count
+    @disability_confident_count ||= base_query(include_distance: false)
+      .unscope(where: { bookings_profiles: :disability_confident })
+      .group("bookings_profiles.disability_confident")
+      .count
+
+    @disability_confident_count[true] || 0
+  end
+
+  def parking_count
+    @parking_count ||= base_query(include_distance: false)
+      .unscope(where: { bookings_profiles: :parking_provided })
+      .group("bookings_profiles.parking_provided")
+      .count
+
+    @parking_count[true] || 0
+  end
+
   def total_count
     base_query(include_distance: false).count.tap do |count|
       save_with_result_count(count)

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -91,9 +91,14 @@ module Candidates
       }
     end
 
-    delegate :results, to: :school_search
-
-    delegate :total_count, to: :school_search
+    delegate :results,
+       :total_count,
+       :phase_count,
+       :subject_count,
+       :dbs_not_required_count,
+       :disability_confident_count,
+       :parking_count,
+       to: :school_search
 
     def valid_search?
       query.present? ||

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -50,29 +50,33 @@
           <%= f.hidden_field :longitude %>
 
           <div class="filter">
-            <%= f.govuk_collection_check_boxes :phases, Candidates::School.phases, :first, :last,
+            <%= f.govuk_collection_check_boxes :phases, Candidates::School.phases, :first,
+              ->(phase) { "#{phase.last.gsub(/\(|\)/, "")} (#{@search.phase_count(phase.first)})" },
               legend: { text: t("helpers.fieldset.phases") }, hint: { text: t("helpers.hint.phases") } %>
           </div>
 
           <div class="filter">
-            <%= f.govuk_collection_check_boxes :subjects, Candidates::School.subjects, :first, :last,
+            <%= f.govuk_collection_check_boxes :subjects, Candidates::School.subjects, :first,
+              ->(subject) { "#{subject.last} (#{@search.subject_count(subject.first)})" },
               classes: %w(search-subjects-checkboxes), hint: { text: t("helpers.hint.subjects") } %>
           </div>
 
           <div class="filter">
-            <%= f.govuk_collection_check_boxes :dbs_policies, [[2, t("helpers.label.dbs_policies_2")]], :first, :last,
+            <%= f.govuk_collection_check_boxes :dbs_policies, [[2, t("helpers.label.dbs_policies_2")]], :first,
+              ->(dbs_policy) { "#{dbs_policy.last} (#{@search.dbs_not_required_count})" },
               legend: { text: t("helpers.fieldset.dbs_policies") }, hint: { text: t("helpers.hint.dbs_policies") } %>
           </div>
 
           <div class="filter">
             <%= f.govuk_check_boxes_fieldset :disability_confident, multiple: false, legend: { text: t("helpers.fieldset.disability_confident") } do %>
-              <%= f.govuk_check_box :disability_confident, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.disability_confident") } %>
+              <%= f.govuk_check_box :disability_confident, "1", multiple: false, link_errors: true, include_hidden: false,
+                label: { text: "#{t("helpers.label.disability_confident")} (#{@search.disability_confident_count})" } %>
             <% end %>
           </div>
 
           <div class="filter">
             <%= f.govuk_check_boxes_fieldset :parking, multiple: false, legend: { text: t("helpers.fieldset.parking") } do %>
-              <%= f.govuk_check_box :parking, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: t("helpers.label.parking") } %>
+              <%= f.govuk_check_box :parking, "1", multiple: false, link_errors: true, include_hidden: false, label: { text: "#{t("helpers.label.parking")} (#{@search.parking_count})" } %>
             <% end %>
           </div>
 

--- a/features/schools/placement_dates/edit.feature
+++ b/features/schools/placement_dates/edit.feature
@@ -21,17 +21,14 @@ Feature: Editing placement dates
 
     Scenario: Filling in and submitting the form
         Given I am on the edit page for my placement
-        And I fill in the form with a duration of 6
+        And I fill in the placement details form with a duration of 6
         When I submit the form
-        Then I should be on the new configuration page for this date
-        Given I am on the 'placement dates' page
-        Then my newly-created placement date should be listed
+        Then I am on the 'placement dates' page
+        And my newly-created placement date should be listed
 
     @smoke_test
     Scenario: Activating a placement date
         Given I am on the edit page for my 'inactive' placement
         And I submit the form
-        Then I should be on the new configuration page for this date
-        And I submit the form
-        Given I am on the 'placement dates' page
-        Then my placement should have been 'activated'
+        Then I am on the 'placement dates' page
+        And my placement should have been 'activated'

--- a/features/step_definitions/schools/placement_dates/placement_date_steps.rb
+++ b/features/step_definitions/schools/placement_dates/placement_date_steps.rb
@@ -76,6 +76,11 @@ Then "I should be on the new subject selection page for this date" do
     path_for('new subject selection', placement_date_id: @school.bookings_placement_dates.last.id)
 end
 
+Then "I should be on the new configuration page for this date" do
+  expect(page.current_path).to eq \
+    path_for('new configuration', placement_date_id: @school.bookings_placement_dates.last.id)
+end
+
 Then "I should see a list of subjects the school offers" do
   @school.subjects.each do |subject|
     expect(page).to have_field(subject.name, type: 'checkbox')

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe Candidates::SchoolSearch do
     it { expect(subject).to delegate_method(:errors).to(:school_search) }
     it { expect(subject).to delegate_method(:location_name).to(:school_search) }
     it { expect(subject).to delegate_method(:has_coordinates?).to(:school_search) }
+    it { expect(subject).to delegate_method(:phase_count).to(:school_search) }
+    it { expect(subject).to delegate_method(:subject_count).to(:school_search) }
+    it { expect(subject).to delegate_method(:dbs_not_required_count).to(:school_search) }
+    it { expect(subject).to delegate_method(:disability_confident_count).to(:school_search) }
+    it { expect(subject).to delegate_method(:parking_count).to(:school_search) }
   end
 
   context '.subjects=' do

--- a/spec/views/candidates/schools/index.html.erb_spec.rb
+++ b/spec/views/candidates/schools/index.html.erb_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "candidates/schools/index.html.erb", type: :view do
       let(:schools) { [build(:bookings_school), build(:bookings_school)] }
 
       it "shows when more than one result" do
-        expect(rendered).to have_css 'p', text: 'Sorted by distance'
+        expect(rendered).to have_css 'div', text: 'Sorted by distance'
       end
     end
 


### PR DESCRIPTION
### Trello card

[Trello-559](https://trello.com/c/AB5YiS3G/559-dev-can-we-add-counts-to-our-facet-tag-filters)

### Context

We want to be able to indicate to the user if there are going to be any results for a given search filter.

### Changes proposed in this pull request

- Add total counts to school search filters

Add counts to each filter; if they are in the same group they are OR'ed together, whereas different groups of filters are AND'ed together.

Remove the brackets from the phase labels to avoid doubling up, e.g. "Primary (11 - 14) (2)".

- Fix broken Cucumber tests

Unrelated to my changes, but I noticed we had warnings from Cucumber that a few steps weren't defined; this defines them and/or fixes the underlying tests.

### Guidance to review

<img width="985" alt="Screenshot 2022-03-18 at 12 16 48" src="https://user-images.githubusercontent.com/29867726/159001484-4dac4e8c-bb19-4fac-9b7c-6a2f702afb50.png">
