### PR TITLE
Fix scheduled status bug

### DIFF
--- a/app/helpers/schools/placement_dates_helper.rb
+++ b/app/helpers/schools/placement_dates_helper.rb
@@ -1,8 +1,10 @@
 module Schools::PlacementDatesHelper
   def placement_date_status_tag(placement_date)
+    availability_end_date_in_future = (placement_date.date - placement_date.end_availability_offset).future?
+
     if placement_date.available?
       tag.strong "Open", class: "govuk-tag govuk-tag--available"
-    elsif placement_date.active
+    elsif placement_date.active && availability_end_date_in_future
       tag.strong "Scheduled", class: "govuk-tag govuk-tag--grey"
     else
       tag.strong "Closed", class: "govuk-tag govuk-tag--taken"

--- a/spec/helpers/schools/placement_dates_helper_spec.rb
+++ b/spec/helpers/schools/placement_dates_helper_spec.rb
@@ -16,6 +16,12 @@ describe Schools::PlacementDatesHelper, type: 'helper' do
       it { is_expected.to have_css "strong", text: "Scheduled", class: "govuk-tag govuk-tag--grey" }
     end
 
+    context "when placement date is active and end of availability is not in the future" do
+      let(:placement_date) { create(:bookings_placement_date, :active, date: Date.tomorrow, end_availability_offset: 1) }
+
+      it { is_expected.to have_css "strong", text: "Closed", class: "govuk-tag govuk-tag--taken" }
+    end
+
     context "when placement date is inactive" do
       let(:placement_date) { create(:bookings_placement_date, :inactive) }
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/CZUFR55q

### Context
When the date is not inside the availability window, but it is active, it will have the scheduled tag. When the availability end date has passed, we want these to be closed instead.

### Changes proposed in this pull request
- Only show the scheduled tag when the availability end date is in the future.

### Guidance to review
<img width="995" alt="image" src="https://user-images.githubusercontent.com/47089130/158851544-98c1c045-4103-45b6-ab86-d56492986c82.png">
The 23rd March closes 6 days before (today), if I update it to 7 days, its still closed.

