### PR TITLE
Profile complete email

### DIFF
--- a/app/jobs/cron/reminders/add_availability_job.rb
+++ b/app/jobs/cron/reminders/add_availability_job.rb
@@ -1,0 +1,23 @@
+module Cron
+  module Reminders
+    class AddAvailabilityJob < CronJob
+      self.cron_expression = '40 9 * * *'
+
+      def perform
+        profiles_created_yesterday_with_no_availability.each do |booking_profile|
+          NotifyEmail::SchoolAddAvailabilityReminder.new(
+            to: booking_profile.admin_contact_email,
+          ).despatch_later!
+        end
+      end
+
+    private
+
+      def profiles_created_yesterday_with_no_availability
+        Bookings::Profile.where(created_at: Date.yesterday.beginning_of_day...Date.yesterday.end_of_day)
+           .joins(:school)
+           .merge(Bookings::School.without_availability)
+      end
+    end
+  end
+end

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -153,6 +153,18 @@ class Bookings::School < ApplicationRecord
 
   scope :with_availability, -> { flexible_with_description.or(fixed_with_available_dates) }
 
+  scope :without_availability, lambda {
+    flexible.where(availability_info: nil).or(
+      fixed.where.not(
+        id: Bookings::School
+          .default_scoped
+          .joins(:available_placement_dates)
+          .except(:select)
+          .select(:id)
+      )
+    )
+  }
+
   scope :with_dbs_policies, lambda { |policies|
     if policies.present?
       joins(:profile).where('bookings_profiles.dbs_policy_conditions IN (?)', policies)

--- a/app/notify/notify_email/school_add_availability_reminder.eee3d861-3365-40ff-a178-80516f771024.md
+++ b/app/notify/notify_email/school_add_availability_reminder.eee3d861-3365-40ff-a178-80516f771024.md
@@ -1,0 +1,21 @@
+Hello,
+
+Thank you for joining the Get school experience service.
+
+We hope you’re finding the service useful to promote and manage the school experiences you offer.
+
+Please make sure you complete the Experience dates section of your profile. You can choose to list specific dates or show a description of when you can host candidates (for examples, set days of the week or at certain times of the year).
+
+^ Add your availability: https://schoolexperience.education.gov.uk/schools/availability_preference/edit
+
+Get school experience has over 4,000 users each month and we want to continue to increase the number of schools offering experiences through the service.
+
+If other schools in your trust or partnership would benefit from using the service, they can email school.experience@education.gov.uk for more information.
+
+If you manage school experiences for more than one school, you can create profiles for additional schools in the same way that you created your initial school profile.
+
+If you have any questions or would prefer to send your feedback by email, please don’t hesitate to get in touch,
+
+With thanks and best wishes,
+
+Get school experience service.

--- a/app/notify/notify_email/school_add_availability_reminder.rb
+++ b/app/notify/notify_email/school_add_availability_reminder.rb
@@ -1,0 +1,18 @@
+class NotifyEmail::SchoolAddAvailabilityReminder < NotifyDespatchers::Email
+  def initialize(
+    to:
+  )
+
+    super(to: to)
+  end
+
+private
+
+  def template_id
+    'eee3d861-3365-40ff-a178-80516f771024'
+  end
+
+  def personalisation
+    {}
+  end
+end

--- a/spec/jobs/cron/reminders/add_availability_job_spec.rb
+++ b/spec/jobs/cron/reminders/add_availability_job_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe Cron::Reminders::AddAvailabilityJob, type: :job do
+  specify 'should have a schedule of daily at 09:40' do
+    expect(described_class.cron_expression).to eql('40 9 * * *')
+  end
+
+  describe '#perform' do
+    let(:reminder_email_double) { instance_double(NotifyEmail::SchoolAddAvailabilityReminder, despatch_later!: true) }
+    let(:admin_contact_email) { "admin@email.com" }
+
+    before do
+      create(:bookings_profile, created_at: DateTime.yesterday.midday)
+      create(:bookings_profile, created_at: DateTime.yesterday.midday, school: create(:bookings_school, :without_availability),
+                                admin_contact_email: admin_contact_email)
+      create(:bookings_profile, created_at: Date.today, school: create(:bookings_school, :without_availability))
+
+      allow(NotifyEmail::SchoolAddAvailabilityReminder).to receive(:new).with(to: admin_contact_email) do
+        reminder_email_double
+      end
+    end
+
+    subject! { described_class.new.perform }
+
+    it 'sends a reminder email to all schools who created their profile yesterday and have no availability' do
+      expect(reminder_email_double).to have_received(:despatch_later!).once
+    end
+  end
+end

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -427,6 +427,7 @@ describe Bookings::School, type: :model do
       specify { expect(described_class).to respond_to(:fixed) }
       specify { expect(described_class).to respond_to(:fixed_with_available_dates) }
       specify { expect(described_class).to respond_to(:with_availability) }
+      specify { expect(described_class).to respond_to(:without_availability) }
 
       specify { expect(described_class.new).to have_db_column(:availability_info).of_type(:text) }
       specify { expect(described_class.new).to have_db_column(:availability_preference_fixed).of_type(:boolean).with_options(default: false) }
@@ -505,6 +506,22 @@ describe Bookings::School, type: :model do
 
         specify 'should not include schools that are flexible with no availability_description' do
           expect(subject).not_to include(flexible_without_description)
+        end
+      end
+
+      context '.without_availability' do
+        subject { described_class.without_availability }
+
+        it 'includes schools that are flexible without availability info or fixed without available dates' do
+          expect(subject).to include(fixed_without_dates, flexible_without_description)
+        end
+
+        it 'does not include schools that are fixed with available dates' do
+          expect(subject).not_to include(fixed_with_dates)
+        end
+
+        it 'does not include schools that are flexible with availability_description' do
+          expect(subject).not_to include(flexible_with_description)
         end
       end
     end

--- a/spec/notify/notify_email/school_add_availability_reminder_spec.rb
+++ b/spec/notify/notify_email/school_add_availability_reminder_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe NotifyEmail::SchoolAddAvailabilityReminder do
+  it_should_behave_like "email template", "eee3d861-3365-40ff-a178-80516f771024"
+end

--- a/spec/support/notify_email_shared_examples.rb
+++ b/spec/support/notify_email_shared_examples.rb
@@ -26,7 +26,7 @@ shared_examples_for "notify template" do |template_id, personalisation|
   end
 
   subject do
-    described_class.new(to: to, **personalisation)
+    described_class.new(to: to, **personalisation || {})
   end
 
   before do
@@ -44,7 +44,7 @@ shared_examples_for "notify template" do |template_id, personalisation|
   end
 
   describe 'Initialization' do
-    personalisation.each do |k, _|
+    personalisation&.each do |k, _|
       specify "should raise an error if supplied without :#{k}" do
         { to: to }.merge(personalisation.except(k)).tap do |args|
           expect { described_class.new(args) }.to raise_error(ArgumentError, "missing keyword: :#{k}")
@@ -54,7 +54,7 @@ shared_examples_for "notify template" do |template_id, personalisation|
   end
 
   describe 'Attributes' do
-    personalisation.each do |k, _|
+    personalisation&.each do |k, _|
       specify "should respond to #{k}" do
         expect(subject).to respond_to(k)
       end
@@ -82,7 +82,7 @@ shared_examples_for "notify template" do |template_id, personalisation|
   end
 
   describe 'Template' do
-    subject { described_class.new(to: to, **personalisation) }
+    subject { described_class.new(to: to, **personalisation || {}) }
     let(:template_path) { [Rails.root, "app", "notify", template_folder] }
 
     let(:template) do


### PR DESCRIPTION
### Trello card
 https://trello.com/c/orbxaF6t

### Context
Schools that haven't yet added dates to their profile don't appear in the search. We want to send a reminder email which will help them take the next step and add some dates.

### Changes proposed in this pull request
- Update shared notify email spec to handle no personalisation.
- Send email reminding schools to complete the dates section

