### PR TITLE
Position all error summaries above the h1 tag

### DIFF
--- a/app/views/candidates/booking_feedbacks/_form.html.erb
+++ b/app/views/candidates/booking_feedbacks/_form.html.erb
@@ -1,8 +1,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Give feedback on your experience</h1>
     <%= form_for(feedback, url: candidates_booking_feedback_path(params[:booking_token])) do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Give feedback on your experience</h1>
 
       <p>
         Help us improve the school experience service.

--- a/app/views/candidates/placement_requests/cancellations/_new_booking.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_new_booking.html.erb
@@ -1,9 +1,10 @@
 <div class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Cancel booking</h1>
       <%= form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
         <%= f.govuk_error_summary %>
+
+        <h1 class="govuk-heading-l">Cancel booking</h1>
 
         <p>
           You've chosen to cancel your school experience booking for <%= cancellation.school_name %>.

--- a/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
+++ b/app/views/candidates/placement_requests/cancellations/_new_placement_request.html.erb
@@ -2,9 +2,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Cancel request</h1>
-      <%= form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
-        <%= f.govuk_error_summary %>
+    <%= form_for cancellation, url: candidates_placement_request_cancellation_path(cancellation.placement_request.token) do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">Cancel request</h1>
 
       <p>
       You've chosen to cancel your school experience request for <%= f.object.school_name %>.

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -5,9 +5,10 @@
         url: candidates_school_registrations_confirmation_email_path,
         data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
   <div class="govuk-grid-column-two-thirds">
+    <%= f.govuk_error_summary %>
+
     <h1 class="govuk-heading-l">Check your answers before requesting your school experience</h1>
     <p>You'll receive an email with the following details once you've sent your school experience request.</p>
-    <%= f.govuk_error_summary %>
 
     <h2 class="govuk-heading-m">Personal details</h2>
     <dl class="govuk-summary-list">

--- a/app/views/candidates/registrations/background_checks/_form.html.erb
+++ b/app/views/candidates/registrations/background_checks/_form.html.erb
@@ -2,26 +2,26 @@
 <%= govuk_back_link %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Background and security checks</h1>
-    <p>
-      Some schools may ask you to have a criminal record check through the
-      <%= link_to 'Disclosure and Barring Service (DBS)', 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about' %>
-      before offering you school experience.
-    </p>
-    <p>
-      These are commonly known as ‘DBS checks’ and provide you with a ‘DBS certificate’ to show you’re suitable to work with children and young people.
-    </p>
-    <p class="govuk-!-font-weight-bold">
-      Schools will let you know if you need to have a DBS check before offering you school experience.
-    </p>
-    <p>
-      <strong>
-        <%= link_to "Find out more", 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about' %> about 'DBS checks' and 'DBS certificates'.
-      </strong>
-    </p>
-
     <%= form_for background_check, url: candidates_school_registrations_background_check_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Background and security checks</h1>
+      <p>
+        Some schools may ask you to have a criminal record check through the
+        <%= link_to 'Disclosure and Barring Service (DBS)', 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about' %>
+        before offering you school experience.
+      </p>
+      <p>
+        These are commonly known as ‘DBS checks’ and provide you with a ‘DBS certificate’ to show you’re suitable to work with children and young people.
+      </p>
+      <p class="govuk-!-font-weight-bold">
+        Schools will let you know if you need to have a DBS check before offering you school experience.
+      </p>
+      <p>
+        <strong>
+          <%= link_to "Find out more", 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about' %> about 'DBS checks' and 'DBS certificates'.
+        </strong>
+      </p>
 
       <% # force the params to submit if the user has not selected an option %>
       <%= f.hidden_field :has_dbs_check, value: nil %>

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -6,26 +6,26 @@
 <%= govuk_back_link %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">
-      <%- if candidate_signed_in? -%>
-      <%= 'Confirm your contact details' %>
-      <%- else -%>
-      <%= 'Enter your contact details' %>
-      <%- end -%>
-    </h1>
-
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">
-          Schools will use these details to contact you about school experience once you've sent them a request.
-        </p>
-
-        <p>
-          If a school accepts your request, the school experience service will send you text message alerts about your booking.
-        </p>
-
         <%= form_for contact_information, url: candidates_school_registrations_contact_information_path do |f| %>
           <%= f.govuk_error_summary %>
+
+          <h1 class="govuk-heading-l">
+            <%- if candidate_signed_in? -%>
+            <%= 'Confirm your contact details' %>
+            <%- else -%>
+            <%= 'Enter your contact details' %>
+            <%- end -%>
+          </h1>
+
+          <p>
+            Schools will use these details to contact you about school experience once you've sent them a request.
+          </p>
+
+          <p>
+            If a school accepts your request, the school experience service will send you text message alerts about your booking.
+          </p>
 
           <%= f.govuk_phone_field :phone, autocomplete: 'on' %>
 

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -4,26 +4,27 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">
-      Check if we already have your details
-    </h1>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <p class="govuk-body">
-          Provide the following information so we can check if we already have
-          your details.
-        </p>
-
-        <p>
-        If we do not have your details, we'll register them with the DfE's Get Into Teaching service.
-        Get Into Teaching offers help and advice about becoming a teacher.
-        </p>
-
         <%= form_for personal_information,
               url: candidates_school_registrations_personal_information_path,
               data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
 
           <%= f.govuk_error_summary %>
+
+          <h1 class="govuk-heading-l">
+            Check if we already have your details
+          </h1>
+
+          <p>
+            Provide the following information so we can check if we already have
+            your details.
+          </p>
+
+          <p>
+          If we do not have your details, we'll register them with the DfE's Get Into Teaching service.
+          Get Into Teaching offers help and advice about becoming a teacher.
+          </p>
 
           <%= f.govuk_text_field :first_name, autocomplete: 'given-name',
                 readonly: personal_information.read_only,

--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -2,33 +2,33 @@
 <%= govuk_back_link %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1>You’re already registered with us</h1>
-    <p>
-      The details you have entered match our records.
-      You could have given them to us when you:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>attended one of our teaching events</li>
-      <li>previously used this service</li>
-      <li>
-        registered with our partner
-        <a href="https://getintoteaching.education.gov.uk/" class="govuk-link">
-          Get Into Teaching Information Service
-        </a>
-      </li>
-    </ul>
-
-    <h2>Verify your details to continue</h2>
-
-    <p>We've emailed a verification code to:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= @email_address %></li>
-    </ul>
-
     <%= form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1>You’re already registered with us</h1>
+      <p>
+        The details you have entered match our records.
+        You could have given them to us when you:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>attended one of our teaching events</li>
+        <li>previously used this service</li>
+        <li>
+          registered with our partner
+          <a href="https://getintoteaching.education.gov.uk/" class="govuk-link">
+            Get Into Teaching Information Service
+          </a>
+        </li>
+      </ul>
+
+      <h2>Verify your details to continue</h2>
+
+      <p>We've emailed a verification code to:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li><%= @email_address %></li>
+      </ul>
 
       <%= f.hidden_field :email %>
       <%= f.hidden_field :firstname %>

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -3,9 +3,10 @@
 
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">Choose a date</h1>
     <%= form_for subject_and_date_information, url: candidates_school_registrations_subject_and_date_information_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">Choose a date</h1>
 
       <%= f.hidden_field :date_and_subject_ids %>
 

--- a/app/views/candidates/sessions/create.html.erb
+++ b/app/views/candidates/sessions/create.html.erb
@@ -2,20 +2,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Verify your school experience sign in
-    </h1>
-
-    <p>
-      You now need to <strong>enter the verification code</strong> we've sent to the following email address:
-    </p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li><%= @verification_code.email %></li>
-    </ul>
-
     <%= form_for @verification_code, url: candidates_signin_code_path, method: :put do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Verify your school experience sign in
+      </h1>
+
+      <p>
+        You now need to <strong>enter the verification code</strong> we've sent to the following email address:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li><%= @verification_code.email %></li>
+      </ul>
 
       <%= f.hidden_field :firstname %>
       <%= f.hidden_field :lastname %>

--- a/app/views/candidates/sessions/new.html.erb
+++ b/app/views/candidates/sessions/new.html.erb
@@ -1,17 +1,16 @@
 <% self.page_title = 'Sign in to school experience' %>
 
-<h1>Get school experience sign in</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <p>
-      Please supply details below and we will send you a link which
-      you can sign in with.
-    </p>
-
     <%= form_for @candidates_session, url: candidates_signin_path, html: {novalidate: true} do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1>Get school experience sign in</h1>
+
+      <p>
+        Please supply details below and we will send you a link which
+        you can sign in with.
+      </p>
 
       <%= f.govuk_email_field :email, autocomplete: 'on', class: 'govuk-input govuk-input--width-30' %>
       <%= f.govuk_text_field :firstname, autocomplete: 'given-name', class: 'govuk-input govuk-input--width-20' %>

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">Give feedback on this service</h1>
     <%= form_for feedback do |f| %>
       <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-l">Give feedback on this service</h1>
       <p>
         Help us improve the school experience service.
       </p>

--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -7,13 +7,13 @@
   }
 %>
 
-<h1>Confirm attendance</h1>
-
 <%- if @bookings.any? %>
 
   <%= form_for @updated_attendance, url: nil do |f| %>
     <%= f.govuk_error_summary %>
   <% end %>
+
+  <h1>Confirm attendance</h1>
 
   <%= form_with url: schools_confirm_attendance_path, method: 'put' do |f| %>
     <%= pagination_bar @bookings %>
@@ -61,6 +61,8 @@
   <% end %>
 
 <% else %>
+  <h1>Confirm attendance</h1>
+
   <p>
     There are no bookings that need their attendance to be confirmed.
   </p>

--- a/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
@@ -4,11 +4,11 @@
 <%= form_for cancellation, url: schools_booking_cancellation_path do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-l">
         Review and send cancellation email to candidate
       </h1>
-
-      <%= f.govuk_error_summary %>
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -4,20 +4,20 @@
   <div class="govuk-grid-column-two-thirds">
      <%= govuk_back_link schools_booking_path(@booking) %>
 
-    <h1>Change the booking date for <%= gitis_contact_full_name(@booking.gitis_contact) %></h1>
-
-    <p>
-      Before you change the date contact the candidate and make sure they can
-      attend.
-    </p>
-
-    <p>
-      When you've changed the date they'll be sent an email with their new
-      booking date.
-    </p>
-
     <%= form_for @booking, url: schools_booking_date_path(@booking), method: 'patch' do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1>Change the booking date for <%= gitis_contact_full_name(@booking.gitis_contact) %></h1>
+
+      <p>
+        Before you change the date contact the candidate and make sure they can
+        attend.
+      </p>
+
+      <p>
+        When you've changed the date they'll be sent an email with their new
+        booking date.
+      </p>
 
       <%= f.govuk_date_field :date, heading: true %>
         <div id="school-booking-show" class="booking">

--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -4,12 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      <%= title %>
-    </h1>
-
     <%= form_for model, url: submission_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= title %>
+      </h1>
 
       <%= f.govuk_number_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.9, label: { class: 'govuk-heading-m' }, prefix_text: '£' %>
 

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -4,11 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Admin contact details
-    </h1>
     <%= form_for admin_contact, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Admin contact details
+      </h1>
 
       <p>
         These should be details of the person who will manage school experience requests for your school.

--- a/app/views/schools/on_boarding/candidate_dress_codes/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_dress_codes/_form.html.erb
@@ -4,15 +4,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="gouvk-heading-l">
-      Do you have a dress code for candidates?
-    </h1>
-    <p>
-      Select all that apply.
-    </p>
-
     <%= form_for candidate_dress_code, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :business_dress_1 %>
+
+      <h1 class="gouvk-heading-l">
+        Do you have a dress code for candidates?
+      </h1>
+      <p>
+        Select all that apply.
+      </p>
 
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
         <h2 class="govuk-fieldset__heading"></h2>

--- a/app/views/schools/on_boarding/candidate_experience_schedules/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_schedules/_form.html.erb
@@ -4,12 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="gouvk-heading-l">
-      Enter start and finish times for candidates
-    </h1>
-
     <%= form_for candidate_experience_schedule, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="gouvk-heading-l">
+        Enter start and finish times for candidates
+      </h1>
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">

--- a/app/views/schools/on_boarding/candidate_parking_informations/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_parking_informations/_form.html.erb
@@ -4,12 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="gouvk-heading-l">
-      Parking information
-    </h1>
-
     <%= form_for candidate_parking_information, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="gouvk-heading-l">
+        Parking information
+      </h1>
 
       <%= f.govuk_radio_buttons_fieldset :parking_provided do %>
         <%= f.govuk_radio_button :parking_provided, "true", link_errors: true do %>

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -4,13 +4,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      What requirements do you have?
-    </h1>
-
     <%= form_for candidate_requirements_selection, url: schools_on_boarding_candidate_requirements_selection_path, method: method,
                  html: { class: "candidate-requirements-selection" } do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :on_teacher_training_course_1 %>
+
+      <h1 class="govuk-heading-l">
+        What requirements do you have?
+      </h1>
 
       <p>
         Select all that apply.

--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -4,11 +4,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      DBS check costs
-    </h1>
-
     <%= form_for @dbs_fee, url: schools_on_boarding_dbs_fee_path do |f| %>
+      <h1 class="govuk-heading-l">
+        DBS check costs
+      </h1>
+
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_number_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.9, label: { class: 'govuk-heading-m' }, prefix_text: '£' %>

--- a/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
@@ -4,22 +4,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Enter your school experience details
-    </h1>
-
-    <p>
-      These details will help candidates select a school experience.
-    </p>
-
-    <p>
-      You'll be given a chance to check and change the details you enter.
-    </p>
-
     <%= form_for dbs_requirement, url: url, method: method do |f| %>
-      <%= f.govuk_radio_buttons_fieldset :dbs_policy_conditions do %>
-        <%= f.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
+      <h1 class="govuk-heading-l">
+        Enter your school experience details
+      </h1>
+
+      <p>
+        These details will help candidates select a school experience.
+      </p>
+
+      <p>
+        You'll be given a chance to check and change the details you enter.
+      </p>
+
+      <%= f.govuk_radio_buttons_fieldset :dbs_policy_conditions do %>
         <%= f.govuk_radio_button :dbs_policy_conditions, 'required', link_errors: true do %>
           <%= f.govuk_text_area :dbs_policy_details, max_words: 50 %>
         <% end %>

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -4,12 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Do you charge fees to cover any of the following?
-    </h1>
-
     <%= form_for fees, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Do you charge fees to cover any of the following?
+      </h1>
 
       <p>
         Some schools charge fees to cover the associated costs of running school experience.

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -4,11 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Which key stages do you offer experience with?
-    </h1>
     <%= form_for key_stage_list, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :early_years_1 %>
+
+      <h1 class="govuk-heading-l">
+        Which key stages do you offer experience with?
+      </h1>
 
       <p>
         Select all that apply.

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -4,12 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Which school phases do you offer experience with?
-    </h1>
-
     <%= form_for phases_list, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :primary_1 %>
+
+      <h1 class="govuk-heading-l">
+        Which school phases do you offer experience with?
+      </h1>
 
       <p>
         Select all that apply.

--- a/app/views/schools/on_boarding/profiles/editing.html.erb
+++ b/app/views/schools/on_boarding/profiles/editing.html.erb
@@ -9,15 +9,15 @@
 
 <div class="govuk-grid-row" id="school-onboarding-profile">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-caption-l">
-      Edit school profile
-    </h1>
-    <div class="govuk-heading-l" role="doc-subtitle"><%= @current_school.name %></div>
-
-    <%= render 'success_notice' %>
-
     <%= form_for @confirmation, url: schools_on_boarding_confirmation_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-caption-l">
+        Edit school profile
+      </h1>
+      <div class="govuk-heading-l" role="doc-subtitle"><%= @current_school.name %></div>
+
+      <%= render 'success_notice' %>
 
       <div class="govuk-tabs" data-module="govuk-tabs">
         <ul class="govuk-tabs__list">

--- a/app/views/schools/on_boarding/profiles/onboarding.html.erb
+++ b/app/views/schools/on_boarding/profiles/onboarding.html.erb
@@ -2,22 +2,22 @@
 
 <div class="govuk-grid-row" id="school-onboarding-profile">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">
-      Check your answers before setting up your profile
-    </h1>
-
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        To set up your profile, select the checkbox at the bottom of the page and select 'Accept and set up profile'.
-      </strong>
-    </div>
-
-    <%= render 'schools/on_boarding/profiles/success_notice' %>
-
     <%= form_for @confirmation, url: schools_on_boarding_confirmation_path do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Check your answers before setting up your profile
+      </h1>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          To set up your profile, select the checkbox at the bottom of the page and select 'Accept and set up profile'.
+        </strong>
+      </div>
+
+      <%= render 'schools/on_boarding/profiles/success_notice' %>
 
       <h2 class="govuk-heading-m">School details</h2>
       <dl class="govuk-summary-list">

--- a/app/views/schools/on_boarding/subjects/_form.html.erb
+++ b/app/views/schools/on_boarding/subjects/_form.html.erb
@@ -4,11 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Select school experience subjects
-    </h1>
     <%= form_for subject_list, url: schools_on_boarding_subjects_path, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :subject_ids_1 %>
+      <h1 class="govuk-heading-l">
+        Select school experience subjects
+      </h1>
+
       <p>
         Tell us which subjects you offer for secondary school experience and
         select continue.

--- a/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
+++ b/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
@@ -4,12 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Teacher training details
-    </h1>
-
     <%= form_for teacher_training, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        Teacher training details
+      </h1>
 
       <%= f.govuk_radio_buttons_fieldset :provides_teacher_training do %>
         <%= f.govuk_radio_button :provides_teacher_training, "true", link_errors: true do %>

--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -4,14 +4,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
-    <h1>
-      Edit booking details for <%= @placement_request.candidate_name %>
-    </h1>
-
     <%= form_for @booking, url: schools_placement_request_acceptance_make_changes_path, method: 'post' do |f| %>
       <%= f.govuk_error_summary %>
-      <div>
 
+      <h1>Edit booking details for <%= @placement_request.candidate_name %></h1>
+
+      <div>
         <%- if @placement_request.fixed_date_is_bookable? %>
           <h3 class="govuk-heading-m">The candidate requested</h3>
 

--- a/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
+++ b/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
@@ -4,16 +4,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1>Send details to candidate</h1>
-
-    <p>
-      The following contains the wording of the confirmation email which will be
-      sent to <%= @placement_request.candidate_name %>
-      to confirm their booking.
-    </p>
-
     <%= form_for @booking, url: schools_placement_request_acceptance_preview_confirmation_email_path(@placement_request.id) do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1>Send details to candidate</h1>
+
+      <p>
+        The following contains the wording of the confirmation email which will be
+        sent to <%= @placement_request.candidate_name %>
+        to confirm their booking.
+      </p>
+
       <div class="email-preview">
         <p>Dear <%= @placement_request.candidate_name %>,</p>
 

--- a/app/views/schools/placement_requests/cancellations/_form.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_form.html.erb
@@ -5,11 +5,11 @@
 <%= form_for cancellation, url: schools_placement_request_cancellation_path do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
+      <%= f.govuk_error_summary %>
+
       <h1 class="govuk-heading-l">
         Review and send rejection email to candidate
       </h1>
-
-      <%= f.govuk_error_summary %>
 
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Trello card

[Trello-557](https://trello.com/c/5kWqIQTY/557-display-error-summaries-at-the-top-of-the-pages)

### Context

The GOV.UK design guidance suggests placing the `error_summary` component above the initial `h1` tag of each page.

### Changes proposed in this pull request

- Position all error summaries above the h1 tag

### Guidance to review

