### PR TITLE
Fix nil candidate error

### DIFF
--- a/app/controllers/schools/rejected_requests_controller.rb
+++ b/app/controllers/schools/rejected_requests_controller.rb
@@ -21,17 +21,5 @@ module Schools
     def scope
       current_school.placement_requests.rejected
     end
-
-    def assign_gitis_contacts(requests)
-      return requests if requests.empty?
-
-      contact_ids = requests.map(&:contact_uuid)
-      api = GetIntoTeachingApiClient::SchoolsExperienceApi.new
-      contacts = api.get_schools_experience_sign_ups(contact_ids).index_by(&:candidate_id)
-
-      requests.each do |req|
-        req.candidate.gitis_contact = contacts[req.contact_uuid]
-      end
-    end
   end
 end


### PR DESCRIPTION
### Trello card
https://trello.com/c/QWioFdT0

### Context
We have seen a few errors via Sentry of `ActionView::Template::Error: undefined method first_name for nil:NilClass`, all originating from the RejectedRequestsController.

This controller doesn't use the contact fetcher; it must have been missed when the contact fetcher was originally created.

Update the controller to use the contact fetcher, this should handle missing contact errors where they weren't handled previously.

### Changes proposed in this pull request
- Fix nil candidate error
