### PR TITLE
Simplify the initial fees question

### DIFF
--- a/app/controllers/schools/on_boarding/fees_controller.rb
+++ b/app/controllers/schools/on_boarding/fees_controller.rb
@@ -11,7 +11,6 @@ module Schools
 
       def create
         @fees = Fees.new fees_params
-
         if @fees.valid?
           current_school_profile.update! fees: @fees
           continue(current_school_profile)
@@ -42,10 +41,7 @@ module Schools
     private
 
       def fees_params
-        params.require(:schools_on_boarding_fees).permit \
-          :administration_fees,
-          :dbs_fees,
-          :other_fees
+        params.require(:schools_on_boarding_fees).permit(selected_fees: [])
       end
     end
   end

--- a/app/forms/schools/on_boarding/current_step.rb
+++ b/app/forms/schools/on_boarding/current_step.rb
@@ -54,6 +54,8 @@ module Schools
       end
 
       def fees_required?
+        return true if @school_profile.fees.dup.dbs_fees_not_present
+
         @school_profile.fees.dup.invalid?
       end
 

--- a/app/forms/schools/on_boarding/current_step.rb
+++ b/app/forms/schools/on_boarding/current_step.rb
@@ -58,7 +58,7 @@ module Schools
       end
 
       def administration_fee_required?
-        return false unless @school_profile.fees.administration_fees
+        return false unless @school_profile.fees.administration_fees?
 
         return true if @school_profile.administration_fee.dup.invalid?
 
@@ -66,7 +66,7 @@ module Schools
       end
 
       def dbs_fee_required?
-        return false unless @school_profile.fees.dbs_fees
+        return false unless @school_profile.fees.dbs_fees?
 
         return true if @school_profile.dbs_fee.dup.invalid?
 
@@ -74,7 +74,7 @@ module Schools
       end
 
       def other_fee_required?
-        return false unless @school_profile.fees.other_fees
+        return false unless @school_profile.fees.other_fees?
 
         return true if @school_profile.other_fee.dup.invalid?
 

--- a/app/forms/schools/on_boarding/current_step.rb
+++ b/app/forms/schools/on_boarding/current_step.rb
@@ -54,7 +54,7 @@ module Schools
       end
 
       def fees_required?
-        return true if @school_profile.fees.dup.dbs_fees_not_present
+        return true if @school_profile.dbs_requirement.requires_check && !@school_profile.fees.dup.dbs_fees_specified
 
         @school_profile.fees.dup.invalid?
       end

--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -7,11 +7,13 @@ module Schools
 
       def self.compose(administration_fees, dbs_fees, other_fees)
         selected_fees = []
-
         selected_fees << "administration_fees" if administration_fees
         selected_fees << "dbs_fees" if dbs_fees
         selected_fees << "other_fees" if other_fees
-        selected_fees << "none" if !administration_fees && !dbs_fees & !other_fees
+
+        unless [administration_fees, dbs_fees, other_fees].all?(&:nil?)
+          selected_fees << "none" if !administration_fees && !dbs_fees & !other_fees
+        end
 
         new(selected_fees: selected_fees)
       end

--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -4,8 +4,8 @@ module Schools
       attribute :selected_fees, default: []
       # When a school chooses to update their DBS check requirements to yes, we want to redirect them
       # to the fees step, as they won't yet have had the option to select whether any DBS fees are
-      # required. Use dbs_fees_not_present to control the flow in that scenario.
-      attribute :dbs_fees_not_present
+      # required. Use dbs_fees_specified to control the flow in that scenario.
+      attribute :dbs_fees_specified, :boolean, default: true
 
       validate :fees_or_none_selected
 
@@ -20,7 +20,7 @@ module Schools
           selected_fees << "none"
         end
 
-        new(selected_fees: selected_fees, dbs_fees_not_present: dbs_fees.nil?)
+        new(selected_fees: selected_fees, dbs_fees_specified: !dbs_fees.nil?)
       end
 
       def administration_fees?

--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -2,6 +2,10 @@ module Schools
   module OnBoarding
     class Fees < Step
       attribute :selected_fees, default: []
+      # When a school chooses to update their DBS check requirements to yes, we want to redirect them
+      # to the fees step, as they won't yet have had the option to select whether any DBS fees are
+      # required. Use dbs_fees_not_present to control the flow in that scenario.
+      attribute :dbs_fees_not_present
 
       validate :fees_or_none_selected
 
@@ -16,7 +20,7 @@ module Schools
           selected_fees << "none"
         end
 
-        new(selected_fees: selected_fees)
+        new(selected_fees: selected_fees, dbs_fees_not_present: dbs_fees.nil?)
       end
 
       def administration_fees?

--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -11,8 +11,9 @@ module Schools
         selected_fees << "dbs_fees" if dbs_fees
         selected_fees << "other_fees" if other_fees
 
-        unless [administration_fees, dbs_fees, other_fees].all?(&:nil?)
-          selected_fees << "none" if !administration_fees && !dbs_fees & !other_fees
+        # Comparing explicitly to false because a nil attribute shouldn't infer "none".
+        if administration_fees == false && dbs_fees == false && other_fees == false
+          selected_fees << "none"
         end
 
         new(selected_fees: selected_fees)

--- a/app/forms/schools/on_boarding/fees.rb
+++ b/app/forms/schools/on_boarding/fees.rb
@@ -1,31 +1,46 @@
 module Schools
   module OnBoarding
     class Fees < Step
-      attribute :administration_fees, :boolean
-      attribute :dbs_fees, :boolean
-      attribute :other_fees, :boolean
+      attribute :selected_fees, default: []
 
-      validates :administration_fees, inclusion: [true, false]
-      validates :dbs_fees, inclusion: [true, false]
-      validates :other_fees, inclusion: [true, false]
+      validate :fees_or_none_selected
 
       def self.compose(administration_fees, dbs_fees, other_fees)
-        new \
-          administration_fees: administration_fees,
-          dbs_fees: dbs_fees,
-          other_fees: other_fees
+        selected_fees = []
+
+        selected_fees << "administration_fees" if administration_fees
+        selected_fees << "dbs_fees" if dbs_fees
+        selected_fees << "other_fees" if other_fees
+        selected_fees << "none" if !administration_fees && !dbs_fees & !other_fees
+
+        new(selected_fees: selected_fees)
       end
 
       def administration_fees?
-        administration_fees
+        selected_fees.include?("administration_fees")
       end
 
       def dbs_fees?
-        dbs_fees
+        selected_fees.include?("dbs_fees")
       end
 
       def other_fees?
-        other_fees
+        selected_fees.include?("other_fees")
+      end
+
+      def none?
+        selected_fees.include?("none")
+      end
+
+    private
+
+      def fees_or_none_selected
+        no_options_selected = !none? && !administration_fees? && !dbs_fees? && !other_fees?
+        fees_and_no_fees_selected = none? && (administration_fees? || dbs_fees? || other_fees?)
+
+        if no_options_selected || fees_and_no_fees_selected
+          errors.add(:selected_fees, :no_fees_selected)
+        end
       end
     end
   end

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -85,9 +85,9 @@ module Schools
       :fees,
       class_name: 'Schools::OnBoarding::Fees',
       mapping: [
-        %w[fees_administration_fees administration_fees],
-        %w[fees_dbs_fees dbs_fees],
-        %w[fees_other_fees other_fees]
+        %w[fees_administration_fees administration_fees?],
+        %w[fees_dbs_fees dbs_fees?],
+        %w[fees_other_fees other_fees?]
       ],
       constructor: :compose
 

--- a/app/presenters/schools/on_boarding/school_profile_presenter.rb
+++ b/app/presenters/schools/on_boarding/school_profile_presenter.rb
@@ -38,15 +38,15 @@ module Schools
       def fees
         output = []
 
-        if @school_profile.fees.administration_fees
+        if @school_profile.fees.administration_fees?
           output << description_for_fee(@school_profile.administration_fee)
         end
 
-        if @school_profile.fees.dbs_fees
+        if @school_profile.fees.dbs_fees?
           output << description_for_fee(@school_profile.dbs_fee)
         end
 
-        if @school_profile.fees.other_fees
+        if @school_profile.fees.other_fees?
           output << description_for_fee(@school_profile.other_fee)
         end
 

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -1,4 +1,4 @@
-<%- self.page_title = 'Do you charge fees to cover any of the following?' -%>
+<%- self.page_title = 'Fees' -%>
 
 <%= govuk_back_link javascript: true %>
 
@@ -8,37 +8,35 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        Do you charge fees to cover any of the following?
+        Fees
       </h1>
 
       <p>
-        Some schools charge fees to cover the associated costs of running school experience.
+        Some schools charge fees to cover the costs of running school experience.
       </p>
 
       <p>
-        This includes fees to cover administration costs, background and security ‘DBS check’ charges or any other school experience-related costs schools might incur.
+        This includes fees to cover administration costs, DBS checks and any other costs related to school experience.
       </p>
 
-      <% # hidden_field ensures the form is submitted if no radios selected %>
-      <%= f.hidden_field :administration_fees %>
+      <p>
+        Select which fees candidates have to pay.
+      </p>
 
-      <%= f.govuk_radio_buttons_fieldset :administration_fees do %>
-        <%= f.govuk_radio_button :administration_fees, "true", 'aria-label': 'Yes, we charge a fee to cover administration costs', link_errors: true %>
-        <%= f.govuk_radio_button :administration_fees, "false", 'aria-label': 'No, we do not charge a fee to cover administration costs' %>
+      <%= f.govuk_check_boxes_fieldset :administration_fees, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :administration_fees, 1, 0, multiple: false %>
       <% end %>
 
       <% if requires_dbs_check %>
-        <%= f.govuk_radio_buttons_fieldset :dbs_fees do %>
-          <%= f.govuk_radio_button :dbs_fees, "true", 'aria-label': 'Yes, we charge a fee to cover DBS check costs', link_errors: true %>
-          <%= f.govuk_radio_button :dbs_fees, "false", 'aria-label': 'No, we do not charge a fee to cover DBS check costs' %>
+        <%= f.govuk_check_boxes_fieldset :dbs_fees, multiple: false, legend: nil do %>
+          <%= f.govuk_check_box :dbs_fees, 1, 0, multiple: false %>
         <% end %>
       <% else %>
         <%= f.hidden_field :dbs_fees, value: "false" %>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset :other_fees do %>
-        <%= f.govuk_radio_button :other_fees, "true", 'aria-label': 'Yes, we charge a fee to cover other costs', link_errors: true %>
-        <%= f.govuk_radio_button :other_fees, "false", 'aria-label': 'No, we do not charge a fee to cover other costs' %>
+      <%= f.govuk_check_boxes_fieldset :other_fees, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :other_fees, 1, 0, multiple: false %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -29,8 +29,6 @@
 
         <% if requires_dbs_check %>
           <%= f.govuk_check_box :selected_fees, "dbs_fees" %>
-        <% else %>
-          <%= f.hidden_field :dbs_fees, value: "false" %>
         <% end %>
 
         <%= f.govuk_check_box :selected_fees, "other_fees" %>

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -23,20 +23,21 @@
         Select which fees candidates have to pay.
       </p>
 
-      <%= f.govuk_check_boxes_fieldset :administration_fees, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :administration_fees, 1, 0, multiple: false %>
-      <% end %>
+      <%= f.govuk_check_boxes_fieldset :selected_fees, legend: nil do %>
 
-      <% if requires_dbs_check %>
-        <%= f.govuk_check_boxes_fieldset :dbs_fees, multiple: false, legend: nil do %>
-          <%= f.govuk_check_box :dbs_fees, 1, 0, multiple: false %>
+        <%= f.govuk_check_box :selected_fees, "administration_fees" %>
+
+        <% if requires_dbs_check %>
+          <%= f.govuk_check_box :selected_fees, "dbs_fees" %>
+        <% else %>
+          <%= f.hidden_field :dbs_fees, value: "false" %>
         <% end %>
-      <% else %>
-        <%= f.hidden_field :dbs_fees, value: "false" %>
-      <% end %>
 
-      <%= f.govuk_check_boxes_fieldset :other_fees, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :other_fees, 1, 0, multiple: false %>
+        <%= f.govuk_check_box :selected_fees, "other_fees" %>
+
+        <%= f.govuk_check_box_divider %>
+
+        <%= f.govuk_check_box :selected_fees, "none", exclusive: true %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -847,14 +847,11 @@ en:
         requirements_details: 'Provide details.'
       schools_on_boarding_fees:
         administration_fees_options:
-          true: 'Yes'
-          false: 'No'
+          1: Administration costs
         dbs_fees_options:
-          true: 'Yes'
-          false: 'No'
+          1: DBS check costs
         other_fees_options:
-          true: 'Yes'
-          false: 'No'
+          1: Other costs
       schools_on_boarding_administration_fee:
         <<: *schools_on_boarding_school_fee_labels
       schools_on_boarding_dbs_fee:
@@ -1041,10 +1038,6 @@ en:
         available_for_all_subjects: Select type of experience
       schools_on_boarding_dbs_requirement:
         dbs_policy_conditions: 'Do you require candidates to have or get a DBS check?'
-      schools_on_boarding_fees:
-        administration_fees: Administration costs
-        dbs_fees: DBS check costs
-        other_fees: Other costs
       schools_on_boarding_administration_fee:
         <<: *schools_on_boarding_school_fee_helpers
       schools_on_boarding_dbs_fee:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -291,12 +291,8 @@ en:
               blank: 'Details required'
         schools/on_boarding/fees:
           attributes:
-            administration_fees:
-              inclusion: 'Select Yes or No for Administration costs'
-            dbs_fees:
-              inclusion: 'Select Yes or No for DBS check costs'
-            other_fees:
-              inclusion: 'Select Yes or No for Other costs'
+            selected_fees:
+              no_fees_selected: Select which fees candidates have to pay, or select “None”
         schools/on_boarding/administration_fee:
           <<: *schools_on_boarding_school_fee_errors
         schools/on_boarding/dbs_fee:
@@ -846,12 +842,11 @@ en:
           false: 'No'
         requirements_details: 'Provide details.'
       schools_on_boarding_fees:
-        administration_fees_options:
-          1: Administration costs
-        dbs_fees_options:
-          1: DBS check costs
-        other_fees_options:
-          1: Other costs
+        selected_fees_options:
+          administration_fees: Administration costs
+          dbs_fees: DBS check costs
+          other_fees: Other costs
+          none: None
       schools_on_boarding_administration_fee:
         <<: *schools_on_boarding_school_fee_labels
       schools_on_boarding_dbs_fee:

--- a/features/schools/onboarding/dbs_required_toggling_fees.feature
+++ b/features/schools/onboarding/dbs_required_toggling_fees.feature
@@ -10,9 +10,7 @@ Feature: Dbs required toggling available fees
   Scenario: New DBS requirement choosing Yes
     Given I have completed the DBS Requirements step
     When I am on the 'fees charged' page
-    Then I should see radio buttons for 'DBS check costs' with the following options:
-      | Yes |
-      | No  |
+    Then there should be a "DBS check costs" checkbox
 
   Scenario: New DBS requirement choosing No
     Given I have completed the DBS Requirements step, choosing No
@@ -68,6 +66,6 @@ Feature: Dbs required toggling available fees
     And I choose 'Yes - Outline your DBS requirements' from the 'Do you require candidates to have or get a DBS check?' radio buttons
     And I enter 'Always require DBS check' into the 'Provide details in 50 words or less.' text area
     And I submit the form
-    And I choose 'Yes' from the 'DBS check costs' radio buttons
+    And I check 'DBS check costs'
     When I submit the form
     Then I should be on the 'DBS check costs' page

--- a/features/schools/onboarding/fees.feature
+++ b/features/schools/onboarding/fees.feature
@@ -12,36 +12,30 @@ Feature: Fees
 
   Scenario: Page title
     Given I am on the 'fees charged' page
-    Then the page title should be 'Do you charge fees to cover any of the following?'
+    Then the page title should be 'Fees'
 
   Scenario: Completing step choosing Adminsitration costs only
     Given I am on the 'fees charged' page
-    And I choose 'Yes' from the 'Administration costs' radio buttons
-    And I choose 'No' from the 'DBS check costs' radio buttons
-    And I choose 'No' from the 'Other costs' radio buttons
+    And I check 'Administration costs'
     When I submit the form
     Then I should be on the 'Administration costs' page
 
   Scenario: Completing step choosing DBS costs only
     Given I am on the 'fees charged' page
-    And I choose 'Yes' from the 'DBS check costs' radio buttons
-    And I choose 'No' from the 'Administration costs' radio buttons
-    And I choose 'No' from the 'Other costs' radio buttons
+    And I check 'DBS check costs'
     When I submit the form
     Then I should be on the 'DBS check costs' page
 
   Scenario: Completing step choosing Other costs only
     Given I am on the 'fees charged' page
-    And I choose 'Yes' from the 'Other costs' radio buttons
-    And I choose 'No' from the 'DBS check costs' radio buttons
-    And I choose 'No' from the 'Administration costs' radio buttons
+    And I check 'Other costs'
     When I submit the form
     Then I should be on the 'Other costs' page
 
   Scenario: Completing step choosing all costs
     Given I am on the 'fees charged' page
-    And I choose 'Yes' from the 'Administration costs' radio buttons
-    And I choose 'Yes' from the 'DBS check costs' radio buttons
-    And I choose 'Yes' from the 'Other costs' radio buttons
+    And I check 'Administration costs'
+    And I check 'DBS check costs'
+    And I check 'Other costs'
     When I submit the form
     Then I should be on the 'Administration costs' page

--- a/features/schools/onboarding/school_profile.feature
+++ b/features/schools/onboarding/school_profile.feature
@@ -110,7 +110,7 @@ Feature: School Profile
       Given my school is fully-onboarded
       And I am on the 'Profile' page
       When I click the 'Change' button for the 'Fees' row
-      And I choose 'Yes' from the 'Administration costs' radio buttons
+      And I check 'Administration costs'
       When I submit the form
       When I have entered the following details into the form:
         | Enter the number of pounds   | 100                        |

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -139,6 +139,10 @@ Then("there should not be a {string} checkbox") do |label_text|
   expect(page).not_to have_css('label', text: label_text)
 end
 
+Then("{string} checkbox should be selected") do |label_text|
+  expect(find(:checkbox, label_text)).to be_checked
+end
+
 Then("{string} radio button should be selected") do |label_text|
   expect(find(:radio_button, label_text)).to be_checked
 end

--- a/features/step_definitions/schools/onboarding_steps.rb
+++ b/features/step_definitions/schools/onboarding_steps.rb
@@ -34,9 +34,7 @@ end
 Given "I have completed the Fees step, choosing only Administration costs" do
   steps %(
     Given I am on the 'fees charged' page
-    And I choose 'Yes' from the 'Administration costs' radio buttons
-    And I choose 'No' from the 'DBS check costs' radio buttons
-    And I choose 'No' from the 'Other costs' radio buttons
+    And I check 'Administration costs'
     When I submit the form
   )
 end
@@ -44,9 +42,7 @@ end
 Given "I have completed the Fees step, choosing only DBS costs" do
   steps %(
     Given I am on the 'fees charged' page
-    And I choose 'Yes' from the 'DBS check costs' radio buttons
-    And I choose 'No' from the 'Administration costs' radio buttons
-    And I choose 'No' from the 'Other costs' radio buttons
+    And I check 'DBS check costs'
     When I submit the form
   )
 end
@@ -54,9 +50,7 @@ end
 Given "I have completed the Fees step, choosing only Other costs" do
   steps %(
     Given I am on the 'fees charged' page
-    And I choose 'Yes' from the 'Other costs' radio buttons
-    And I choose 'No' from the 'Administration costs' radio buttons
-    And I choose 'No' from the 'DBS check costs' radio buttons if available
+    And I check 'Other costs'
     When I submit the form
   )
 end

--- a/spec/controllers/schools/on_boarding/fees_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/fees_controller_spec.rb
@@ -16,7 +16,7 @@ describe Schools::OnBoarding::FeesController, type: :request do
     end
 
     it 'assigns the model' do
-      expect(assigns(:fees)).to eq Schools::OnBoarding::Fees.new
+      expect(assigns(:fees)).to eq Schools::OnBoarding::Fees.new(dbs_fees_not_present: true)
     end
 
     it 'renders the new template' do

--- a/spec/controllers/schools/on_boarding/fees_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/fees_controller_spec.rb
@@ -16,7 +16,7 @@ describe Schools::OnBoarding::FeesController, type: :request do
     end
 
     it 'assigns the model' do
-      expect(assigns(:fees)).to eq Schools::OnBoarding::Fees.new(dbs_fees_not_present: true)
+      expect(assigns(:fees)).to eq Schools::OnBoarding::Fees.new(dbs_fees_specified: false)
     end
 
     it 'renders the new template' do

--- a/spec/controllers/schools/on_boarding/fees_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/fees_controller_spec.rb
@@ -41,11 +41,11 @@ describe Schools::OnBoarding::FeesController, type: :request do
 
     context 'invalid' do
       let :fees do
-        Schools::OnBoarding::Fees.new(administration_fees: nil, dbs_fees: nil, other_fees: nil)
+        Schools::OnBoarding::Fees.new(selected_fees: %w[administration_fees none])
       end
 
       it "doesn't update the school_profile" do
-        expect(school_profile.reload.fees).to eq fees
+        expect(school_profile.reload.fees).not_to eq fees
       end
 
       it 'rerenders the new template' do
@@ -93,9 +93,7 @@ describe Schools::OnBoarding::FeesController, type: :request do
     end
 
     let :params do
-      {
-        schools_on_boarding_fees: fees.attributes
-      }
+      { schools_on_boarding_fees: fees.attributes }
     end
 
     before do
@@ -104,21 +102,21 @@ describe Schools::OnBoarding::FeesController, type: :request do
 
     context 'invalid' do
       let :fees do
-        Schools::OnBoarding::Fees.new(administration_fees: nil, dbs_fees: nil, other_fees: nil)
+        Schools::OnBoarding::Fees.new(selected_fees: %w[administration_fees none])
       end
 
       it "doesn't update the school_profile" do
         expect(school_profile.reload.fees).not_to eq fees
       end
 
-      it 'rerenders the edit template' do
+      it 're-renders the edit template' do
         expect(response).to render_template :edit
       end
     end
 
     context 'valid' do
       let :fees do
-        FactoryBot.build :fees, dbs_fees: !school_profile.dbs_fee
+        FactoryBot.build :fees
       end
 
       it 'updates the school_profile' do

--- a/spec/factories/schools/on_boarding/fees_factory.rb
+++ b/spec/factories/schools/on_boarding/fees_factory.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :fees, class: Schools::OnBoarding::Fees do
     selected_fees { %w[administration_fees dbs_fees other_fees] }
+    dbs_fees_not_present { false }
   end
 end

--- a/spec/factories/schools/on_boarding/fees_factory.rb
+++ b/spec/factories/schools/on_boarding/fees_factory.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :fees, class: Schools::OnBoarding::Fees do
-    administration_fees { true }
-    dbs_fees { true }
-    other_fees { true }
+    selected_fees { %w[administration_fees dbs_fees other_fees] }
   end
 end

--- a/spec/factories/schools/on_boarding/fees_factory.rb
+++ b/spec/factories/schools/on_boarding/fees_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :fees, class: Schools::OnBoarding::Fees do
     selected_fees { %w[administration_fees dbs_fees other_fees] }
-    dbs_fees_not_present { false }
+    dbs_fees_specified { true }
   end
 end

--- a/spec/factories/schools/school_profile_factory.rb
+++ b/spec/factories/schools/school_profile_factory.rb
@@ -24,6 +24,13 @@ FactoryBot.define do
       fees_other_fees { true }
     end
 
+    trait :dbs_fees_not_present do
+      after :build do |profile|
+        profile.fees = \
+          FactoryBot.build :fees, dbs_fees_not_present: true
+      end
+    end
+
     trait :with_administration_fee do
       administration_fee_amount_pounds { 123.45 }
       administration_fee_description { 'General administration' }

--- a/spec/factories/schools/school_profile_factory.rb
+++ b/spec/factories/schools/school_profile_factory.rb
@@ -24,10 +24,10 @@ FactoryBot.define do
       fees_other_fees { true }
     end
 
-    trait :dbs_fees_not_present do
+    trait :with_dbs_fees_not_specified do
       after :build do |profile|
         profile.fees = \
-          FactoryBot.build :fees, dbs_fees_not_present: true
+          FactoryBot.build :fees, selected_fees: %w[administration_fees other_fees], dbs_fees_specified: false
       end
     end
 

--- a/spec/forms/schools/on_boarding/current_step_spec.rb
+++ b/spec/forms/schools/on_boarding/current_step_spec.rb
@@ -69,6 +69,22 @@ describe Schools::OnBoarding::CurrentStep do
       it 'returns :fees' do
         expect(returned_step).to eq :fees
       end
+
+      context "when DBS fees not present" do
+        let :school_profile do
+          FactoryBot.build :school_profile,
+                           :with_dbs_requirement,
+                           :with_candidate_requirements_selection,
+                           :with_fees,
+                           :with_administration_fee,
+                           :with_other_fee,
+                           :dbs_fees_not_present
+        end
+
+        it 'returns :fees' do
+          expect(returned_step).to eq :fees
+        end
+      end
     end
 
     context 'administration_fee required' do

--- a/spec/forms/schools/on_boarding/current_step_spec.rb
+++ b/spec/forms/schools/on_boarding/current_step_spec.rb
@@ -70,15 +70,14 @@ describe Schools::OnBoarding::CurrentStep do
         expect(returned_step).to eq :fees
       end
 
-      context "when DBS fees not present" do
+      context "when DBS fees not yet specified" do
         let :school_profile do
           FactoryBot.build :school_profile,
                            :with_dbs_requirement,
                            :with_candidate_requirements_selection,
-                           :with_fees,
+                           :with_dbs_fees_not_specified,
                            :with_administration_fee,
-                           :with_other_fee,
-                           :dbs_fees_not_present
+                           :with_other_fee
         end
 
         it 'returns :fees' do

--- a/spec/forms/schools/on_boarding/fees_spec.rb
+++ b/spec/forms/schools/on_boarding/fees_spec.rb
@@ -2,14 +2,34 @@ require 'rails_helper'
 
 describe Schools::OnBoarding::Fees, type: :model do
   context '#attributes' do
-    it { is_expected.to respond_to :administration_fees }
-    it { is_expected.to respond_to :dbs_fees }
-    it { is_expected.to respond_to :other_fees }
+    it { is_expected.to respond_to :selected_fees }
   end
 
   context 'validations' do
-    it { is_expected.not_to allow_value(nil).for :administration_fees }
-    it { is_expected.not_to allow_value(nil).for :dbs_fees }
-    it { is_expected.not_to allow_value(nil).for :other_fees }
+    describe "#selected_fees" do
+      context "when no options are selected" do
+        subject do
+          described_class.new(selected_fees: [])
+        end
+
+        it { expect(subject.invalid?).to be true }
+      end
+
+      context "when fees and no fees are selected" do
+        subject do
+          described_class.new(selected_fees: %w[administration_fees none])
+        end
+
+        it { expect(subject.invalid?).to be true }
+      end
+    end
+  end
+
+  describe ".compose" do
+    subject { described_class.compose(false, true, false) }
+
+    it "assigns selected fees" do
+      expect(subject.selected_fees).to eq %w[dbs_fees]
+    end
   end
 end

--- a/spec/forms/schools/on_boarding/fees_spec.rb
+++ b/spec/forms/schools/on_boarding/fees_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 describe Schools::OnBoarding::Fees, type: :model do
   context '#attributes' do
     it { is_expected.to respond_to :selected_fees }
+    it { is_expected.to respond_to :dbs_fees_specified }
+  end
+
+  describe 'default values' do
+    it { expect(subject.dbs_fees_specified).to be(true) }
   end
 
   context 'validations' do

--- a/spec/models/schools/school_profile_spec.rb
+++ b/spec/models/schools/school_profile_spec.rb
@@ -298,15 +298,15 @@ describe Schools::SchoolProfile, type: :model do
 
       it 'sets fees_administration_fees' do
         expect(model.fees_administration_fees).to eq \
-          form_model.administration_fees
+          form_model.administration_fees?
       end
 
       it 'sets fees_dbs_fees' do
-        expect(model.fees_dbs_fees).to eq form_model.dbs_fees
+        expect(model.fees_dbs_fees).to eq form_model.dbs_fees?
       end
 
       it 'sets fees_other_fees' do
-        expect(model.fees_other_fees).to eq form_model.other_fees
+        expect(model.fees_other_fees).to eq form_model.other_fees?
       end
 
       it 'returns the form model' do
@@ -676,7 +676,7 @@ describe Schools::SchoolProfile, type: :model do
 
         before do
           school_profile.update! \
-            fees: FactoryBot.build(:fees, administration_fees: false)
+            fees: FactoryBot.build(:fees, selected_fees: %w[dbs_fees other_fees])
         end
 
         it 'resets administration_fee' do
@@ -691,7 +691,7 @@ describe Schools::SchoolProfile, type: :model do
         end
 
         before do
-          school_profile.update! fees: FactoryBot.build(:fees, dbs_fees: false)
+          school_profile.update! fees: FactoryBot.build(:fees, selected_fees: %w[administration_fees other_fees])
         end
 
         it 'resets dbs_fee' do
@@ -706,7 +706,7 @@ describe Schools::SchoolProfile, type: :model do
 
         before do
           school_profile.update! \
-            fees: FactoryBot.build(:fees, other_fees: false)
+            fees: FactoryBot.build(:fees, selected_fees: %w[administration_fees dbs_fees])
         end
 
         it 'resets other_fee' do


### PR DESCRIPTION
### Trello card
https://trello.com/c/Yjx2EUw9

### Context
As part of the onboarding redesign, we want to use checkboxes instead of yes no radios for the initial fees question.

### Changes proposed in this pull request
- Simplify the initial fees question.
- Add an option for "none" to the fees question: GOV guidance says that we should have an option for "none", when that is a valid answer. The built in GOV "none" checkbox requires the fields to have matching names, so introduce a new "selected_fees" attribute, which we can map the user's selection to. We also need to make sure "none" works with JavaScript disabled, so add some addition validation. Additionally, persist the "none" selection, for when the user revisits this page.

### Guidance to review

Before:
![image](https://user-images.githubusercontent.com/47089130/159673335-4746bb48-99b2-40d0-8aa8-85e1f52ad1a1.png)

After:
![image](https://user-images.githubusercontent.com/47089130/162008869-294d4275-d7b8-4603-ab24-c5cdbe7db268.png)
