### PR TITLE
Upgrade Postgres on dev/staging

### DIFF
--- a/terraform/paas/dev.env.tfvars
+++ b/terraform/paas/dev.env.tfvars
@@ -9,4 +9,4 @@ delayed_jobs              = 1
 environment               = "dev"
 azure_key_vault           = "s105d01-kv"
 azure_resource_group      = "s105d01-dev-vault-resource-group"
-database_plan             = "small-12"
+database_plan             = "small-13"

--- a/terraform/paas/staging.env.tfvars
+++ b/terraform/paas/staging.env.tfvars
@@ -11,6 +11,8 @@ environment               = "staging"
 application_environment   = "dfe-school-experience-staging"
 azure_key_vault           = "s105t01-kv"
 azure_resource_group      = "s105t01-staging-vault-resource-group"
+database_plan             = "small-13"
+
 alerts = {
   SchoolExperience_Staging = {
     website_name   = "School Experience (Staging)"


### PR DESCRIPTION
Upgrades Postgres to v13 (latest available) on dev and staging; terraform isn't able to execute this as it complains about the Postgis extension being enabled so have performed the upgrade manually with:

```
cf update-service school-experience-dev/test-pg-common-svc -p small-13
```