### PR TITLE
Change CF healthcheck to use port

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -14,17 +14,17 @@ locals {
 
 
 resource "cloudfoundry_app" "application" {
-  name         = var.paas_application_name
-  space        = data.cloudfoundry_space.space.id
-  command      = "/app/docker-entrypoint.sh ${var.FRONTEND}" 
-  docker_image = var.paas_docker_image
-  stopped      = var.application_stopped
-  instances    = var.application_instances
-  memory       = var.application_memory
-  disk_quota   = var.application_disk
-  strategy     = var.strategy
-  health_check_type = "process"
-  timeout      = var.timeout
+  name              = var.paas_application_name
+  space             = data.cloudfoundry_space.space.id
+  command           = "/app/docker-entrypoint.sh ${var.FRONTEND}" 
+  docker_image      = var.paas_docker_image
+  stopped           = var.application_stopped
+  instances         = var.application_instances
+  memory            = var.application_memory
+  disk_quota        = var.application_disk
+  strategy          = var.strategy
+  health_check_type = "port"
+  timeout           = var.timeout
 
 
   dynamic "service_binding" {


### PR DESCRIPTION
### Trello card

[Trello-588](https://trello.com/c/IquM2i7n/588-check-cloud-foundry-health-check-configuration)

### Context

We changed the health check to `process` when we were struggling to get the DelayedJobs metrics working a few weeks ago. This has resulted in a few seconds of downtime during deployments to production as the process goes 'live' before the web service has fully booted; StatusCake then hits the app and it gets an error. I don't think the `process` check type was necessary in the end for the metrics to work so reverting back to `port`.

### Changes proposed in this pull request

- Change CF healthcheck to use port

### Guidance to review

