### PR TITLE
March Service update

### DIFF
--- a/app/models/service_update.rb
+++ b/app/models/service_update.rb
@@ -35,4 +35,8 @@ class ServiceUpdate
       COOKIE_KEY
     end
   end
+
+  def title_with_date
+    "#{date.to_formatted_s(:govuk)} - #{title}"
+  end
 end

--- a/app/views/schools/dashboards/_service_update_notice.html.erb
+++ b/app/views/schools/dashboards/_service_update_notice.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-inset-text" id="service-update-notice">
   <h2 class="govuk-heading-m">
-    <%= @latest_service_update.title %>
+    <%= @latest_service_update.title_with_date %>
   </h2>
 
   <p>

--- a/app/views/service_updates/_service_update.html.erb
+++ b/app/views/service_updates/_service_update.html.erb
@@ -1,6 +1,5 @@
 <h3 class="govuk-heading-s">
-  <%= service_update.date.to_formatted_s(:govuk) %> -
-  <%= service_update.title %>
+  <%= service_update.title_with_date %>
 </h3>
 
 <p>

--- a/app/views/service_updates/index.html.erb
+++ b/app/views/service_updates/index.html.erb
@@ -12,7 +12,7 @@
 
     <%- if @latest -%>
     <h2 class="govuk-heading-m">
-      <%= @latest.title %>
+      <%= @latest.title_with_date %>
     </h2>
 
     <%= sanitize @latest.html_content %>
@@ -21,9 +21,9 @@
       <em>No service updates are currently available</em>
     </p>
     <%- end -%>
-    
+
     <hr>
-    
+
     <%- if @recent_updates.any? -%>
     <h2 class="govuk-heading-m">
       Previous service updates

--- a/data/service_updates/20211025.yml
+++ b/data/service_updates/20211025.yml
@@ -1,15 +1,15 @@
 ---
-title: 25 October 2021 - 'Under consideration' status tag and new features
+title: "'Under consideration' status tag and new features"
 summary: You can now place a request ‘under consideration’ before you accept it or decline it.
 html_content: |-
   <p>
-    We’ve created a new status tag for requests that are under consideration. 
+    We’ve created a new status tag for requests that are under consideration.
   </p>
   <p>
   This allows you to contact a candidate for more information before you make a decision about their request.
   </p>
   <p>
-  When you open up a request you’ll now have 3 actions to choose from: 
+  When you open up a request you’ll now have 3 actions to choose from:
 
   <ul class="govuk-list govuk-list--bullet">
   <li>‘Accept request’</li>
@@ -17,7 +17,7 @@ html_content: |-
   <li>‘Place under consideration’</li>
   </ul>
   </p>
-  
+
   <p>
   If you place a request ‘under consideration’, you’ll see this new tag next to it in ‘Manage requests’.
   </p>
@@ -33,7 +33,7 @@ html_content: |-
 
   <h3>Flagging duplicate requests</h3>
 
-  <p>If a candidate who has already requested experience at your school tries to make another request, the system will recognise this as a duplicate request. 
+  <p>If a candidate who has already requested experience at your school tries to make another request, the system will recognise this as a duplicate request.
 
   You’ll see the ‘flagged’ status tag next to these requests on the ‘Manage requests’ page. This will help you to decline requests from candidates you’ve already turned down.
   </p>

--- a/data/service_updates/20220127.yml
+++ b/data/service_updates/20220127.yml
@@ -1,5 +1,5 @@
 ---
-title: 27 January 2022 - Choose when to publish and close dates to candidates (and other features)
+title: Choose when to publish and close dates to candidates (and other features)
 summary: We've created a new feature that allows you to choose when you want to publish and close a school experience date.
 html_content: |-
 

--- a/data/service_updates/20220322.yml
+++ b/data/service_updates/20220322.yml
@@ -1,0 +1,15 @@
+---
+title: 22 March 2022 – Publish multiple experience dates
+summary: |-
+  We've created a new feature that allows you to publish multiple school experience dates.
+html_content: |-
+
+  <p>When you add a school experience date, you’ll be asked whether this is a recurring date.
+  For example, you might want to publish a school experience date that occurs at a regular interval, for example every fortnight to coincide with your teaching timetable.
+  You can schedule as many dates as you would like, up to 4 months in advance.</p>
+
+  <h3>Scheduled experience dates</h3>
+  <p>When you decide to publish an experience date available to candidates in the future, this will now show a ‘scheduled’ status, instead of ‘closed’.</p>
+
+  <h3>Improved profile editing</h3>
+  <p>The ‘update profile’ page is now split into 3 tabbed sections – school experience details, candidate information and contact information. This will make it easier to find the information that you wish to edit on your school profile.</p>

--- a/data/service_updates/20220322.yml
+++ b/data/service_updates/20220322.yml
@@ -1,5 +1,5 @@
 ---
-title: 22 March 2022 – Publish multiple experience dates
+title: Publish multiple experience dates
 summary: |-
   We've created a new feature that allows you to publish multiple school experience dates.
 html_content: |-

--- a/spec/models/service_update_spec.rb
+++ b/spec/models/service_update_spec.rb
@@ -77,4 +77,12 @@ describe ServiceUpdate, type: :model do
     subject { described_class.from_param attrs[:date] }
     it { is_expected.to eq service_update }
   end
+
+  describe "#title_with_date" do
+    subject { described_class.new(attrs).title_with_date }
+
+    it "returns the title preceded by the date" do
+      expect(subject).to eq "1 June 2020 - Service Update A"
+    end
+  end
 end


### PR DESCRIPTION
### Trello card

### Context

### Changes proposed in this pull request
- Add March 2022 service update
- Fix service update titles: We have hardcoded the date in the title for the past few service updates (e.g., "25 October 2021 - 'Under consideration' status tag and new features"). However, the list of previous service updates interpret the date from the file name and add this to the title, which means the dates are doubled up (e.g., "25 October 2021 - 25 October 2021 - 'Under consideration' status tag and new features"). To fix, add the generated date to the service update notice and latest service update, and remove any hardcoded dates from previous service updates.

### Guidance to review
**New service update**
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/47089130/159897315-e6c22056-a582-4ba4-9ee8-8da50e67be3b.png">
<img width="656" alt="image" src="https://user-images.githubusercontent.com/47089130/159898023-32f8043a-e711-4608-8b87-3367865c2ea8.png">

**Fixed Titles**
|Before|After|
|-|-|
|<img width="744" alt="image" src="https://user-images.githubusercontent.com/47089130/159898752-d7314a08-d869-40d5-ad82-e29bfb67a805.png">|<img width="680" alt="image" src="https://user-images.githubusercontent.com/47089130/159900263-1cf17eb9-2b1a-4598-98db-f906b680e278.png">|


