### PR TITLE
Update terraform with correct Postgres version

### DIFF
--- a/terraform/paas/dev.env.tfvars
+++ b/terraform/paas/dev.env.tfvars
@@ -9,4 +9,4 @@ delayed_jobs              = 1
 environment               = "dev"
 azure_key_vault           = "s105d01-kv"
 azure_resource_group      = "s105d01-dev-vault-resource-group"
-database_plan             = "small-12"
+database_plan             = "small-13"


### PR DESCRIPTION
We're already running v13 in dev; this makes terraform consistent.
