### PR TITLE
Fix warning with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ RUN gem install bundler --version='~> 2.3.4' && \
 
 # Add code and compile assets
 COPY . .
-RUN gem install nokogiri:1.13.3
-RUN bundle exec rake assets:precompile SECRET_KEY_BASE=stubbed SKIP_REDIS=true
+RUN gem install nokogiri:1.13.3 && \
+    bundle exec rake assets:precompile SECRET_KEY_BASE=stubbed SKIP_REDIS=true
 
 # Create symlinks for CSS files without digest hashes for use in error pages
 RUN bundle exec rake assets:symlink_non_digested SECRET_KEY_BASE=stubbed SKIP_REDIS=true


### PR DESCRIPTION
The multiple consecutive RUN statements was resulting in a warning during linting.
