### PR TITLE
Remove yabeda-gc gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Metrics
 gem "webrick"
 gem 'yabeda-delayed_job', github: "DFE-Digital/yabeda-delayed_job", ref: "2251f9d"
-gem 'yabeda-gc'
 gem 'yabeda-http_requests'
 gem 'yabeda-prometheus'
 gem 'yabeda-puma-plugin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -592,8 +592,6 @@ GEM
       anyway_config (>= 1.0, < 3)
       concurrent-ruby
       dry-initializer
-    yabeda-gc (0.1.1)
-      yabeda (~> 0.6)
     yabeda-http_requests (0.2.0)
       sniffer
       yabeda
@@ -690,7 +688,6 @@ DEPENDENCIES
   webmock
   webrick
   yabeda-delayed_job!
-  yabeda-gc
   yabeda-http_requests
   yabeda-prometheus
   yabeda-puma-plugin


### PR DESCRIPTION
This doesn't appear to be compatible with Ruby 3.1 yet and we see an error on the metrics endpoint in production.

Removing it for now and we can look to bring it back in at a later date.
