### PR TITLE
Update staging terraform with correct postgres version

### DIFF
--- a/terraform/paas/staging.env.tfvars
+++ b/terraform/paas/staging.env.tfvars
@@ -9,6 +9,7 @@ application_instances     = 1
 delayed_jobs              = 1
 environment               = "staging"
 application_environment   = "dfe-school-experience-staging"
+database_plan             = "small-13"
 azure_key_vault           = "s105t01-kv"
 azure_resource_group      = "s105t01-staging-vault-resource-group"
 alerts = {


### PR DESCRIPTION
We have updated to v13 via Cloud Foundry now, so this makes terraform consistent.
