### PR TITLE
Update school experience statuses

### DIFF
--- a/app/controllers/candidates/placement_requests/cancellations_controller.rb
+++ b/app/controllers/candidates/placement_requests/cancellations_controller.rb
@@ -23,7 +23,8 @@ module Candidates
           notify_candidate @cancellation
           @cancellation.sent!
 
-          Bookings::Gitis::SchoolExperience.from_cancellation(@cancellation, :cancelled_by_candidate)
+          status = placement_request.booking.present? ? :cancelled_by_candidate : :withdrawn
+          Bookings::Gitis::SchoolExperience.from_cancellation(@cancellation, status)
             .write_to_gitis_contact(@cancellation.contact_uuid)
 
           redirect_to candidates_placement_request_cancellation_path \

--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -15,7 +15,7 @@ module Schools
           notify_candidate @cancellation
           @cancellation.sent!
 
-          Bookings::Gitis::SchoolExperience.from_cancellation(@cancellation, :cancelled_by_school)
+          Bookings::Gitis::SchoolExperience.from_cancellation(@cancellation, :rejected)
             .write_to_gitis_contact(@cancellation.contact_uuid)
 
           redirect_to \

--- a/app/services/bookings/gitis/school_experience.rb
+++ b/app/services/bookings/gitis/school_experience.rb
@@ -9,19 +9,21 @@ module Bookings
 
       # requested: placement requested by candidate
       # confirmed: placement request accepted by school
-      # withdrawn: candidate didn't attend placement
-      # rejected: request rejected by school
-      # cancelled_by_school: cancelled by school
-      # cancelled_by_candidate: cancelled by candidate
+      # did_not_attend: candidate did not attend placement
+      # rejected: request rejected by school (before being accepted)
+      # cancelled_by_school: cancelled by school (after being accepted)
+      # cancelled_by_candidate: cancelled by candidate (after being accepted)
       # completed: candidate attended placement
+      # withdrawn: placement withdrawn by candidate (before being accepted)
       GITIS_STATUS = {
         requested: 1,
         confirmed: 222_750_000,
-        withdrawn: 222_750_001,
+        did_not_attend: 222_750_001,
         rejected: 222_750_002,
         cancelled_by_school: 222_750_003,
         cancelled_by_candidate: 222_750_004,
-        completed: 222_750_005
+        completed: 222_750_005,
+        withdrawn: 222_750_006,
       }.freeze.with_indifferent_access
 
       attr_reader :date, :urn, :school_name, :teaching_subject_name, :duration, :status

--- a/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/candidates/placement_requests/cancellations_controller_spec.rb
@@ -212,12 +212,26 @@ describe Candidates::PlacementRequests::CancellationsController, type: :request 
             expect(placement_request).to be_closed
           end
 
-          it 'creates a school experience and sends it to the API' do
+          it 'creates a withdrawn school experience and sends it to the API' do
             expect(Bookings::Gitis::SchoolExperience).to \
-              have_received(:from_cancellation).with(instance_of(Bookings::PlacementRequest::Cancellation), :cancelled_by_candidate)
+              have_received(:from_cancellation).with(instance_of(Bookings::PlacementRequest::Cancellation), :withdrawn)
 
             expect(school_experience).to \
               have_received(:write_to_gitis_contact).with(placement_request.contact_uuid)
+          end
+
+          context "when the request has been accepted by the school (it has a booking)" do
+            let :placement_request do
+              FactoryBot.create :placement_request, :booked
+            end
+
+            it 'creates a cancelled by candidate school experience and sends it to the API' do
+              expect(Bookings::Gitis::SchoolExperience).to \
+                have_received(:from_cancellation).with(instance_of(Bookings::PlacementRequest::Cancellation), :cancelled_by_candidate)
+
+              expect(school_experience).to \
+                have_received(:write_to_gitis_contact).with(placement_request.contact_uuid)
+            end
           end
 
           it 'redirects to the show action' do

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -88,7 +88,7 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
 
       it 'creates a school experience and sends it to the API' do
         expect(Bookings::Gitis::SchoolExperience).to \
-          have_received(:from_cancellation).with(instance_of(Bookings::PlacementRequest::Cancellation), :cancelled_by_school)
+          have_received(:from_cancellation).with(instance_of(Bookings::PlacementRequest::Cancellation), :rejected)
 
         expect(school_experience).to \
           have_received(:write_to_gitis_contact).with(placement_request.contact_uuid)


### PR DESCRIPTION
### Trello card
https://trello.com/c/MrgxyV50

### Context
I accidentally used the withdrawn status for candidates who did not attend their placement when migrating the app to use the CandidateSchoolExperience entity. Withdrawing is a separate action, when a candidate cancels their placement request before it has been accepted by the school.

To fix this, we have updated the withdrawn status name to did not attend (which will fix the existing requests), and added a new status for withdrawn (so that this can be used in the correct place).

Also, distinguish `rejected` requests from `cancelled by school` requests. These were replaced like-for-like when the initial migration was done.

### Changes proposed in this pull request
- Update school experience statuses

### Guidance to review

