### PR TITLE
Fix typo on school teacher_training_website attribute

### DIFF
--- a/app/views/candidates/schools/_profile_compact.erb
+++ b/app/views/candidates/schools/_profile_compact.erb
@@ -39,7 +39,7 @@
 
       <% if @school.teacher_training_provider? && @school.teacher_training_website.present? %>
       <li>
-        <%= link_to "Teacher training: #{@school.name}", cleanup_school_url(@school.school.teacher_training_website) %>
+        <%= link_to "Teacher training: #{@school.name}", cleanup_school_url(@school.teacher_training_website) %>
       </li>
       <% end %>
     </ul>


### PR DESCRIPTION
This was flagged by Sentry:

https://sentry.io/organizations/dfe-teacher-services/issues/3172895416/?project=5856726&referrer=slack

Ideally it should have a test covering it; I'll add one on Monday though so this can go out before the weekend.