### PR TITLE
Add permissions to build and deploy workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+  deployments: write
+  pull-requests: write
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   deployments: write
+  packages: write
   pull-requests: write
 
 jobs:
@@ -33,7 +34,7 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: SE-INFRA-SECRETS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
+          key: SLACK-WEBHOOK
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -67,13 +68,12 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to GitHub Container Registry
         uses: docker/build-push-action@v2.10.0
         with:
           cache-from: ${{ env.DOCKER_REPOSITORY }}:master
-          builder: ${{ steps.buildx.outputs.name }}
           tags: |
                  ${{ steps.docker.outputs.DOCKER_IMAGE }}
                  ${{ steps.docker.outputs.DOCKER_MASTER }}
@@ -110,7 +110,7 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: SE-INFRA-SECRETS
-          key: ACTIONS-API-ACCESS-TOKEN, SLACK-WEBHOOK
+          key: SLACK-WEBHOOK
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -119,7 +119,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bring up Docker compose Stack
         run: docker-compose -f docker-compose-paas.yml up -d
@@ -176,7 +176,7 @@ jobs:
         with:
           keyvault: ${{ secrets.KEY_VAULT}}
           secret: SE-INFRA-SECRETS
-          key: ACTIONS-API-ACCESS-TOKEN, SNYK-TOKEN
+          key: SNYK-TOKEN
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
@@ -185,7 +185,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master
@@ -217,21 +217,12 @@ jobs:
         with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - uses: DfE-Digital/keyvault-yaml-secret@v1
-        id:  keyvault-yaml-secret
-        with:
-          keyvault: ${{ secrets.KEY_VAULT}}
-          secret: SE-INFRA-SECRETS
-          key: ACTIONS-API-ACCESS-TOKEN
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1.14.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Cucumber Tests
         run: |-
@@ -274,21 +265,12 @@ jobs:
         with:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - uses: DfE-Digital/keyvault-yaml-secret@v1
-        id:  keyvault-yaml-secret
-        with:
-          keyvault: ${{ secrets.KEY_VAULT}}
-          secret: SE-INFRA-SECRETS
-          key: ACTIONS-API-ACCESS-TOKEN
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1.14.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ steps.keyvault-yaml-secret.outputs.ACTIONS-API-ACCESS-TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Cucumber Tests
         run: |-


### PR DESCRIPTION
### Context
Dependabot by default has readonly permissions, some steps in the workflow require write permissions.

### Changes proposed in this pull request
This change sets workflow permissions for Actions and Dependabot.

### Guidance to review
Check that workflow is running as expected

