### PR TITLE
Add issues write permission to build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   deployments: write
+  issues: write
   packages: write
   pull-requests: write
 


### PR DESCRIPTION
### Context
The `zaproxy/action-full-scan` action creates or updates a GitHub issue so requires the `issues: write` permission.

### Changes proposed in this pull request
Add the `issues: write` permission to the build workflow.

### Guidance to review
The  `zaproxy/action-full-scan` action is only ran after a merge to `master` so this change cannot be tested.
