### PR TITLE
Ensure postcodes are not sent to Google Analytics

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,2 +1,2 @@
 # Add public environment variables here for the Test environment
-
+SECRET_KEY_BASE=stubbed

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,8 @@ gem 'meta-tags', '~> 2.16', '>= 2.16.0'
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
+gem 'hashids'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,7 @@ GEM
       activesupport (>= 6.1)
       deep_merge (~> 1.2.1)
     hashdiff (1.0.1)
+    hashids (1.0.6)
     htmlentities (4.3.4)
     httpclient (2.8.3)
     i18n (1.10.0)
@@ -638,6 +639,7 @@ DEPENDENCIES
   geocoder
   get_into_teaching_api_client_faraday!
   govuk_design_system_formbuilder (~> 3.0)
+  hashids
   ice_cube
   invisible_captcha (>= 2.0.0)
   json (>= 2.3.0)

--- a/app/controllers/candidates/school_searches_controller.rb
+++ b/app/controllers/candidates/school_searches_controller.rb
@@ -2,7 +2,7 @@ class Candidates::SchoolSearchesController < ApplicationController
   before_action :redirect_if_deactivated
 
   def new
-    @search = Candidates::SchoolSearch.new(search_params)
+    @search = Candidates::SchoolSearch.new_decrypt(search_params)
   end
 
 private

--- a/app/controllers/candidates/schools_controller.rb
+++ b/app/controllers/candidates/schools_controller.rb
@@ -4,8 +4,13 @@ class Candidates::SchoolsController < ApplicationController
 
   before_action :redirect_if_deactivated
 
+  def create
+    encrypted_params = Candidates::SchoolSearch.new(search_params).encrypted_attributes
+    redirect_to(candidates_schools_path(encrypted_params))
+  end
+
   def index
-    @search = Candidates::SchoolSearch.new(search_params)
+    @search = Candidates::SchoolSearch.new_decrypt(search_params)
     render 'candidates/school_searches/new' and return unless @search.valid? && location_present?
 
     @facet_tags = FacetTagsPresenter.new(@search.applied_filters)
@@ -14,7 +19,7 @@ class Candidates::SchoolsController < ApplicationController
 
     if @search.results.empty? && !@search.whitelisted_urns?
       @expanded_search_radius = true
-      @search = Candidates::SchoolSearch.new(search_params.merge(distance: EXPANDED_SEARCH_RADIUS))
+      @search = Candidates::SchoolSearch.new_decrypt(search_params.merge(distance: EXPANDED_SEARCH_RADIUS))
     end
   end
 

--- a/app/models/candidates/school_search.rb
+++ b/app/models/candidates/school_search.rb
@@ -1,6 +1,9 @@
 module Candidates
   class SchoolSearch
     include ActiveModel::Model
+    include ActiveModel::Attributes
+    include EncryptedAttributes
+    encrypt_attributes :location
 
     DISTANCES = [
       [1, '1 mile'],
@@ -19,9 +22,15 @@ module Candidates
       ['90', 'up to £90']
     ].freeze
 
-    attr_accessor :query, :location, :latitude, :disability_confident,
-                  :longitude, :page, :parking
-    attr_reader :distance, :max_fee
+    attribute :query
+    attribute :location
+    attribute :latitude
+    attribute :disability_confident
+    attribute :longitude
+    attribute :page
+    attribute :parking
+    attribute :distance, :integer, default: 10
+    attribute :max_fee
 
     delegate :location_name, :country, :has_coordinates?, :valid?, :errors, to: :school_search
     delegate :whitelisted_urns, :whitelisted_urns?, to: Bookings::SchoolSearch
@@ -34,16 +43,6 @@ module Candidates
       def distances
         DISTANCES
       end
-    end
-
-    def initialize(*args)
-      @distance = 10
-
-      super
-    end
-
-    def distance=(dist)
-      @distance = dist.present? ? dist.to_i : nil
     end
 
     def subjects
@@ -72,7 +71,7 @@ module Candidates
 
     def max_fee=(max_f)
       max_f = max_f.to_s.strip
-      @max_fee = FEES.map(&:first).include?(max_f) ? max_f : ''
+      super(FEES.map(&:first).include?(max_f) ? max_f : '')
     end
 
     def applied_filters

--- a/app/models/concerns/encrypted_attributes.rb
+++ b/app/models/concerns/encrypted_attributes.rb
@@ -1,0 +1,34 @@
+require "encryptor"
+
+module EncryptedAttributes
+  extend ActiveSupport::Concern
+
+  included do |_base|
+    delegate :encrypt?, to: :class
+    class_attribute :encrypted_attributes
+
+    def self.new_decrypt(attributes)
+      decrypted_attributes = attributes.to_h.each_with_object({}) do |(k, v), hash|
+        hash[k] = encrypt?(k) ? ::Encryptor.decrypt(v) : v
+      end
+
+      new(decrypted_attributes)
+    end
+
+    def encrypted_attributes
+      attributes.each_with_object({}) do |(k, v), hash|
+        hash[k] = encrypt?(k) ? ::Encryptor.encrypt(v) : v
+      end
+    end
+  end
+
+  class_methods do
+    def encrypt_attributes(*attributes)
+      self.encrypted_attributes = attributes.map(&:to_s)
+    end
+
+    def encrypt?(key)
+      key.to_s.in?(encrypted_attributes)
+    end
+  end
+end

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -17,7 +17,7 @@
       <%= form_for(@search,
                    as: '',
                    url: candidates_schools_path,
-                   method: :get,
+                   method: :post,
                    html: { class: 'school-search-form' },
                    data: { controller: :autocomplete,
                            "autocomplete-target": "wrapper",

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row" data-controller="search autocomplete" data-autocomplete-target="wrapper" data-autocomplete-api-key-value="<%= Rails.application.config.x.google_maps_key %>"
   data-search-results-id-value="search-results" data-search-form-id-value="search-form">
   <section id="search-bar" class="govuk-grid-column-full">
-    <%= form_for @search, as: '', url: candidates_schools_path, method: :get do |f| %>
+    <%= form_for @search, as: '', url: candidates_schools_path, method: :post do |f| %>
       <%= f.govuk_text_field :location, width: 'full', label: { text: t('helpers.label.location') },
                              data: { "autocomplete-target": "nonJsInput" }%>
 
@@ -44,7 +44,7 @@
                      data: { "search-target": "form", "action": "change->search#performSearch" } do |f| %>
 
           <%= f.hidden_field :query %>
-          <%= f.hidden_field :location %>
+          <%= f.hidden_field :location, value: @search.encrypted_attributes["location"] %>
           <%= f.hidden_field :distance %>
           <%= f.hidden_field :latitude %>
           <%= f.hidden_field :longitude %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,7 +161,7 @@ Rails.application.routes.draw do
     get 'verify/:school_id/:token/:uuid', to: 'registrations/sign_ins#update', as: :registration_verify
     put 'verify/:school_id', to: 'registrations/sign_ins#update', as: :registration_verify_code
 
-    resources :schools, only: %i[index show] do
+    resources :schools, only: %i[index show create] do
       namespace :registrations do
         resource :personal_information, only: %i[new create edit update]
         resource :sign_in, only: %i[show create]

--- a/features/step_definitions/candidates/schools/results_steps.rb
+++ b/features/step_definitions/candidates/schools/results_steps.rb
@@ -31,7 +31,7 @@ Given("there are some schools with a range of fees containing the word {string}"
 end
 
 Given("I have searched for {string} and am on the results page") do |string|
-  path = candidates_schools_path(location: string, distance: 100)
+  path = candidates_schools_path(location: Encryptor.encrypt(string), distance: 100)
   visit(path)
   path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
   expect(path_with_query).to eql(path)
@@ -131,7 +131,7 @@ Given("there are some schools just outside it") do
 end
 
 When("I search for schools within {int} miles") do |int|
-  path = candidates_schools_path(location: 'Bury', distance: int)
+  path = candidates_schools_path(location: Encryptor.encrypt('Bury'), distance: int)
   visit(path)
   path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
   expect(path_with_query).to eql(path)

--- a/features/step_definitions/candidates/schools/search_steps.rb
+++ b/features/step_definitions/candidates/schools/search_steps.rb
@@ -30,6 +30,6 @@ end
 
 Given("I have made an invalid search for schools near {string}") do |string|
   path = candidates_schools_path
-  visit(candidates_schools_path(location: string))
+  visit(candidates_schools_path(location: Encryptor.encrypt(string)))
   expect(page.current_path).to eql(path)
 end

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -22,7 +22,7 @@ Given("there there are schools with the following attributes:") do |table|
 end
 
 When("I have provided {string} as my location") do |location|
-  path = candidates_schools_path(location: location, distance: 25)
+  path = candidates_schools_path(location: Encryptor.encrypt(location), distance: 25)
   visit(path)
   path_with_query = [page.current_path, URI.parse(page.current_url).query].join("?")
   expect(path_with_query).to eql(path)

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -1,0 +1,32 @@
+class Encryptor
+  delegate :encrypt_and_sign, :decrypt_and_verify, to: :crypt
+
+  class << self
+    def encrypt(value)
+      return nil if value.blank?
+
+      new.encrpyt_string(value)
+    end
+
+    def decrypt(value)
+      return nil if value.blank?
+
+      new.decrypt_string(value)
+    end
+  end
+
+  def encrpyt_string(value)
+    hashids.encode(value.chars.map(&:ord))
+  end
+
+  def decrypt_string(value)
+    hashids.decode(value).map(&:chr).join
+  end
+
+private
+
+  def hashids
+    salt = (ENV["SECRET_KEY_BASE"] || Rails.application.credentials.secret_key_base)[0..31]
+    Hashids.new(salt)
+  end
+end

--- a/spec/controllers/candidates/schools_controller_spec.rb
+++ b/spec/controllers/candidates/schools_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Candidates::SchoolsController, type: :request do
     let(:query_params) do
       {
         query: 'Something',
-        location: 'Manchester',
+        location: Encryptor.encrypt('Manchester'),
         latitude: '53.481',
         longitude: '-2.241',
         distance: '10',

--- a/spec/lib/encryptor_spec.rb
+++ b/spec/lib/encryptor_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require "encryptor"
+
+RSpec.describe Encryptor do
+  let(:value) { "value" }
+
+  describe ".encrypt" do
+    subject { described_class.encrypt(value) }
+
+    it { is_expected.to eq("kgWFVkC1wi2Pt3E") }
+
+    context "when nil" do
+      let(:value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe ".decrypt_hash" do
+    let(:encrypted_value) { described_class.encrypt(value) }
+
+    subject { described_class.decrypt(encrypted_value) }
+
+    it { is_expected.to eq(value) }
+
+    context "when nil" do
+      let(:encrypted_value) { nil }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/models/candidates/school_search_spec.rb
+++ b/spec/models/candidates/school_search_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe Candidates::SchoolSearch do
     end
   end
 
+  describe ".encrypted_attributes" do
+    subject { described_class.encrypted_attributes }
+
+    it { is_expected.to eq(%w[location]) }
+  end
+
   context '.new' do
     subject do
       described_class.new(

--- a/spec/models/concerns/encrypted_attributes_spec.rb
+++ b/spec/models/concerns/encrypted_attributes_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe EncryptedAttributes do
+  let(:test_model) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include EncryptedAttributes
+      encrypt_attributes :name, :email
+
+      attribute :name
+      attribute :email
+      attribute :height
+      attribute :age
+    end
+  end
+  let(:instance) do
+    test_model.new(name: "Name", email: "email@address.com", height: nil, age: 20)
+  end
+
+  describe "#encrypted_attributes" do
+    subject { instance.encrypted_attributes }
+
+    it "encrypts attributes flagged for encryption" do
+      is_expected.to include({
+        "name" => "EMLFEkHwBtL0",
+        "email" => "V0DuvAtJPsp4skoCYxU10S2nFDpC1pSLQF5kIwLhPRTXkFe5Hn4",
+        "height" => nil,
+        "age" => 20,
+      })
+    end
+  end
+
+  describe ".new_decrypt" do
+    let(:encrypted_attributes) { instance.encrypted_attributes }
+
+    subject { test_model.new_decrypt(encrypted_attributes).attributes }
+
+    it { is_expected.to eq(instance.attributes) }
+
+    context "when passed permitted ActionController::Parameters" do
+      let(:encrypted_attributes) { ActionController::Parameters.new(instance.encrypted_attributes).permit! }
+
+      it { is_expected.to eq(instance.attributes) }
+    end
+
+    context "when passed a malformed value that cannot be decrypted" do
+      let(:encrypted_attributes) { { name: "malformed" } }
+
+      it { is_expected.to include({ "height" => nil }) }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-608](https://trello.com/c/lfyfQ4dT/608-obscure-postcode-in-location-searches)

### Context

A UK postcode is considered Personally Identifiable Information (PII) and therefore should not be sent to external services such as Google Analytics or output in URL/made available in the browser history.

We want to avoid this happening by encrypting postcodes before they are rendered in the URL of a GET request.

### Changes proposed in this pull request

- Add simple Encryptor lib

Add a simple `Encryptor` library that can encrypt/decrypt string values. We are using [Hashids](https://hashids.org/) which is intended for obfuscating your database ids when used in URLs and results in a short hash when given a postcode (mapped to character integer values).

This isn't going to be as secure as something like `ActiveSupport::MessageEncryptor` but I think for the purpose of obfuscating PII it should be sufficient and results in a much shorter hash.

- Add concern to encrypt ActiveModel attributes

We plan on encrypting the attributes of a form model when rendering the GET request that contains PII in the URL query string. In order to do this we need to be able to query the encrypted attributes of a model (to construct the URL)
and then be able to instantiate the same model using the encrypted attributes (decrypting the fields into the model attributes).

The usage will be along the lines of:

```
model = Model.new(attributes_from_post_request)
url = model_path(model.encrypted_attributes)
redirect_to url
model = Model.new_decrypt(attributes_from_get_request)
```

- Encrypt postcode in school search

Encrypt the location in the school search URL so as not to expose it to Google Analytics/the browser history.

In order to do this we include the `EncryptedAttributes` concern into the `Events::Search` model and change the form method from `get` to `post`. This ensures the location is transmitted securely to the controller action, whereby
we can encrypt it and redirect to the `GET` search endpoint, decrypt it and display the relevant results to the user. This method ensures the location is not leaked to the URL and yet the search results URL can be copied/bookmarked.

Update search model to use `ActiveModel::Attributes`.

### Guidance to review

Are there any other forms that accept a location/postcode I could have missed?