### PR TITLE
Enable maintenance mode in dev/prod

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -119,7 +119,7 @@ Rails.application.configure do
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 100)
 
-  config.x.maintenance_mode = %w[1 yes true].include?(ENV['MAINTENANCE_MODE'].to_s)
+  config.x.maintenance_mode = true
 
   config.x.git_api_token = Rails.application.credentials.git_api_token.presence
   config.x.git_api_endpoint = "https://get-into-teaching-api-dev.london.cloudapps.digital/api"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -164,7 +164,7 @@ Rails.application.configure do
 
   config.ab_threshold = Integer ENV.fetch('AB_TEST_THRESHOLD', 70)
 
-  config.x.maintenance_mode = %w[1 yes true].include?(ENV['MAINTENANCE_MODE'].to_s)
+  config.x.maintenance_mode = true
 
   config.x.git_api_token = ENV['GIT_API_TOKEN']
   config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "GIT-API-HTTP")


### PR DESCRIPTION
We are doing a major upgrade of the Postgres database which will mean the website has some downtime; putting it into maintenance mode so that users are locked out while we do this.

I'm enabling it for dev as well so that I can test the maintenance page is working as expected as its not been used in a while.