### PR TITLE
Add none option to candidate requirements step

### DIFF
--- a/app/controllers/schools/on_boarding/candidate_requirements_selections_controller.rb
+++ b/app/controllers/schools/on_boarding/candidate_requirements_selections_controller.rb
@@ -43,16 +43,12 @@ module Schools
     private
 
       def candidate_requirements_selection_params
-        params.require(:schools_on_boarding_candidate_requirements_selection).permit \
-          :on_teacher_training_course,
-          :not_on_another_training_course,
-          :has_or_working_towards_degree,
-          :live_locally,
+        params.require(:schools_on_boarding_candidate_requirements_selection).permit(
           :maximum_distance_from_school,
-          :provide_photo_identification,
           :photo_identification_details,
-          :other,
-          :other_details
+          :other_details,
+          selected_requirements: []
+        )
       end
     end
   end

--- a/app/forms/schools/on_boarding/candidate_requirements_selection.rb
+++ b/app/forms/schools/on_boarding/candidate_requirements_selection.rb
@@ -1,28 +1,18 @@
 module Schools
   module OnBoarding
     class CandidateRequirementsSelection < Step
-      attribute :on_teacher_training_course, :boolean
-      attribute :not_on_another_training_course, :boolean
-      attribute :has_or_working_towards_degree, :boolean
-      attribute :live_locally, :boolean
+      attribute :selected_requirements, default: []
       attribute :maximum_distance_from_school, :integer
-      attribute :provide_photo_identification, :boolean
       attribute :photo_identification_details, :string
-      attribute :other, :boolean
       attribute :other_details, :string
 
-      validates :on_teacher_training_course, inclusion: [true, false]
-      validates :not_on_another_training_course, inclusion: [true, false]
-      validates :has_or_working_towards_degree, inclusion: [true, false]
-      validates :live_locally, inclusion: [true, false]
-      validates :provide_photo_identification, inclusion: [true, false]
-      validates :other, inclusion: [true, false]
-      validates :maximum_distance_from_school, presence: true, if: :live_locally
+      validates :maximum_distance_from_school, presence: true, if: :live_locally?
       validates :maximum_distance_from_school, numericality: { greater_than: 0 }, if: :maximum_distance_from_school
-      validates :maximum_distance_from_school, absence: true, unless: :live_locally
-      validates :photo_identification_details, presence: true, if: :provide_photo_identification
-      validates :other_details, presence: true, if: :other
-      validates :other_details, absence: true, unless: :other
+      validates :maximum_distance_from_school, absence: true, unless: :live_locally?
+      validates :photo_identification_details, presence: true, if: :provide_photo_identification?
+      validates :other_details, presence: true, if: :other?
+      validates :other_details, absence: true, unless: :other?
+      validate :candidate_requirements_or_none_selected
 
       def self.compose(
         on_teacher_training_course,
@@ -35,16 +25,61 @@ module Schools
         other,
         other_details
       )
-        new \
-          on_teacher_training_course: on_teacher_training_course,
-          not_on_another_training_course: not_on_another_training_course,
-          has_or_working_towards_degree: has_or_working_towards_degree,
-          live_locally: live_locally,
+        selected_requirements = []
+
+        selected_requirements << "on_teacher_training_course" if on_teacher_training_course
+        selected_requirements << "not_on_another_training_course" if not_on_another_training_course
+        selected_requirements << "has_or_working_towards_degree" if has_or_working_towards_degree
+        selected_requirements << "live_locally" if live_locally
+        selected_requirements << "provide_photo_identification" if provide_photo_identification
+        selected_requirements << "other" if other
+
+        # Comparing explicitly to false because a nil attribute shouldn't infer "none".
+        if [
+          on_teacher_training_course,
+          not_on_another_training_course,
+          has_or_working_towards_degree,
+          live_locally,
+          provide_photo_identification,
+          other
+        ].all?(false)
+          selected_requirements << "none"
+        end
+
+        new(
+          selected_requirements: selected_requirements,
           maximum_distance_from_school: maximum_distance_from_school,
-          provide_photo_identification: provide_photo_identification,
           photo_identification_details: photo_identification_details,
-          other: other,
-          other_details: other_details
+          other_details: other_details,
+        )
+      end
+
+      def on_teacher_training_course?
+        "on_teacher_training_course".in?(selected_requirements)
+      end
+
+      def not_on_another_training_course?
+        "not_on_another_training_course".in?(selected_requirements)
+      end
+
+      def has_or_working_towards_degree?
+        "has_or_working_towards_degree".in?(selected_requirements)
+      end
+
+      def live_locally?
+        "live_locally".in?(selected_requirements)
+      end
+
+      def provide_photo_identification?
+        "provide_photo_identification".in?(selected_requirements)
+      end
+
+      def other?
+        "other".in?(selected_requirements)
+      end
+
+      def none?
+        "none".in?(selected_requirements)
       end
 
       def valid?(*args)
@@ -54,10 +89,21 @@ module Schools
 
     private
 
+      def candidate_requirements_or_none_selected
+        # selected_requirements will always contain an empty string from the form body
+        requirements = selected_requirements.reject(&:empty?)
+        no_options_selected = requirements.empty?
+        requirements_and_none_selected = none? && requirements.count > 1
+
+        if no_options_selected || requirements_and_none_selected
+          errors.add(:selected_requirements, :no_requirements_selected)
+        end
+      end
+
       def ux_fix
-        self.maximum_distance_from_school = nil unless live_locally
-        self.photo_identification_details = nil unless provide_photo_identification
-        self.other_details = nil unless other
+        self.maximum_distance_from_school = nil unless live_locally?
+        self.photo_identification_details = nil unless provide_photo_identification?
+        self.other_details = nil unless other?
       end
     end
   end

--- a/app/models/schools/school_profile.rb
+++ b/app/models/schools/school_profile.rb
@@ -69,14 +69,14 @@ module Schools
       :candidate_requirements_selection,
       class_name: 'Schools::OnBoarding::CandidateRequirementsSelection',
       mapping: [
-        %w[candidate_requirements_selection_on_teacher_training_course on_teacher_training_course],
-        %w[candidate_requirements_selection_not_on_another_training_course not_on_another_training_course],
-        %w[candidate_requirements_selection_has_or_working_towards_degree has_or_working_towards_degree],
-        %w[candidate_requirements_selection_live_locally live_locally],
+        %w[candidate_requirements_selection_on_teacher_training_course on_teacher_training_course?],
+        %w[candidate_requirements_selection_not_on_another_training_course not_on_another_training_course?],
+        %w[candidate_requirements_selection_has_or_working_towards_degree has_or_working_towards_degree?],
+        %w[candidate_requirements_selection_live_locally live_locally?],
         %w[candidate_requirements_selection_maximum_distance_from_school maximum_distance_from_school],
-        %w[candidate_requirements_selection_provide_photo_identification provide_photo_identification],
+        %w[candidate_requirements_selection_provide_photo_identification provide_photo_identification?],
         %w[candidate_requirements_selection_photo_identification_details photo_identification_details],
-        %w[candidate_requirements_selection_other other],
+        %w[candidate_requirements_selection_other other?],
         %w[candidate_requirements_selection_other_details other_details]
       ],
       constructor: :compose

--- a/app/presenters/schools/on_boarding/candidate_requirements_selection_presenter.rb
+++ b/app/presenters/schools/on_boarding/candidate_requirements_selection_presenter.rb
@@ -45,6 +45,10 @@ module Schools
           output << other_details
         end
 
+        if none?
+          output << "None"
+        end
+
         output
       end
 
@@ -86,6 +90,17 @@ module Schools
 
       def other?
         @attributes.fetch :candidate_requirements_selection_other
+      end
+
+      def none?
+        [
+          on_teacher_training_course?,
+          not_on_another_training_course?,
+          has_or_working_towards_degree?,
+          live_locally?,
+          provide_photo_identification?,
+          other?
+        ].all?(false)
       end
 
       def other_details

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for candidate_requirements_selection, url: schools_on_boarding_candidate_requirements_selection_path, method: method,
                  html: { class: "candidate-requirements-selection" } do |f| %>
-      <%= f.govuk_error_summary link_base_errors_to: :on_teacher_training_course_1 %>
+      <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
         What requirements do you have?
@@ -16,34 +16,21 @@
         Select all that apply.
       </p>
 
-      <%= f.govuk_check_boxes_fieldset :on_teacher_training_course, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :on_teacher_training_course, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :not_on_another_training_course, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :not_on_another_training_course, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :has_or_working_towards_degree, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :has_or_working_towards_degree, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :live_locally, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :live_locally, 1, 0, multiple: false do %>
+      <%= f.govuk_check_boxes_fieldset :selected_requirements, legend: nil do %>
+        <%= f.govuk_check_box :selected_requirements, "on_teacher_training_course" %>
+        <%= f.govuk_check_box :selected_requirements, "not_on_another_training_course" %>
+        <%= f.govuk_check_box :selected_requirements, "has_or_working_towards_degree" %>
+        <%= f.govuk_check_box :selected_requirements, "live_locally" do %>
           <%= f.govuk_number_field :maximum_distance_from_school %>
         <% end %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :provide_photo_identification, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :provide_photo_identification, 1, 0, multiple: false do %>
+        <%= f.govuk_check_box :selected_requirements, "provide_photo_identification" do %>
           <%= f.govuk_text_field :photo_identification_details %>
         <% end %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :other, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :other, 1, 0, multiple: false do %>
+        <%= f.govuk_check_box :selected_requirements, "other" do %>
           <%= f.govuk_text_field :other_details %>
         <% end %>
+        <%= f.govuk_check_box_divider %>
+        <%= f.govuk_check_box :selected_requirements, "none", exclusive: true %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -269,6 +269,8 @@ en:
 
         schools/on_boarding/candidate_requirements_selection:
           attributes:
+            selected_requirements:
+              no_requirements_selected: Select candidate requirements, or select “None”
             maximum_distance_from_school:
               blank: "Enter how close to your school a candidate must live"
               not_a_number: 'Enter a valid number for how close to your school a candidate must live'
@@ -816,20 +818,16 @@ en:
           inschool: 'Yes - only when in school - outline your DBS requirements'
           notrequired: 'No - Candidates will be accompanied at all times when in school'
       schools_on_boarding_candidate_requirements_selection:
-        on_teacher_training_course_options:
-          1: "Candidates must apply to our (or a partner school's) teacher training course"
-        not_on_another_training_course_options:
-          1: "Candidates must not have a place on another teacher training course"
-        has_or_working_towards_degree_options:
-          1: "Candidates must have, or be working towards, a degree"
-        live_locally_options:
-          1: "Candidates must live locally"
+        selected_requirements_options:
+          on_teacher_training_course: Candidates must apply to our (or a partner school's) teacher training course
+          not_on_another_training_course: Candidates must not have a place on another teacher training course
+          has_or_working_towards_degree: Candidates must have, or be working towards, a degree
+          live_locally: Candidates must live locally
+          provide_photo_identification: Candidates must provide photo ID
+          other: Other
+          none: None
         maximum_distance_from_school: "Tell us within how many miles of your school. For example, 20."
-        provide_photo_identification_options:
-          1: "Candidates must provide photo ID"
         photo_identification_details: "Provide details. For example, passport or driving licence."
-        other_options:
-          1: "Other"
         other_details: "Provide details."
       schools_on_boarding_candidate_requirement:
         dbs_requirement:

--- a/spec/controllers/schools/on_boarding/candidate_requirements_selections_controller_spec.rb
+++ b/spec/controllers/schools/on_boarding/candidate_requirements_selections_controller_spec.rb
@@ -124,7 +124,7 @@ describe Schools::OnBoarding::CandidateRequirementsSelectionsController, type: :
     context 'valid' do
       let :candidate_requirements_selection do
         school_profile.candidate_requirements_selection.dup.tap do |m|
-          m.has_or_working_towards_degree = !m.has_or_working_towards_degree
+          m.selected_requirements << "has_or_working_towards_degree" unless m.has_or_working_towards_degree?
         end
       end
 

--- a/spec/factories/schools/on_boarding/candidate_requirements_selection_factory.rb
+++ b/spec/factories/schools/on_boarding/candidate_requirements_selection_factory.rb
@@ -1,13 +1,8 @@
 FactoryBot.define do
   factory :candidate_requirements_selection, class: Schools::OnBoarding::CandidateRequirementsSelection do
-    on_teacher_training_course { true }
-    not_on_another_training_course { false }
-    has_or_working_towards_degree { true }
-    live_locally { true }
+    selected_requirements { %w[on_teacher_training_course has_or_working_towards_degree live_locally provide_photo_identification other] }
     maximum_distance_from_school { 8 }
-    provide_photo_identification { true }
     photo_identification_details { 'Make sure photo is clear' }
-    other { true }
     other_details { 'Some other requirements' }
   end
 end

--- a/spec/forms/schools/on_boarding/candidate_requirements_selection_spec.rb
+++ b/spec/forms/schools/on_boarding/candidate_requirements_selection_spec.rb
@@ -2,21 +2,16 @@ require 'rails_helper'
 
 describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
   context 'attributes' do
-    it { is_expected.to respond_to :on_teacher_training_course }
-    it { is_expected.to respond_to :not_on_another_training_course }
-    it { is_expected.to respond_to :has_or_working_towards_degree }
-    it { is_expected.to respond_to :live_locally }
+    it { is_expected.to respond_to :selected_requirements }
     it { is_expected.to respond_to :maximum_distance_from_school }
-    it { is_expected.to respond_to :provide_photo_identification }
     it { is_expected.to respond_to :photo_identification_details }
-    it { is_expected.to respond_to :other }
     it { is_expected.to respond_to :other_details }
   end
 
   context 'before_validation' do
     context 'when the live_locally option is selected' do
       before do
-        subject.live_locally = true
+        subject.selected_requirements = %w[live_locally]
         subject.maximum_distance_from_school = 7
         subject.valid?
       end
@@ -28,7 +23,6 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
 
     context 'when the live_locally option is not selected' do
       before do
-        subject.live_locally = false
         subject.maximum_distance_from_school = 7
         subject.valid?
       end
@@ -40,7 +34,7 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
 
     context 'when provide_photo_identification is selected' do
       before do
-        subject.provide_photo_identification = true
+        subject.selected_requirements = %w[provide_photo_identification]
         subject.photo_identification_details = 'photo details'
         subject.valid?
       end
@@ -52,7 +46,6 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
 
     context 'when provide_photo_identification is not selected' do
       before do
-        subject.provide_photo_identification = false
         subject.photo_identification_details = 'photo details'
         subject.valid?
       end
@@ -64,7 +57,7 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
 
     context 'when other option is selected' do
       before do
-        subject.other = true
+        subject.selected_requirements = %w[other]
         subject.other_details = 'some details'
         subject.valid?
       end
@@ -76,7 +69,6 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
 
     context 'when other option is not selected' do
       before do
-        subject.other = false
         subject.other_details = 'some details'
         subject.valid?
       end
@@ -88,38 +80,49 @@ describe Schools::OnBoarding::CandidateRequirementsSelection, type: :model do
   end
 
   context 'validations' do
+    describe "#selected_requirements" do
+      context "when no options are selected" do
+        subject { described_class.new(selected_requirements: []) }
+
+        it { expect(subject).to be_invalid }
+      end
+
+      context "when requirement and no requirements are selected" do
+        subject { described_class.new(selected_requirements: %w[on_teacher_training_course none]) }
+
+        it { expect(subject).to be_invalid }
+      end
+    end
+
     context 'maximum_distance_from_school' do
       context 'when the live_locally is selected' do
-        before { subject.live_locally = true }
+        before { subject.selected_requirements = %w[live_locally] }
         it { is_expected.to validate_presence_of :maximum_distance_from_school }
       end
 
       context 'when the live_locally is not selected' do
-        before { subject.live_locally = false }
         it { is_expected.not_to validate_presence_of :maximum_distance_from_school }
       end
     end
 
     context 'photo_identification_details' do
       context 'when provide_photo_identification is selected' do
-        before { subject.provide_photo_identification = true }
+        before { subject.selected_requirements = %w[provide_photo_identification] }
         it { is_expected.to validate_presence_of :photo_identification_details }
       end
 
       context 'when provide_photo_identification is not selected' do
-        before { subject.provide_photo_identification = false }
         it { is_expected.not_to validate_presence_of :photo_identification_details }
       end
     end
 
     context 'other details' do
       context 'when other is selected' do
-        before { subject.other = true }
+        before { subject.selected_requirements = %w[other] }
         it { is_expected.to validate_presence_of :other_details }
       end
 
       context 'when other is not select' do
-        before { subject.other = false }
         it { is_expected.not_to validate_presence_of :other_details }
       end
     end


### PR DESCRIPTION
### Trello card

[Trello-590](https://trello.com/c/4K2U9iP5/590-make-sure-checkboxes-have-a-none-option)

### Context

We want to have a 'None' option on the candidate requirements checkbox for if none of the other options apply. The form builder requires the checkboxes to have the same attribute name in order to add a `None` option.

Refactor `CandidateRequirementsSelection` to have a single `selected_requirements` attribute that contains the selected options.

### Changes proposed in this pull request

- Add none option to candidate requirements step

### Guidance to review

