### PR TITLE
Add rake task to transfer a placement request to another school

### DIFF
--- a/lib/placement_request_transfer.rb
+++ b/lib/placement_request_transfer.rb
@@ -1,0 +1,130 @@
+# When a school converts to an academy they appear as
+# a new school (with separate URN) in School Experience.
+# Occasionally we get requests to migrate placement requests
+# from the original school to the new academy account - this aims
+# to make that process automated.
+#
+# The transfer is very limited at the moment; it attempts to handle
+# new placement requests only and match subject specific/placement dates.
+#
+# You are expected to pull the production database and test the transfer
+# locally prior to running it in production (or risk data integrity issues)!
+# If we find this request becomes frequent we can expand the logic
+# to be more robust/safer.
+class PlacementRequestTransfer
+  class TransferError < RuntimeError; end
+
+  def initialize(placement_request_id, school_id)
+    @placement_request_id = placement_request_id
+    @school_id = school_id
+  end
+
+  def transfer!
+    verify!
+
+    placement_request.school = school
+    placement_request.subject = matching_subject
+    placement_request.placement_date = matching_fixed_placement_date
+    placement_request.save!
+  end
+
+private
+
+  def verify!
+    raise TransferError, "you cannot transfer a booked placement request" if booked?
+    raise TransferError, "you cannot transfer a placement request with a '#{status}' status" unless new_or_viewed?
+
+    verify_subject!
+    verify_subject_first_choice!
+    verify_fixed_placement_date!
+    verify_flexible_placement_date!
+    verify_experience_type!
+  end
+
+  def verify_subject!
+    return unless subject_specific?
+
+    raise TransferError, "could not match subject '#{subject_name}' in school" if matching_subject.nil?
+  end
+
+  def verify_subject_first_choice!
+    raise TransferError, "school does not support subject '#{placement_request.subject_first_choice}'" if matching_subject_first_choice.nil?
+  end
+
+  def verify_fixed_placement_date!
+    return unless fixed_placement_date?
+
+    raise TransferError, "school does not support fixed placement dates" unless school.availability_preference_fixed?
+    raise TransferError, "could not match fixed placement date '#{fixed_placement_date}' in school" if matching_fixed_placement_date.nil?
+  end
+
+  def verify_flexible_placement_date!
+    return if fixed_placement_date?
+
+    raise TransferError, "school does not support flexible placement dates" if school.availability_preference_fixed?
+  end
+
+  def verify_experience_type!
+    return if school.experience_type == "both"
+
+    unless school.experience_type == placement_request.school.experience_type
+      raise TransferError, "school does not support #{placement_request.school.experience_type} experience type"
+    end
+  end
+
+  def matching_subject_first_choice
+    school_subjects.find { |subject| subject == placement_request.subject_first_choice }
+  end
+
+  def school_subjects
+    if school.subjects.any?
+      school.subjects.pluck(:name)
+    else
+      Candidates::School.subjects.map(&:last)
+    end
+  end
+
+  def matching_subject
+    school.subjects.find_by(name: subject_name)
+  end
+
+  def subject_name
+    placement_request.subject&.name
+  end
+
+  def status
+    placement_request.status
+  end
+
+  def new_or_viewed?
+    status.in?(%w[New Viewed])
+  end
+
+  def fixed_placement_date
+    placement_request.placement_date&.date
+  end
+
+  def booked?
+    placement_request.booking.present?
+  end
+
+  def subject_specific?
+    placement_request.subject.present?
+  end
+
+  def fixed_placement_date?
+    fixed_placement_date.present?
+  end
+
+  def matching_fixed_placement_date
+    school.bookings_placement_dates.find_by(date: fixed_placement_date)
+  end
+
+  def placement_request
+    @placement_request ||= Bookings::PlacementRequest.find(@placement_request_id)
+  end
+
+  def school
+    @school ||= Bookings::School.find(@school_id)
+  end
+end

--- a/lib/tasks/data/placement_requests.rake
+++ b/lib/tasks/data/placement_requests.rake
@@ -1,0 +1,13 @@
+require "placement_request_transfer"
+
+namespace :data do
+  namespace :placement_requests do
+    # Important: see notes in PlacementRequestTransfer class!
+    desc "Transfer a placement request from one school to another"
+    task :transfer, %i[placement_request_id school_id] => :environment do |_t, args|
+      placement_request_id, school_id = args.values_at(:placement_request_id, :school_id)
+
+      PlacementRequestTransfer.new(placement_request_id, school_id).transfer!
+    end
+  end
+end

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -71,6 +71,14 @@ FactoryBot.define do
       end
     end
 
+    trait :subject_specific do
+      before(:create) do |bb|
+        bb.subject = \
+          Bookings::Subject.find_by! \
+            name: bb.available_subject_choices.first
+      end
+    end
+
     trait :booked do
       after :create do |placement_request|
         FactoryBot.create \

--- a/spec/lib/placement_request_transfer_spec.rb
+++ b/spec/lib/placement_request_transfer_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+require "placement_request_transfer"
+
+RSpec.describe PlacementRequestTransfer do
+  let(:placement_request) { create(:placement_request) }
+  let(:school) { create(:bookings_school) }
+  let(:placement_request_id) { placement_request.id }
+  let(:school_id) { school.id }
+
+  describe "#transfer!" do
+    let(:instance) { described_class.new(placement_request_id, school_id) }
+
+    subject(:transfer) { instance.transfer! }
+
+    it { expect { transfer }.to change { placement_request.reload.school }.to(school) }
+
+    context "when the placement request has been viewed" do
+      before { placement_request.viewed! }
+
+      it { expect { transfer }.to change { placement_request.reload.school }.to(school) }
+    end
+
+    context "when the placement request is subject specific" do
+      let(:placement_request) { create(:placement_request, :subject_specific) }
+
+      context "when a matching subject is found in the school" do
+        before do
+          school.subjects = placement_request.school.subjects
+          school.save!
+        end
+
+        it "transfers the placement request and retains the subject" do
+          transfer
+          placement_request.reload
+
+          expect(placement_request.school).to eq(school)
+          expect(placement_request.subject).to be_present
+        end
+      end
+
+      context "when a matching subject is not found in the school" do
+        let(:message) { "could not match subject '#{placement_request.subject.name}' in school" }
+
+        it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+      end
+    end
+
+    context "when the subject_first_choice is not available in the school" do
+      let(:message) { "school does not support subject '#{placement_request.subject_first_choice}'" }
+
+      before { school.update(subjects: [create(:bookings_subject, name: "Test")]) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the placement request has a fixed placement date" do
+      let(:placement_request) { create(:placement_request, :with_a_fixed_date) }
+
+      context "when the school supports fixed availability dates" do
+        before { school.update(availability_preference_fixed: true) }
+
+        it "transfers the placement request and links to a matching date in the school" do
+          placement_date = create(:bookings_placement_date,
+            :active,
+            date: placement_request.placement_date.date,
+            bookings_school: school)
+
+          transfer
+          placement_request.reload
+
+          expect(placement_request.school).to eq(school)
+          expect(placement_request.placement_date).to eq(placement_date)
+        end
+
+        context "when a matching placement date is not found in the school" do
+          let(:message) { "could not match fixed placement date '#{placement_request.placement_date.date}' in school" }
+
+          before do
+            school.update(availability_preference_fixed: true)
+            create(:bookings_placement_date,
+              :active,
+              date: placement_request.placement_date.date + 1.week,
+              bookings_school: school)
+          end
+
+          it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+        end
+      end
+
+      context "when the school does not support fixed placement dates" do
+        let(:message) { "school does not support fixed placement dates" }
+
+        it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+      end
+    end
+
+    context "when the placement is flexible but the school supports fixed dates" do
+      let(:message) { "school does not support flexible placement dates" }
+
+      before { school.update(availability_preference_fixed: true) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the school experience types are incompatible" do
+      let(:message) { "school does not support #{placement_request.school.experience_type} experience type" }
+
+      before { school.update(experience_type: "virtual") }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the placement request does not exist" do
+      let(:placement_request_id) { -1 }
+
+      it { expect { transfer }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context "when the school does not exist" do
+      let(:school_id) { -1 }
+
+      it { expect { transfer }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context "when the placement request has a booking" do
+      let(:message) { "you cannot transfer a booked placement request" }
+      let(:placement_request) { create(:placement_request, :booked) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the placement request has expired" do
+      let(:message) { "you cannot transfer a placement request with a 'Expired' status" }
+      let(:placement_request) { create(:placement_request, :with_a_fixed_date_in_the_past) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the placement request is under consideration" do
+      let(:message) { "you cannot transfer a placement request with a 'Under consideration' status" }
+
+      before { placement_request.update(under_consideration_at: Date.today) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the placement request is flagged" do
+      let(:message) { "you cannot transfer a placement request with a 'Flagged' status" }
+      let(:candidate) { create(:recurring_candidate, school: placement_request.school) }
+
+      before { placement_request.update(candidate: candidate) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the placement request has been cancelled by the school" do
+      let(:message) { "you cannot transfer a placement request with a 'Rejected' status" }
+      let(:placement_request) { create(:placement_request, :cancelled_by_school) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+
+    context "when the placement request has been withdrawn by the candidate" do
+      let(:message) { "you cannot transfer a placement request with a 'Withdrawn' status" }
+      let(:placement_request) { create(:placement_request, :cancelled) }
+
+      it { expect { transfer }.to raise_error(described_class::TransferError).with_message(message) }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-614](https://trello.com/c/YKeOes5L/614-move-requests-and-delete-school-profile-the-hollins?filter=member:rossoliver15,member:josephkempster)

### Context

When a school becomes an academy they end up with a new School Experience account and often get locked out of their old account/no longer sign in to it. They may have pending placement requests that they have not yet actioned and want to see them under the new school account that they use.

### Changes proposed in this pull request

- Add rake task to transfer a placement request to another school

Add a rake task to transfer a placement request from one school to another (unlinking it from the original school and linking it to the new school). Currently the functionality is limited/restricted and it will only transfer new placement requests (providing matching subjects and placement dates can be found).

### Guidance to review

If we find we need to transfer placement requests in other states we can expand the transfer library to accommodate.

Example usage: `rake "data:placement_requests:transfer[1,2]"`