### PR TITLE
Increase TTL on session store

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -123,7 +123,7 @@ Rails.application.configure do
 
   config.session_store :cache_store,
     key: 'schoolex-session',
-    expire_after: 1.hour # Sets explicit TTL for Session Redis keys
+    expire_after: 3.hours # Sets explicit TTL for Session Redis keys
 
   config.active_job.queue_adapter = :delayed_job
 


### PR DESCRIPTION
We are seeing a reasonable number of invalid CSRF token errors; as far as I can tell the only way a user would legitimately get these is if the CSRF token expires. As they are stored in the `session_store` (Redis in our case) the TTL will be 1 hour.

The errors we see primarily come from steps that ask a free-text question; I expect people are routinely taking > 1 hour to complete these steps and subsequently find their session expiring (which will be an irritating user experience as they will have to re-enter it).

Increase to 3 hours so that we can see the impact on these errors; if they're not suitably reduced we can look to increase further, but its a trade-off with security (and a max of 24 hours as we can't store PII longer than that).