### PR TITLE
Increase to use all 20 available DSi routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "postcss-preset-env": "^6.7.1",
     "sass": "^1.52.1",
     "sass-loader": "^13.0.0",
-    "shakapacker": "^6.2.1",
+    "shakapacker": "6.2.1",
     "stimulus": "^3.0",
     "style-loader": "^3.3.1",
     "terser-webpack-plugin": "^5.3.1",

--- a/script/get_next_mapping.sh
+++ b/script/get_next_mapping.sh
@@ -6,7 +6,7 @@ DOMAIN="london.cloudapps.digital"
 URL="https://api.london.cloud.service.gov.uk/v3/"
 STATIC="review-school-experience-"
 STATIC_START=1
-STATIC_END=10
+STATIC_END=20
 create=0
 
 # Get the token needed to run this
@@ -22,11 +22,11 @@ if [[ -z "${CURRENT}"  ]] ; then
    create=1
 else
    create=1
-   GUID=$(echo ${CURRENT}  | jq -r '.guid' ) 
+   GUID=$(echo ${CURRENT}  | jq -r '.guid' )
    LIST_OF_ROUTES=$(curl -s "${URL}/routes?app_guids=${GUID}"  -X GET  -H "Authorization: ${TOKEN}" | jq '.resources[] | {host,guid,url}')
    while read i; do
-      for (( v=${STATIC_START} ; v<${STATIC_END}+1 ; v++ )) 
-      do 
+      for (( v=${STATIC_START} ; v<${STATIC_END}+1 ; v++ ))
+      do
           if [[ "${i}" == "${STATIC}${v}" ]] ; then
 	      echo "${i}"
               create=0
@@ -42,8 +42,8 @@ if [[ ${create} == 1 ]]; then
 
            LIST_OF_ROUTES=$(curl -s "${URL}/routes?per_page=2000&app_guids=${CSV_LIST}"  -X GET  -H "Authorization: ${TOKEN}" | jq '.resources[] | {host,guid,url}')
 
-	   for (( v=${STATIC_START} ; v<${STATIC_END}+1 ; v++ )) 
-           do 
+	   for (( v=${STATIC_START} ; v<${STATIC_END}+1 ; v++ ))
+           do
               USED[$v]=0
               while read i; do
 		if [[ "${STATIC}${v}.${DOMAIN}" == ${i} ]]; then
@@ -53,10 +53,10 @@ if [[ ${create} == 1 ]]; then
            done
 
 	   c=${STATIC_START}
-	   for i in "${USED[@]}"; do 
+	   for i in "${USED[@]}"; do
 		   if [[ ${i} == 0 ]] ; then
 	              echo "${STATIC}${c}"
-	              #echo cf map-route ${ADD_ROUTE}  ${DOMAIN} --hostname ${STATIC}${c} 
+	              #echo cf map-route ${ADD_ROUTE}  ${DOMAIN} --hostname ${STATIC}${c}
 	              #echo cf set-env ${ADD_ROUTE} DFE_SIGNIN_BASE_URL https://${STATIC}${c}.${DOMAIN}
 	              #echo cf restage  ${ADD_ROUTE}
                       break

--- a/yarn.lock
+++ b/yarn.lock
@@ -5629,7 +5629,7 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@^6.2.1:
+shakapacker@6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-6.2.1.tgz#b59765ddf891f6f1e4e55a7816ef3925c6039ca3"
   integrity sha512-Q8PSOVsaUlMCQiu9hw3vc6X2THMocxn/0cnmmHwkHw1V/RoxQhhh9DWEX2pmvUP+QlyY33q/UwuU6XbVf96AyA==


### PR DESCRIPTION
A while ago we added another 10 routes to DfE Sign In but neglected to update this script, which meant only 10 were being pulled instead of the full 20 and the pool was getting exhausted due to open dependabot PRs.

Increase to use all available DSi routes.

Also pins Shackapacker gem/node module so the version matches (otherwise we get an error on boot).