### PR TITLE
Update database plan to match production

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -12,7 +12,7 @@ environment               = "production"
 application_environment   = "dfe-school-experience-production"
 azure_key_vault           = "s105p01-kv"
 azure_resource_group      = "s105p01-prod-vault-resource-group"
-database_plan             = "small-ha-11"
+database_plan             = "small-ha-13"
 redis_1_plan              = "micro-ha-5_x"
 
 alerts = {


### PR DESCRIPTION
We upgraded Postgres in production a while ago and I forgot to update the plan (as we did the upgrade manually) so its causing the prod deployments to fail as its out of sync.