### PR TITLE
Periodically email list of onboarded, closed schools

### DIFF
--- a/app/jobs/cron/identify_closed_schools_job.rb
+++ b/app/jobs/cron/identify_closed_schools_job.rb
@@ -1,0 +1,52 @@
+class Cron::IdentifyClosedSchoolsJob < CronJob
+  # Every Monday at 9am
+  self.cron_expression = "0 9 * * 1"
+
+  SERVICE_INBOX = "school.experience@education.gov.uk".freeze
+  EMPTY_TEXT = "There are no closed, on-boarded schools.".freeze
+
+  def perform
+    return unless Rails.env.production?
+
+    NotifyEmail::ClosedOnboardedSchoolsSummary.new(
+      to: SERVICE_INBOX,
+      closed_onboarded_schools: closed_onboarded_schools,
+    ).despatch_later!
+  end
+
+private
+
+  def closed_onboarded_schools
+    return EMPTY_TEXT if closed_schools.none?
+
+    closed_schools.map(&method(:sentence)).join(" ")
+  end
+
+  def sentence(school)
+    "#{school.name} is #{enabled_text(school)} (URN #{school.urn}#{replacement_urns_text(school)})."
+  end
+
+  def enabled_text(school)
+    school.enabled ? "enabled" : "disabled"
+  end
+
+  def replacement_urns_text(school)
+    urns = reopened_urns[school.urn].to_sentence
+
+    return if urns.blank?
+
+    ", replacement URN(s) #{urns}"
+  end
+
+  def reconciler
+    @reconciler ||= Bookings::Data::GiasReconciler.new
+  end
+
+  def closed_schools
+    @closed_schools ||= reconciler.identify_onboarded_closed
+  end
+
+  def reopened_urns
+    @reopened_urns ||= reconciler.find_reopened_urns(closed_schools.pluck(:urn))
+  end
+end

--- a/app/notify/notify_email/closed_onboarded_schools_summary.a9547f2d-adb2-4cff-b9df-f2afc1ccbc66.md
+++ b/app/notify/notify_email/closed_onboarded_schools_summary.a9547f2d-adb2-4cff-b9df-f2afc1ccbc66.md
@@ -1,0 +1,5 @@
+Hello,
+
+Here are the schools that are marked as closed by GIAS yet are on-boarded to School Experience:
+
+((closed_onboarded_schools))

--- a/app/notify/notify_email/closed_onboarded_schools_summary.rb
+++ b/app/notify/notify_email/closed_onboarded_schools_summary.rb
@@ -1,0 +1,21 @@
+class NotifyEmail::ClosedOnboardedSchoolsSummary < NotifyDespatchers::Email
+  attr_accessor :closed_onboarded_schools
+
+  def initialize(to:, closed_onboarded_schools:)
+    self.closed_onboarded_schools = closed_onboarded_schools
+
+    super(to: to)
+  end
+
+private
+
+  def template_id
+    "a9547f2d-adb2-4cff-b9df-f2afc1ccbc66"
+  end
+
+  def personalisation
+    {
+      closed_onboarded_schools: closed_onboarded_schools,
+    }
+  end
+end

--- a/spec/jobs/cron/identify_closed_schools_job_spec.rb
+++ b/spec/jobs/cron/identify_closed_schools_job_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+describe Cron::IdentifyClosedSchoolsJob, type: :job do
+  it 'is scheduled for 9am on Mondays' do
+    expect(described_class.cron_expression).to eql("0 9 * * 1")
+  end
+
+  describe "#perform" do
+    let(:email_double) { instance_double(NotifyEmail::ClosedOnboardedSchoolsSummary, despatch_later!: nil) }
+    let(:closed_school_1) { create(:bookings_school, :onboarded) }
+    let(:closed_school_2) { create(:bookings_school, :onboarded) }
+    let(:closed_school_3) { create(:bookings_school, :onboarded) }
+    let(:reopened_school_1) { create(:bookings_school) }
+    let(:reopened_school_2) { create(:bookings_school) }
+    let(:csv) do
+      <<~CSV
+        URN,CloseDate,LA (code),EstablishmentNumber,LA (name)
+        #{closed_school_1.urn},#{1.month.ago},888,1572,Hillend Primary
+        #{closed_school_2.urn},#{1.day.ago},888,1572,Hillend Primary
+        #{reopened_school_1.urn},,888,1572,Hillend Primary
+        #{reopened_school_2.urn},,888,1572,Hillend Primary
+        #{closed_school_3.urn},#{2.days.ago},999,1984,Main St Secondary
+      CSV
+    end
+
+    subject(:perform) { described_class.new.perform }
+
+    before do
+      temp_csv = Tempfile.new
+      temp_csv.write(csv)
+      temp_csv.close
+      allow_any_instance_of(Bookings::Data::GiasDataFile).to receive(:path) { temp_csv.path }
+      allow(Rails).to receive(:env) { "production".inquiry }
+    end
+
+    it "emails the service inbox with closed, on-boarded school details" do
+      closed_text = "#{closed_school_1.name} is enabled (URN #{closed_school_1.urn}, replacement URN(s) #{reopened_school_1.urn} and #{reopened_school_2.urn}). "\
+      "#{closed_school_2.name} is enabled (URN #{closed_school_2.urn}, replacement URN(s) #{reopened_school_1.urn} and #{reopened_school_2.urn}). "\
+      "#{closed_school_3.name} is enabled (URN #{closed_school_3.urn})."
+
+      params = {
+        to: described_class::SERVICE_INBOX,
+        closed_onboarded_schools: closed_text
+      }
+      allow(NotifyEmail::ClosedOnboardedSchoolsSummary).to receive(:new).with(params) { email_double }
+      perform
+      expect(email_double).to have_received(:despatch_later!)
+    end
+
+    context "when there are no closed, on-boarded schools" do
+      let(:csv) { "" }
+
+      it "emails the service inbox" do
+        params = {
+          to: described_class::SERVICE_INBOX,
+          closed_onboarded_schools: "There are no closed, on-boarded schools."
+        }
+        allow(NotifyEmail::ClosedOnboardedSchoolsSummary).to receive(:new).with(params) { email_double }
+        perform
+        expect(email_double).to have_received(:despatch_later!)
+      end
+    end
+
+    context "when not running in production" do
+      before { allow(Rails).to receive(:env) { "preprod".inquiry } }
+
+      it "does not send any emails" do
+        expect(NotifyEmail::ClosedOnboardedSchoolsSummary).not_to receive(:new)
+      end
+    end
+  end
+end

--- a/spec/notify/notify_email/closed_onboarded_schools_summary_spec.rb
+++ b/spec/notify/notify_email/closed_onboarded_schools_summary_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+describe NotifyEmail::ClosedOnboardedSchoolsSummary do
+  it_should_behave_like "email template", "a9547f2d-adb2-4cff-b9df-f2afc1ccbc66",
+    closed_onboarded_schools: "data"
+end


### PR DESCRIPTION
### Trello card

[Trello-625](https://trello.com/c/AybmKNMB/625-post-closed-on-boarded-schools-to-slack)

### Context

We want to keep track of schools that have been onboarded to the service but subsequently marked as closed according to the latest GIAS data. We will aim to get in touch with these schools and transition them to a new account on the system (for their replacement school if one exists).

### Changes proposed in this pull request

- Periodically email list of onboarded, closed schools

Run periodic cron job (Mondays at 9am) to email the service inbox with a list of closed, on-boarded school details.

Originally I wanted to include this as a markdown formatted table but the GOV.UK Notify service is very restricted on what it will accept and it blocks this kind of content. Instead I've opted to format it as a sentence that can be read out (I wasn't even able to get line breaks working consistently).

### Guidance to review

With hindsight this may have been better as a Slack integration, but to do that we would either need to expose our production credentials to our CI pipeline or pull in a whole new Slack integration, which felt like overkill.

I opted to send the email regardless of if there are any schools; this way we can be confident its still running and as its only once per week its not going to be spammy.

| When there are none      | When there are some |
| ----------- | ----------- |
| <img width="863" alt="Screenshot 2022-06-16 at 14 10 57" src="https://user-images.githubusercontent.com/29867726/174077108-d534f561-012e-46ff-8c98-69f683785941.png">      | <img width="863" alt="Screenshot 2022-06-16 at 14 10 47" src="https://user-images.githubusercontent.com/29867726/174077070-7b91f3c2-2f1b-4ba9-b820-5c29fb600067.png">       |


