### PR TITLE
High Priority WCAG Level A Accessibility Updates

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -79,14 +79,19 @@ module Candidates::SchoolHelper
     school.phases.map(&:name).to_sentence
   end
 
-  def describe_current_search(search)
-    if search.location_name.present?
-      "near #{search.location_name}"
-    elsif search.location.present?
-      "near #{search.location}"
-    else
-      "matching #{search.query}"
-    end
+  def describe_current_search(search, include_result_count: false)
+    description = if search.location_name.present?
+                    "near #{search.location_name}"
+                  elsif search.location.present?
+                    "near #{search.location}"
+                  else
+                    "matching #{search.query}"
+                  end
+
+    return description unless include_result_count
+
+    result_count = pluralize(number_with_delimiter(search.total_count), "result")
+    "#{result_count} #{description}"
   end
 
   def show_lower_navigation?(count)

--- a/app/views/candidates/home/index.html.erb
+++ b/app/views/candidates/home/index.html.erb
@@ -74,27 +74,27 @@ Visit schools to see how teachers plan lessons, manage classrooms and teach subj
         <ul class="govuk-list govuk-!-font-size-16 govuk-se-spaced-list">
           <li>
             <a href="<%= candidates_guide_for_candidates_path %>" class="govuk-!-font-weight-bold">
-              School experience: guide for candidates<span class="govuk-visually-hidden">in Subsection</span>
+              School experience: guide for candidate
             </a>
           </li>
           <li>
             <a href="https://getintoteaching.education.gov.uk/" class="govuk-!-font-weight-bold">
-              Get Into Teaching<span class="govuk-visually-hidden">in Subsection</span>
+              Get Into Teaching
             </a>
           </li>
           <li>
             <a href="https://www.gov.uk/find-postgraduate-teacher-training-courses " class="govuk-!-font-weight-bold">
-              Find postgraduate teacher training courses<span class="govuk-visually-hidden">in Subsection</span>
+              Find postgraduate teacher training courses
             </a>
           </li>
           <li>
             <a href="https://www.gov.uk/school-term-holiday-dates" class="govuk-!-font-weight-bold">
-              School term and holiday dates<span class="govuk-visually-hidden">in Subsection</span>
+              School term and holiday dates
             </a>
           </li>
           <li>
             <a href="https://www.gov.uk/types-of-school" class="govuk-!-font-weight-bold">
-              Types of school<span class="govuk-visually-hidden">in Subsection</span>
+              Types of school
             </a>
           </li>
         </ul>
@@ -106,7 +106,7 @@ Visit schools to see how teachers plan lessons, manage classrooms and teach subj
         <ul class="govuk-list govuk-!-font-size-16 govuk-se-spaced-list">
           <li>
             <%= link_to schools_path, class: "govuk-!-font-weight-bold" do %>
-              Manage school experience <span class="govuk-visually-hidden">in Subsection</span>
+              Manage school experience
             <% end %>
           </li>
         </ul>
@@ -118,7 +118,7 @@ Visit schools to see how teachers plan lessons, manage classrooms and teach subj
         <ul class="govuk-list govuk-!-font-size-16 govuk-se-spaced-list">
           <li>
             <%= link_to candidates_dashboard_path, class: "govuk-!-font-weight-bold" do %>
-              Manage your bookings<span class="govuk-visually-hidden">in Subsection</span>
+              Manage your bookings
             <% end %>
           </li>
         </ul>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -1,4 +1,4 @@
-<% self.page_title = "School experience placements #{ describe_current_search @search }" %>
+<% self.page_title = "School experience placements #{ describe_current_search @search, include_result_count: true }" %>
 <%= govuk_back_link new_candidates_school_search_path(school_new_search_params) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -110,7 +110,7 @@
         <%= render 'expanded_search', search: @search %>
       <% end %>
 
-      <% @search.results.each_with_index do |school, _| %>
+      <% @search.results.each_with_index do |school, idx| %>
         <li data-school-urn="<%= school.urn %>">
           <article class="school-result">
             <h2 class="govuk-heading-l">
@@ -124,10 +124,10 @@
             </h2>
 
             <dl class="govuk-summary-list">
-              <%= summary_row 'Address', format_school_address(school), nil, show_action: false %>
-              <%= summary_row 'Education phases', format_school_phases(school), nil, show_action: false %>
-              <%= summary_row 'Subjects', format_school_subjects(school), nil, show_action: false %>
-              <%= summary_row 'Experience type', format_school_placement_locations(school), nil, show_action: false %>
+              <%= summary_row 'Address', format_school_address(school), nil, show_action: false, id: "result-#{idx}-address" %>
+              <%= summary_row 'Education phases', format_school_phases(school), nil, show_action: false, id: "result-#{idx}-education-phase" %>
+              <%= summary_row 'Subjects', format_school_subjects(school), nil, show_action: false, id: "result-#{idx}-subjects" %>
+              <%= summary_row 'Experience type', format_school_placement_locations(school), nil, show_action: false, id: "result-#{idx}-experience-type" %>
             </dl>
 
             <%= govuk_link_to 'View school details',

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,5 +8,13 @@
     remote:        data-remote
 -%>
 <span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
+  <% if page.current? %>
+    <span class="govuk-visually-hidden">Current page:</span>
+    <%= page %>
+  <% else %>
+    <%= link_to(url, remote: remote, rel: page.rel) do %>
+      <span class="govuk-visually-hidden">Page:</span>
+      <%= page %>
+    <% end %>
+  <% end %>
 </span>

--- a/app/views/schools/dashboards/_service_update_notice.html.erb
+++ b/app/views/schools/dashboards/_service_update_notice.html.erb
@@ -8,6 +8,8 @@
   </p>
 
   <p>
-    <%= link_to 'Read more', service_updates_path %>
+    <%= link_to service_updates_path do %>
+      Read more <span class="govuk-visually-hidden">about "<%= @latest_service_update.title %>"</span>
+    <% end %>
   </p>
 </div>

--- a/app/views/schools/on_boarding/access_needs_details/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_details/_form.html.erb
@@ -5,15 +5,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for access_needs_detail, url: schools_on_boarding_access_needs_detail_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
-      <h1 class="govuk-heading-l">
-        Enter details about the facilities and support you provide for candidates with disabilities and access needs
-      </h1>
 
-      <p>
-        You can edit, or add to, the following suggested wording.
-      </p>
-
-      <%= f.govuk_text_area :description, rows: 9, label: nil %>
+      <%= f.govuk_text_area :description, rows: 9, label: { tag: "h1", size: "l" } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -8,15 +8,7 @@
                  html: { class: "candidate-requirements-selection" } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
-        What requirements do you have?
-      </h1>
-
-      <p>
-        Select all that apply.
-      </p>
-
-      <%= f.govuk_check_boxes_fieldset :selected_requirements, legend: nil do %>
+      <%= f.govuk_check_boxes_fieldset :selected_requirements, legend: { tag: "h1", size: "l" } do %>
         <%= f.govuk_check_box :selected_requirements, "on_teacher_training_course" %>
         <%= f.govuk_check_box :selected_requirements, "not_on_another_training_course" %>
         <%= f.govuk_check_box :selected_requirements, "has_or_working_towards_degree" %>

--- a/app/views/service_updates/_service_update.html.erb
+++ b/app/views/service_updates/_service_update.html.erb
@@ -5,5 +5,7 @@
 <p>
   <%= service_update.summary %>
   -
-  <%= link_to 'read more', service_update %>
+  <%= link_to service_update do %>
+    read more <span class="govuk-visually-hidden">about "<%= service_update.title %>"</span>
+  <% end %>
 </p>

--- a/app/views/shared/application/_cookie_banner.html.erb
+++ b/app/views/shared/application/_cookie_banner.html.erb
@@ -38,7 +38,7 @@
         </div>
 
         <div class="govuk-grid-column-one-third">
-          <%= link_to 'Hide', request.fullpath %>
+          <%= link_to 'Hide cookies message', request.fullpath %>
         </div>
       </div>
     </div>

--- a/app/webpacker/controllers/search_controller.js
+++ b/app/webpacker/controllers/search_controller.js
@@ -52,7 +52,9 @@ export default class extends Controller {
     }
   }
 
-  performSearch() {
+  performSearch(e) {
+    this.focusElementId = e?.target.getAttribute('id');
+
     if (!this.supported) {
       return
     }
@@ -84,6 +86,11 @@ export default class extends Controller {
         this.updateInterface()
 
         this.loadingTarget.classList.remove('active')
+
+        const focusElement = document.getElementById(this.focusElementId);
+        if (focusElement) {
+          focusElement.focus();
+        }
       })
   }
 

--- a/app/webpacker/controllers/search_controller.js
+++ b/app/webpacker/controllers/search_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
 
   connect() {
     if (this.supported) {
-      this.updateInterface()
+      this.updateInterfaceState()
     }
   }
 
@@ -62,10 +62,8 @@ export default class extends Controller {
     const params = new URLSearchParams(new FormData(this.formTarget))
     const url = `${this.formAction}?${params.toString()}`
 
+    this.updateHistory(url)
     this.executeSearch(url)
-
-    history.replaceState({}, document.title, url)
-
     this.sendPageView(url)
   }
 
@@ -82,16 +80,14 @@ export default class extends Controller {
 
         document.getElementById(this.resultsIdValue).innerHTML = results.innerHTML
         document.getElementById(this.formIdValue).innerHTML = form.innerHTML
+        document.title = response.title;
 
-        this.updateInterface()
-
-        this.loadingTarget.classList.remove('active')
-
-        const focusElement = document.getElementById(this.focusElementId);
-        if (focusElement) {
-          focusElement.focus();
-        }
+        this.updateInterfaceState()
       })
+  }
+
+  updateHistory(url) {
+    history.replaceState({}, document.title, url)
   }
 
   sendPageView(url) {
@@ -101,9 +97,15 @@ export default class extends Controller {
     }
   }
 
-  updateInterface() {
+  updateInterfaceState() {
     this.submitTarget.classList.add('hidden')
     this.tagTargets.forEach(tag => tag.classList.add('interactive'))
+    this.loadingTarget.classList.remove('active')
+
+    const focusElement = document.getElementById(this.focusElementId);
+    if (focusElement) {
+      focusElement.focus();
+    }
   }
 
   get formAction() {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1061,5 +1061,5 @@ en:
 
   views:
     pagination:
-      next: Next
-      previous: Previous
+      next: Next page
+      previous: Previous page

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -675,6 +675,8 @@ en:
         location: Describe where the candidate should report to on the day of the experience
       schools_on_boarding_school_fee_hints: &schools_on_boarding_school_fee_hints
         payment_method: For example, by bank transfer, in cash or via PayPal.
+      schools_on_boarding_candidate_requirements_selection:
+        selected_requirements: Select all that apply.
       schools_on_boarding_administration_fee:
         <<: *schools_on_boarding_school_fee_hints
       schools_on_boarding_dbs_fee:
@@ -1042,6 +1044,8 @@ en:
         <<: *schools_on_boarding_school_fee_helpers
       schools_on_boarding_candidate_experience_schedule:
         times_flexible: 'Are your start and finish times flexible?'
+      schools_on_boarding_candidate_requirements_selection:
+        selected_requirements: What requirements do you have?
       schools_on_boarding_candidate_parking_information:
         parking_provided: 'Do you provide parking for candidates?'
       schools_on_boarding_access_needs_support:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -669,6 +669,8 @@ en:
         end_time: 'For example, 3:30pm.'
       schools_on_boarding_teacher_training:
         provides_teacher_training: 'For example, are you a School Direct lead or partner school or do you offer mainstream teacher training placements.'
+      schools_on_boarding_access_needs_detail:
+        description: You can edit, or add to, the following suggested wording.
       schools_placement_requests_add_more_details:
         location: Describe where the candidate should report to on the day of the experience
       schools_on_boarding_school_fee_hints: &schools_on_boarding_school_fee_hints
@@ -891,6 +893,8 @@ en:
           true: 'Yes'
           false: 'No'
         times_flexible_details: 'Provide details.'
+      schools_on_boarding_access_needs_detail:
+        description: Enter details about the facilities and support you provide for candidates with disabilities and access needs
       schools_on_boarding_access_needs_support:
         supports_access_needs_options:
           true: 'Yes'

--- a/spec/helpers/candidates/school_helper_spec.rb
+++ b/spec/helpers/candidates/school_helper_spec.rb
@@ -150,51 +150,69 @@ RSpec.describe Candidates::SchoolHelper, type: :helper do
   end
 
   context '.describe_current_search' do
+    let(:opts) { {} }
+
+    subject { describe_current_search(search, **opts) }
+
     context 'with location search' do
       context 'and name supplied by search' do
-        subject do
-          double('Location search',
+        let(:search) do
+          instance_double(Candidates::SchoolSearch,
             latitude: '',
             longitude: '',
+            total_count: 3435,
             location: 'Manchester',
             location_name: 'Manchester, United Kingdom',
             query: '')
         end
 
-        it('should say near Manchester') do
-          expect(describe_current_search(subject)).to match(/near Manchester, United Kingdom/)
+        it { is_expected.to eq("near Manchester, United Kingdom") }
+
+        context "when include_result_count is true" do
+          let(:opts) { { include_result_count: true } }
+
+          it { is_expected.to eq("3,435 results near Manchester, United Kingdom") }
         end
       end
 
       context 'without name supplied by search' do
-        subject do
-          double('Location search',
+        let(:search) do
+          instance_double(Candidates::SchoolSearch,
             latitude: '',
             longitude: '',
             location: 'Manchester',
             location_name: nil,
+            total_count: 0,
             query: '')
         end
 
-        it('should say near Manchester') do
-          expect(describe_current_search(subject)).to match(/near Manchester$/)
+        it { is_expected.to eq("near Manchester") }
+
+        context "when include_result_count is true" do
+          let(:opts) { { include_result_count: true } }
+
+          it { is_expected.to eq("0 results near Manchester") }
         end
       end
     end
 
     context 'with query search' do
-      subject do
-        double('Text search',
+      let(:search) do
+        instance_double(Candidates::SchoolSearch,
           latitude: '',
           longitude: '',
           location: '',
+          total_count: 1,
           location_name: nil,
           query: 'special school')
       end
 
-      it('should say matching special school') do
-        expect(describe_current_search(subject)).to \
-          match(/matching special school/i)
+      it { is_expected.to eq("matching special school") }
+
+      context "when include_result_count is true" do
+        let(:opts) { { include_result_count: true } }
+
+        it { is_expected.to eq("1 result matching special school") }
       end
     end
   end

--- a/spec/javascript/controllers/search_controller_spec.js
+++ b/spec/javascript/controllers/search_controller_spec.js
@@ -25,7 +25,17 @@ describe('SearchController', () => {
       expect(loading.classList).toContain('active')
 
       return Promise.resolve({
-        text: () => Promise.resolve(`${responseForm}${responseSearchResults}`),
+        text: () => Promise.resolve(`
+          <html>
+            <head>
+              <title>New Title</title>
+            </head>
+            <body>
+              ${responseForm}
+              ${responseSearchResults}
+            </body>
+            </html>
+          `),
       })
     })
   }
@@ -39,7 +49,8 @@ describe('SearchController', () => {
     window.gtag = jest.fn();
   };
 
-  const setBody = () => {
+  const setDocument = () => {
+    document.title = 'Title'
     document.body.innerHTML = `
       <div data-controller="search" data-search-results-id-value="search-results" data-search-form-id-value="form">
         ${generateForm()}
@@ -90,7 +101,7 @@ describe('SearchController', () => {
     beforeEach(() => {
       mockFetch()
       mockHistory()
-      setBody()
+      setDocument()
       mockGtag()
     })
 
@@ -137,7 +148,7 @@ describe('SearchController', () => {
       })
 
       it('updates the page history', () => {
-        expect(history.replaceState).toHaveBeenCalledWith({}, document.title, '/path?checkbox1=1&checkbox2=2&checkbox3=3')
+        expect(history.replaceState).toHaveBeenCalledWith({}, "Title", '/path?checkbox1=1&checkbox2=2&checkbox3=3')
       })
 
       it('sends a page view to gtag', () => {
@@ -148,6 +159,10 @@ describe('SearchController', () => {
       it('re-focuses on the target element', () => {
         var focusedElementId = document.activeElement.getAttribute('id')
         expect(focusedElementId).toEqual('checkbox-1-field')
+      })
+
+      it('updates the page title', () => {
+          expect(document.title).toEqual('New Title')
       })
     })
 
@@ -197,7 +212,7 @@ describe('SearchController', () => {
       delete global.fetch;
       delete global.URLSearchParams;
 
-      setBody()
+      setDocument()
     })
 
     it('does not hide the search button', () => {

--- a/spec/javascript/controllers/search_controller_spec.js
+++ b/spec/javascript/controllers/search_controller_spec.js
@@ -107,7 +107,14 @@ describe('SearchController', () => {
     describe('changing the form', () => {
       beforeEach(() => {
         const form = document.getElementById('form')
-        form.dispatchEvent(new Event('change'))
+        const event = new Event('change')
+
+        Object.defineProperty(event, 'target', {
+          writable: false,
+          value: document.getElementById('checkbox-1-field')
+        });
+
+        form.dispatchEvent(event)
       })
 
       it('performs a search', () => {
@@ -136,6 +143,11 @@ describe('SearchController', () => {
       it('sends a page view to gtag', () => {
         expect(window.gtag).toHaveBeenCalledWith('set', 'page_path', '/path?checkbox1=1&checkbox2=2&checkbox3=3');
         expect(window.gtag).toHaveBeenCalledWith('event', 'page_view');
+      })
+
+      it('re-focuses on the target element', () => {
+        var focusedElementId = document.activeElement.getAttribute('id')
+        expect(focusedElementId).toEqual('checkbox-1-field')
       })
     })
 


### PR DESCRIPTION
### Trello card

[Trello-607](https://trello.com/c/3bGRyQDV/607-fix-accessibility-issues-from-april-22-accessibility-report?filter=member:rossoliver15,member:josephkempster)

### Context

DAC flagged a number of WCAG Level A accessibility issues on the website; we want to fix these to give our users a better experience.

### Changes proposed in this pull request

- Ensure unique index in search result summary rows

The search result summary rows default to have an `id` of the key for the row; if there are multiple results this causes duplicate `id` values.

Prefix the summary row key with the index of the result to ensure it will always be unique.

- Make pagination component accessible

When a user focuses on a page indicator its not clear what the navigation is for (it just reads out a number). Instead, we want to provide the 'page' context, so "Page: 1", "Current page: 3", etc. Similarly, suffix the next/previous links so they are "Next page" and "Previous page".

- Make read more links more accessible

If a user tabs to one of these links it may not be clear as to what content it relates to; add visually hidden text to clarify.

- Update hide cookie message link text

The 'Hide' link on the cookie message after changing your cookie preferences is not clear to all users. Update to be inline with GOV.UK guidance as "Hide cookies message".

- Remove 'in subsection' visually hidden text

This was highlighted by users in the DAC report as being confusing; they suggest it is more accessible without the 'in subsection' helper text.

- Update textarea to have a label

We were missing a label for this text area; the heading should be the label and the extra text can be a hint.

- Ensure candidate requirements options share common legend

Its not clear to users with a screen reader that these are grouped; they should have a common legend.

We also have this issue on the `key_stage_lists` and `phases_lists` forms, however as they are checkboxes for individual named attributes we can't easily group them, so I've left that until we refactor those steps to be inline with `candidate_requirements` (they should also have a `None` option).

- Return focus to live filter after search

When we perform a 'live search' the results, including filters, are overwritten with the response from the server. This results in the loss of focus state on the page and tabbing will continue back at the top of the document.

Instead, we want the focus to return to the filter element that caused the live update.

Pulls in `jest-environment-jsdom` - I think this used to be bundled with `jest`.

- Include number of results in page title

The search results page was flagged as having a duplicate page title after executing a search as the results change but its potentially not clear to the user that they are now on a new/updated page.

Update page title to include the number of results. Ensure the page title updates on live search updates.

### Guidance to review

Best reviewed by-commit.