### PR TITLE
Medium Priority WCAG Level AA Accessibility Updates #2545

### DIFF
--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -129,8 +129,7 @@
 
     <div class="govuk-form-group">
       <%= f.govuk_check_boxes_fieldset :acceptance, multiple: false do %>
-        <%= f.govuk_check_box :acceptance, 1, 0, multiple: false, link_errors: true, label: { text: "By checking this box you're confirming that:" } %>
-        <p>
+        <p>By continuing you're confirming that:</p>
         <ul class="govuk-list govuk-list--bullet">
           <li>the details you've provided are correct</li>
           <li>you're aged 18 or over</li>
@@ -140,7 +139,7 @@
             will use your personal details to provide you with
             tailored advice and information about teacher training and a career as a teacher</li>
         </ul>
-        </p>
+        <%= f.govuk_check_box :acceptance, 1, 0, multiple: false, link_errors: true, label: { text: "I confirm that the application is accurate" } %>
       <% end %>
     </div>
     <% if candidate_signed_in? %>

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -30,15 +30,15 @@
           <%= f.govuk_phone_field :phone, autocomplete: 'on' %>
 
           <h2 class="govuk-heading-m">Address</h2>
-          <%= f.govuk_text_field :building, autocomplete: 'home address-line1' %>
+          <%= f.govuk_text_field :building, autocomplete: 'address-line1' %>
           <% if f.object.errors[:street].any? %>
-            <%= f.govuk_text_field :street, autocomplete: 'home address-line2' %>
+            <%= f.govuk_text_field :street, autocomplete: 'address-line2' %>
           <% else %>
-            <%= f.govuk_text_field :street, autocomplete: 'home address-line2', label: { class: 'govuk-visually-hidden' } %>
+            <%= f.govuk_text_field :street, autocomplete: 'address-line2', label: { class: 'govuk-visually-hidden' } %>
           <% end %>
-          <%= f.govuk_text_field :town_or_city, autocomplete: 'home address-level2', class: 'govuk-!-width-two-thirds' %>
-          <%= f.govuk_text_field :county, autocomplete: 'home address-level1', class: 'govuk-!-width-two-thirds' %>
-          <%= f.govuk_text_field :postcode, autocomplete: 'home postal-code', class: 'govuk-input govuk-input--width-10' %>
+          <%= f.govuk_text_field :town_or_city, autocomplete: 'address-level2', class: 'govuk-!-width-two-thirds' %>
+          <%= f.govuk_text_field :county, autocomplete: 'address-level1', class: 'govuk-!-width-two-thirds' %>
+          <%= f.govuk_text_field :postcode, autocomplete: 'postal-code', class: 'govuk-input govuk-input--width-10' %>
 
           <%= f.govuk_submit 'Continue' %>
         <% end %>

--- a/features/candidates/registrations/contact_information.feature
+++ b/features/candidates/registrations/contact_information.feature
@@ -15,12 +15,12 @@ Feature: Contact Information
     Scenario: Form contents
         Given I am on the 'Enter your contact details' page for my school of choice
         Then I should see a form with the following fields:
-            | Label               | Type | Autocompletion      |
-            | UK telephone number | tel  | on                  |
-            | Building and street | text | home address-line1  |
-            | Town or city        | text | home address-level2 |
-            | County              | text | home address-level1 |
-            | Postcode            | text | home postal-code    |
+            | Label               | Type | Autocompletion     |
+            | UK telephone number | tel  | on                 |
+            | Building and street | text | address-line1      |
+            | Town or city        | text | address-level2     |
+            | County              | text | address-level1     |
+            | Postcode            | text | postal-code        |
 
     Scenario: Submitting my data
       Given I am on the 'Enter your contact details' page for my school of choice


### PR DESCRIPTION
### Trello card

[Trello607-](https://trello.com/c/3bGRyQDV/607-fix-accessibility-issues-from-april-22-accessibility-report?filter=member:rossoliver15,member:josephkempster)

### Context

We want to address all the AA issues that DAC raised in their accessibility audit.

### Changes proposed in this pull request

- Remove home from autocomplete value

According to DAC we should omit this and just use the `address-x` values. On reading up online I can't find much of a reference to the use of `home` apart from this spec, which suggests the attributes it can be used with (and they don't include address):

https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-home

- Make acceptance label accessible

Screen readers read out "By checking this box you're confirming that:" which doesn't make sense; instead, we can put the bullet list of points before the checkbox and clarify the label as "I confirm that the application is accurate".

### Guidance to review

