### PR TITLE
Low Priority WCAG Level AAA Accessibility Updates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,8 +2,9 @@ module ApplicationHelper
   def page_title
     safe_join([
       content_for(:page_title).presence,
-      'DfE School Experience'
-    ].compact, ' | ')
+      'Get school experience',
+      'GOV.UK'
+    ].compact, ' - ')
   end
 
   def page_title=(title)

--- a/app/views/candidates/home/guide_for_candidates.html.erb
+++ b/app/views/candidates/home/guide_for_candidates.html.erb
@@ -1,11 +1,11 @@
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link %>
-
     <h1 class="govuk-heading-xl">School experience: guide for candidates</h1>
 
         <p>
-         School experience allows you to learn more about teaching by visiting schools. 
+         School experience allows you to learn more about teaching by visiting schools.
         </p>
 
          <p>
@@ -16,15 +16,15 @@
             <li>build a relationship with a school you might want to work with later</li>
         </ul>
     </p>
-  
+
   <h2 class="govuk-heading-m">When to get your school experience</h2>
 
         <p>
          If you’re considering going into teaching, you may want to do school experience before you apply for teacher training.
         </p>
-  
+
   <h2 class="govuk-heading-m">Eligibility</h2>
-  
+
    <p>
          You can request school experience if you:
           <ul class="govuk-list govuk-list--bullet">
@@ -37,13 +37,13 @@
     <h2 class="govuk-heading-m">What to expect</h2>
 
        <p>
-        School experience is usually one or 2 days long, but can sometimes be as long as 3 weeks. 
+        School experience is usually one or 2 days long, but can sometimes be as long as 3 weeks.
        </p>
-  
+
        <p>
         You can choose to do virtual or in-school experience, depending on what schools offer.
       </p>
-  
+
          <p>
            During your experience, you'll get to do things like:
             <ul class="govuk-list govuk-list--bullet">
@@ -54,7 +54,7 @@
               <li>learn more about teacher training - including the application and interview process</li>
           </ul>
       </p>
-  
+
         <p>
          Some schools will offer a mixture of classroom observation and a presentation.
         </p>

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -1,5 +1,6 @@
 <% self.page_title = 'Check your answers' %>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row" id="application-preview">
   <%= form_for @privacy_policy,
         url: candidates_school_registrations_confirmation_email_path,

--- a/app/views/candidates/registrations/availability_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/availability_preferences/_form.html.erb
@@ -1,5 +1,6 @@
 <% self.page_title = 'When are you available for school experience?' %>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row" id="availability-preference">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/candidates/registrations/background_checks/_form.html.erb
+++ b/app/views/candidates/registrations/background_checks/_form.html.erb
@@ -1,5 +1,6 @@
 <% self.page_title = 'Background and security checks' %>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for background_check, url: candidates_school_registrations_background_check_path do |f| %>

--- a/app/views/candidates/registrations/background_checks/unmet_requirements.html.erb
+++ b/app/views/candidates/registrations/background_checks/unmet_requirements.html.erb
@@ -1,19 +1,22 @@
 <% self.page_title = 'DBS certificate is required' %>
+<% content_for :back_link do
+  govuk_back_link edit_candidates_school_registrations_background_check_path(
+    anchor: 'candidates_registrations_background_check_has_dbs_check_container'
+  )
+end %>
 
-<%= govuk_back_link edit_candidates_school_registrations_background_check_path(
-          anchor: 'candidates_registrations_background_check_has_dbs_check_container'
-        ) %>
+<%=  %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">You need a DBS certificate at this school</h1>
-    <p>This school requires you to have a DBS certificate for the requested school experience type. 
+    <p>This school requires you to have a DBS certificate for the requested school experience type.
     There are schools that do not require a DBS certificate for all types of school experience.</p>
-        
+
       <p>
         <%= govuk_link_to 'Search again', new_candidates_school_search_path %>
       </p>
 
-    
+
     <p>
       <strong>
         <%= link_to "Find out more about 'DBS checks' and 'DBS certificates'", 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about' %>

--- a/app/views/candidates/registrations/confirmation_emails/show.html.erb
+++ b/app/views/candidates/registrations/confirmation_emails/show.html.erb
@@ -1,5 +1,6 @@
 <% self.page_title = 'Check your email to complete your request' %>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -32,11 +32,7 @@
 
           <h2 class="govuk-heading-m">Address</h2>
           <%= f.govuk_text_field :building, autocomplete: 'address-line1' %>
-          <% if f.object.errors[:street].any? %>
-            <%= f.govuk_text_field :street, autocomplete: 'address-line2' %>
-          <% else %>
-            <%= f.govuk_text_field :street, autocomplete: 'address-line2', label: { class: 'govuk-visually-hidden' } %>
-          <% end %>
+          <%= f.govuk_text_field :street, autocomplete: 'address-line2' %>
           <%= f.govuk_text_field :town_or_city, autocomplete: 'address-level2', class: 'govuk-!-width-two-thirds' %>
           <%= f.govuk_text_field :county, autocomplete: 'address-level1', class: 'govuk-!-width-two-thirds' %>
           <%= f.govuk_text_field :postcode, autocomplete: 'postal-code', class: 'govuk-input govuk-input--width-10' %>

--- a/app/views/candidates/registrations/contact_informations/_form.html.erb
+++ b/app/views/candidates/registrations/contact_informations/_form.html.erb
@@ -3,7 +3,8 @@
 <%- else -%>
 <% self.page_title = 'Enter your contact details' %>
 <%- end -%>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-grid-row">

--- a/app/views/candidates/registrations/educations/_form.html.erb
+++ b/app/views/candidates/registrations/educations/_form.html.erb
@@ -1,12 +1,13 @@
 <% content_for :back_link do govuk_back_link; end %>
-<%= page_heading 'We need some more details' %>
-
-<p>
-  The following will be used to help schools offer you school experience.
-</p>
 
 <%= form_for education, url: candidates_school_registrations_education_path, data: { controller: 'education-form' } do |f| %>
   <%= f.govuk_error_summary %>
+
+  <%= page_heading 'We need some more details' %>
+
+  <p>
+    The following will be used to help schools offer you school experience.
+  </p>
 
   <section id="education-degree-stage-container" data-education-form-target="degreeStagesContainer">
     <%= f.govuk_radio_buttons_fieldset :degree_stage do %>

--- a/app/views/candidates/registrations/educations/_form.html.erb
+++ b/app/views/candidates/registrations/educations/_form.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 <%= page_heading 'We need some more details' %>
 
 <p>

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Enter your personal details' %>
-
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/candidates/registrations/placement_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/placement_preferences/_form.html.erb
@@ -1,5 +1,6 @@
 <% self.page_title = 'What do you want to get out of your school experience?' %>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for placement_preference, url: candidates_school_registrations_placement_preference_path do |f| %>

--- a/app/views/candidates/registrations/sign_ins/show.html.erb
+++ b/app/views/candidates/registrations/sign_ins/show.html.erb
@@ -1,5 +1,6 @@
 <% self.page_title = 'We already have your details' %>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @verification_code, url: candidates_registration_verify_code_path, method: :put do |f| %>

--- a/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
+++ b/app/views/candidates/registrations/subject_and_date_informations/_form.html.erb
@@ -1,5 +1,5 @@
 <% self.page_title = 'Choose a school experience date' %>
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row" id="placement-preference">
   <div class="govuk-grid-column-full">

--- a/app/views/candidates/registrations/teaching_preferences/_form.html.erb
+++ b/app/views/candidates/registrations/teaching_preferences/_form.html.erb
@@ -1,5 +1,6 @@
 <% self.page_title = 'Which of the following best describes how you feel about teaching?' %>
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
+
 <div id="teaching-preference">
   <%= form_for teaching_preference, url: candidates_school_registrations_teaching_preference_path, data: { controller: 'subject-preference-form' } do |f| %>
     <%= f.govuk_error_summary %>

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Search for school experience' %>
-
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -1,5 +1,5 @@
 <% self.page_title = "School experience placements #{ describe_current_search @search, include_result_count: true }" %>
-<%= govuk_back_link new_candidates_school_search_path(school_new_search_params) %>
+<% content_for :back_link do govuk_back_link(new_candidates_school_search_path(school_new_search_params)); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/candidates/schools/show.html.erb
+++ b/app/views/candidates/schools/show.html.erb
@@ -1,8 +1,7 @@
 <% self.page_title = @school.name %>
 <% description "#{@school.name} is offering school experience opportunities through the DfE's Get school experience service.
 Find out more about a career in teaching, experience days and how to apply." %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <% if !@school.onboarded? %>
   <div class="govuk-inset-text">

--- a/app/views/cookie_preferences/edit.html.erb
+++ b/app/views/cookie_preferences/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
     <%= page_heading 'Edit your cookie settings' %>
 

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,19 +1,17 @@
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Sorry, there is a problem with the service</h1>
 
-      <p class="govuk-body">
-        We are currently experiencing technical difficulties.
-      </p>
+    <p class="govuk-body">
+      We are currently experiencing technical difficulties.
+    </p>
 
-      <p class="govuk-body">
-        If you continue to encounter this problem, contact the Organise School
-        Experience team on
-        <a href="mailto:organise.school-experience@education.gov.uk">organise.school-experience@education.gov.uk</a>
-        for assistance.
-      </p>
+    <p class="govuk-body">
+      If you continue to encounter this problem, contact the Organise School
+      Experience team on
+      <a href="mailto:organise.school-experience@education.gov.uk">organise.school-experience@education.gov.uk</a>
+      for assistance.
+    </p>
 
-    </div>
   </div>
-</main>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,18 +1,16 @@
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">Page not found</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Page not found</h1>
 
-      <p class="govuk-body">
-        If you typed or copied the web address, check it is correct.
-      </p>
+    <p class="govuk-body">
+      If you typed or copied the web address, check it is correct.
+    </p>
 
-      <p class="govuk-body">
-        If you continue to encounter this problem, contact the Organise School
-        Experience team on
-        <a href="mailto:organise.school-experience@education.gov.uk">organise.school-experience@education.gov.uk</a>
-        for assistance.
-      </p>
-    </div>
+    <p class="govuk-body">
+      If you continue to encounter this problem, contact the Organise School
+      Experience team on
+      <a href="mailto:organise.school-experience@education.gov.uk">organise.school-experience@education.gov.uk</a>
+      for assistance.
+    </p>
   </div>
-</main>
+</div>

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,10 +1,8 @@
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">Too many requests</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">Too many requests</h1>
 
-      <p class="govuk-body">You have tried to access a page too often in a short space of time.</p>
-      <p class="govuk-body">You can <a href="/">browse the homepage</a> or try to access the page again in 1 minute.</p>
-    </div>
+    <p class="govuk-body">You have tried to access a page too often in a short space of time.</p>
+    <p class="govuk-body">You can <a href="/">browse the homepage</a> or try to access the page again in 1 minute.</p>
   </div>
-</main>
+</div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,14 +1,12 @@
-<main class="govuk-main-wrapper" id="main-content" role="main">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">We were unable to process this request</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">We were unable to process this request</h1>
 
-      <p class="govuk-body">
-        If you continue to encounter this problem, contact the Organise School
-        Experience team on
-        <a href="mailto:organise.school-experience@education.gov.uk">organise.school-experience@education.gov.uk</a>
-        for assistance.
-      </p>
-    </div>
+    <p class="govuk-body">
+      If you continue to encounter this problem, contact the Organise School
+      Experience team on
+      <a href="mailto:organise.school-experience@education.gov.uk">organise.school-experience@education.gov.uk</a>
+      for assistance.
+    </p>
   </div>
-</main>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,10 @@
 
       <%= render 'shared/candidates/alert_notification' if show_candidate_alert_notification? %>
 
+      <% if content_for?(:back_link) %>
+        <%= yield(:back_link) %>
+      <% end %>
+
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= yield %>
       </main>

--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -1,7 +1,7 @@
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
+
 <div class="govuk-grid-row">
   <article class="govuk-grid-column-full">
-    <%= govuk_back_link javascript: true %>
-
     <%= page_heading do %>
       Accessibility statement for the school experience service
     <% end %>
@@ -58,8 +58,8 @@
 
       <ul class="govuk-list">
         <li>
-          <%= mail_to 'organise.school-experience@education.gov.uk', 
-                'organise.school-experience@education.gov.uk', 
+          <%= mail_to 'organise.school-experience@education.gov.uk',
+                'organise.school-experience@education.gov.uk',
                 aria: { label: 'School experience support email address' } %>
         </li>
       </ul>
@@ -78,7 +78,7 @@
 
       <p>
         If you find any problems that are not listed on this page or think we're
-        not meeting accessibility requirements email 
+        not meeting accessibility requirements email
         <%= mail_to 'organise.school-experience@education.gov.uk' %>.
       </p>
     </section>

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -1,7 +1,7 @@
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= govuk_back_link %>
-
     <%= page_heading 'Cookies' %>
 
     <section>

--- a/app/views/pages/dfe_signin_help.html.erb
+++ b/app/views/pages/dfe_signin_help.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/pages/help_and_support_access_needs.html.erb
+++ b/app/views/pages/help_and_support_access_needs.html.erb
@@ -1,7 +1,7 @@
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link %>
-
     <%= page_heading do %>
       Help and support candidates with disability and access needs
     <% end %>

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,7 +1,7 @@
+<% content_for :back_link do govuk_back_link(request.referer || candidates_root_path); end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= govuk_back_link (request.referer || candidates_root_path) %>
-
     <%= page_heading do %>
       Privacy Policy
     <% end %>

--- a/app/views/pages/schools_privacy_policy.html.erb
+++ b/app/views/pages/schools_privacy_policy.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Privacy policy for Manage school experience' %>
-
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/app/views/pages/schools_request_organisation.html.erb
+++ b/app/views/pages/schools_request_organisation.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/availability_info/edit.html.erb
+++ b/app/views/schools/availability_info/edit.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = "Describe your school experience availability" %>
-
-<%= govuk_back_link edit_schools_availability_preference_path %>
+<% content_for :back_link do govuk_back_link(edit_schools_availability_preference_path); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -3,6 +3,7 @@
     <% if Schools::ChangeSchool.allow_school_change_in_app? %>
       <% if @schools.any? %>
         <%= form_for @change_school, url: schools_change_path, method: :post do |f| %>
+          <%= f.govuk_error_summary %>
           <%= f.govuk_radio_buttons_fieldset :change_to_urn, legend: { tag: "h1", size: "l" } do %>
             <% @schools.each do |school| %>
               <%= f.govuk_radio_button :change_to_urn, school.urn, label: -> do %>

--- a/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_form.html.erb
@@ -1,5 +1,5 @@
 <%- self.page_title = "Review and send cancellation email to candidate" %>
-<%= govuk_back_link schools_booking_path(@booking) %>
+<% content_for :back_link do govuk_back_link(schools_booking_path(@booking)); end %>
 
 <%= form_for cancellation, url: schools_booking_cancellation_path do |f| %>
   <div class="govuk-grid-row">

--- a/app/views/schools/confirmed_bookings/cancellations/show.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/show.html.erb
@@ -1,7 +1,7 @@
+<% content_for :back_link do govuk_back_link(edit_schools_booking_cancellation_path(@booking)); end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link edit_schools_booking_cancellation_path(@booking) %>
-
     <h1 class="govuk-heading-l">
       Review and send cancellation email to candidate
     </h1>

--- a/app/views/schools/confirmed_bookings/date/edit.html.erb
+++ b/app/views/schools/confirmed_bookings/date/edit.html.erb
@@ -1,9 +1,8 @@
 <%- self.page_title = "Change booking date" %>
+<% content_for :back_link do govuk_back_link(schools_booking_path(@booking)); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-     <%= govuk_back_link schools_booking_path(@booking) %>
-
     <%= form_for @booking, url: schools_booking_date_path(@booking), method: 'patch' do |f| %>
       <%= f.govuk_error_summary %>
 

--- a/app/views/schools/confirmed_bookings/date/uneditable.html.erb
+++ b/app/views/schools/confirmed_bookings/date/uneditable.html.erb
@@ -1,7 +1,7 @@
+<% content_for :back_link do govuk_back_link(schools_booking_path(@booking)); end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link schools_booking_path @booking %>
-
     <%= page_heading 'Booking date cannot be edited' %>
 
     <p>

--- a/app/views/schools/errors/inaccessible_school/show.html.erb
+++ b/app/views/schools/errors/inaccessible_school/show.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = "Error - you do not have access to this school" -%>
-
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = title -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/access_needs_details/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_details/_form.html.erb
@@ -1,6 +1,6 @@
 <%- self.page_title = 'Access needs details' -%>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
-<%= govuk_back_link javascript: true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for access_needs_detail, url: schools_on_boarding_access_needs_detail_path, method: method do |f| %>

--- a/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Access needs policy' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
@@ -1,6 +1,6 @@
 <%- self.page_title = 'Access needs support' -%>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
-<%= govuk_back_link javascript: true %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for access_needs_support, url: schools_on_boarding_access_needs_support_path, method: method do |f| %>

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -25,7 +25,7 @@
         Provide admin contact details
       </h2>
 
-      <%= f.govuk_text_field :phone, width: 'one-half' %>
+      <%= f.govuk_phone_field :phone, width: 'one-half' %>
       <%= f.govuk_text_field :email %>
       <%= f.govuk_text_field :email_secondary %>
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Admin contact details' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/candidate_dress_codes/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_dress_codes/_form.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Enter dress code details for candidates' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/candidate_experience_schedules/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_schedules/_form.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Enter start and finish times for candidates' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/candidate_parking_informations/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_parking_informations/_form.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Enter parking information for candidates' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'What requirements do you have?' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/dbs_fees/new.html.erb
+++ b/app/views/schools/on_boarding/dbs_fees/new.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'DBS check costs' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'DBS requirements' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'School description' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/disability_confidents/_form.html.erb
+++ b/app/views/schools/on_boarding/disability_confidents/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Disability Confident' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/experience_outlines/_form.html.erb
+++ b/app/views/schools/on_boarding/experience_outlines/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'School experience details' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Fees' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Which key stages do you offer experience with?' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Which school phases do you offer experience with?' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/subjects/_form.html.erb
+++ b/app/views/schools/on_boarding/subjects/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Select school experience subjects' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
+++ b/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Teacher training details' -%>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_dates/configurations/new.html.erb
+++ b/app/views/schools/placement_dates/configurations/new.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Set date options' %>
-
-<%= govuk_back_link edit_schools_placement_date_path(@placement_date) %>
+<% content_for :back_link do govuk_back_link(edit_schools_placement_date_path(@placement_date)); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_dates/placement_details/new.html.erb
+++ b/app/views/schools/placement_dates/placement_details/new.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Placement details' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_dates/publish_dates/new.html.erb
+++ b/app/views/schools/placement_dates/publish_dates/new.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Check your placement details' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <h1>Check your placement details</h2>
 

--- a/app/views/schools/placement_dates/recurrences_selections/new.html.erb
+++ b/app/views/schools/placement_dates/recurrences_selections/new.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Placement date recurrences' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_dates/review_recurrences/new.html.erb
+++ b/app/views/schools/placement_dates/review_recurrences/new.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Review dates' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <%= form_for @review_recurrences, url: schools_placement_date_review_recurrences_path(@placement_date), method: "post" do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/schools/placement_dates/subject_selections/new.html.erb
+++ b/app/views/schools/placement_dates/subject_selections/new.html.erb
@@ -1,6 +1,5 @@
 <% self.page_title = 'Select school experience subjects' %>
-
-<%= govuk_back_link javascript: true %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/confirm_booking/new.html.erb
@@ -1,6 +1,5 @@
-<%= govuk_back_link javascript: true %>
-
 <%- self.page_title = "Confirm booking" %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
+++ b/app/views/schools/placement_requests/acceptance/make_changes/new.html.erb
@@ -1,6 +1,5 @@
-<%= govuk_back_link javascript: true %>
-
 <%- self.page_title = "Edit booking details" %>
+<% content_for :back_link do govuk_back_link(javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">

--- a/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
+++ b/app/views/schools/placement_requests/acceptance/preview_confirmation_email/edit.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = "Send details to candidate" %>
-
-<%= govuk_back_link new_schools_placement_request_acceptance_make_changes_path(@placement_request), javascript: true %>
+<% content_for :back_link do govuk_back_link(new_schools_placement_request_acceptance_make_changes_path(@placement_request), javascript: true); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_requests/cancellations/_form.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_form.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = "Review and send rejection email to candidate" %>
-
-<%= govuk_back_link schools_placement_request_path(@cancellation.placement_request) %>
+<% content_for :back_link do govuk_back_link(schools_placement_request_path(@cancellation.placement_request)); end %>
 
 <%= form_for cancellation, url: schools_placement_request_cancellation_path do |f| %>
   <div class="govuk-grid-row">

--- a/app/views/schools/placement_requests/cancellations/show.html.erb
+++ b/app/views/schools/placement_requests/cancellations/show.html.erb
@@ -1,7 +1,7 @@
+<% content_for :back_link do govuk_back_link(edit_schools_placement_request_cancellation_path(@cancellation.placement_request)); end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_back_link edit_schools_placement_request_cancellation_path(@cancellation.placement_request) %>
-
     <h1 class="govuk-heading-l">
       Send rejection email to candidate
     </h1>

--- a/app/views/schools/placement_requests/reject/new.html.erb
+++ b/app/views/schools/placement_requests/reject/new.html.erb
@@ -1,6 +1,5 @@
 <%- self.page_title = 'Reject request' -%>
-
-<%= govuk_back_link schools_dashboard_path %>
+<% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -1,90 +1,85 @@
 <%- self.page_title = 'Manage school experience' -%>
 
-<div class="govuk-width-container">
-  <main class="govuk-main-wrapper">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Manage school experience</h1>
 
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Manage school experience</h1>
+    <section>
+      <p>
+        Use this service if you're a school in England and want to offer
+        school experience.
+      </p>
 
-        <section>
-          <p>
-            Use this service if you're a school in England and want to offer
-            school experience.
-          </p>
+      <p>
+        The service will enable you to advertise your school and allow
+        candidates to request experience dates. You'll be able to accept
+        or reject each request.
+      </p>
 
-          <p>
-            The service will enable you to advertise your school and allow
-            candidates to request experience dates. You'll be able to accept
-            or reject each request.
-          </p>
+      <p>
+        You need a <strong>DfE Sign-in account</strong> with access to School Experience.
+      </p>
 
-          <p>
-            You need a <strong>DfE Sign-in account</strong> with access to School Experience.
-          </p>
+      <p>
+        If you have any questions read our <%= link_to 'DfE Sign-in help', dfe_signin_help_path %>.
+      </p>
+    </section>
 
-          <p>
-            If you have any questions read our <%= link_to 'DfE Sign-in help', dfe_signin_help_path %>.
-          </p>
-        </section>
+    <%- if @signin_deactivated -%>
+      <div id="dfe-signin-deactivated" class="govuk-inset-text">
+        <p>
+          Sign-ins to this service are currently unavailable.
+        </p>
 
-        <%- if @signin_deactivated -%>
-          <div id="dfe-signin-deactivated" class="govuk-inset-text">
-            <p>
-              Sign-ins to this service are currently unavailable.
-            </p>
+        <p>
+          <%- if @signin_message -%>
+            <%= @signin_message %>
+          <%- else -%>
+            You will be able to use this service later today.
+          <%- end -%>
+        </p>
 
-            <p>
-              <%- if @signin_message -%>
-                <%= @signin_message %>
-              <%- else -%>
-                You will be able to use this service later today.
-              <%- end -%>
-            </p>
-
-            <p>
-              Contact
-              <a href="mailto:organise.school-experience@education.gov.uk">
-                organise.school-experience@education.gov.uk
-              </a> if you need further information.
-            </p>
-          </div>
-        <%- else -%>
-          <%= govuk_link_to schools_dashboard_path,
-            role:'button',
-            class:'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' do %>
-            Start now <%= render 'shared/start_button_chevron' %>
-          <% end %>
-        <%- end -%>
-
-        <section>
-          <h2 class="govuk-heading-m">Before you start</h2>
-
-          <p>
-            The service will ask you to outline the kind of experience you
-            offer including details about DBS-checks and any fees you charge candidates.
-          </p>
-
-          <p>
-            It's your responsibility to decide if candidates comply with your
-            school DBS and safeguarding policies.
-          </p>
-        </section>
+        <p>
+          Contact
+          <a href="mailto:organise.school-experience@education.gov.uk">
+            organise.school-experience@education.gov.uk
+          </a> if you need further information.
+        </p>
       </div>
+    <%- else -%>
+      <%= govuk_link_to schools_dashboard_path,
+        role:'button',
+        class:'govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8' do %>
+        Start now <%= render 'shared/start_button_chevron' %>
+      <% end %>
+    <%- end -%>
 
-      <div class="govuk-grid-column-one-third column-top-border">
-        <nav>
-          <h2 class="govuk-heading-m">Help and guidance</h2>
-          <ul class="govuk-list">
-            <li>
-              <%= link_to 'Manage school experience: information for schools', 'https://www.gov.uk/government/publications/school-experience-programme-information-for-schools' %>
-            </li>
-            <li>
-              <%= link_to 'DfE Sign-in help', dfe_signin_help_path %>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-  </main>
+    <section>
+      <h2 class="govuk-heading-m">Before you start</h2>
+
+      <p>
+        The service will ask you to outline the kind of experience you
+        offer including details about DBS-checks and any fees you charge candidates.
+      </p>
+
+      <p>
+        It's your responsibility to decide if candidates comply with your
+        school DBS and safeguarding policies.
+      </p>
+    </section>
+  </div>
+
+  <div class="govuk-grid-column-one-third column-top-border">
+    <nav>
+      <h2 class="govuk-heading-m">Help and guidance</h2>
+      <ul class="govuk-list">
+        <li>
+          <%= link_to 'Manage school experience: information for schools', 'https://www.gov.uk/government/publications/school-experience-programme-information-for-schools' %>
+        </li>
+        <li>
+          <%= link_to 'DfE Sign-in help', dfe_signin_help_path %>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>

--- a/app/views/service_updates/index.html.erb
+++ b/app/views/service_updates/index.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_back_link schools_dashboard_path %>
+<% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
 
 <%= page_heading do %>
   Service updates and guidance

--- a/app/views/service_updates/show.html.erb
+++ b/app/views/service_updates/show.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_back_link service_updates_path %>
+<% content_for :back_link do govuk_back_link(service_updates_path); end %>
 
 <%= page_heading do %>
   Service update - <%= @update.date.to_formatted_s(:govuk) %>

--- a/app/views/shared/failed_gitis_connection.html.erb
+++ b/app/views/shared/failed_gitis_connection.html.erb
@@ -1,7 +1,6 @@
 
 <%- self.page_title = "Sorry, the information is unavailable" %>
-
-<%= govuk_back_link %>
+<% content_for :back_link do govuk_back_link; end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,10 +160,9 @@ en:
         candidates/registrations/contact_information:
           attributes:
             building:
-              blank: "Enter your building"
-              too_long: "Building must be 250 characters or fewer"
+              blank: "Enter the first line of your address"
+              too_long: "Address line 1 must be 250 characters or fewer"
             county:
-              blank: "Enter your county"
               too_long: "County must be 50 characters or fewer"
             phone:
               blank: "Enter your telephone number"
@@ -174,10 +173,8 @@ en:
               invalid: 'Enter a valid postcode'
               too_long: "Postcode must be 20 characters or fewer"
             street:
-              blank: "Enter your street"
-              too_long: "Street must be 250 characters or fewer"
+              too_long: "Address line 2 must be 250 characters or fewer"
             town_or_city:
-              blank: "Enter your town or city"
               too_long: "Town or city must be 80 characters or fewer"
 
         candidates/registrations/education:
@@ -761,9 +758,11 @@ en:
           inschool: In school
           virtual: Virtual
       candidates_registrations_contact_information:
-        building: "Building and street"
+        building: "Address line 1"
+        street: "Address line 2 (optional)"
         phone: "UK telephone number"
-        town_or_city: "Town or city"
+        town_or_city: "Town or city (optional)"
+        county: "County (optional)"
       candidates_registrations_personal_information:
         first_name: First name
         last_name: Last name

--- a/features/candidates/registrations/contact_information.feature
+++ b/features/candidates/registrations/contact_information.feature
@@ -15,23 +15,24 @@ Feature: Contact Information
     Scenario: Form contents
         Given I am on the 'Enter your contact details' page for my school of choice
         Then I should see a form with the following fields:
-            | Label               | Type | Autocompletion     |
-            | UK telephone number | tel  | on                 |
-            | Building and street | text | address-line1      |
-            | Town or city        | text | address-level2     |
-            | County              | text | address-level1     |
-            | Postcode            | text | postal-code        |
+            | Label                     | Type | Autocompletion |
+            | UK telephone number       | tel  | on             |
+            | Address line 1            | text | address-line1  |
+            | Address line 2 (optional) | text | address-line2  |
+            | Town or city (optional)   | text | address-level2 |
+            | County (optional)         | text | address-level1 |
+            | Postcode                  | text | postal-code    |
 
     Scenario: Submitting my data
       Given I am on the 'Enter your contact details' page for my school of choice
         And I have entered the following details into the form:
-            | UK telephone number | 01234567890            |
-            | Building and street | 221B           |
-            | Street              | Baker Street   |
-            | Town or city        | London         |
-            | County              | Greater London |
-            | Postcode            | NW1 6XE        |
-            | UK telephone number | 07765 432 100  |
+            | UK telephone number       | 01234567890    |
+            | Address line 1            | 221B           |
+            | Address line 2 (optional) | Baker Street   |
+            | Town or city (optional)   | London         |
+            | County (optional)         | Greater London |
+            | Postcode                  | NW1 6XE        |
+            | UK telephone number       | 07765 432 100  |
 
         When I submit the form
         Then I should be on the 'education' page for my school of choice

--- a/features/step_definitions/candidates/registrations/application_preview_steps.rb
+++ b/features/step_definitions/candidates/registrations/application_preview_steps.rb
@@ -53,10 +53,10 @@ end
 
 Given("I have filled in my contact information successfully") do
   # Submit contact information form successfully
-  fill_in 'Building', with: 'Test house'
-  fill_in 'Street', with: 'Test street'
-  fill_in 'Town or city', with: 'Test Town'
-  fill_in 'County', with: 'Testshire'
+  fill_in 'Address line 1', with: 'Test house'
+  fill_in 'Address line 2 (optional)', with: 'Test street'
+  fill_in 'Town or city (optional)', with: 'Test Town'
+  fill_in 'County (optional)', with: 'Testshire'
   fill_in 'Postcode', with: 'TE57 1NG'
   fill_in 'UK telephone number', with: '01234567890'
   click_button 'Continue'

--- a/features/step_definitions/candidates/registrations/wizard_steps.rb
+++ b/features/step_definitions/candidates/registrations/wizard_steps.rb
@@ -26,10 +26,10 @@ end
 
 Given("I have completed the contact information form") do
   visit path_for 'enter your contact details', school: @school
-  fill_in 'Building', with: 'Test house'
-  fill_in 'Street', with: 'Test street'
-  fill_in 'Town or city', with: 'Test Town'
-  fill_in 'County', with: 'Testshire'
+  fill_in 'Address line 1', with: 'Test house'
+  fill_in 'Address line 2 (optional)', with: 'Test street'
+  fill_in 'Town or city (optional)', with: 'Test Town'
+  fill_in 'County (optional)', with: 'Testshire'
   fill_in 'Postcode', with: 'TE57 1NG'
   fill_in 'UK telephone number', with: '01234567890'
   click_button 'Continue'
@@ -85,10 +85,10 @@ end
 
 Then("the contact information form should populated with the details I've entered so far") do
   visit path_for 'enter your contact details', school: @school
-  expect(find_field('Building').value).to eq 'Test house'
-  expect(find_field('Street').value).to eq 'Test street'
-  expect(find_field('Town or city').value).to eq 'Test Town'
-  expect(find_field('County').value).to eq 'Testshire'
+  expect(find_field('Address line 1').value).to eq 'Test house'
+  expect(find_field('Address line 2 (optional)').value).to eq 'Test street'
+  expect(find_field('Town or city (optional)').value).to eq 'Test Town'
+  expect(find_field('County (optional)').value).to eq 'Testshire'
   expect(find_field('Postcode').value).to eq 'TE57 1NG'
   expect(find_field('UK telephone number').value).to eq '01234567890'
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -64,9 +64,9 @@ Then("I should see a {string} link to the booking") do |link_text|
 end
 
 Then("the page title should be {string}") do |title|
-  title_suffix = "DfE School Experience"
+  title_suffix = "Get school experience - GOV.UK"
   expect(title).to be_present
-  expect(page.title).to eql([title, title_suffix].join(' | '))
+  expect(page.title).to eql([title, title_suffix].join(' - '))
 end
 
 Then("there should be a {string} warning") do |string|

--- a/spec/features/candidates/api_registrations_spec.rb
+++ b/spec/features/candidates/api_registrations_spec.rb
@@ -174,15 +174,15 @@ feature 'Candidate Registrations (via the API)', type: :feature do
       "/candidates/schools/#{school_urn}/registrations/contact_information/new"
 
     # Submit contact information form with errors
-    fill_in 'Building', with: ''
+    fill_in 'Address line 1', with: ''
     click_button 'Continue'
     expect(page).to have_text 'There is a problem'
 
     # Submit contact information form successfully
-    fill_in 'Building', with: 'Test house'
-    fill_in 'Street', with: 'Test street'
-    fill_in 'Town or city', with: 'Test Town'
-    fill_in 'County', with: 'Testshire'
+    fill_in 'Address line 1', with: 'Test house'
+    fill_in 'Address line 2 (optional)', with: 'Test street'
+    fill_in 'Town or city (optional)', with: 'Test Town'
+    fill_in 'County (optional)', with: 'Testshire'
     fill_in 'Postcode', with: 'TE57 1NG'
     fill_in 'UK telephone number', with: '01234567890'
     click_button 'Continue'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -113,19 +113,19 @@ describe ApplicationHelper, type: :helper do
     context 'with parameter' do
       subject! { page_heading('My Page Title') }
       it { is_expected.to eql('<h1 class="govuk-heading-l">My Page Title</h1>') }
-      it { expect(page_title).to eql('My Page Title | DfE School Experience') }
+      it { expect(page_title).to eql('My Page Title - Get school experience - GOV.UK') }
     end
 
     context 'with block' do
       subject! { page_heading { 'My Page Title' } }
       it { is_expected.to eql('<h1 class="govuk-heading-l">My Page Title</h1>') }
-      it { expect(page_title).to eql('My Page Title | DfE School Experience') }
+      it { expect(page_title).to eql('My Page Title - Get school experience - GOV.UK') }
     end
 
     context 'with custom options' do
       subject! { page_heading('Page Title', class: 'govuk-heading-xl') }
       it { is_expected.to eql('<h1 class="govuk-heading-xl">Page Title</h1>') }
-      it { expect(page_title).to eql('Page Title | DfE School Experience') }
+      it { expect(page_title).to eql('Page Title - Get school experience - GOV.UK') }
     end
   end
 

--- a/spec/services/candidates/registrations/contact_information_spec.rb
+++ b/spec/services/candidates/registrations/contact_information_spec.rb
@@ -17,12 +17,12 @@ describe Candidates::Registrations::ContactInformation, type: :model do
     context 'building' do
       it { is_expected.to validate_presence_of :building }
 
-      let(:too_long_msg) { 'Building must be 250 characters or fewer' }
+      let(:too_long_msg) { 'Address line 1 must be 250 characters or fewer' }
       it { is_expected.to validate_length_of(:building).is_at_most(250).with_message(too_long_msg) }
     end
 
     context 'street' do
-      let(:too_long_msg) { 'Street must be 250 characters or fewer' }
+      let(:too_long_msg) { 'Address line 2 must be 250 characters or fewer' }
 
       it { is_expected.to validate_length_of(:street).is_at_most(250).with_message(too_long_msg) }
     end


### PR DESCRIPTION
### Trello card

[Trello-607](https://trello.com/c/3bGRyQDV/607-fix-accessibility-issues-from-april-22-accessibility-report)

### Context

DAC flagged a number of WCAG Level AAA accessibility issues on the website; we want to fix these to give our users a better experience.

### Changes proposed in this pull request

- Add error summary to the school change form

This was missing and picked up by the DAC accessibility report.

- Update page title to be consistent with GOV services

The GOV.UK design system states that the title should be in the format:

```
Main heading - Service name - GOV.UK
```

- Ensure back links appear above the main content

This was flagged by the DAC audit; the back links should not be part of the main content.

I think we could do a more comprehensive clean up of this but this is the easiest/least likely to break solution for now.

- Update address inputs to match design system

Set the labels to match the design system, ensuring its clear to the user which are optional.

- Reposition error summary above heading

As per the GOV.UK design system.

- Make phone field input type tel

This will mean a numerical keyboard will be presented on mobile devices, which makes it easier to input.

- Remove duplicate main elements

The application layout contains a `<main>` tag, so there's no need to have another in the views.

### Guidance to review

