### PR TITLE
Improve error message when DfE sign in callback fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -464,6 +464,14 @@ jobs:
           ARM_ACCESS_KEY:    ${{ secrets.ARM_ACCESS_KEY }}
           GITHUB_TOKEN:      ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine DfE Sign In Message
+        uses: haya14busa/action-cond@v1
+        id: dsiMessage
+        with:
+          cond: ${{ env.STATIC_ROUTE != '' }}
+          if_true: ':white_check_mark: DfE sign in route obtained: https://${{env.STATIC_ROUTE}}.london.cloudapps.digital'
+          if_false: ':warning: **DfE sign in route pool exhausted (close some open PRs!)**'
+
       - name: Post sticky pull request comment
         if: matrix.environment == 'Review'
         uses: marocchino/sticky-pull-request-comment@v2
@@ -471,7 +479,7 @@ jobs:
           recreate: true
           message: |
                    Review app deployed to https://${{env.REVIEW_APPLICATION}}-${{github.event.number}}.${{env.DOMAIN}}
-                   Static DFE_SIGNIN Path used https://${{env.STATIC_ROUTE}}.london.cloudapps.digital
+                   ${{ steps.dsiMessage.outputs.value }}
 
       - name: Add Review Label
         if: matrix.environment == 'Review' && contains(github.event.pull_request.user.login, 'dependabot') == false


### PR DESCRIPTION
[Trello-602](https://trello.com/c/adaiTcHo/602-improve-error-message-when-dfe-sign-in-redirect-url-was-not-obtained)

We have a pool of 20 routes available for DfE sign in; when a review app builds it locks one of the routes. If we have more than 20 PRs open then new PRs will fail to obtain a DfE sign in route - its not currently clear what the issue is when this happens.

Update the Slack message to indicate if a DfE sign in route was successfully obtained or not.

#### Success

<img width="917" alt="Screenshot 2022-06-24 at 10 24 13" src="https://user-images.githubusercontent.com/29867726/175506228-805660d3-b319-4832-8bdf-d3d8cfd94317.png">

#### Failure

<img width="909" alt="Screenshot 2022-06-24 at 10 07 49" src="https://user-images.githubusercontent.com/29867726/175503799-c97594e9-7b37-4cac-aeec-3923f1c43f10.png">

