### PR TITLE
Add a heart beat scheduled job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ COPY .ruby-version Gemfile Gemfile.lock ./
 # hadolint ignore=SC2046
 RUN gem install bundler --version='~> 2.3.4' && \
     bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java && \
-    bundle config set without 'development' && \
     bundle install --jobs=$(nproc --all) && \
     rm -rf /root/.bundle/cache && \
     rm -rf /usr/local/bundle/cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ruby:3.1.0-alpine3.15
-# remove upgrade zlib-dev & busybox when ruby:3.1.0-alpine3.15 base image is updated to address snyk vuln https://snyk.io/vuln/SNYK-ALPINE315-ZLIB-2434420
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \
@@ -19,8 +18,9 @@ ARG SHA
 RUN echo "sha-${SHA}" > /etc/school-experience-sha
 
 # remove upgrade zlib-dev & busybox when ruby:3.1.0-alpine3.15 base image is updated to address snyk vuln https://snyk.io/vuln/SNYK-ALPINE315-ZLIB-2434420
+# also https://security.snyk.io/vuln/SNYK-ALPINE315-NCURSES-2952568
 # hadolint ignore=DL3018
-RUN apk update && apk add -Uu --no-cache zlib-dev busybox
+RUN apk update && apk add -Uu --no-cache zlib-dev busybox ncurses
 
 # hadolint ignore=DL3018
 RUN apk add -U --no-cache bash build-base git tzdata libxml2 libxml2-dev \

--- a/app/jobs/cron/heart_beat_job.rb
+++ b/app/jobs/cron/heart_beat_job.rb
@@ -1,0 +1,7 @@
+class Cron::HeartBeatJob < CronJob
+  self.cron_expression = "* * * * *"
+
+  def perform
+    Yabeda.gse.delayed_job_heart_beat.increment({}, by: 1)
+  end
+end

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -1,3 +1,9 @@
+if Rails.env.test?
+  # Default tags are not important in test but this ensures
+  # our custom metrics are setup/testable.
+  ENV["VCAP_APPLICATION"] ||= "{}"
+end
+
 if ENV.key?("VCAP_APPLICATION")
   vcap_config = JSON.parse(ENV["VCAP_APPLICATION"])
 
@@ -6,5 +12,9 @@ if ENV.key?("VCAP_APPLICATION")
     default_tag :app_instance, ENV["CF_INSTANCE_INDEX"]
     default_tag :organisation, vcap_config["organization_name"]
     default_tag :space, vcap_config["space_name"]
+
+    group :gse do
+      counter :delayed_job_heart_beat, comment: "Counter for a delayed job heart beat/monitoring"
+    end
   end
 end

--- a/spec/jobs/cron/heart_beat_job_spec.rb
+++ b/spec/jobs/cron/heart_beat_job_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe Cron::HeartBeatJob, type: :job do
+  it "runs every minute" do
+    expect(described_class.cron_expression).to eq("* * * * *")
+  end
+
+  describe "#perform" do
+    let(:school_sync_instance) { double Object, sync: true }
+
+    subject(:perform) { described_class.new.perform }
+
+    it "increments the delayed_job_heart_beat metric" do
+      expect { perform }.to increment_yabeda_counter(Yabeda.gse.delayed_job_heart_beat).by(1)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ end
 
 require 'rspec/rails'
 require 'webmock/rspec'
+require 'yabeda/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
### Trello card

[Trello-632](https://trello.com/c/ABJDfPlN/632-investigate-issues-with-alerting-in-gse-failed-jobs-and-queue)

### Context

Our delayed job worker occasionally hangs/crashes in production, resulting in candidate emails not going out. We have monitoring to catch this at the moment however its not firing reliably (we use pending job count however GSE sometimes bulk-enqueues a batch meaning we have a high-threshold). 

The purpose of this job is to simply provide a 'heart beat' counter metric that fires from a delayed job on a consistent schedule; that way we can infer that the worker has crashed if the metric does not increment over a short period of
time (a couple of minutes). We should then get a near-instant notification when our worker fails.

### Changes proposed in this pull request

- Add a heart beat scheduled job

### Guidance to review

