### PR TITLE
Fix default docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ print-infra-secrets: install-fetch-config set-azure-account
 	./fetch_config.rb -s azure-key-vault-secret:${KEY_VAULT}/${INFRA_SECRETS}  -f yaml
 
 terraform-init: set-azure-account
-	$(if $(or $(IMAGE_TAG), $(NO_IMAGE_TAG_DEFAULT)), , $(eval export IMAGE_TAG=main))
+	$(if $(or $(IMAGE_TAG), $(NO_IMAGE_TAG_DEFAULT)), , $(eval export IMAGE_TAG=master))
 	$(if $(IMAGE_TAG), , $(error Missing environment variable "IMAGE_TAG"))
 	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/schools-experience:$(IMAGE_TAG))
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/FvvgC3LY

### Context
Bug fix

### Changes proposed in this pull request
The default branch is master so the default image is master, not main

### Guidance to review

