### PR TITLE
Default school availability and backfill existing data

### DIFF
--- a/app/helpers/candidates/school_helper.rb
+++ b/app/helpers/candidates/school_helper.rb
@@ -72,7 +72,7 @@ module Candidates::SchoolHelper
   end
 
   def format_school_availability(availability_info)
-    availability_info.present? ? safe_format(availability_info) : 'No information supplied'
+    safe_format(availability_info)
   end
 
   def format_phases(school)

--- a/app/helpers/schools/dashboards_helper.rb
+++ b/app/helpers/schools/dashboards_helper.rb
@@ -32,11 +32,6 @@ module Schools::DashboardsHelper
       school.bookings_placement_dates.available.none?
   end
 
-  def show_no_availability_info_warning?(school)
-    !school.availability_preference_fixed? &&
-      school.availability_info.blank?
-  end
-
   def status_column_size(status)
     {
       disabled: 'govuk-grid-column-one-third',

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -274,7 +274,7 @@ private
   end
 
   def has_available_flex_dates?
-    !availability_preference_fixed? && availability_info?
+    !availability_preference_fixed?
   end
 
   def nilify_availability_info

--- a/app/views/schools/dashboards/_profile_status.html.erb
+++ b/app/views/schools/dashboards/_profile_status.html.erb
@@ -4,8 +4,4 @@
   <% if show_no_placement_dates_warning?(@current_school) %>
     <%= render partial: 'status', locals: { type: :enabled_without_dates} %>
   <% end %>
-
-  <% if show_no_availability_info_warning?(@current_school) %>
-    <%= render partial: 'status', locals: { type: :enabled_without_availability} %>
-  <% end %>
 <% end %>

--- a/app/views/schools/dashboards/_status.html.erb
+++ b/app/views/schools/dashboards/_status.html.erb
@@ -9,13 +9,6 @@
         <%= link_to 'add experience dates',
           schools_placement_dates_path, class: 'govuk-link' %>.
       </p>
-    <% elsif type == :enabled_without_availability %>
-      <p>
-        You have no upcoming placement dates or information about availability.
-        Your profile will not appear in candidate searches.
-        <%= link_to 'Add dates or availability',
-          edit_schools_availability_preference_path, class: 'govuk-link' %>.
-      </p>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-third">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,10 @@ en:
         unit: '£'
         delimiter: ''
 
+  defaults:
+    bookings_school:
+      availability_info: This school has not yet provided their availability for offering school experience. You can still request experience with this school and they will contact you when they have availability.
+
   subject_and_date_information_errors: &subject_and_date_information_errors
     attributes:
       bookings_placement_date_id:

--- a/db/migrate/20220810101108_add_default_to_bookings_school_availability.rb
+++ b/db/migrate/20220810101108_add_default_to_bookings_school_availability.rb
@@ -1,0 +1,22 @@
+class AddDefaultToBookingsSchoolAvailability < ActiveRecord::Migration[7.0]
+  def up
+    change_column_default :bookings_schools, :availability_info, default_availability_info
+    change_column_default :bookings_schools, :experience_type, :inschool
+
+    Bookings::School.where(availability_info: nil).update_all(availability_info: default_availability_info)
+    Bookings::School.where(experience_type: nil).update_all(experience_type: :inschool)
+  end
+
+  def down
+    change_column_default :bookings_schools, :availability_info, nil
+    change_column_default :bookings_schools, :experience_type, nil
+
+    Bookings::School.where(availability_info: default_availability_info).update_all(availability_info: nil)
+  end
+
+private
+
+  def default_availability_info
+    I18n.t("defaults.bookings_school.availability_info")
+  end
+end

--- a/db/migrate/20220810142124_make_availability_info_and_experience_type_not_nullable.rb
+++ b/db/migrate/20220810142124_make_availability_info_and_experience_type_not_nullable.rb
@@ -1,0 +1,6 @@
+class MakeAvailabilityInfoAndExperienceTypeNotNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :bookings_schools, :availability_info, false
+    change_column_null :bookings_schools, :experience_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_08_10_101108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
   enable_extension "plpgsql"
@@ -22,8 +21,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.integer "bookings_subject_id", null: false
     t.integer "bookings_placement_request_id", null: false
     t.integer "bookings_school_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "placement_details"
     t.string "contact_name"
     t.string "contact_number"
@@ -31,7 +30,7 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.text "location"
     t.string "candidate_instructions"
     t.integer "duration", default: 1, null: false
-    t.datetime "accepted_at"
+    t.datetime "accepted_at", precision: nil
     t.boolean "attended"
     t.string "experience_type"
     t.index ["bookings_placement_request_id"], name: "index_bookings_bookings_on_bookings_placement_request_id", unique: true
@@ -41,17 +40,17 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
 
   create_table "bookings_candidates", force: :cascade do |t|
     t.uuid "gitis_uuid", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "confirmed_at"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "confirmed_at", precision: nil
     t.boolean "created_in_gitis", default: false
     t.index ["gitis_uuid"], name: "index_bookings_candidates_on_gitis_uuid", unique: true
   end
 
   create_table "bookings_phases", force: :cascade do |t|
     t.string "name", limit: 32, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "position"
     t.integer "edubase_id"
     t.boolean "supports_subjects", default: true, null: false
@@ -62,21 +61,21 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
   create_table "bookings_placement_date_subjects", force: :cascade do |t|
     t.bigint "bookings_placement_date_id"
     t.bigint "bookings_subject_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["bookings_placement_date_id"], name: "index_placement_date_subject_on_date_id"
     t.index ["bookings_subject_id"], name: "index_placement_date_subject_on_subject_id"
   end
 
   create_table "bookings_placement_dates", force: :cascade do |t|
     t.date "date", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "duration", default: 1, null: false
     t.boolean "active", default: true, null: false
     t.integer "bookings_school_id", null: false
     t.integer "max_bookings_count"
-    t.datetime "published_at"
+    t.datetime "published_at", precision: nil
     t.boolean "subject_specific", default: false, null: false
     t.boolean "supports_subjects"
     t.boolean "virtual"
@@ -90,12 +89,12 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
   create_table "bookings_placement_request_cancellations", force: :cascade do |t|
     t.bigint "bookings_placement_request_id"
     t.text "reason"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "cancelled_by", null: false
-    t.datetime "sent_at"
+    t.datetime "sent_at", precision: nil
     t.text "extra_details"
-    t.datetime "viewed_at"
+    t.datetime "viewed_at", precision: nil
     t.string "rejection_category"
     t.index ["bookings_placement_request_id"], name: "index_cancellations_on_bookings_placement_request_id", unique: true
     t.index ["rejection_category"], name: "index_bookings_placement_request_cancellations_category"
@@ -111,17 +110,17 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.string "subject_first_choice", null: false
     t.string "subject_second_choice", null: false
     t.boolean "has_dbs_check", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "availability"
     t.integer "bookings_placement_date_id"
     t.integer "bookings_school_id"
     t.string "token"
     t.uuid "analytics_tracking_uuid"
-    t.datetime "viewed_at"
+    t.datetime "viewed_at", precision: nil
     t.bigint "candidate_id"
     t.bigint "bookings_subject_id"
-    t.datetime "under_consideration_at"
+    t.datetime "under_consideration_at", precision: nil
     t.string "experience_type"
     t.index ["bookings_placement_date_id"], name: "index_bookings_placement_requests_on_bookings_placement_date_id"
     t.index ["bookings_school_id"], name: "index_bookings_placement_requests_on_bookings_school_id"
@@ -171,8 +170,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.text "other_fee_description"
     t.string "other_fee_interval"
     t.text "other_fee_payment_method"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.text "flexible_on_times_details"
     t.string "admin_contact_email_secondary"
     t.boolean "dbs_requires_check"
@@ -196,8 +195,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.integer "page"
     t.integer "number_of_results", default: 0
     t.geography "coordinates", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.uuid "analytics_tracking_uuid"
     t.integer "dbs_policies", array: true
     t.boolean "disability_confident"
@@ -207,16 +206,16 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
   create_table "bookings_school_types", force: :cascade do |t|
     t.string "name", limit: 64, null: false
     t.integer "edubase_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["name"], name: "index_bookings_school_types_on_name", unique: true
   end
 
   create_table "bookings_schools", force: :cascade do |t|
     t.string "name", limit: 128, null: false
     t.geography "coordinates", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "fee", default: 0, null: false
     t.integer "urn", null: false
     t.string "website"
@@ -232,13 +231,13 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.boolean "teacher_training_provider", default: false, null: false
     t.text "teacher_training_info"
     t.text "primary_key_stage_info"
-    t.text "availability_info"
+    t.text "availability_info", default: "This school has not yet provided their availability for offering school experience.\nYou can still request experience with this school and they will contact you when they have availability\n"
     t.string "teacher_training_website"
     t.boolean "enabled", default: false, null: false
     t.boolean "availability_preference_fixed", default: false
     t.integer "views", default: 0, null: false
     t.uuid "dfe_signin_organisation_uuid"
-    t.string "experience_type"
+    t.string "experience_type", default: "inschool"
     t.index ["coordinates"], name: "index_bookings_schools_on_coordinates", using: :gist
     t.index ["name"], name: "index_bookings_schools_on_name"
     t.index ["urn"], name: "index_bookings_schools_on_urn", unique: true
@@ -247,23 +246,23 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
   create_table "bookings_schools_phases", force: :cascade do |t|
     t.integer "bookings_school_id", null: false
     t.integer "bookings_phase_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["bookings_school_id", "bookings_phase_id"], name: "index_bookings_schools_phases_school_id_and_phase_id", unique: true
   end
 
   create_table "bookings_schools_subjects", force: :cascade do |t|
     t.integer "bookings_school_id", null: false
     t.integer "bookings_subject_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["bookings_school_id", "bookings_subject_id"], name: "index_bookings_schools_subjects_school_id_and_subject_id", unique: true
   end
 
   create_table "bookings_subjects", force: :cascade do |t|
     t.string "name", limit: 64, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.boolean "hidden", default: false
     t.boolean "secondary_subject", default: true, null: false
     t.index ["hidden"], name: "index_bookings_subjects_on_hidden"
@@ -277,18 +276,18 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.boolean "influenced_decision"
     t.boolean "intends_to_apply"
     t.integer "effect_on_decision"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["bookings_booking_id"], name: "index_candidates_booking_feedbacks_on_bookings_booking_id", unique: true
   end
 
   create_table "candidates_session_tokens", force: :cascade do |t|
     t.string "token", null: false
     t.bigint "candidate_id", null: false
-    t.datetime "expired_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "confirmed_at"
+    t.datetime "expired_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "confirmed_at", precision: nil
     t.index ["candidate_id"], name: "index_candidates_session_tokens_on_candidate_id"
     t.index ["token"], name: "index_candidates_session_tokens_on_token", unique: true
   end
@@ -298,13 +297,13 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.integer "attempts", default: 0, null: false
     t.text "handler", null: false
     t.text "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
+    t.datetime "run_at", precision: nil
+    t.datetime "locked_at", precision: nil
+    t.datetime "failed_at", precision: nil
     t.string "locked_by"
     t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "cron"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
@@ -314,8 +313,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.string "event_type", null: false
     t.integer "recordable_id"
     t.string "recordable_type"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "bookings_candidate_id"
     t.index ["bookings_candidate_id"], name: "index_events_on_bookings_candidate_id"
     t.index ["bookings_school_id"], name: "index_events_on_bookings_school_id"
@@ -327,8 +326,8 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
     t.text "reason_for_using_service_explanation"
     t.integer "rating", null: false
     t.text "improvements"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.integer "urn"
     t.boolean "successful_visit"
     t.text "unsuccessful_visit_explanation"
@@ -338,16 +337,16 @@ ActiveRecord::Schema[6.1].define(version: 2022_03_10_115236) do
   create_table "schools_on_boarding_profile_subjects", force: :cascade do |t|
     t.bigint "schools_school_profile_id"
     t.bigint "bookings_subject_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["bookings_subject_id"], name: "index_profile_subjects_on_school_profile_i"
     t.index ["schools_school_profile_id", "bookings_subject_id"], name: "index_profile_subjects_school_profile_id_and_subject_id", unique: true
     t.index ["schools_school_profile_id"], name: "index_profile_subjects_on_school_profile_id"
   end
 
   create_table "schools_school_profiles", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "candidate_requirement_dbs_requirement"
     t.text "candidate_requirement_dbs_policy"
     t.boolean "candidate_requirement_requirements"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -231,7 +231,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_10_142124) do
     t.boolean "teacher_training_provider", default: false, null: false
     t.text "teacher_training_info"
     t.text "primary_key_stage_info"
-    t.text "availability_info", default: "This school has not yet provided their availability for offering school experience.\nYou can still request experience with this school and they will contact you when they have availability\n", null: false
+    t.text "availability_info", default: "This school has not yet provided their availability for offering school experience. You can still request experience with this school and they will contact you when they have availability.", null: false
     t.string "teacher_training_website"
     t.boolean "enabled", default: false, null: false
     t.boolean "availability_preference_fixed", default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_10_101108) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_10_142124) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
   enable_extension "plpgsql"
@@ -231,13 +231,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_10_101108) do
     t.boolean "teacher_training_provider", default: false, null: false
     t.text "teacher_training_info"
     t.text "primary_key_stage_info"
-    t.text "availability_info", default: "This school has not yet provided their availability for offering school experience.\nYou can still request experience with this school and they will contact you when they have availability\n"
+    t.text "availability_info", default: "This school has not yet provided their availability for offering school experience.\nYou can still request experience with this school and they will contact you when they have availability\n", null: false
     t.string "teacher_training_website"
     t.boolean "enabled", default: false, null: false
     t.boolean "availability_preference_fixed", default: false
     t.integer "views", default: 0, null: false
     t.uuid "dfe_signin_organisation_uuid"
-    t.string "experience_type", default: "inschool"
+    t.string "experience_type", default: "inschool", null: false
     t.index ["coordinates"], name: "index_bookings_schools_on_coordinates", using: :gist
     t.index ["name"], name: "index_bookings_schools_on_name"
     t.index ["urn"], name: "index_bookings_schools_on_urn", unique: true

--- a/features/candidates/registrations/availability_preference.feature
+++ b/features/candidates/registrations/availability_preference.feature
@@ -22,11 +22,6 @@ Feature: Availability preference
         When I am on the 'Availability preference' page for my school of choice
         Then I should see a warning containing the availability information
 
-    Scenario: No warning should be displayed if the availability information is absent
-        Given my school has no availability information set
-        When I am on the 'Availability preference' page for my school of choice
-        Then I should see no warning containing the availability information
-
     @javascript
     Scenario: Word counting in placement objectives
         Given I am on the 'Availability preference' page for my school of choice

--- a/features/candidates/schools/show/full_school_details.feature
+++ b/features/candidates/schools/show/full_school_details.feature
@@ -66,11 +66,6 @@ Feature: School show page (enhanced data)
             """
         When I am on the profile page for the chosen school
         Then I should see availability information
-
-    Scenario: Placement availability
-        Given the chosen school has no availability information
-        When I am on the profile page for the chosen school
-        Then the availability information should read 'No information supplied'
     
     Scenario: DBS Check info
         Given I am on the profile page for the chosen school

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -140,15 +140,6 @@ Feature: The School Dashboard
         Then there should be a status notification for missing dates
         And there should be a 'add experience dates' link to the 'placement dates'
 
-    Scenario: Displaying a warning when flexible with no description
-        Given my school has fully-onboarded
-        And my school is enabled
-        And it has 'flexible' availability
-        And my school has no availability information set
-        When I am on the 'schools dashboard' page
-        Then there should be a status notification for missing availability
-        And there should be a 'Add dates or availability' link to the 'availability preferences'
-
     Scenario: Display CTA when in a school group
         Given my school is part of a group of schools
         When I am on the 'schools dashboard' page

--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -41,11 +41,6 @@ Then("I should see a warning containing the availability information") do
   end
 end
 
-Given("my school has no availability information set") do
-  @school ||= FactoryBot.create(:bookings_school)
-  @school.update! availability_info: nil
-end
-
 Then("I should see no warning containing the availability information") do
   expect(page).not_to have_css('section.govuk-se-warning')
 end

--- a/features/step_definitions/candidates/schools/show_steps.rb
+++ b/features/step_definitions/candidates/schools/show_steps.rb
@@ -152,11 +152,6 @@ Then("the placement information section should not be visible") do
   expect(page).not_to have_css("#school-placement-info")
 end
 
-Given("the chosen school has no availability information") do
-  @school.update!(availability_info: nil, availability_preference_fixed: false)
-  expect(@school.availability_info).to be_nil
-end
-
 Then("the availability information should read {string}") do |string|
   within("#placement-availability") do
     expect(page).to have_css('p', text: string)

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -29,8 +29,7 @@ FactoryBot.define do
     end
 
     trait :without_availability do
-      availability_info { nil }
-      experience_type { nil }
+      availability_preference_fixed { true }
     end
 
     trait :with_fixed_availability_preference do

--- a/spec/helpers/schools/dashboards_helper_spec.rb
+++ b/spec/helpers/schools/dashboards_helper_spec.rb
@@ -97,35 +97,6 @@ describe Schools::DashboardsHelper, type: 'helper' do
     end
   end
 
-  context '#show_no_availability_info_warning?' do
-    context 'when availability preference is flexible and availability info present' do
-      let(:school) { create(:bookings_school) }
-      subject { show_no_availability_info_warning?(school) }
-
-      specify 'should be false' do
-        expect(subject).to be false
-      end
-    end
-
-    context 'when availability preference is fixed and availability info is present' do
-      let(:school) { create(:bookings_school, :with_fixed_availability_preference) }
-      subject { show_no_availability_info_warning?(school) }
-
-      specify 'should be false' do
-        expect(subject).to be false
-      end
-    end
-
-    context 'when availability preference is not fixed and dates are not available' do
-      let(:school) { create(:bookings_school, availability_info: nil) }
-      subject { show_no_availability_info_warning?(school) }
-
-      specify 'should be true' do
-        expect(subject).to be true
-      end
-    end
-  end
-
   context '#not_onboarded_warning' do
     let(:school) { create(:bookings_school) }
     context 'when the school has placement requests' do


### PR DESCRIPTION
### Trello card

[Trello-629](https://trello.com/c/xBEYXmhr/629-make-flexible-dates-the-default-for-all-future-schools-with-placeholder-text)

### Context

We want new schools to have preset availability info text and accept in-school bookings by default. We also want existing schools that have not specified availability info text/experience type to be backfilled with the defaults.

### Changes proposed in this pull request

- Default school availability and backfill existing data

Add migration to default the `availability_info` text and set `experience_type` to in-school.

Backfill existing data to set defaults when the `availability_info` has not yet been specified by the user. Supports rolling back the `availability_info`, however we will not be able to determine the previous `experience_type` in all cases so this will remain as in-school. Using `update_all` without batching should be fine as it'll result in a single SQL query to do the update.

The schema has been updated to add a default precision to datetime attributes (the default is `nil` and will use the database default, so no change); this appears to be Rails 7 behaviour and must have been missed during the upgrade.

### Guidance to review

I initially tried defaulting this in the model so that I could test it but it wasn't playing nice with the `activerecord-import` gem we use to mass import school data. I thought about breaking the backfill out into a rake task but it looks like we usually just let it run as part of the migrations, so opted to keep it consistent.

Testing this is a bit tricky; on staging you can SSH into the box and start a Rails console to verify the data looks correct:

```
cf ssh review-school-experience-2610
cd /app
export PATH=${PATH}:/usr/local/bin
bundle exec rails c
Bookings::School.where(availability_info: nil).count # 0
Bookings::School.where(experience_type: nil).count # 0
Bookings::School.where("availability_info LIKE '%not yet provided their availability%'").count #48014
Bookings::School.where("availability_info NOT LIKE '%not yet provided their availability%'").count # 291
```

The upshot of this change is that any schools that had onboarded but not yet set a flexible date description will now appear in search results; there are 67 such schools and the Trello ticket has been updated with anonymised information for these schools.