### PR TITLE
[660] Remove extra delayed_jobs route

### DIFF
--- a/terraform/paas/application.tf
+++ b/terraform/paas/application.tf
@@ -16,7 +16,7 @@ locals {
 resource "cloudfoundry_app" "application" {
   name              = var.paas_application_name
   space             = data.cloudfoundry_space.space.id
-  command           = "/app/docker-entrypoint.sh ${var.FRONTEND}" 
+  command           = "/app/docker-entrypoint.sh ${var.FRONTEND}"
   docker_image      = var.paas_docker_image
   stopped           = var.application_stopped
   instances         = var.application_instances
@@ -79,10 +79,6 @@ resource "cloudfoundry_app" "delayed_jobs" {
     content {
       service_instance = service_binding.value["id"]
     }
-  }
-
-  routes {
-    route = cloudfoundry_route.route_delayed_internal.id
   }
 
   dynamic "routes" {

--- a/terraform/paas/route.tf
+++ b/terraform/paas/route.tf
@@ -17,12 +17,6 @@ resource "cloudfoundry_route" "route_internal" {
   space    = data.cloudfoundry_space.space.id
 }
 
-resource "cloudfoundry_route" "route_delayed_internal" {
-  domain   = data.cloudfoundry_domain.internal.id
-  hostname = "${var.paas_application_name}-delayed-internal"
-  space    = data.cloudfoundry_space.space.id
-}
-
 resource "cloudfoundry_route" "route_delayed" {
   count    = var.delayed_jobs
   domain   = data.cloudfoundry_domain.internal.id
@@ -31,7 +25,7 @@ resource "cloudfoundry_route" "route_delayed" {
 }
 
 resource "cloudfoundry_route" "static_route" {
-  count    = var.static_route == "" ? 0 :1 
+  count    = var.static_route == "" ? 0 :1
   domain   = data.cloudfoundry_domain.cloudapps.id
   hostname = var.static_route
   space    = data.cloudfoundry_space.space.id


### PR DESCRIPTION
### Trello card
https://trello.com/c/KqqWtveD

### Context
Delete review app failures:
- https://github.com/DFE-Digital/schools-experience/runs/7802362758?check_suite_focus=true
- https://github.com/DFE-Digital/schools-experience/runs/7802807874?check_suite_focus=true

### Changes proposed in this pull request
Delete the redundant delayed_jobs route

### Guidance to review
Run terraform plan
