### PR TITLE
Remove existing StatusCake alerts

### DIFF
--- a/terraform/paas/production.env.tfvars
+++ b/terraform/paas/production.env.tfvars
@@ -14,16 +14,3 @@ azure_key_vault           = "s105p01-kv"
 azure_resource_group      = "s105p01-prod-vault-resource-group"
 database_plan             = "small-ha-13"
 redis_1_plan              = "micro-ha-5_x"
-
-alerts = {
-  SchoolExperience_Production = {
-    website_name   = "School Experience (Production)"
-    website_url    = "https://schoolexperience.education.gov.uk/healthcheck.json"
-    test_type      = "HTTP"
-    check_rate     = 60
-    contact_group  = [239498]
-    trigger_rate   = 0
-    confirmations  = 2
-    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-  }
-}

--- a/terraform/paas/staging.env.tfvars
+++ b/terraform/paas/staging.env.tfvars
@@ -12,15 +12,3 @@ application_environment   = "dfe-school-experience-staging"
 database_plan             = "small-13"
 azure_key_vault           = "s105t01-kv"
 azure_resource_group      = "s105t01-staging-vault-resource-group"
-alerts = {
-  SchoolExperience_Staging = {
-    website_name   = "School Experience (Staging)"
-    website_url    = "https://school-experience-app-staging.london.cloudapps.digital/healthcheck.json"
-    test_type      = "HTTP"
-    check_rate     = 60
-    contact_group  = [239498]
-    trigger_rate   = 0
-    confirmations  = 2
-    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
-  }
-}


### PR DESCRIPTION
### Context
Remove the existing alerts so we can create them again using the new resource compatible with the updated StatusCake Terraform provider. These will be re-added in a subsequent https://github.com/DFE-Digital/schools-experience/pull/2616

### Changes proposed in this pull request
Removal of production and staging StatusCake alerts

### Guidance to review

