### PR TITLE
Disable role checking via rolecheck feature flag

### DIFF
--- a/app/services/schools/dfe_sign_in_api/role_checked_organisations.rb
+++ b/app/services/schools/dfe_sign_in_api/role_checked_organisations.rb
@@ -28,6 +28,8 @@ module Schools
       end
 
       def has_role?(org_uuid, _org_urn)
+        return true unless Schools::DFESignInAPI::Client.role_check_enabled?
+
         Roles.new(user_uuid, org_uuid).has_school_experience_role?
       end
     end

--- a/app/views/pages/_request_organisation_access.html.erb
+++ b/app/views/pages/_request_organisation_access.html.erb
@@ -13,20 +13,4 @@
     <%= govuk_link_to "Request access to a school",
           Schools::ChangeSchool.request_approval_url %>
   </p>
-
-  <details class="govuk-details" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-      If you receive an error saying "You are already linked to this organisation"
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-      This error means you've been associated with this school on DfE Sign In, but you need to have School Experience added to your account by an approver.
-
-      You can request this on DfE Sign In in the 'Services' section.
-      <div class="govuk-!-margin-top-5">
-        <%= govuk_link_to 'Request access to School Experience', @dfe_sign_in_add_service_url %>
-      </div>
-    </div>
-  </details>
 </section>

--- a/spec/controllers/schools/change_schools_controller_spec.rb
+++ b/spec/controllers/schools/change_schools_controller_spec.rb
@@ -35,19 +35,6 @@ describe Schools::ChangeSchoolsController, type: :request do
       let(:current_urn) { nil }
       it { is_expected.to have_http_status :success }
       it { is_expected.to have_rendered :show }
-
-      context 'when add service url is set' do
-        let(:dfe_sign_in_url) { "www.dfe-sign-in.com/sign-in-service" }
-        before do
-          allow(Rails.application.config.x).to receive(:dfe_sign_in_add_service_url) do
-            dfe_sign_in_url
-          end
-        end
-
-        it 'renders the URL' do
-          expect(subject.body).to include(dfe_sign_in_url)
-        end
-      end
     end
   end
 

--- a/spec/services/schools/dfe_sign_in_api/role_checked_organisations_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/role_checked_organisations_spec.rb
@@ -11,6 +11,8 @@ describe Schools::DFESignInAPI::RoleCheckedOrganisations, type: :model do
   let(:rolecheck) { Schools::DFESignInAPI::Roles }
 
   before do
+    allow(Schools::DFESignInAPI::Client).to receive(:role_check_enabled?).and_return(true)
+
     allow(orgcheck).to receive(:new) { double(orgcheck, uuids: uuidmap) }
 
     allow(rolecheck).to receive(:new) \
@@ -38,5 +40,24 @@ describe Schools::DFESignInAPI::RoleCheckedOrganisations, type: :model do
 
   describe '#organisation_urns' do
     it { is_expected.to have_attributes organisation_urns: [1, 3] }
+  end
+
+  context "when role check is disabled" do
+    before { allow(Schools::DFESignInAPI::Client).to receive(:role_check_enabled?).and_return(false) }
+
+    describe '#organisation_uuid_pairs' do
+      it "includes all uuids" do
+        is_expected.to have_attributes \
+          organisation_uuid_pairs: { org1 => 1, org2 => 2, org3 => 3, org4 => 4 }
+      end
+    end
+
+    describe '#organisation_uuids' do
+      it { is_expected.to have_attributes organisation_uuids: [org1, org2, org3, org4] }
+    end
+
+    describe '#organisation_urns' do
+      it { is_expected.to have_attributes organisation_urns: [1, 2, 3, 4] }
+    end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-636](https://trello.com/c/hJhmEc45/636-create-a-feature-flag-for-the-role-checker-code)

### Context

We have an existing feature flag `rolecheck` that appears to disable the role checking for the initial sign in process.

Once signed in we appear to use the `Schools::DFESignInAPI::RoleCheckedOrganisations` module to scope down the available schools so that the user can only access the schools that they have the GSE role enabled for in DFE sign in.

Going forward we want to disable role checking, so that a user will have access to the GSE application if they have access to that school within DFE sign in (removing the need to get a second stage of approval for using the GSE app).

### Changes proposed in this pull request

- Disable role checking via `rolecheck` feature flag

Re-purpose `rolecheck` feature flag; when disabled (which it is on all environments currently) users will not need the GSE service role in order to access a school; they will only need to be assigned to the school in DFE sign in.

### Guidance to review

It's a bit tricky to review, but essentially you need to request access to a new school in preprod and have your request approved. It should then appear in the school switcher menu and allow access _without_ getting the School Experience role setup for that school. I've done this in preprod and verified it worked as expected.