### PR TITLE
Rework checkboxes to improve spacing

### DIFF
--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -14,15 +14,9 @@
         Select all that apply.
       </p>
 
-      <%= f.govuk_check_boxes_fieldset :early_years, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :early_years, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :key_stage_1, multiple: false, legend: nil do %>
+      <%= f.govuk_check_boxes_fieldset :key_stages, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :early_years, 1, 0, multiple: false, link_errors: true %>
         <%= f.govuk_check_box :key_stage_1, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :key_stage_2, multiple: false, legend: nil do %>
         <%= f.govuk_check_box :key_stage_2, 1, 0, multiple: false %>
       <% end %>
 

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -14,19 +14,10 @@
         Select all that apply.
       </p>
 
-      <%= f.govuk_check_boxes_fieldset :primary, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :primary, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :secondary, multiple: false, legend: nil do %>
+      <%= f.govuk_check_boxes_fieldset :phases, multiple: false, legend: nil do %>
+        <%= f.govuk_check_box :primary, 1, 0, multiple: false, link_errors: true %>
         <%= f.govuk_check_box :secondary, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :secondary_and_college, multiple: false, legend: nil do %>
         <%= f.govuk_check_box :secondary_and_college, 1, 0, multiple: false %>
-      <% end %>
-
-      <%= f.govuk_check_boxes_fieldset :college, multiple: false, legend: nil do %>
         <%= f.govuk_check_box :college, 1, 0, multiple: false %>
       <% end %>
 

--- a/app/webpacker/stylesheets/school-profile.scss
+++ b/app/webpacker/stylesheets/school-profile.scss
@@ -66,10 +66,3 @@
     width: 100%;
   }
 }
-
-.candidate-requirements-selection {
-  .govuk-form-group {
-    margin-bottom: 10px;
-    min-height: 50px;
-  }
-}


### PR DESCRIPTION
### Trello card

[Trello-589](https://trello.com/c/hq890weE/589-fix-spacing-between-checkboxes)

### Context

The checkboxes are styled as individual fieldsets as they map to different underlying attributes. With the formbuilder this results in larger spacing between checkboxes than elsewhere on the website. Instead, we can group the checkboxes in a single fieldset (using a generic key) and it will result in the correct spacing to match other areas of the site.

### Changes proposed in this pull request

- Rework checkboxes to improve spacing

### Guidance to review

I only found the spacing issues on the key stage and phases steps of onboarding, so I've sorted them there.