### PR TITLE
Revert "Enable dfe-analytics in production"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -175,5 +175,5 @@ Rails.application.configure do
   config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "GIT-API-HTTP")
   config.x.git_api_endpoint = "https://get-into-teaching-api-prod.london.cloudapps.digital/api"
 
-  config.x.dfe_analytics = true
+  config.x.dfe_analytics = false
 end


### PR DESCRIPTION
Reverts DFE-Digital/schools-experience#2629

We are seeing jobs backing up in production; possibly related to this but I'm not sure why. I would expect to see _more_ jobs as the events are sent asynchronously but I'm not sure why that would cause other jobs to fail. It could be that we need to punt the analytics jobs to a separate queue with lower priority. 