### PR TITLE
Enable dfe-analytics in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -175,5 +175,5 @@ Rails.application.configure do
   config.x.api_client_cache_store = ActiveSupport::Cache::RedisCacheStore.new(namespace: "GIT-API-HTTP")
   config.x.git_api_endpoint = "https://get-into-teaching-api-prod.london.cloudapps.digital/api"
 
-  config.x.dfe_analytics = false
+  config.x.dfe_analytics = true
 end


### PR DESCRIPTION
We now have more workers running so we should be able to handle the additional load on the job queue.
