### PR TITLE
Fix redirect when editing on-boarded profile

### DIFF
--- a/app/controllers/schools/on_boarding/on_boardings_controller.rb
+++ b/app/controllers/schools/on_boarding/on_boardings_controller.rb
@@ -27,11 +27,10 @@ module Schools
         previous_step = request.path.split("/").last.to_sym
         next_step = school_profile.current_step(previous_step)
 
-        if next_step
-          public_send("new_schools_on_boarding_#{next_step}_path")
-        else
-          schools_on_boarding_progress_path
-        end
+        return public_send("new_schools_on_boarding_#{next_step}_path") if next_step
+        return schools_on_boarding_profile_path if school_profile.bookings_school.onboarded?
+
+        schools_on_boarding_progress_path
       end
 
       def continue(school_profile)


### PR DESCRIPTION
When the task-based on-boarding feature is on if a user edits their profile (after already on-boarding) they were being redirected to the task-based progress page instead of their profile preview.

Fix redirect for on-boarded schools.

Ideally we would have this covered by a test; this will be the case when we migrate the cucumber specs to the task-based on-boarding journey (assuming we stick with it permanently).