### PR TITLE
Allow multiple reasons for a placement rejection

### DIFF
--- a/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations/notification_deliveries_controller.rb
@@ -43,7 +43,7 @@ module Schools
           NotifyEmail::CandidateRequestRejection.new(
             to: cancellation.candidate_email,
             school_name: cancellation.school_name,
-            rejection_reasons: cancellation.rejection_description,
+            rejection_reasons: cancellation.humanised_rejection_categories,
             extra_details: cancellation.extra_details,
             dates_requested: cancellation.dates_requested,
             school_search_url: new_candidates_school_search_url,

--- a/app/controllers/schools/placement_requests/cancellations_controller.rb
+++ b/app/controllers/schools/placement_requests/cancellations_controller.rb
@@ -60,8 +60,8 @@ module Schools
       end
 
       def cancellation_params
-        params.require(:bookings_placement_request_cancellation).permit \
-          :rejection_category, :reason, :extra_details
+        params.require(:bookings_placement_request_cancellation)
+          .permit(:reason, :extra_details, *Bookings::PlacementRequest::Cancellation::SCHOOL_REJECTION_REASONS)
       end
     end
   end

--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -33,8 +33,10 @@ module Schools::PlacementRequestsHelper
   end
 
   def cancellation_reasons(cancellation)
-    safe_join(
-      Array.wrap(cancellation.humanised_rejection_categories).map { |r| tag.p(r) }
-    )
+    tag.ul(class: "govuk-list govuk-list--bullet") do |_ul|
+      safe_join(
+        Array.wrap(cancellation.humanised_rejection_categories).map { |r| tag.li(r) }
+      )
+    end
   end
 end

--- a/app/helpers/schools/placement_requests_helper.rb
+++ b/app/helpers/schools/placement_requests_helper.rb
@@ -34,10 +34,7 @@ module Schools::PlacementRequestsHelper
 
   def cancellation_reasons(cancellation)
     safe_join(
-      [
-        cancellation.humanised_rejection_category,
-        cancellation.reason
-      ].reject(&:blank?).map { |r| tag.p(r) }
+      Array.wrap(cancellation.humanised_rejection_categories).map { |r| tag.p(r) }
     )
   end
 end

--- a/app/notify/notify_email/candidate_request_rejection.rb
+++ b/app/notify/notify_email/candidate_request_rejection.rb
@@ -26,11 +26,15 @@ private
   def personalisation
     {
       school_name: school_name,
-      rejection_reasons: rejection_reasons,
+      rejection_reasons: bulleted_rejection_reasons,
       extra_details: extra_details,
       dates_requested: dates_requested,
       school_search_url: school_search_url,
       candidate_name: candidate_name
     }
+  end
+
+  def bulleted_rejection_reasons
+    rejection_reasons.map { |r| "* #{r}" }.join("\n")
   end
 end

--- a/app/views/schools/placement_requests/cancellations/_form.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_form.html.erb
@@ -4,7 +4,7 @@
 <%= form_for cancellation, url: schools_placement_request_cancellation_path do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <%= f.govuk_error_summary %>
+      <%= f.govuk_error_summary link_base_errors_to: :fully_booked_1 %>
 
       <h1 class="govuk-heading-l">
         Review and send rejection email to candidate
@@ -20,19 +20,19 @@
             cancellation: cancellation,
             reason: capture do
               content_tag('div', class: 'editable') do
-                f.govuk_radio_buttons_fieldset(
-                  :rejection_category,
+                f.govuk_check_boxes_fieldset(
+                  :rejection_categories,
                   small: true,
-                  legend: { class: 'govuk-visually-hidden', text: 'Rejection reason' }
+                  legend: { class: 'govuk-visually-hidden', text: 'Rejection reasons' }
                 ) do
                   safe_join(
                     [
                       Bookings::PlacementRequest::Cancellation::SCHOOL_REJECTION_REASONS
-                        .reject { |reason| reason == 'other' }
+                        .reject { |reason| reason == :other }
                         .each_with_index.map do |option, index|
-                          f.govuk_radio_button :rejection_category, option, link_errors: index.zero?
+                          f.govuk_check_box option, 1, 0, multiple: false, link_errors: index.zero?
                         end,
-                      (f.govuk_radio_button :rejection_category, :other do
+                      (f.govuk_check_box :other, 1, 0, multiple: false do
                         f.govuk_text_area :reason
                       end)
                     ]

--- a/app/views/schools/rejected_requests/show.html.erb
+++ b/app/views/schools/rejected_requests/show.html.erb
@@ -25,7 +25,7 @@
       <h2>Rejection details</h2>
 
       <dl class="govuk-summary-list">
-        <%= summary_row 'Reason', @cancellation.rejection_description %>
+        <%= summary_row 'Reason', cancellation_reasons(@cancellation) %>
 
         <% if @cancellation.extra_details.present? %>
           <%= summary_row 'Extra details', @cancellation.extra_details %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -15,6 +15,18 @@
   - sent_at
   - viewed_at
   - rejection_category
+  - fully_booked
+  - accepted_on_ttc
+  - date_not_available
+  - no_relevant_degree
+  - no_phase_availability
+  - candidate_not_local
+  - duplicate
+  - info_not_provided
+  - cancelation_requested
+  - wrong_choice_secondary
+  - wrong_choice_primary
+  - other
   :schools_school_profiles:
   - id
   - created_at

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -520,8 +520,8 @@ en:
           attributes:
             reason:
               blank: 'Cancellation reason is required'
-            rejection_category:
-              inclusion: Chooose a reason for rejecting this candidate
+            base:
+              no_rejection_category_selected: Chooose a reason for rejecting this candidate
         bookings/school_search:
           attributes:
             location:
@@ -767,19 +767,30 @@ en:
       bookings_placement_request_cancellation:
         reason: Cancellation reasons
         extra_details: Extra details
-        rejection_category_options:
-          fully_booked: The date you requested is fully booked.
-          accepted_on_ttc: We cannot offer you school experience because you've already been accepted on a teacher training course.
-          date_not_available: We can no longer offer the date you've requested.
-          no_relevant_degree: We do not believe you have a relevant degree for the school experience you're applying for.
-          no_phase_availability: We're unable to offer you school experience for the teaching phase you're interested in.
-          candidate_not_local: We're looking for candidates that live locally to the school.
-          duplicate: This is a duplicate request.
-          info_not_provided: We did not hear back from you after contacting you for more information.
-          cancelation_requested: You asked us to cancel your request.
-          wrong_choice_secondary: You've told us you want to get primary school experience, but you've chosen a secondary school placement.
-          wrong_choice_primary: You've told us you want to get secondary school experience, but you've chosen a primary school placement.
-          other: Other
+        fully_booked_options:
+          1: The date you requested is fully booked.
+        accepted_on_ttc_options:
+          1: We cannot offer you school experience because you've already been accepted on a teacher training course.
+        date_not_available_options:
+          1: We can no longer offer the date you've requested.
+        no_relevant_degree_options:
+          1: We do not believe you have a relevant degree for the school experience you're applying for.
+        no_phase_availability_options:
+          1: We're unable to offer you school experience for the teaching phase you're interested in.
+        candidate_not_local_options:
+          1: We're looking for candidates that live locally to the school.
+        duplicate_options:
+          1: This is a duplicate request.
+        info_not_provided_options:
+          1: We did not hear back from you after contacting you for more information.
+        cancelation_requested_options:
+          1: You asked us to cancel your request.
+        wrong_choice_secondary_options:
+          1: You've told us you want to get primary school experience, but you've chosen a secondary school placement.
+        wrong_choice_primary_options:
+          1: You've told us you want to get secondary school experience, but you've chosen a primary school placement.
+        other_options:
+          1: Other
       bookings_booking:
         duration: How long will it last?
         contact_name: Name

--- a/db/migrate/20220907093024_add_rejection_categories_to_bookings_placement_request_cancellations.rb
+++ b/db/migrate/20220907093024_add_rejection_categories_to_bookings_placement_request_cancellations.rb
@@ -1,0 +1,22 @@
+class AddRejectionCategoriesToBookingsPlacementRequestCancellations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bookings_placement_request_cancellations, :fully_booked, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :accepted_on_ttc, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :date_not_available, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :no_relevant_degree, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :no_phase_availability, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :candidate_not_local, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :duplicate, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :info_not_provided, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :cancelation_requested, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :wrong_choice_secondary, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :wrong_choice_primary, :boolean, default: false
+    add_column :bookings_placement_request_cancellations, :other, :boolean, default: false
+
+    Bookings::PlacementRequest::Cancellation.where.not(rejection_category: nil).find_in_batches do |cancellations|
+      cancellations.each do |cancellation|
+        cancellation.update(cancellation.rejection_category => true)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_10_142124) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_07_093024) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
   enable_extension "plpgsql"
@@ -96,6 +96,18 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_10_142124) do
     t.text "extra_details"
     t.datetime "viewed_at", precision: nil
     t.string "rejection_category"
+    t.boolean "fully_booked", default: false
+    t.boolean "accepted_on_ttc", default: false
+    t.boolean "date_not_available", default: false
+    t.boolean "no_relevant_degree", default: false
+    t.boolean "no_phase_availability", default: false
+    t.boolean "candidate_not_local", default: false
+    t.boolean "duplicate", default: false
+    t.boolean "info_not_provided", default: false
+    t.boolean "cancelation_requested", default: false
+    t.boolean "wrong_choice_secondary", default: false
+    t.boolean "wrong_choice_primary", default: false
+    t.boolean "other", default: false
     t.index ["bookings_placement_request_id"], name: "index_cancellations_on_bookings_placement_request_id", unique: true
     t.index ["rejection_category"], name: "index_bookings_placement_request_cancellations_category"
   end

--- a/features/schools/placement_requests/cancelling.feature
+++ b/features/schools/placement_requests/cancelling.feature
@@ -39,7 +39,7 @@ Feature: Rejecting placement requests
     Scenario: Reject form
         Given there is at least one placement request
         When I am on the reject placement request page
-        Then I should see radio buttons for 'Rejection reason' with the following options:
+        Then I should see checkboxes for 'Rejection reasons' with the following options:
             | The date you requested is fully booked                                                                    |
             | We cannot offer you school experience because you've already been accepted on a teacher training course   |
             | We can no longer offer the date you've requested                                                          |
@@ -59,7 +59,7 @@ Feature: Rejecting placement requests
     Scenario: Rejecting the requests
         Given there is at least one placement request
         And I am on the reject placement request page
-        And I choose 'You asked us to cancel your request' from the 'Rejection reason' radio buttons
+        And I check the 'You asked us to cancel your request' checkbox
         And I have entered a extra details in the extra details text area
         When I click the 'Preview rejection email' button
         Then I should see a preview of what I have entered
@@ -68,14 +68,14 @@ Feature: Rejecting placement requests
     Scenario: Entering a custom option
         Given there is at least one placement request
         And I am on the reject placement request page
-        And I choose 'Other' from the 'Rejection reason' radio buttons
+        And I check the 'Other' checkbox
         Then a text area labelled 'Cancellation reasons' should have appeared
 
     @javascript
     Scenario: Rejecting the requests with a custom reason
         Given there is at least one placement request
         And I am on the reject placement request page
-        And I choose 'Other' from the 'Rejection reason' radio buttons
+        And I check the 'Other' checkbox
 		And I enter 'The school will be closed' into the 'Cancellation reasons' text area
         When I click the 'Preview rejection email' button
         Then I should see my custom cancellation reason

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -35,6 +35,13 @@ Then("I should see radio buttons for {string} with the following options:") do |
   )
 end
 
+Then("I should see checkboxes for {string} with the following options:") do |string, table|
+  ensure_check_boxes_exist(
+    get_form_group(page, string),
+    table.raw.flatten.to_a
+  )
+end
+
 Then("I should not see {string}") do |string|
   expect(page).not_to have_content string
 end

--- a/features/step_definitions/schools/rejected_requests_steps.rb
+++ b/features/step_definitions/schools/rejected_requests_steps.rb
@@ -72,7 +72,7 @@ end
 
 Given("there is at least one rejected request") do
   step "there is 1 rejected requests"
-  @rejected_request.cancellation.update(rejection_category: :other, reason: 'MyText')
+  @rejected_request.cancellation.update(other: true, reason: 'MyText')
 end
 
 When("I am viewing the rejected request") do
@@ -85,7 +85,7 @@ end
 Given("a request has been rejected because of {string}") do |rejection_category|
   step %(there is 1 rejected requests)
   @cancellation = @rejected_request.cancellation.tap do |cancellation|
-    cancellation.update(rejection_category: rejection_category)
+    cancellation.update(rejection_category => true)
   end
 end
 

--- a/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations/notification_deliveries_controller_spec.rb
@@ -73,7 +73,7 @@ describe Schools::PlacementRequests::Cancellations::NotificationDeliveriesContro
         expect(NotifyEmail::CandidateRequestRejection).to have_received(:new).with \
           to: gitis_contact.email,
           school_name: cancellation.school_name,
-          rejection_reasons: cancellation.rejection_description,
+          rejection_reasons: cancellation.humanised_rejection_categories,
           extra_details: cancellation.extra_details,
           dates_requested: cancellation.dates_requested,
           school_search_url: new_candidates_school_search_url,

--- a/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
+++ b/spec/controllers/schools/placement_requests/cancellations_controller_spec.rb
@@ -45,7 +45,7 @@ describe Schools::PlacementRequests::CancellationsController, type: :request do
 
   context '#create' do
     let :cancellation_params do
-      { bookings_placement_request_cancellation: cancellation.attributes.merge(rejection_category: :other) }
+      { bookings_placement_request_cancellation: cancellation.attributes.merge(other: true) }
     end
 
     before do
@@ -90,7 +90,7 @@ describe Schools::PlacementRequests::CancellationsController, type: :request do
       context 'success' do
         let :cancellation do
           FactoryBot.build :cancellation,
-            rejection_category: 'fully_booked',
+            fully_booked: true,
             reason: "school's out for summer",
             placement_request: placement_request
         end
@@ -160,7 +160,7 @@ describe Schools::PlacementRequests::CancellationsController, type: :request do
       let :cancellation do
         FactoryBot.build :cancellation,
           reason: "school's out for ever",
-          rejection_category: 'fully_booked',
+          fully_booked: true,
           placement_request: placement_request
       end
 
@@ -186,7 +186,7 @@ describe Schools::PlacementRequests::CancellationsController, type: :request do
           FactoryBot.build :cancellation,
             reason: "",
             placement_request: placement_request,
-            rejection_category: :other
+            other: true
         end
 
         it 'rerenders the edit template' do
@@ -203,7 +203,7 @@ describe Schools::PlacementRequests::CancellationsController, type: :request do
         let :cancellation do
           FactoryBot.build :cancellation,
             reason: "school's out for ever",
-            rejection_category: :fully_booked,
+            fully_booked: true,
             placement_request: placement_request
         end
 

--- a/spec/factories/bookings/placement_request/cancellations_factory.rb
+++ b/spec/factories/bookings/placement_request/cancellations_factory.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     cancelled_by { 'candidate' }
 
     trait :cancelled_by_school do
-      rejection_category { 'fully_booked' }
+      fully_booked { true }
       cancelled_by { 'school' }
       sent
     end

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -46,7 +46,7 @@ FactoryBot.define do
       before :create do |placement_request|
         placement_request.school_cancellation = \
           FactoryBot.build :cancellation,
-            :sent, placement_request: placement_request, cancelled_by: 'school', rejection_category: :fully_booked
+            :sent, placement_request: placement_request, cancelled_by: 'school', fully_booked: true
       end
     end
 
@@ -54,7 +54,7 @@ FactoryBot.define do
       before :create do |placement_request|
         placement_request.school_cancellation = \
           FactoryBot.build :cancellation,
-            rejection_category: :fully_booked,
+            fully_booked: true,
             placement_request: placement_request, cancelled_by: 'school'
       end
     end

--- a/spec/helpers/schools/placement_requests_helper_spec.rb
+++ b/spec/helpers/schools/placement_requests_helper_spec.rb
@@ -11,22 +11,22 @@ describe Schools::PlacementRequestsHelper, type: :helper do
 
     subject { cancellation_reasons(cancellation) }
 
-    it { is_expected.to have_css("p", count: 2) }
-    it { is_expected.to have_css("p", text: "The date you requested is fully booked.") }
-    it { is_expected.to have_css("p", text: "Sorry!") }
+    it { is_expected.to have_css("ul li", count: 2) }
+    it { is_expected.to have_css("li", text: "The date you requested is fully booked.") }
+    it { is_expected.to have_css("li", text: "Sorry!") }
 
     context "when there is only a reason" do
       let(:cancellation) { build(:cancellation, reason: "Sorry!") }
 
-      it { is_expected.to have_css("p", count: 1) }
-      it { is_expected.to have_css("p", text: "Sorry!") }
+      it { is_expected.to have_css("li", count: 1) }
+      it { is_expected.to have_css("li", text: "Sorry!") }
     end
 
     context "when there are only categories selected" do
       let(:cancellation) { build(:cancellation, fully_booked: true, reason: nil) }
 
-      it { is_expected.to have_css("p", count: 1) }
-      it { is_expected.to have_css("p", text: "The date you requested is fully booked.") }
+      it { is_expected.to have_css("li", count: 1) }
+      it { is_expected.to have_css("li", text: "The date you requested is fully booked.") }
     end
   end
 end

--- a/spec/helpers/schools/placement_requests_helper_spec.rb
+++ b/spec/helpers/schools/placement_requests_helper_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe Schools::PlacementRequestsHelper, type: :helper do
+  describe "#cancellation_reasons" do
+    let(:cancellation) do
+      build(:cancellation,
+        fully_booked: true,
+        other: true,
+        reason: "Sorry!")
+    end
+
+    subject { cancellation_reasons(cancellation) }
+
+    it { is_expected.to have_css("p", count: 2) }
+    it { is_expected.to have_css("p", text: "The date you requested is fully booked.") }
+    it { is_expected.to have_css("p", text: "Sorry!") }
+
+    context "when there is only a reason" do
+      let(:cancellation) { build(:cancellation, reason: "Sorry!") }
+
+      it { is_expected.to have_css("p", count: 1) }
+      it { is_expected.to have_css("p", text: "Sorry!") }
+    end
+
+    context "when there are only categories selected" do
+      let(:cancellation) { build(:cancellation, fully_booked: true, reason: nil) }
+
+      it { is_expected.to have_css("p", count: 1) }
+      it { is_expected.to have_css("p", text: "The date you requested is fully booked.") }
+    end
+  end
+end

--- a/spec/notify/notify_email/candidate_request_rejection_spec.rb
+++ b/spec/notify/notify_email/candidate_request_rejection_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe NotifyEmail::CandidateRequestRejection do
   it_should_behave_like "email template", "74f84226-539a-43b0-b887-d8ffc9348965",
     school_name: "Springfield Elementary School",
-    rejection_reasons: "Failed security checks",
+    rejection_reasons: ["Failed security checks", "Other reason"],
     extra_details: 'HawHaw',
     dates_requested: 'Whenever really',
     school_search_url: 'https://example.com/',


### PR DESCRIPTION
### Trello card

[Trello-606](https://trello.com/c/NdePhNq2/606-enable-multiple-reasons-for-rejection-on-manage)

### Context

We currently only allow a single rejection reason for a placement request, however we want to allow candidates to specify multiple reasons.

### Changes proposed in this pull request

- Allow multiple reasons for a placement rejection

Add attributes/columns for each available rejection category. Populate new attributes from the existing, single attribute as part of the migration.

Retain the original `rejection_category` attribute and ensure it stays up to date (so when the categories change we pick the latest to populate this attribute) -- assuming we don't need to revert it can later be removed.

Update analytics whitelist to include the new attributes.

### Guidance to review

To test this you need to sign up for a placement at a school then sign in as the school and choose to reject the placement request; you should then be able to select multiple reasons.

Currently wherever we rendered the single reason for rejection (on views/emails) we now display all reasons in the same sentence (separated by periods), i.e. `Reason one. Reason two. Reason three.` etc.

| Form      | Preview | Email  |  View Rejected Request |
| ----------- | ----------- | ----------- | ----------- |
| ![screencapture-localhost-3000-schools-placement-requests-2-cancellation-new-2022-09-08-13_32_57](https://user-images.githubusercontent.com/29867726/189122732-d92919f4-559c-40b8-930e-b9c56d018889.png)      |  <img width="1401" alt="Screenshot 2022-09-30 at 16 00 01" src="https://user-images.githubusercontent.com/29867726/193298808-60c93d79-b6ee-461c-b5d5-ff01a3f31221.png">  |  <img width="619" alt="Screenshot 2022-09-30 at 16 00 29" src="https://user-images.githubusercontent.com/29867726/193298915-a48fb0d2-b988-4ba2-8663-8e3265a0f4a0.png">  | <img width="994" alt="Screenshot 2022-09-30 at 16 01 02" src="https://user-images.githubusercontent.com/29867726/193299014-7815ac63-28c8-4463-a5d8-89b0fde3aa93.png">  |

Once this is deployed and we're happy its behaving I'll raise a follow up PR to remove the redundant `rejection_category` attribute.


