### PR TITLE
Show first required step when no previous step given

### DIFF
--- a/app/forms/schools/on_boarding/wizard.rb
+++ b/app/forms/schools/on_boarding/wizard.rb
@@ -1,8 +1,6 @@
 module Schools
   module OnBoarding
     class Wizard
-      class StepNotFoundError < RuntimeError; end
-
       attr_reader :school_profile
 
       SECTIONS = {
@@ -74,13 +72,15 @@ module Schools
 
       def section_key(step)
         section_info = SECTIONS.invert.find { |steps, _section| step.in?(steps) }
-        raise StepNotFoundError, "#{step} step not found" if section_info.nil?
-
-        section_info.last
+        section_info&.last
       end
 
       def remaining_steps_in_section(after_step)
-        steps_in_section = SECTIONS[section_key(after_step)]
+        key = section_key(after_step)
+
+        return all_steps if key.nil?
+
+        steps_in_section = SECTIONS[key]
         steps_in_section[(steps_in_section.index(after_step) + 1)..]
       end
 

--- a/spec/forms/schools/on_boarding/wizard_spec.rb
+++ b/spec/forms/schools/on_boarding/wizard_spec.rb
@@ -10,13 +10,17 @@ describe Schools::OnBoarding::Wizard do
     context "when previous_step is nil" do
       let(:previous_step) { nil }
 
-      it { expect { next_step }.to raise_error(described_class::StepNotFoundError) }
+      it "returns the first required step (from all steps/sections)" do
+        is_expected.to be(:dbs_requirement)
+      end
     end
 
     context "when previous_step is unknown" do
       let(:previous_step) { :unknown }
 
-      it { expect { next_step }.to raise_error(described_class::StepNotFoundError).with_message("unknown step not found") }
+      it "returns the first required step (from all steps/sections)" do
+        is_expected.to be(:dbs_requirement)
+      end
     end
 
     context "when previous_step is the last step of a section" do


### PR DESCRIPTION
In some scenarios the user will arrive to the on-boarding journey without the initial step being defined (for example if they left half way through on-boarding and returned manually later). In this scenario we want to take them to the first step that is required but they have not completed (to be inline with the existing on-boarding journey).