### PR TITLE
Add network for Sidekiq monitoring

### DIFF
--- a/terraform/paas/network.tf
+++ b/terraform/paas/network.tf
@@ -11,6 +11,13 @@ data "cloudfoundry_app" "monitor_delayed" {
   depends_on = [cloudfoundry_app.delayed_jobs ]
 }
 
+data "cloudfoundry_app" "monitor_sidekiq" {
+  count      = length(cloudfoundry_app.sidekiq_jobs) > 0 ? 1 : 0
+  name_or_id = cloudfoundry_app.sidekiq_jobs.id
+  space      = data.cloudfoundry_space.space.id
+
+  depends_on = [cloudfoundry_app.sidekiq_jobs ]
+}
 
 data "cloudfoundry_app" "monitor_apps" {
 
@@ -37,6 +44,17 @@ resource "cloudfoundry_network_policy" "monitoring-policy-del" {
     policy {
         source_app = data.cloudfoundry_app.prometheus.id
         destination_app = data.cloudfoundry_app.monitor_delayed[0].id
+        port = "3000"
+        protocol = "tcp"
+    }
+}
+
+resource "cloudfoundry_network_policy" "monitoring-policy-sidekiq" {
+
+    count      = length( data.cloudfoundry_app.monitor_sidekiq  ) == 0 ? 0 : 1
+    policy {
+        source_app = data.cloudfoundry_app.prometheus.id
+        destination_app = data.cloudfoundry_app.monitor_sidekiq[0].id
         port = "3000"
         protocol = "tcp"
     }


### PR DESCRIPTION
This is so Prometheus can scrape the Sidekiq instances.