### PR TITLE
Run scheduled jobs with sidekiq-cron

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'rails_semantic_logger'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem "sidekiq"
+gem "sidekiq-cron"
 
 # Metrics
 gem "webrick"

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.2"
 
 gem 'phonelib'
 gem 'sentry-delayed_job'
+gem 'sentry-sidekiq'
 gem 'sentry-rails'
 gem 'sentry-ruby'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -590,6 +590,9 @@ GEM
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-cron (1.7.0)
+      fugit (~> 1)
+      sidekiq (>= 4.2.1)
     signet (0.17.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -752,6 +755,7 @@ DEPENDENCIES
   shakapacker (= 6.5.1)
   shoulda-matchers (~> 5.0)
   sidekiq
+  sidekiq-cron
   simplecov
   spring
   spring-commands-rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,6 +579,9 @@ GEM
       sentry-ruby (~> 5.4.1)
     sentry-ruby (5.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.4.1)
+      sentry-ruby (~> 5.4.1)
+      sidekiq (>= 3.0)
     shakapacker (6.5.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -752,6 +755,7 @@ DEPENDENCIES
   sentry-delayed_job
   sentry-rails
   sentry-ruby
+  sentry-sidekiq
   shakapacker (= 6.5.1)
   shoulda-matchers (~> 5.0)
   sidekiq

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,6 @@
+require "sidekiq/web"
+require "sidekiq/cron/web"
+
 Sidekiq.configure_server do |_config|
   Yabeda::Prometheus::Exporter.start_metrics_server!
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
-require 'sidekiq/web'
-
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 
-  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SECURE_USERNAME"])) &
-      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SECURE_PASSWORD"]))
+  unless Rails.env.development?
+    Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SECURE_USERNAME"])) &
+        ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SECURE_PASSWORD"]))
+    end
   end
 
   mount Sidekiq::Web => "/sidekiq" unless Rails.env.production?

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,0 +1,25 @@
+# Sidekiq scheduled tasks/cron jobs
+
+heart_beat_job:
+  cron: "* * * * *" # every minute
+  class: "Cron::HeartBeatJob"
+
+identify_closed_schools_job:
+  cron: "0 9 * * 1" # at 09:00 on Monday
+  class: "Cron::IdentifyClosedSchoolsJob"
+
+sync_schools_job:
+  cron: "30 7 * * *" # at 07:30
+  class: "Cron::SyncSchoolsJob"
+
+send_tomorrow_reminders_job:
+  cron: "30 9 * * *" # at 09:30
+  class: "Cron::Reminders::TomorrowJob"
+
+send_next_week_reminders_job:
+  cron: "35 9 * * *" # at 09:35
+  class: "Cron::Reminders::NextWeekJob"
+
+add_availability_job:
+  cron: "40 9 * * *" # at 09:40
+  class: "Cron::Reminders::AddAvailabilityJob"


### PR DESCRIPTION
### Trello card

[Trello-641](https://trello.com/c/W6usHTny/641-switch-our-job-processor-to-sidekiq)

### Context

We run a number of jobs using `delayed_cron_job`; as we are moving to Sidekiq we need to replicate this functionality and can do so with `sidekiq-cron`.

### Changes proposed in this pull request

- Add sidekiq-cron for scheduled jobs

Add `sidekiq-cron` gem and configure the jobs/cron expressions to match `delayed_cron_job`.

- Remove basic auth check in dev for sidekiq web

Remove the basic auth check for local development so we can easily access the sidekiq web UI.

- Add sentry-sidekiq gem

Inserts middleware for Sentry into the Sidekiq jobs.

### Guidance to review

The Sidekiq queue adapter is only running in staging at the moment.