### PR TITLE
Fail healcheck on API timeout exception

### DIFF
--- a/app/models/healthcheck.rb
+++ b/app/models/healthcheck.rb
@@ -32,7 +32,7 @@ class Healthcheck
     health = GetIntoTeachingApiClient::OperationsApi.new.health_check
 
     FUNCTIONAL_API_STATUS_CODES.any?(health.status)
-  rescue Faraday::Error, GetIntoTeachingApiClient::ApiError
+  rescue Faraday::Error, GetIntoTeachingApiClient::ApiError, Rack::Timeout::RequestTimeoutException
     false
   end
 

--- a/spec/models/healthcheck_spec.rb
+++ b/spec/models/healthcheck_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe Healthcheck do
 
       it { is_expected.to be true }
     end
+
+    context "when the connection times out" do
+      include_context "api connection timeout"
+
+      it { is_expected.to be false }
+    end
   end
 
   describe "test_postgresql" do

--- a/spec/support/stubbed_api.rb
+++ b/spec/support/stubbed_api.rb
@@ -44,6 +44,13 @@ shared_context "api degraded (CRM online)" do
   end
 end
 
+shared_context "api connection timeout" do
+  before do
+    allow_any_instance_of(GetIntoTeachingApiClient::OperationsApi).to \
+      receive(:health_check).and_raise(Rack::Timeout::RequestTimeoutException.new(double("env")))
+  end
+end
+
 shared_context "api correct verification code" do
   let(:code) { "123456" }
   let(:sign_up) { build(:api_schools_experience_sign_up_with_name) }


### PR DESCRIPTION
> :warning: I've not merged this yet as there is a persistent timeout error in GSE when calling the API health check endpoint. Once that's resolved I'll merge this down (otherwise we will get site down alerts every time it happens).

### Trello card

[Trello-656](https://trello.com/c/LivMzbVO/656-investigate-timeout-exception)

### Context

We are seeing an occasional timeout on the API healthcheck endpoint which raises an exception. Instead, we should be treating this as a failed healthcheck because the API was not available.

A follow up ticket in the API repo will address the timeouts and ship before this to avoid the service being flagged as down when its not (the timeout is a red-herring, the API is still responsive on other endpoints).

### Changes proposed in this pull request

- Fail healthcheck on API timeout exception

### Guidance to review

