### PR TITLE
Increase cache TTL to 12 hours

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -128,7 +128,7 @@ Rails.application.configure do
 
   config.session_store :cache_store,
     key: 'schoolex-session',
-    expire_after: 3.hours # Sets explicit TTL for Session Redis keys
+    expire_after: 12.hours # Sets explicit TTL for Session Redis keys
 
   config.active_job.queue_adapter = :sidekiq
 


### PR DESCRIPTION
### Trello card

[Trello-658](https://trello.com/c/qLK3C1IW/658-investigate-actioncontrollerinvalidauthenticitytoken-error)

### Context

We are seeing a reasonable number of `ActionController::InvalidAuthenticityToken` errors; I'm struggling to get to the bottom of them, but I'm wondering if its because our cache TTL is quite low and the CSRF tokens are expiring if a user starts a search, goes away for a while and comes back later to keep searching.

Increase cache TTL to 12 hours to see if it has an impact on the number of CSRF token errors we are seeing. The maximum we can set this to is 12 hours as we store PII in the cache.

### Changes proposed in this pull request

- Increase cache TTL to 12 hours

### Guidance to review

