### PR TITLE
Change dependabot to monthly interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,12 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: docker
     directory: /
@@ -19,9 +19,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-      
+      interval: daily
+
   - package-ecosystem: terraform
     directory: /terraform/paas/
     schedule:
-      interval: daily      
+      interval: daily


### PR DESCRIPTION
We're finding the weekly interval too frequent and the number of PRs dependabot raises is a pain to keep on top of - monthly should work out better for us.