### PR TITLE
Remove GitHub action minor version pinning

### DIFF
--- a/.github/workflows/actions/deploy/action.yml
+++ b/.github/workflows/actions/deploy/action.yml
@@ -25,7 +25,7 @@ runs:
     using: composite
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v2
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
@@ -106,7 +106,7 @@ runs:
           secret: SE-SECRETS
           key: SECURE_USERNAME , SECURE_PASSWORD
 
-      - uses: hashicorp/setup-terraform@v2.0.0
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.8
 

--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -38,14 +38,14 @@ jobs:
         run:  echo ::set-output name=short::$(echo $GITHUB_SHA | cut -c -7)
 
       - name: Login to GitHub Container Repository
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build docker image
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           tags: ${{ env.DOCKER_REPOSITORY }}:master
           load: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,14 +65,14 @@ jobs:
              fi
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to GitHub Container Registry
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3
         with:
           cache-from: ${{ env.DOCKER_REPOSITORY }}:master
           tags: |
@@ -116,7 +116,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -182,7 +182,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -219,7 +219,7 @@ jobs:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -267,7 +267,7 @@ jobs:
             creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.1.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -362,7 +362,7 @@ jobs:
       - name: Create a GitHub Release
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && steps.tag_version.outputs.pr_found == 1
         id: release
-        uses: actions/create-release@v1.1.4
+        uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -483,7 +483,7 @@ jobs:
 
       - name: Add Review Label
         if: matrix.environment == 'Review' && contains(github.event.pull_request.user.login, 'dependabot') == false
-        uses: actions-ecosystem/action-add-labels@v1.1.3
+        uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: Review

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
               echo ::set-output name=pr_name::${{env.REVIEW_APPLICATION}}-${{github.event.number}}
 
-      - uses: hashicorp/setup-terraform@v2.0.0
+      - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.8
 


### PR DESCRIPTION
### Context
Dependabot is creating too many distracting PRs

### Changes proposed in this pull request
Pin to the major version and let the workflow use the latest minor version

### Guidance to review
Check the workflow run

### Trello card
https://trello.com/c/BYSSVCNY

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
