### PR TITLE
Record CSRF token errors as a metric

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,8 +28,8 @@ protected
     end
   end
 
-  def session_expired(exception)
-    Sentry.capture_exception(exception)
+  def session_expired
+    Yabeda.gse.invalid_authenticity_token.increment({}, by: 1)
 
     render 'shared/session_expired'
   end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,3 +1,1 @@
-Sentry.init do |config|
-  config.excluded_exceptions -= ['ActionController::InvalidAuthenticityToken']
-end
+Sentry.init

--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -15,6 +15,7 @@ if ENV.key?("VCAP_APPLICATION")
 
     group :gse do
       counter :sidekiq_heart_beat, comment: "Counter for a sidekiq job heart beat/monitoring"
+      counter :invalid_authenticity_token, comment: "Counter for tracking invalid authenticity token (CSRF) errors"
     end
   end
 end

--- a/spec/requests/session_expired_spec.rb
+++ b/spec/requests/session_expired_spec.rb
@@ -8,10 +8,16 @@ describe "Expired Session", type: :request do
       end
     end
 
-    it "will show the Expired Session page" do
+    subject(:perform_request) do
       get candidates_root_path
-      expect(response).to have_http_status(200)
-      expect(response.body).to match(/Session expired/)
+      response
+    end
+
+    it { is_expected.to have_http_status(:success) }
+    it { expect(perform_request.body).to include("Session expired") }
+
+    it "increments the invalid_authenticity_token metric" do
+      expect { perform_request }.to increment_yabeda_counter(Yabeda.gse.invalid_authenticity_token).by(1)
     end
   end
 end


### PR DESCRIPTION
### Trello card

[Trello-659](https://trello.com/c/M9u3sqbf/659-switch-csrf-token-errors-to-use-metrics-and-threshold-alerting)

### Context

The CSRF error is unavoidable and we will see them happen on occasion (for example when a candidate's session times out or if they cleared their cookies before submitting a form). We only really care about these if they happen on a scale that is unexpected (several per minute or hour).

To avoid spamming Slack with errors we can't resolve we will instead have Sentry ignore them (which it does by default) and increment a Prometheus counter that we can then alert on at a given threshold.

### Changes proposed in this pull request

- Record CSRF token errors as a metric

### Guidance to review

[Corresponding PR to add an alert rule](https://github.com/DFE-Digital/get-into-teaching-api/compare/master...add-csrf-token-alert?quick_pull=1)