### PR TITLE
Add a user model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'geocoder'
 gem 'puma', '~> 5.6'
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
-gem 'shakapacker', '6.5.1'
+gem 'shakapacker', '6.5.2'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "redis", "~> 4.7"
 
 gem 'kaminari'
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.3.2"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
 
 gem 'phonelib'
 gem 'sentry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 6dc16420e0b5c6b2b722887589b0bc2212798802
-  tag: v1.3.2
+  revision: bfa569a60b4fca7545ca7b72764c526b65d913b9
+  tag: v1.5.3
   specs:
-    dfe-analytics (1.3.2)
+    dfe-analytics (1.5.3)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -206,7 +206,6 @@ GEM
     database_cleaner-core (2.0.1)
     declarative (0.0.20)
     diff-lcs (1.5.0)
-    digest (3.1.0)
     docile (1.4.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -261,9 +260,9 @@ GEM
     geocoder (1.8.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.39.0)
-      google-apis-core (>= 0.7, < 2.a)
-    google-apis-core (0.7.0)
+    google-apis-bigquery_v2 (0.42.0)
+      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-core (0.9.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -283,8 +282,8 @@ GEM
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.2.0)
-    googleauth (1.2.0)
+    google-cloud-errors (1.3.0)
+    googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -313,7 +312,7 @@ GEM
       aes_key_wrap
       bindata
       httpclient
-    jwt (2.4.1)
+    jwt (2.5.0)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -547,7 +547,7 @@ GEM
     sentry-sidekiq (5.4.1)
       sentry-ruby (~> 5.4.1)
       sidekiq (>= 3.0)
-    shakapacker (6.5.1)
+    shakapacker (6.5.2)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
@@ -710,7 +710,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  shakapacker (= 6.5.1)
+  shakapacker (= 6.5.2)
   shoulda-matchers (~> 5.0)
   sidekiq
   sidekiq-cron

--- a/app/controllers/concerns/dfe_authentication.rb
+++ b/app/controllers/concerns/dfe_authentication.rb
@@ -7,7 +7,7 @@ module DFEAuthentication
   protected
 
     def current_user
-      @current_user ||= session[:current_user]
+      @current_user ||= (User.exchange(session[:current_user]) if session[:current_user].present?)
     end
     alias_method :set_current_user, :current_user
     helper_method :current_user

--- a/app/controllers/schools/insecure_sessions_controller.rb
+++ b/app/controllers/schools/insecure_sessions_controller.rb
@@ -11,13 +11,12 @@ class Schools::InsecureSessionsController < ApplicationController
     # NOTE: the sub (subscription) param is the user's unique identifier
     # on DfE Sign-in and is hard-coded here. It must match the corresponding
     # value injected into Schools::SessionsController
-    session[:current_user] = UserInfoDecorator.new(
+    session[:current_user] =
       OpenIDConnect::ResponseObject::UserInfo.new(
         given_name: 'Martin',
         family_name: 'Prince',
         sub: '33333333-4444-5555-6666-777777777777'
       )
-    )
 
     unless Schools::ChangeSchool.allow_school_change_in_app?
       Bookings::School.find_or_create_by(urn: 123_456) do |school|

--- a/app/controllers/schools/sessions_controller.rb
+++ b/app/controllers/schools/sessions_controller.rb
@@ -118,7 +118,7 @@ module Schools
           urn = userinfo.raw_attributes.dig("organisation", "urn")
 
           info[:id_token]              = access_token.id_token # store this for logout flows.
-          info[:current_user]          = UserInfoDecorator.new(userinfo)
+          info[:current_user]          = userinfo
           info[:urn]                   = urn.presence && urn.to_i
           info[:school_name]           = userinfo.raw_attributes.dig("organisation", "name")
           info[:dfe_sign_in_org_uuid]  = userinfo.raw_attributes.dig("organisation", "id").presence

--- a/app/decorators/user_info_decorator.rb
+++ b/app/decorators/user_info_decorator.rb
@@ -1,7 +1,0 @@
-class UserInfoDecorator < SimpleDelegator
-  # The dfe-analytics gem expects current_user to respond
-  # to `id`. Our `current_user` is an instance of the
-  #  `OpenIDConnect::ResponseObject::UserInfo` which does not
-  # respond to `id`, so we alias it to the `sub` attribute here.
-  alias_attribute :id, :sub
-end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,6 +130,6 @@ module ApplicationHelper
 private
 
   def valid_user?(user)
-    user.is_a?(UserInfoDecorator)
+    user.is_a?(User)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,13 @@
+class User < ApplicationRecord
+  attr_writer :dfe_sign_in_user
+
+  delegate :given_name, :family_name, :raw_attributes, to: :@dfe_sign_in_user
+
+  class << self
+    def exchange(dfe_sign_in_user)
+      User.find_or_create_by(sub: dfe_sign_in_user.sub).tap do |user|
+        user.dfe_sign_in_user = dfe_sign_in_user
+      end
+    end
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,5 +1,10 @@
 ---
 :shared:
+  :users:
+  - id
+  - sub
+  - created_at
+  - updated_at
   :schools_on_boarding_profile_subjects:
   - id
   - schools_school_profile_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -36,14 +36,12 @@
   - created_at
   - updated_at
   - confirmed_at
-  :bookings_candidates:
-  - gitis_uuid
-  :bookings_bookings:
-  - placement_details
-  - contact_name
-  - contact_number
+  :bookings_schools:
   - contact_email
-  - candidate_instructions
+  - placement_info
+  - teacher_training_info
+  - primary_key_stage_info
+  - availability_info
   :bookings_profiles:
   - description_details
   - dress_code_other_details
@@ -63,15 +61,17 @@
   - access_needs_description
   - access_needs_policy_url
   - dbs_policy_conditions
-  :feedbacks:
-  - reason_for_using_service_explanation
-  - unsuccessful_visit_explanation
-  :bookings_schools:
-  - contact_email
-  - placement_info
-  - teacher_training_info
-  - primary_key_stage_info
-  - availability_info
+  :bookings_candidates:
+  - gitis_uuid
   :bookings_placement_requests:
   - degree_stage_explaination
   - token
+  :bookings_bookings:
+  - placement_details
+  - contact_name
+  - contact_number
+  - contact_email
+  - candidate_instructions
+  :feedbacks:
+  - reason_for_using_service_explanation
+  - unsuccessful_visit_explanation

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,5 +1,8 @@
 ---
 :shared:
+  :users:
+  - id
+  - sub
   :bookings_school_searches:
   - query
   - location

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -44,6 +44,8 @@ DfE::Analytics.configure do |config|
   #
   config.enable_analytics = proc { Rails.application.config.x.dfe_analytics }
 
+  config.user_identifier = proc { |user| user&.sub }
+
   # The environment we’re running in. This value will be attached
   # to all events we send to BigQuery.
   #

--- a/db/migrate/20221031134558_create_users.rb
+++ b/db/migrate/20221031134558_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :users do |t|
+      t.string :sub
+
+      t.timestamps
+    end
+
+    add_index :users, :sub, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_07_093024) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_31_134558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
   enable_extension "plpgsql"
@@ -437,6 +437,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_07_093024) do
     t.text "dbs_requirement_dbs_policy_details_inschool"
     t.boolean "candidate_dress_code_step_completed", default: false
     t.index ["bookings_school_id"], name: "index_schools_school_profiles_on_bookings_school_id"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "sub"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["sub"], name: "index_users_on_sub", unique: true
   end
 
   add_foreign_key "bookings_bookings", "bookings_placement_requests"

--- a/lib/servertest/sessions_controller.rb
+++ b/lib/servertest/sessions_controller.rb
@@ -14,11 +14,9 @@ Schools::SessionsController.class_eval do
 
     session[:id_token]     = 'abc123'
     session[:urn]          = 123_456
-    session[:current_user] = UserInfoDecorator.new(
-      OpenIDConnect::ResponseObject::UserInfo.new(
-        name: params[:name] || 'Joey',
-        sub: '33333333-4444-5555-6666-777777777777'
-      )
+    session[:current_user] = OpenIDConnect::ResponseObject::UserInfo.new(
+      name: params[:name] || 'Joey',
+      sub: '33333333-4444-5555-6666-777777777777'
     )
 
     redirect_to '/schools/dashboard'

--- a/spec/controllers/concerns/dfe_authentication_spec.rb
+++ b/spec/controllers/concerns/dfe_authentication_spec.rb
@@ -6,7 +6,14 @@ describe DFEAuthentication do
   describe Schools::DashboardsController, type: :controller do
     it { expect(described_class.ancestors).to include(DFEAuthentication) }
 
-    let(:teacher) { { name: "Seymour Skinner" } }
+    let(:teacher_session) do
+      UserInfoDecorator.new(
+        OpenIDConnect::ResponseObject::UserInfo.new(
+          sub: teacher_user.sub
+        )
+      )
+    end
+    let(:teacher_user) { create(:user) }
     let(:auth_host) { Rails.application.config.x.oidc_host }
 
     describe 'login redirect' do
@@ -48,20 +55,20 @@ describe DFEAuthentication do
     context '#current_user' do
       context 'when the current_user is set' do
         before do
-          subject.instance_variable_set(:@current_user, teacher)
+          subject.instance_variable_set(:@current_user, teacher_user)
         end
 
         specify 'should return the current user' do
-          expect(subject.send(:current_user)).to eql(teacher)
+          expect(subject.send(:current_user)).to eql(teacher_user)
         end
       end
 
       context 'when the current user is not set' do
         before { get :show }
-        before { controller.session[:current_user] = teacher }
+        before { controller.session[:current_user] = teacher_session }
 
         specify 'should retrieve the current user from the session' do
-          expect(subject.send(:current_user)).to eql(teacher)
+          expect(subject.send(:current_user)).to eql(teacher_user)
         end
       end
     end
@@ -69,7 +76,7 @@ describe DFEAuthentication do
     context '#user_signed_in?' do
       context 'when a user is signed in' do
         before do
-          subject.instance_variable_set(:@current_user, teacher)
+          subject.instance_variable_set(:@current_user, teacher_user)
         end
 
         it 'should be true' do

--- a/spec/controllers/concerns/dfe_authentication_spec.rb
+++ b/spec/controllers/concerns/dfe_authentication_spec.rb
@@ -7,10 +7,8 @@ describe DFEAuthentication do
     it { expect(described_class.ancestors).to include(DFEAuthentication) }
 
     let(:teacher_session) do
-      UserInfoDecorator.new(
-        OpenIDConnect::ResponseObject::UserInfo.new(
-          sub: teacher_user.sub
-        )
+      OpenIDConnect::ResponseObject::UserInfo.new(
+        sub: teacher_user.sub
       )
     end
     let(:teacher_user) { create(:user) }

--- a/spec/controllers/schools/sessions_controller_spec.rb
+++ b/spec/controllers/schools/sessions_controller_spec.rb
@@ -90,7 +90,7 @@ describe Schools::SessionsController, type: :request do
       end
 
       specify 'should save the current user in the session' do
-        expect(session[:current_user]).to be_a(UserInfoDecorator)
+        expect(session[:current_user]).to be_a(OpenIDConnect::ResponseObject::UserInfo)
       end
 
       context 'errors' do
@@ -173,9 +173,7 @@ describe Schools::SessionsController, type: :request do
       before do
         session_hash[:return_url] = return_url
         session_hash[:state] = state
-        session_hash[:current_user] = UserInfoDecorator.new(
-          OpenIDConnect::ResponseObject::UserInfo.new(sub: "abc1243", name: 'Milhouse')
-        )
+        session_hash[:current_user] = OpenIDConnect::ResponseObject::UserInfo.new(sub: "abc1243", name: 'Milhouse')
       end
 
       subject { get auth_callback_path }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :user do
+    sub { SecureRandom.uuid }
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -7,12 +7,16 @@ end
 describe ApplicationHelper, type: :helper do
   let(:given_name) { 'Martin' }
   let(:family_name) { 'Prince' }
-  let(:user) do
+  let(:dfe_sign_in_user) do
     UserInfoDecorator.new(
-      OpenIDConnect::ResponseObject::UserInfo.new(given_name: given_name,
-                                                  family_name: family_name)
+      OpenIDConnect::ResponseObject::UserInfo.new(
+        sub: "33333333-4444-5555-6666-777777777777",
+        given_name: given_name,
+        family_name: family_name
+      )
     )
   end
+  let(:user) { User.exchange(dfe_sign_in_user) }
 
   context 'Breadcrumbs' do
     let(:args) do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -8,12 +8,10 @@ describe ApplicationHelper, type: :helper do
   let(:given_name) { 'Martin' }
   let(:family_name) { 'Prince' }
   let(:dfe_sign_in_user) do
-    UserInfoDecorator.new(
-      OpenIDConnect::ResponseObject::UserInfo.new(
-        sub: "33333333-4444-5555-6666-777777777777",
-        given_name: given_name,
-        family_name: family_name
-      )
+    OpenIDConnect::ResponseObject::UserInfo.new(
+      sub: "33333333-4444-5555-6666-777777777777",
+      given_name: given_name,
+      family_name: family_name
     )
   end
   let(:user) { User.exchange(dfe_sign_in_user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe User, type: :model do
+  let(:dfe_sign_in_user) do
+    OpenIDConnect::ResponseObject::UserInfo.new(
+      sub: "33333333-4444-5555-6666-777777777777",
+      given_name: "John",
+      family_name: "Doe",
+    )
+  end
+
+  describe ".exchange" do
+    subject(:exchange) { described_class.exchange(dfe_sign_in_user) }
+
+    it { expect { exchange }.to change(described_class, :count).by(1) }
+    it do
+      is_expected.to have_attributes(
+        sub: dfe_sign_in_user.sub,
+        given_name: dfe_sign_in_user.given_name,
+        family_name: dfe_sign_in_user.family_name,
+        raw_attributes: dfe_sign_in_user.raw_attributes
+      )
+    end
+
+    context "when the user already exists" do
+      before { create(:user, sub: dfe_sign_in_user.sub) }
+
+      it { expect { exchange }.not_to change(described_class, :count) }
+    end
+  end
+end


### PR DESCRIPTION
### Trello card

[Trello-662](https://trello.com/c/g44WHRsw/662-add-user-model-for-managing-roles-within-gse)

### Context

We are shifting the responsibility for managing roles/permissions to schools from DfE sign in to the application. Currently if a user wants access to a school they need to setup an account for the school/organisation in DfE sign in and _then_ request access to the School Experience service. This is unintuitive for users and causes many to drop out/not get access to the service.

Instead, we will use ID-only access via DfE sign in so that the user only needs to be part of the correct organisation and then we will manage permissions to sign in to the school on School Experience from within the app.

The first step along this route is to setup a `User` model so that we can manage roles/permissions (currently a user is a hash wrapped on an OpenId `UserInfo` object).

### Changes proposed in this pull request

- Add user model

Going forward we are going to be managing roles/permissions in the application instead of via DfE sign in. As most role libraries expect a `User` model it makes sense to add one, wrapping the DfE sign in user.

A convenience method to exchange a DfE sign in user for a `User` model is provided (creating a new record if a matching one does not yet exist).

-  Wrap current_user with User model

It makes sense to use the `User` model when referencing a user within the application; this way we will be able to more easily query roles/permissions by doing so on `current_user`.

- Update dfe-analytics to remove UserDecorator

The latest version of `dfe-analytics` allows you to specify the `id` attribute of the `current_user`. We had to use a decorator previously to map the default `id` attribute to `sub`, which is the subscription ID we use from DfE sign in as a unique identifier.

### Guidance to review

The plan is to use the [Rolify](https://github.com/RolifyCommunity/rolify) gem to manage roles/permissions going forward; we only need basic access control and it seems to fit the bill well.