### PR TITLE
Add rolify gem to manage school permissions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'kaminari'
 
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
 
+gem "rolify"
+
 gem 'phonelib'
 gem 'sentry-rails'
 gem 'sentry-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,6 +472,7 @@ GEM
     rgeo-activerecord (7.0.1)
       activerecord (>= 5.0)
       rgeo (>= 1.0.0)
+    rolify (6.0.0)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)
@@ -701,6 +702,7 @@ DEPENDENCIES
   rails-erd
   rails_semantic_logger
   redis (~> 4.7)
+  rolify
   rspec-json_expectations (~> 2.2)
   rspec-rails (~> 5.1)
   rspec-sonarqube-formatter

--- a/app/models/bookings/school.rb
+++ b/app/models/bookings/school.rb
@@ -1,4 +1,6 @@
 class Bookings::School < ApplicationRecord
+  resourcify
+
   self.ignored_columns += %w[dfe_signin_organisation_uuid]
   include FullTextSearch
   include GeographicSearch

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,9 @@
+class Role < ApplicationRecord
+  has_and_belongs_to_many :users, join_table: :users_roles
+
+  belongs_to :resource, polymorphic: true, optional: true
+
+  validates :resource_type, inclusion: { in: Rolify.resource_types }, allow_nil: true
+
+  scopify
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  rolify
+
   attr_writer :dfe_sign_in_user
 
   delegate :given_name, :family_name, :raw_attributes, to: :@dfe_sign_in_user

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -289,3 +289,15 @@
   - created_at
   - updated_at
   - bookings_candidate_id
+  :users_roles:
+  - user_id
+  - role_id
+  - created_at
+  - updated_at
+  :roles:
+  - id
+  - name
+  - resource_type
+  - resource_id
+  - created_at
+  - updated_at

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,5 +1,7 @@
 ---
 :shared:
+  :users_roles:
+  - user_id
   :users:
   - id
   - sub

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -1,0 +1,10 @@
+Rolify.configure do |config|
+  # By default ORM adapter is ActiveRecord. uncomment to use mongoid
+  # config.use_mongoid
+
+  # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
+  # config.use_dynamic_shortcuts
+
+  # Configuration to remove roles from database once the last resource is removed. Default is: true
+  # config.remove_role_if_empty = false
+end

--- a/db/migrate/20221104080002_rolify_create_roles.rb
+++ b/db/migrate/20221104080002_rolify_create_roles.rb
@@ -1,0 +1,21 @@
+class RolifyCreateRoles < ActiveRecord::Migration[7.0]
+  def change
+    create_table(:roles) do |t|
+      t.string :name
+      t.references :resource, polymorphic: true
+
+      t.timestamps
+    end
+
+    create_table(:users_roles, id: false) do |t|
+      t.references :user
+      t.references :role
+
+      t.timestamps
+    end
+
+    add_index(:roles, :name)
+    add_index(:roles, %i[name resource_type resource_id])
+    add_index(:users_roles, %i[user_id role_id])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_31_134558) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_04_080002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "address_standardizer"
   enable_extension "plpgsql"
@@ -346,6 +346,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_31_134558) do
     t.string "referrer"
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
+    t.index ["name"], name: "index_roles_on_name"
+    t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
+  end
+
   create_table "schools_on_boarding_profile_subjects", force: :cascade do |t|
     t.bigint "schools_school_profile_id"
     t.bigint "bookings_subject_id"
@@ -444,6 +455,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_31_134558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["sub"], name: "index_users_on_sub", unique: true
+  end
+
+  create_table "users_roles", id: false, force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "role_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["role_id"], name: "index_users_roles_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
   add_foreign_key "bookings_bookings", "bookings_placement_requests"

--- a/spec/models/bookings/school_spec.rb
+++ b/spec/models/bookings/school_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe Bookings::School, type: :model do
+  it { is_expected.to respond_to(:roles) }
+
   describe 'Validation' do
     context 'name' do
       it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe Role, type: :model do
+  describe "relationships" do
+    it { is_expected.to have_and_belong_to_many(:users).join_table(:users_roles) }
+    it { is_expected.to belong_to(:resource).optional }
+  end
+
+  describe "validation rules" do
+    it { is_expected.to validate_inclusion_of(:resource_type).in_array(Rolify.resource_types).allow_nil }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe User, type: :model do
     )
   end
 
+  it { is_expected.to respond_to(:has_role?) }
+
   describe ".exchange" do
     subject(:exchange) { described_class.exchange(dfe_sign_in_user) }
 


### PR DESCRIPTION
### Trello card

[Trello-664](https://trello.com/c/NUHQxJWP/664-add-role-library-for-controlling-access-to-schools)

### Context

We want to manage permissions within the app going forward (instead of via DfE sign in). To do this we need a way of tracking who has access to which resource/school.

### Changes proposed in this pull request

- Add rolify gem to manage roles

Add `rolify` gem; this is a simple and well maintained gem that will enable us to manage user roles on a per-resource/school basis.

### Guidance to review

