### PR TITLE
Reinstate UserInfoDecorator

### DIFF
--- a/app/decorators/user_info_decorator.rb
+++ b/app/decorators/user_info_decorator.rb
@@ -1,0 +1,8 @@
+# TODO: remove this class once all user sessions have expired
+class UserInfoDecorator < SimpleDelegator
+  # The dfe-analytics gem expects current_user to respond
+  # to `id`. Our `current_user` is an instance of the
+  #  `OpenIDConnect::ResponseObject::UserInfo` which does not
+  # respond to `id`, so we alias it to the `sub` attribute here.
+  alias_attribute :id, :sub
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,6 +130,6 @@ module ApplicationHelper
 private
 
   def valid_user?(user)
-    user.is_a?(User)
+    user.is_a?(User) || user.is_a?(UserInfoDecorator)
   end
 end


### PR DESCRIPTION
I removed this class in a previous PR, however some sessions have objects of this class stored in them still; until all sessions have expired/are using the new `User` model its not safe to remove.

The interface of `User` and `UserInfoDecorator` are the same so the rest of the code shouldn't need updating.

