### PR TITLE
Make not applicable tag grey in on-boarding

### DIFF
--- a/app/helpers/schools/on_boarding_helper.rb
+++ b/app/helpers/schools/on_boarding_helper.rb
@@ -22,8 +22,6 @@ module Schools::OnBoardingHelper
     return nil if status == :cannot_start_yet
 
     color = case status
-            when :not_applicable
-              "blue"
             when :complete
               "green"
             else

--- a/spec/helpers/schools/on_boarding_helper_spec.rb
+++ b/spec/helpers/schools/on_boarding_helper_spec.rb
@@ -50,7 +50,7 @@ describe Schools::OnBoardingHelper, type: :helper do
     context "when not_applicable" do
       let(:status) { :not_applicable }
 
-      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--blue", text: "Not applicable") }
+      it { is_expected.to have_css("strong.govuk-tag.govuk-tag--grey", text: "Not applicable") }
     end
 
     context "when cannot_start_yet" do


### PR DESCRIPTION
### Trello card

[Trello-647](https://trello.com/c/NfP8R5C1/647-convert-not-applicable-tag-to-grey)

### Context

We want the not applicable tag in the on-boarding journey to be grey instead of blue. User research flagged that the different tag colours result in a high cognitive load on filling out this section.

### Changes proposed in this pull request

- Make not applicable tag grey in on-boarding

### Guidance to review

