### PR TITLE
Update on-boarding heading structure

### DIFF
--- a/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
+++ b/app/views/schools/on_boarding/_school_fees_shared_form.html.erb
@@ -6,24 +6,23 @@
     <%= form_for model, url: submission_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
-        <%= title %>
-      </h1>
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
 
-      <%= f.govuk_number_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.9, label: { class: 'govuk-heading-m' }, prefix_text: '£' %>
+      <h2 class="govuk-heading-l">
+        <%= title %>
+      </h2>
+
+      <%= f.govuk_number_field :amount_pounds, width: 5, step: 0.01, min: 0, max: 9999.9, label: { tag: "h3", size: "m" }, prefix_text: '£' %>
 
       <%= f.govuk_text_area :description, rows: 7 %>
 
-      <%= f.govuk_radio_buttons_fieldset :interval do %>
+      <%= f.govuk_radio_buttons_fieldset :interval, legend: { tag: "h3", size: "m" } do %>
         <% f.object.available_intervals.each_with_index do |interval, index| %>
           <%= f.govuk_radio_button :interval, interval, label: { text: interval }, link_errors: index.zero? %>
         <% end %>
       <% end %>
 
-      <%= f.govuk_text_area :payment_method, rows: 7,
-        label: {
-          class: 'govuk-heading-m'
-        } %>
+      <%= f.govuk_text_area :payment_method, rows: 7, label: { tag: "h3", size: "m" } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/schools/on_boarding/access_needs_details/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_details/_form.html.erb
@@ -6,7 +6,9 @@
     <%= form_for access_needs_detail, url: schools_on_boarding_access_needs_detail_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_area :description, rows: 9, label: { tag: "h1", size: "l" } %>
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <%= f.govuk_text_area :description, rows: 9, label: { tag: "h2", size: "l" } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_policies/_form.html.erb
@@ -5,7 +5,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for access_needs_policy, url: schools_on_boarding_access_needs_policy_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_radio_buttons_fieldset :has_access_needs_policy, legend: { tag: "h1", size: "l" } do %>
+
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <%= f.govuk_radio_buttons_fieldset :has_access_needs_policy, legend: { tag: "h2", size: "l" } do %>
         <p class="govuk-hint">
           For example, a link to a relevant document or page on your school
           website

--- a/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
+++ b/app/views/schools/on_boarding/access_needs_supports/_form.html.erb
@@ -7,7 +7,9 @@
       <%= f.govuk_error_summary %>
       <%= f.hidden_field :supports_access_needs, value: nil %>
 
-      <%= f.govuk_radio_buttons_fieldset :supports_access_needs, inline: true, legend: { tag: "h1", size: "l" } do %>
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <%= f.govuk_radio_buttons_fieldset :supports_access_needs, inline: true, legend: { tag: "h2", size: "l" } do %>
         <p>These details will be added to your school profile.</p>
         <%= f.govuk_radio_button :supports_access_needs, "true", link_errors: true %>
         <%= f.govuk_radio_button :supports_access_needs, "false" %>

--- a/app/views/schools/on_boarding/admin_contacts/_form.html.erb
+++ b/app/views/schools/on_boarding/admin_contacts/_form.html.erb
@@ -6,9 +6,11 @@
     <%= form_for admin_contact, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Admin contact details
-      </h1>
+      </h2>
 
       <p>
         These should be details of the person who will manage school experience requests for your school.
@@ -21,9 +23,9 @@
         The contact details you provide will not be shared publicly or with candidates until you’ve confirmed their school experience booking.
       </p>
 
-      <h2 class="govuk-heading-m">
+      <h3 class="govuk-heading-m">
         Provide admin contact details
-      </h2>
+      </h3>
 
       <%= f.govuk_phone_field :phone, width: 'one-half' %>
       <%= f.govuk_text_field :email %>

--- a/app/views/schools/on_boarding/candidate_dress_codes/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_dress_codes/_form.html.erb
@@ -6,16 +6,15 @@
     <%= form_for candidate_dress_code, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="gouvk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Do you have a dress code for candidates?
-      </h1>
+      </h2>
+
       <p>
         Select all that apply.
       </p>
-
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-        <h2 class="govuk-fieldset__heading"></h2>
-      </legend>
 
       <%= f.govuk_check_boxes_fieldset :selected_requirements, legend: nil do %>
         <%= f.govuk_check_box :selected_requirements, "business_dress" %>

--- a/app/views/schools/on_boarding/candidate_experience_schedules/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_experience_schedules/_form.html.erb
@@ -6,18 +6,20 @@
     <%= form_for candidate_experience_schedule, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="gouvk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Enter start and finish times for candidates
-      </h1>
+      </h2>
 
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
-          <%= f.govuk_text_field :start_time, class: 'govuk-!-width-one-quarter', label: { class: 'govuk-label govuk-label--m' } %>
-          <%= f.govuk_text_field :end_time, class: 'govuk-!-width-one-quarter', label: { class: 'govuk-label govuk-label--m' } %>
+          <%= f.govuk_text_field :start_time, class: 'govuk-!-width-one-quarter', label: { tag: "h3", class: 'govuk-label govuk-label--m' } %>
+          <%= f.govuk_text_field :end_time, class: 'govuk-!-width-one-quarter', label: { tag: "h3", class: 'govuk-label govuk-label--m' } %>
         </fieldset>
       </div>
 
-      <%= f.govuk_radio_buttons_fieldset :times_flexible do %>
+      <%= f.govuk_radio_buttons_fieldset :times_flexible, legend: { tag: "h3", size: "m" } do %>
         <p>
           For example, if you let candidates start and finish later, depending on their individual needs.
         </p>

--- a/app/views/schools/on_boarding/candidate_parking_informations/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_parking_informations/_form.html.erb
@@ -6,11 +6,13 @@
     <%= form_for candidate_parking_information, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="gouvk-heading-l">
-        Parking information
-      </h1>
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
 
-      <%= f.govuk_radio_buttons_fieldset :parking_provided do %>
+      <h2 class="govuk-heading-l">
+        Parking information
+      </h2>
+
+      <%= f.govuk_radio_buttons_fieldset :parking_provided, legend: { tag: "h3", size: "m" } do %>
         <%= f.govuk_radio_button :parking_provided, "true", link_errors: true do %>
           <%= f.govuk_text_area :parking_details, rows: 7 %>
         <% end %>

--- a/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
+++ b/app/views/schools/on_boarding/candidate_requirements_selections/_form.html.erb
@@ -7,7 +7,9 @@
                  html: { class: "candidate-requirements-selection" } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_check_boxes_fieldset :selected_requirements, legend: { tag: "h1", size: "l" } do %>
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <%= f.govuk_check_boxes_fieldset :selected_requirements, legend: { tag: "h2", size: "l" } do %>
         <%= f.govuk_check_box :selected_requirements, "on_teacher_training_course" %>
         <%= f.govuk_check_box :selected_requirements, "not_on_another_training_course" %>
         <%= f.govuk_check_box :selected_requirements, "has_or_working_towards_degree" %>

--- a/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
+++ b/app/views/schools/on_boarding/dbs_requirements/_form.html.erb
@@ -6,9 +6,11 @@
     <%= form_for dbs_requirement, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Enter your school experience details
-      </h1>
+      </h2>
 
       <p>
         These details will help candidates select a school experience.
@@ -18,7 +20,7 @@
         You'll be given a chance to check and change the details you enter.
       </p>
 
-      <%= f.govuk_radio_buttons_fieldset :dbs_policy_conditions do %>
+      <%= f.govuk_radio_buttons_fieldset :dbs_policy_conditions, legend: { tag: "h3" } do %>
         <%= f.govuk_radio_button :dbs_policy_conditions, 'required', link_errors: true do %>
           <%= f.govuk_text_area :dbs_policy_details, max_words: 50 %>
         <% end %>

--- a/app/views/schools/on_boarding/descriptions/_form.html.erb
+++ b/app/views/schools/on_boarding/descriptions/_form.html.erb
@@ -6,9 +6,11 @@
     <%= form_for description, url: schools_on_boarding_description_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         School description
-      </h1>
+      </h2>
 
       <p>
         Use this section to tell candidates about your school.
@@ -29,7 +31,7 @@
         able to add those details later.
       </p>
 
-      <%= f.govuk_text_area :details, max_words: 200, rows: 10, label: -> { tag.h2('Enter a description of your school') } %>
+      <%= f.govuk_text_area :details, max_words: 200, rows: 10, label: -> { tag.h3('Enter a description of your school', class: "govuk-heading-m") } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/schools/on_boarding/disability_confidents/_form.html.erb
+++ b/app/views/schools/on_boarding/disability_confidents/_form.html.erb
@@ -6,7 +6,10 @@
     <%= form_for disability_confident, url: schools_on_boarding_disability_confident_path, method: method do |f| %>
       <%= f.govuk_error_summary %>
       <%= f.hidden_field :is_disability_confident, value: nil %>
-      <%= f.govuk_radio_buttons_fieldset :is_disability_confident, legend: { tag: "h1", size: "l" } do %>
+
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <%= f.govuk_radio_buttons_fieldset :is_disability_confident, legend: { tag: "h2", size: "l" } do %>
 
         <div>
           <%= image_pack_tag 'disability-confident-small.png', alt: 'Disability confident logo' %>

--- a/app/views/schools/on_boarding/experience_outlines/_form.html.erb
+++ b/app/views/schools/on_boarding/experience_outlines/_form.html.erb
@@ -6,9 +6,11 @@
     <%= form_for experience_outline, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         School experience details
-      </h1>
+      </h2>
 
       <p>
         Use this section to tell candidates what they can expect when they get experience at your school.
@@ -29,7 +31,7 @@
         </ul>
       </p>
 
-      <%= f.govuk_text_area :candidate_experience, max_words: 200, rows: 4, label: -> { tag.h2('What kind of school experience do you offer?') } %>
+      <%= f.govuk_text_area :candidate_experience, max_words: 200, rows: 4, label: -> { tag.h3('What kind of school experience do you offer?', class: "govuk-heading-m") } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/schools/on_boarding/fees/_form.html.erb
+++ b/app/views/schools/on_boarding/fees/_form.html.erb
@@ -6,9 +6,11 @@
     <%= form_for fees, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Fees
-      </h1>
+      </h2>
 
       <p>
         Some schools charge fees to cover the costs of running school experience.

--- a/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/key_stage_lists/_form.html.erb
@@ -6,9 +6,11 @@
     <%= form_for key_stage_list, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :early_years_1 %>
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Which key stages do you offer experience with?
-      </h1>
+      </h2>
 
       <p>
         Select all that apply.

--- a/app/views/schools/on_boarding/phases_lists/_form.html.erb
+++ b/app/views/schools/on_boarding/phases_lists/_form.html.erb
@@ -6,9 +6,11 @@
     <%= form_for phases_list, url: url, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :primary_1 %>
 
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Which school phases do you offer experience with?
-      </h1>
+      </h2>
 
       <p>
         Select all that apply.

--- a/app/views/schools/on_boarding/subjects/_form.html.erb
+++ b/app/views/schools/on_boarding/subjects/_form.html.erb
@@ -5,9 +5,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for subject_list, url: schools_on_boarding_subjects_path, method: method do |f| %>
       <%= f.govuk_error_summary link_base_errors_to: :subject_ids_1 %>
-      <h1 class="govuk-heading-l">
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
+
+      <h2 class="govuk-heading-l">
         Select school experience subjects
-      </h1>
+      </h2>
 
       <p>
         Tell us which subjects you offer for secondary school experience and

--- a/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
+++ b/app/views/schools/on_boarding/teacher_trainings/_form.html.erb
@@ -6,11 +6,13 @@
     <%= form_for teacher_training, url: url, method: method do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-l">
-        Teacher training details
-      </h1>
+      <h1 class="govuk-heading-xl"><%= @current_school.name %></h1>
 
-      <%= f.govuk_radio_buttons_fieldset :provides_teacher_training do %>
+      <h2 class="govuk-heading-l">
+        Teacher training details
+      </h2>
+
+      <%= f.govuk_radio_buttons_fieldset :provides_teacher_training, legend: { tag: "h3", size: "m" } do %>
         <%= f.govuk_radio_button :provides_teacher_training, "true", link_errors: true do %>
           <%= f.govuk_text_area :teacher_training_details, rows: 7 %>
           <%= f.govuk_url_field :teacher_training_url, placeholder: 'https://example.org' %>


### PR DESCRIPTION
### Trello card

[Trello-3911](https://trello.com/c/MEZlmkIu/3911-update-about-git-events-page-for-end-of-autumn-programme)

### Context

We want to add the school name as the top-level `h1` heading on all on-boarding steps so that users on-boarding multiple schools can easily see which school they are filling out the current step for. Bump previous top-level headings down to `h2` and subsequent step fields should be `h3`.

### Changes proposed in this pull request

- Update on-boarding heading structure

### Guidance to review

<img width="1436" alt="Screenshot 2022-11-28 at 11 20 10" src="https://user-images.githubusercontent.com/29867726/204265398-800b358f-26f0-4daf-abe4-27fb9d818469.png">

