### PR TITLE
Add 'Get help' section to candidate footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,7 +72,27 @@
     <footer class="govuk-footer " role="contentinfo">
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
-          <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <section class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+            <% unless in_schools_namespace? %>
+              <h2 class="govuk-heading-m">Get help</h2>
+
+              <p class="govuk-body-s govuk-!-margin-bottom-1">
+                Call 0800 389 2500 or <%= link_to("chat online", "https://getintoteaching.education.gov.uk/#talk-to-us", class: "govuk-footer__link") %>
+              </p>
+
+              <p class="govuk-body-s govuk-!-margin-bottom-1">
+                Monday to Friday, 8:30am to 5:30pm (except public holidays)
+              </p>
+
+              <p class="govuk-body-s">
+                Free of charge
+              </p>
+
+              <div class="govuk-!-margin-bottom-5">
+                <%= link_to("Make a complaint or give feedback", new_candidates_feedback_path, class: "govuk-footer__link")%>
+              </div>
+            <% end %>
 
             <h2 class="govuk-visually-hidden">
               Support links
@@ -109,7 +129,7 @@
               All content is available under the
               <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
             </span>
-          </div>
+          </section>
           <div class="govuk-footer__meta-item">
             <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
           </div>

--- a/features/candidates/landing_page.feature
+++ b/features/candidates/landing_page.feature
@@ -34,3 +34,7 @@ Feature: Candidate landing page
     Scenario: No account links in the phase banner
         Given I am on the 'landing' page
         Then there should be no 'Choose another service' link in the phase banner
+
+    Scenario: Get help footer section
+        Given I am on the 'landing' page
+        Then there should be a section titled 'Get help'

--- a/features/schools/landing_page.feature
+++ b/features/schools/landing_page.feature
@@ -11,3 +11,7 @@ Feature: The School Landing Page
     Scenario: Start now button
         Given I am on the 'schools' page
         Then there should be a 'Start now' link to the 'schools dashboard'
+
+    Scenario: Get help footer section
+        Given I am on the 'schools' page
+        Then there should not be a section titled 'Get help'

--- a/features/schools/service_updates.feature
+++ b/features/schools/service_updates.feature
@@ -13,6 +13,6 @@ Feature: Service Updates
     
     Scenario: Viewing the Dashboard after viewing Service Updates
         Given I am on the 'service updates' page
-        And I click 'back'
+        And I click 'Back'
         Then I am on the 'schools dashboard' page
         And I should not see the latest service update notification

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -35,6 +35,10 @@ Then("there should be a section titled {string}") do |string|
   expect(page).to have_css('section > h2.govuk-heading-m', text: string)
 end
 
+Then("there should not be a section titled {string}") do |string|
+  expect(page).not_to have_css('section > h2.govuk-heading-m', text: string)
+end
+
 Then("the page should have a heading called {string}") do |string|
   expect(page).to have_css("h1.govuk-fieldset__heading", text: string)
 end


### PR DESCRIPTION
### Trello card

[Trello-653](https://trello.com/c/xYJXz7M2/653-add-get-help-section-to-the-footer-of-candidate-facing-pages-of-gse-but-not-manage)

### Context

We want to display a 'Get help' section in the footer for all candidate-facing pages (and not the school/manage pages) so that candidates know where to go to get support or give feedback with their School Experience.

### Changes proposed in this pull request

- Add 'Get help' section to candidate footer

### Guidance to review

