### PR TITLE
Compare placement request experience type

### DIFF
--- a/lib/placement_request_transfer.rb
+++ b/lib/placement_request_transfer.rb
@@ -67,8 +67,8 @@ private
   def verify_experience_type!
     return if school.experience_type == "both"
 
-    unless school.experience_type == placement_request.school.experience_type
-      raise TransferError, "school does not support #{placement_request.school.experience_type} experience type"
+    unless school.experience_type == placement_request.experience_type
+      raise TransferError, "school does not support #{placement_request.experience_type} experience type"
     end
   end
 

--- a/spec/lib/placement_request_transfer_spec.rb
+++ b/spec/lib/placement_request_transfer_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe PlacementRequestTransfer do
     end
 
     context "when the school experience types are incompatible" do
-      let(:message) { "school does not support #{placement_request.school.experience_type} experience type" }
+      let(:message) { "school does not support #{placement_request.experience_type} experience type" }
 
       before { school.update(experience_type: "virtual") }
 


### PR DESCRIPTION
Comparing the supported experience type of the school is a bit too restrictive; we can transfer the placement request if the school we're transferring it to supports the experience type of the placement.
