### PR TITLE
Purge orphaned candidate records

### DIFF
--- a/app/models/bookings/candidate.rb
+++ b/app/models/bookings/candidate.rb
@@ -94,6 +94,10 @@ class Bookings::Candidate < ApplicationRecord
     "#{gitis_contact.first_name} #{gitis_contact.last_name}"
   end
 
+  def orphaned?
+    gitis_contact.is_a?(Bookings::Gitis::MissingContact)
+  end
+
   def confirmed?
     confirmed_at?
   end

--- a/lib/orphaned_candidate_purger.rb
+++ b/lib/orphaned_candidate_purger.rb
@@ -1,0 +1,44 @@
+# All personal candidate information is stored in the CRM
+# contact entity. Occasionally, the contacts in the CRM will
+# be deleted (if they have not seen activity in a long time).
+# This can result in orphaned candidates in the application, where
+# the gitis_uuid foreign key no longer points to a contact in the CRM.
+# To keep the two datasets consistent we purge orphaned candidates
+# from the School Exepreience database.
+class OrphanedCandidatePurger
+  BATCH_SIZE = 100
+
+  def initialize(dry_run: true)
+    @dry_run = dry_run
+  end
+
+  def purge!
+    orphaned_candidates = []
+    batch_candidates do |candidates|
+      contact_fetcher.assign_to_models(candidates)
+      orphaned_candidates += candidates.select(&:orphaned?)
+    end
+
+    if @dry_run
+      Rails.logger.info("Orphaned candidates", orphaned_candidates)
+    else
+      Bookings::Candidate.destroy(orphaned_candidates.map(&:id))
+    end
+  end
+
+private
+
+  # Batch candidates ignoring those recently created in case
+  # they haven't been pushed to the CRM yet.
+  def batch_candidates
+    Bookings::Candidate
+      .where("created_at < ?", 1.day.ago)
+      .find_in_batches(batch_size: BATCH_SIZE) do |candidates|
+        yield(candidates)
+      end
+  end
+
+  def contact_fetcher
+    @contact_fetcher ||= Bookings::Gitis::ContactFetcher.new
+  end
+end

--- a/spec/factories/bookings/candidates_factory.rb
+++ b/spec/factories/bookings/candidates_factory.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
       gitis_uuid { gitis_contact.candidate_id }
     end
 
+    trait :with_missing_api_contact do
+      gitis_contact { Bookings::Gitis::MissingContact.new(gitis_uuid) }
+    end
+
     trait :with_attended_booking do
       after :create do |candidate|
         FactoryBot.create(:placement_request, :with_attended_booking, candidate: candidate)

--- a/spec/lib/orphaned_candidate_purger_spec.rb
+++ b/spec/lib/orphaned_candidate_purger_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+require "orphaned_candidate_purger"
+
+RSpec.describe OrphanedCandidatePurger do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:dry_run) { false }
+  let(:instance) { described_class.new(dry_run: dry_run) }
+
+  describe "#purge!" do
+    let!(:candidates) do
+      travel_to 2.days.ago do
+        2.times.collect { create(:candidate) }
+      end
+    end
+    let!(:orphans) do
+      travel_to 2.days.ago do
+        3.times.collect { create(:candidate) }
+      end
+    end
+    let!(:recent_orphans) { 2.times.collect { create(:candidate) } }
+
+    before do
+      candidate_uuids = candidates.map(&:gitis_uuid)
+      orphan_uuids = orphans.map(&:gitis_uuid)
+      requested_uuids = candidate_uuids + orphan_uuids
+
+      allow_any_instance_of(GetIntoTeachingApiClient::SchoolsExperienceApi).to \
+        receive(:get_schools_experience_sign_ups).with(requested_uuids) do
+          candidate_uuids.map do |id|
+            GetIntoTeachingApiClient::SchoolsExperienceSignUp.new(
+              candidate_id: id,
+              merged: false
+            )
+          end
+        end
+    end
+
+    subject(:purge) { instance.purge! }
+
+    it "deletes orphaned candidates created more than a day ago" do
+      expect { purge }.to change(Bookings::Candidate, :count).by(-orphans.count)
+
+      orphans.each do |orphan|
+        expect { orphan.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when dry_run is true" do
+      let(:dry_run) { true }
+
+      it "does not delete candidates" do
+        expect(Rails.logger).to receive(:info).with("Orphaned candidates", orphans)
+
+        expect { purge }.not_to change(Bookings::Candidate, :count)
+      end
+    end
+  end
+end

--- a/spec/models/bookings/candidate_spec.rb
+++ b/spec/models/bookings/candidate_spec.rb
@@ -365,4 +365,22 @@ RSpec.describe Bookings::Candidate, type: :model do
       end
     end
   end
+
+  describe "#orphaned?" do
+    subject { build(:candidate) }
+
+    it { is_expected.not_to be_orphaned }
+
+    context "when an gitis_contact is set" do
+      subject { build(:candidate, :with_api_contact) }
+
+      it { is_expected.not_to be_orphaned }
+    end
+
+    context "when the gitis_contact is missing" do
+      subject { build(:candidate, :with_missing_api_contact) }
+
+      it { is_expected.to be_orphaned }
+    end
+  end
 end


### PR DESCRIPTION
> :warning: WIP; we need to figure out additional criteria around deletion and how often/if to run it periodically

### Trello card

[Trello-4001](https://trello.com/c/lFZAHtzA/4001-fix-get-school-experience-data-errors)

### Context

Occasionally a contact will be removed from the CRM. This leaves us with a candidate in School Experience that doesn't have any personally identifiable information attached.

We currently display these contacts as 'unknown', but going forward we want to periodically remove the orphaned candidates from our database.

### Changes proposed in this pull request

- Purge orphaned candidate records

Add a library to identify and remove orphaned candidates. As contact records can be created in the CRM asynchronously we need to exclude recently created candidates from this operation (as it may run before the async job creates the corresponding contact record, therefore incorrectly being identified as orphaned).

### Guidance to review

