### PR TITLE
Update API client gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,11 +9,11 @@ GIT
 
 GIT
   remote: https://github.com/DFE-Digital/get-into-teaching-api-ruby-client.git
-  revision: cf858eb830316acbb9a7cb1f2991a7eb89f17f36
+  revision: faced708d161b73a567d7eea766c6afb5795834c
   specs:
-    get_into_teaching_api_client (2.1.0)
+    get_into_teaching_api_client (2.3.0)
       faraday (~> 1.0, >= 1.0.1)
-    get_into_teaching_api_client_faraday (2.1.0)
+    get_into_teaching_api_client_faraday (2.3.0)
       activesupport
       faraday
       faraday-encoding
@@ -237,7 +237,7 @@ GEM
     faraday-encoding (0.0.5)
       faraday
     faraday-excon (1.1.0)
-    faraday-http-cache (2.2.0)
+    faraday-http-cache (2.4.1)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
@@ -249,9 +249,9 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    faraday_middleware-circuit_breaker (0.4.1)
+    faraday_middleware-circuit_breaker (0.5.0)
       faraday (>= 0.9, < 2.0)
-      stoplight (~> 2.1)
+      stoplight (>= 2.1, < 4.0)
     ffi (1.15.5)
     foreman (0.87.2)
     fugit (1.8.0)
@@ -462,6 +462,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redis (4.8.0)
+    redlock (1.3.2)
+      redis (>= 3.0.0, < 6.0)
     regexp_parser (2.5.0)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -582,7 +584,8 @@ GEM
     spring (4.1.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    stoplight (2.2.1)
+    stoplight (3.0.1)
+      redlock (~> 1.0)
     swd (1.3.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)


### PR DESCRIPTION
### Trello card

[Trello-4014](https://trello.com/c/W50wYBTV/4014-fix-gse-timeout-when-calling-api-crm)

### Context

This will reduce the API client timeout to 10 seconds, which is less than the 30s app timeout. Hopefully this will result in a retry and fix timeout errors we occasionally get (mainly from the health check endpoint).

### Changes proposed in this pull request

- Update API client gem

### Guidance to review

