### PR TITLE
Fix dfe-analytics deprecation warning

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,3 @@
 class ApplicationRecord < ActiveRecord::Base
-  include DfE::Analytics::Entities
-
   self.abstract_class = true
 end

--- a/spec/requests/big_query_analytics_spec.rb
+++ b/spec/requests/big_query_analytics_spec.rb
@@ -4,4 +4,9 @@ RSpec.describe "BigQuery Analytics", type: :request do
   it "sends a DFE Analytics web request event" do
     expect { get root_path }.to have_sent_analytics_event_types(:web_request)
   end
+
+  it "sends a DFE Analytics entity event" do
+    params = { candidates_feedback: build(:candidates_feedback).attributes }
+    expect { post "/candidates/feedbacks", params: params }.to have_sent_analytics_event_types(:create_entity)
+  end
 end


### PR DESCRIPTION
### Trello card

[Trello-4028](https://trello.com/c/oDECMFWN/4028-fix-deprecation-warnings-in-git-website-tta-service)

### Context

We no longer need to include `DfE::Analytics::Entities` explicitly; as of v1.4 it is included automatically.

### Changes proposed in this pull request

- Fix dfe-analytics deprecation warning

### Guidance to review

