### PR TITLE
Remove confirmation step

### DIFF
--- a/app/controllers/candidates/registrations/confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/confirmation_emails_controller.rb
@@ -1,6 +1,8 @@
 module Candidates
   module Registrations
     class ConfirmationEmailsController < RegistrationsController
+      invisible_captcha only: [:create], timestamp_threshold: 1.second
+
       def show
         @email = current_registration.email
         @school_name = current_registration.school.name

--- a/app/controllers/candidates/registrations/confirmation_emails_controller.rb
+++ b/app/controllers/candidates/registrations/confirmation_emails_controller.rb
@@ -8,24 +8,38 @@ module Candidates
       end
 
       def create
+        sign_in_candidate if !candidate_signed_in? && Feature.enabled?(:skip_candidate_confirmation_emails)
+
         if candidate_signed_in?
           RegistrationStore.instance.store! current_registration
           redirect_to candidates_confirm_path uuid: current_registration.uuid
         else
-          current_registration.flag_as_pending_email_confirmation!
-          RegistrationStore.instance.store! current_registration
-
-          SendEmailConfirmationJob.perform_later \
-            current_registration.uuid,
-            request.host
-
-          redirect_to candidates_school_registrations_confirmation_email_path
+          send_confirmation_email
         end
       rescue RegistrationSession::NotCompletedError
         # We can get here if the school changes their date format while the
         # candidate is applying, or we push a code change mid way through a
         # registration.
         redirect_to next_step_path(current_registration)
+      end
+
+    private
+
+      def sign_in_candidate
+        self.current_candidate = Bookings::Candidate.create_or_update_from_registration_session! \
+          current_registration,
+          current_contact
+      end
+
+      def send_confirmation_email
+        current_registration.flag_as_pending_email_confirmation!
+        RegistrationStore.instance.store! current_registration
+
+        SendEmailConfirmationJob.perform_later \
+          current_registration.uuid,
+          request.host
+
+        redirect_to candidates_school_registrations_confirmation_email_path
       end
     end
   end

--- a/app/views/candidates/registrations/application_previews/show.html.erb
+++ b/app/views/candidates/registrations/application_previews/show.html.erb
@@ -4,6 +4,9 @@
 <div class="govuk-grid-row" id="application-preview">
   <%= form_with url: candidates_school_registrations_confirmation_email_path,
         data: { controller: "prevent-double-click", action: "submit->prevent-double-click#disableSubmitButton" } do |f| %>
+
+  <%= invisible_captcha %>
+
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Check your answers before requesting your school experience</h1>
     <p>You'll receive an email with the following details once you've sent your school experience request.</p>

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,7 +17,7 @@ module Rack
       end
 
       # Throttle candidate registration submissions by IP (5rpm)
-      throttle("registrations/confirmation_email req/ip", limit: 5, period: 1.minute) do |req|
+      throttle("registrations/confirmation_email req/ip", limit: 3, period: 1.minute) do |req|
         req.ip if req.post? && req.path.match?(/registrations\/confirmation_email/)
       end
     end

--- a/feature-flags.json
+++ b/feature-flags.json
@@ -34,6 +34,13 @@
       "enabled_for": {
         "environments": ["development", "staging", "production"]
       }
+    },
+    {
+      "name": "skip_candidate_confirmation_emails",
+      "description": "Removes the need for new candidates to confirm their email address",
+      "enabled_for": {
+        "environments": ["development", "staging"]
+      }
     }
   ]
 }

--- a/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
@@ -122,6 +122,8 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
 
       before do
         allow_any_instance_of(ActionDispatch::Request::Session).to \
+          receive(:[]).and_call_original
+        allow_any_instance_of(ActionDispatch::Request::Session).to \
           receive(:[]).with(:gitis_contact).and_return(contact_attributes)
 
         post candidates_school_registrations_confirmation_email_path(school)

--- a/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
+++ b/spec/controllers/candidates/registrations/confirmation_emails_controller_spec.rb
@@ -28,6 +28,10 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
   end
 
   context '#create' do
+    let(:skip_confirmation_emails) { false }
+
+    before { allow(Feature).to receive(:enabled?).with(:skip_candidate_confirmation_emails) { skip_confirmation_emails } }
+
     context 'skipped step' do
       before { registration_store.send :delete, 'some-uuid' } # ensure key not left lying around
 
@@ -81,6 +85,30 @@ describe Candidates::Registrations::ConfirmationEmailsController, type: :request
       it 'redirects to the check your email page' do
         expect(response).to redirect_to \
           candidates_school_registrations_confirmation_email_path school
+      end
+
+      context "when the skip_candidate_confirmation_emails feature is enabled" do
+        let(:skip_confirmation_emails) { true }
+
+        it "does not mark the session as pending" do
+          expect(registration_session).not_to be_pending_email_confirmation
+        end
+
+        it "stores the session" do
+          expect(registration_store.retrieve!(registration_session.uuid)).to \
+            eq registration_session
+        end
+
+        it "does not enqueue the confirmation email job" do
+          expect(Candidates::Registrations::SendEmailConfirmationJob).not_to \
+            have_received(:perform_later).with \
+              registration_session.uuid, "www.example.com"
+        end
+
+        it "redirects to the placement_request page" do
+          expect(response).to redirect_to \
+            candidates_confirm_path registration_session.uuid
+        end
       end
     end
 

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -34,7 +34,7 @@ describe "Rate limiting" do
                                               ]
     end
 
-    it_behaves_like "an IP-based rate limited endpoint", "POST /candidates/schools/:school_id/registrations/confirmation_email", 5, 1.minute do
+    it_behaves_like "an IP-based rate limited endpoint", "POST /candidates/schools/:school_id/registrations/confirmation_email", 3, 1.minute do
       def perform_request
         post candidates_school_registrations_confirmation_email_path(11_048), headers: { "REMOTE_ADDR" => ip }
       end


### PR DESCRIPTION
### Trello card

[Trello-599](https://trello.com/c/dwv1HiJ0/599-implement-now-spike-is-complete-alternative-ways-to-prevent-spam-record-creation)

### Context

Currently if a new candidate signs up for a placement they are required to confirm their email address before the request is processed. We've had support tickets for candidates struggling to sign up and we believe that they are not actioning the sent email. Going forward we want to remove this requirement and introduce other, non-intrusive checks to prevent spam record creation.

### Changes proposed in this pull request

- Remove confirmation requirement for new candidates

Currently we require new candidates to confirm their email before issuing the placement request. We believe that this prevents a number of candidates from successfully finishing their request (the email doesn't arrive and/or they don't action it).

Add feature flag to allow us to trial skipping the confirmation step. We will be adding other measures in order to reduce the risk of spam record creation.

- Reduce rate limits on sign up endpoints

As these will be more accessible now the confirmations step is being removed we want to lower the rate limits to be more conservative.

- Enable invisible_captcha on sign up endpoint

As we are now allowing users to sign up/create placement requests without verifying their email address we want to introduce additional checks to help prevent spam record creation.

Enable `invisible_captcha` on the placement request creation endpoint; this will ensure that immediate submissions (sub 1 second) are treated as bots and also adds a honeypot field which, if filled in, will prevent the submission.

### Guidance to review

This is currently only enabled in non-production environments.