### PR TITLE
Whitelist gitis_uuid for dfe-analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -230,6 +230,7 @@
   - edubase_id
   - supports_subjects
   :bookings_candidates:
+  - gitis_uuid
   - id
   - created_at
   - updated_at

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -61,8 +61,6 @@
   - access_needs_description
   - access_needs_policy_url
   - dbs_policy_conditions
-  :bookings_candidates:
-  - gitis_uuid
   :bookings_placement_requests:
   - degree_stage_explaination
   - token


### PR DESCRIPTION
[Trello-4424](https://trello.com/c/o7ECY3uk/4424-whitelist-gitisuuid-in-gse-dfe-analytics)

Alex Christensen has requested this field to be sent to BigQuery so that he can match up records to those in the GiTiS CRM.
