### PR TITLE
Add Online Provider school type

### DIFF
--- a/db/data/school_types.yml
+++ b/db/data/school_types.yml
@@ -34,4 +34,5 @@
 44: Academy special converter
 45: Academy 16-19 converter
 46: Academy 16 to 19 sponsor led
+49: Online provider
 56: Institution funded by other government department


### PR DESCRIPTION
### Trello card

[Trello-683](https://trello.com/c/S8ucFDaE/683-investigate-mass-importer-errors)

### Context

This was recently added to the school data we import on a nightly basis. I've manually added it to the dev/staging/production environments; this updates the seed data to be consistent.

### Changes proposed in this pull request

- Add Online Provider school type

### Guidance to review

Manually added with:

```
Bookings::SchoolType.create!(name: "Online provider", edubase_id: 49)
```
