### PR TITLE
Add Realistic Job Preview link to search results page

### DIFF
--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -92,7 +92,7 @@
     <div class="pagination-info higher">
       <div class="pagination-slice">
       <div class="govuk-inset-text">
-       Do you think like a teacher? Try out responding to a <a href ="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a> to see.
+       Do you think like a teacher? Try out responding to a <a href="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a> to see.
       </div>
       <hr/>
         <%= school_results_info @search %>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -101,6 +101,10 @@
       <hr/>
       <div>Sorted by distance</div>
       <hr/>
+      <div class="govuk-inset-text">
+       Do you think like a teacher? See if you respond like teachers in a <a href ="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a>.
+      </div>
+      <hr/>
     <% end %>
 
     <ul id="results">

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -92,7 +92,7 @@
     <div class="pagination-info higher">
       <div class="pagination-slice">
       <div class="govuk-inset-text">
-       Do you think like a teacher? See if you respond like teachers in a <a href ="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a>.
+       Do you think like a teacher? Try out responding to a <a href ="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a> to see.
       </div>
       <hr/>
         <%= school_results_info @search %>

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -105,10 +105,6 @@
       <hr/>
       <div>Sorted by distance</div>
       <hr/>
-      <div class="govuk-inset-text">
-       Do you think like a teacher? See if you respond like teachers in a <a href ="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a>.
-      </div>
-      <hr/>
     <% end %>
 
     <ul id="results">

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -91,6 +91,10 @@
 
     <div class="pagination-info higher">
       <div class="pagination-slice">
+      <div class="govuk-inset-text">
+       Do you think like a teacher? See if you respond like teachers in a <a href ="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a>.
+      </div>
+      <hr/>
         <%= school_results_info @search %>
       </div>
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/jD8JzBiE/685-implement-link-to-university-of-york-realistic-job-preview

### Context

We are experimenting with Realistic Job Previews. This link is added to the results page and has UTM parameters attached.

### Changes proposed in this pull request

Add new module to search results page (NB copy has been tweaked slightly since this screengrab):

![image](https://github.com/DFE-Digital/schools-experience/assets/35870975/6b8d2dda-7b78-4c4c-99ca-1ff3f73ae59b)


### Guidance to review

Do we want any tests?
