### PR TITLE
Update env context to use staging.

### DIFF
--- a/.github/workflows/check_sp.yml
+++ b/.github/workflows/check_sp.yml
@@ -15,7 +15,7 @@ jobs:
         id: select-tests
         run: |
           d="{'environment' :'Development'  , 'principal': 's105d01-keyvault-readonly-access', 'keyvault': 's105d01-kv'}"
-          t="{'environment' :'Test'         , 'principal': 's105t01-keyvault-readonly-access', 'keyvault': 's105t01-kv'}"
+          t="{'environment' :'Staging'      , 'principal': 's105t01-keyvault-readonly-access', 'keyvault': 's105t01-kv'}"
           p="{'environment' :'Production'   , 'principal': 's105p01-keyvault-readonly-access', 'keyvault': 's105p01-kv'}"
           tests="{ 'data':[ ${d} ,  ${t} ,  ${p} ]}"
           echo "tests=${tests}" >> $GITHUB_OUTPUT
@@ -61,8 +61,6 @@ jobs:
           keyvault: ${{ matrix.data.keyvault }}
           secret: SE-INFRA-SECRETS
           key: SLACK-WEBHOOK
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Slack Notification
         if:   fromJson(steps.pwsh_check_expire.outputs.json_data).data.Alert


### PR DESCRIPTION
### Trello card

### Context
The test service principal secret is expiring, but the alert is not appearing in the channel.

The error appears to suggest the service principal in use doesn't have access to the s105t01-kv key vault.

It appears that as the check is using the 'test' environment context which does not exist, it does not pickup the updated AZURE_CREDENTIAL value and therefore does not have the proper access to the test subscription key vault to retrieve the Slack webhook.

### Changes proposed in this pull request
Change the environment in the check to 'Staging'
Removed the token auth as we login to Azure the step before

### Guidance to review
Confirmed the workflow runs using the Staging environment for the test subscription.

