### PR TITLE
[576] Add Terraform code to manage DNS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,15 +46,12 @@ coverage
 # Visual Studio Code
 .vscode
 
-# devops files
+# DevOps files
 
 bin/terrafile
 
-# Downloaded terraform modules
-terraform/aks/vendor/
+# Terraform files
+vendor/
 
 .terraform
-terraform/application/vendor
-terraform/domains/environment_domains/vendor
 terraform.tfstate*
-terraform/application/.terraform.lock.hcl

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ help:
 	echo "        make  development edit-app-secrets"
 	echo ""
 
+	@grep -E '^[a-zA-Z\._\-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 APPLICATION_SECRETS=SE-SECRETS
 INFRA_SECRETS=SE-INFRA-SECRETS
 
@@ -86,7 +88,6 @@ production:
 .PHONY: production_aks
 production_aks:
 	$(eval include global_config/production.sh)
-
 
 .PHONY: ci
 ci:
@@ -197,9 +198,9 @@ deploy-arm-resources: composed-variables arm-deployment
 
 validate-arm-resources: composed-variables set-what-if arm-deployment
 
-deploy-domain-arm-resources: domains domains-composed-variables arm-deployment # make deploy-domain-arm-resources
+deploy-domain-arm-resources: domains domains-composed-variables arm-deployment ## Deploy initial Azure resources (resource group, tfstate storage and key vault) will be deployed. Usage: make deploy-domain-arm-resources
 
-validate-domain-arm-resources: set-what-if domains domains-composed-variables arm-deployment # make validate-domain-arm-resources
+validate-domain-arm-resources: set-what-if domains domains-composed-variables arm-deployment ## Validate what Azure resources will be deployed. Usage: make validate-domain-arm-resources
 
 domains-infra-init: bin/terrafile domains-composed-variables set-azure-account
 	./bin/terrafile -p terraform/domains/infrastructure/vendor/modules -f terraform/domains/infrastructure/config/zones_Terrafile
@@ -209,10 +210,10 @@ domains-infra-init: bin/terrafile domains-composed-variables set-azure-account
 		-backend-config=storage_account_name=${STORAGE_ACCOUNT_NAME} \
 		-backend-config=key=domains_infrastructure.tfstate
 
-domains-infra-plan: domains domains-infra-init # make domains-infra-plan
+domains-infra-plan: domains domains-infra-init ## Terraform plan for DNS infrastructure (zone and front door. Usage: make domains-infra-plan
 	terraform -chdir=terraform/domains/infrastructure plan -var-file config/zones.tfvars.json
 
-domains-infra-apply: domains domains-infra-init # make domains-infra-apply
+domains-infra-apply: domains domains-infra-init ## Terraform apply for DNS infrastructure (zone and front door). Usage: make domains-infra-apply
 	terraform -chdir=terraform/domains/infrastructure apply -var-file config/zones.tfvars.json ${AUTO_APPROVE}
 
 domains-init: bin/terrafile domains-composed-variables set-azure-account
@@ -223,8 +224,8 @@ domains-init: bin/terrafile domains-composed-variables set-azure-account
 		-backend-config=storage_account_name=${STORAGE_ACCOUNT_NAME} \
 		-backend-config=key=${ENVIRONMENT}.tfstate
 
-domains-plan: domains domains-init # make development_aks domains-plan
+domains-plan: domains domains-init ## Terraform plan for DNS environment domains. Usage: make development_aks domains-plan
 	terraform -chdir=terraform/domains/environment_domains plan -var-file config/${CONFIG}.tfvars.json
 
-domains-apply: domains domains-init # make development_aks domains-apply
+domains-apply: domains domains-init ## Terraform apply for DNS environment domains. Usage: make development_aks domains-apply
 	terraform -chdir=terraform/domains/environment_domains apply -var-file config/${CONFIG}.tfvars.json ${AUTO_APPROVE}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 TERRAFILE_VERSION=0.8
 ARM_TEMPLATE_TAG=1.1.6
 RG_TAGS={"Product" : "Get Schools Experience"}
-DOMAIN_RG_TAGS={"Product" : "Teacher services cloud"}
 REGION=UK South
 SERVICE_NAME=get-schools-experience
 SERVICE_SHORT=gse
@@ -176,7 +175,6 @@ domains-composed-variables:
 	$(eval RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}domains-rg)
 	$(eval KEYVAULT_NAMES=["${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}domains-kv"])
 	$(eval STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}domainstf)
-	$(eval RG_TAGS=${DOMAIN_RG_TAGS})
 
 set-azure-account:
 	[ "${SKIP_AZURE_LOGIN}" != "true" ] && az account set -s ${AZURE_SUBSCRIPTION} || true

--- a/global_config/domains.sh
+++ b/global_config/domains.sh
@@ -1,0 +1,2 @@
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+AZURE_RESOURCE_PREFIX=s189p01

--- a/global_config/production.sh
+++ b/global_config/production.sh
@@ -1,0 +1,7 @@
+CONFIG=production
+ENVIRONMENT=production
+CONFIG_SHORT=pd
+AZURE_SUBSCRIPTION=s189-teacher-services-cloud-production
+AZURE_RESOURCE_PREFIX=s189p01
+KV_PURGE_PROTECTION=false
+PLATFORM=aks

--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.62.1"
+  constraints = "3.62.1"
+  hashes = [
+    "h1:DjR9eGTQPL9YX1fF539MPOrKYLrEmBgrGSBYDJo2iNE=",
+    "zh:0fa21ac98474f3a2aeab1191628735ddf1fdb0767f935e8b0f7e259a335773cd",
+    "zh:45ca710ffc39d194e0a29ca6983117a180302f3e1babb425257a23a1f38bb974",
+    "zh:481fd2ace1cf52ebae940ec8c66d025d2582af3aaf67340b6afbfa7a19b86864",
+    "zh:4fd32a7442f052fdf48ce6379f001581312a3ca7a10da837ee1c4e46c2f882dc",
+    "zh:507fff425b941a0fd53a57a4b79763183d37fac7ba3d4aa46a74dadf13ee5ced",
+    "zh:a09964b92e227cbceec7bf62e92bb71638b74738e465e5dafd75899a3c098eab",
+    "zh:a64ac7583675b0e704c6d6d1de31595e99ac7c270fd3e180d5f50d3f81f18801",
+    "zh:b20f4dbbd39aab6a3833541704771794790485ce62a85730f1cd671cf064ea8a",
+    "zh:d03b5c537e40fae12a9dd7750f0e29820b54f58efb1be1c7005ffb0ad70c6876",
+    "zh:ed19a03b3da4dfc000d278ffe986c5b3ab7114ccbe1d59e8bd474f065cfad377",
+    "zh:f53bb11e7be3d109f8763cb90910d79044693be35968c06eb31aa48f5375db31",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/domains/environment_domains/config/development.tfvars.json
+++ b/terraform/domains/environment_domains/config/development.tfvars.json
@@ -10,8 +10,7 @@
         "/packs/*"
       ],
       "environment_short": "dv",
-      "origin_hostname": "get-schools-experience-development.test.teacherservices.cloud",
-      "null_host_header": true
+      "origin_hostname": "get-school-experience-development.test.teacherservices.cloud"
     }
   }
 }

--- a/terraform/domains/environment_domains/config/development.tfvars.json
+++ b/terraform/domains/environment_domains/config/development.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "schoolexperience.education.gov.uk": {
+      "front_door_name": "s189p01-gsedomains-fd",
+      "resource_group_name": "s189p01-gsedomains-rg",
+      "domains": [
+        "development"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
+      "environment_short": "dv",
+      "origin_hostname": "get-schools-experience-development.test.teacherservices.cloud",
+      "null_host_header": false
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/development.tfvars.json
+++ b/terraform/domains/environment_domains/config/development.tfvars.json
@@ -11,7 +11,7 @@
       ],
       "environment_short": "dv",
       "origin_hostname": "get-schools-experience-development.test.teacherservices.cloud",
-      "null_host_header": false
+      "null_host_header": true
     }
   }
 }

--- a/terraform/domains/environment_domains/config/development_Terrafile
+++ b/terraform/domains/environment_domains/config/development_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/domains/environment_domains/config/development_Terrafile
+++ b/terraform/domains/environment_domains/config/development_Terrafile
@@ -1,3 +1,3 @@
 domains:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "stable"
+    version: "testing"

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -1,0 +1,23 @@
+{
+  "hosted_zone": {
+    "schoolexperience.education.gov.uk": {
+      "front_door_name": "s189p01-gsedomains-fd",
+      "resource_group_name": "s189p01-gsedomains-rg",
+      "domains": [
+        "apex"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
+      "environment_short": "pd",
+      "origin_hostname": "school-experience-app-production.london.cloudapps.digital",
+      "null_host_header": true,
+      "cnames": {
+        "_7008a420a72d06695f51ec61fb05296b": {
+          "target": "_3ef4070fa34b63f766060919d8588585.dxhlbxbsbv.acm-validations.aws",
+          "ttl": 86400
+        }
+      }
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/production_Terrafile
+++ b/terraform/domains/environment_domains/config/production_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -1,0 +1,17 @@
+{
+  "hosted_zone": {
+    "schoolexperience.education.gov.uk": {
+      "front_door_name": "s189p01-gsedomains-fd",
+      "resource_group_name": "s189p01-gsedomains-rg",
+      "domains": [
+        "staging"
+      ],
+      "cached_paths": [
+        "/packs/*"
+      ],
+      "environment_short": "stg",
+      "origin_hostname": "get-schools-experience-staging.test.teacherservices.cloud",
+      "null_host_header": false
+    }
+  }
+}

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -11,7 +11,7 @@
       ],
       "environment_short": "stg",
       "origin_hostname": "get-schools-experience-staging.test.teacherservices.cloud",
-      "null_host_header": false
+      "null_host_header": true
     }
   }
 }

--- a/terraform/domains/environment_domains/config/staging.tfvars.json
+++ b/terraform/domains/environment_domains/config/staging.tfvars.json
@@ -10,8 +10,7 @@
         "/packs/*"
       ],
       "environment_short": "stg",
-      "origin_hostname": "get-schools-experience-staging.test.teacherservices.cloud",
-      "null_host_header": true
+      "origin_hostname": "get-school-experience-staging.test.teacherservices.cloud"
     }
   }
 }

--- a/terraform/domains/environment_domains/config/staging_Terrafile
+++ b/terraform/domains/environment_domains/config/staging_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "stable"

--- a/terraform/domains/environment_domains/config/staging_Terrafile
+++ b/terraform/domains/environment_domains/config/staging_Terrafile
@@ -1,3 +1,3 @@
 domains:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "stable"
+    version: "testing"

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -1,0 +1,19 @@
+# Used to create domains to be managed by front door.
+module "domains" {
+  for_each            = var.hosted_zone
+  source              = "./vendor/modules/domains//domains/environment_domains"
+  zone                = each.key
+  front_door_name     = each.value.front_door_name
+  resource_group_name = each.value.resource_group_name
+  domains             = each.value.domains
+  environment         = each.value.environment_short
+  host_name           = each.value.origin_hostname
+  null_host_header    = try(each.value.null_host_header, false)
+  cached_paths        = try(each.value.cached_paths, [])
+}
+
+# Takes values from hosted_zone.domain_name.cnames (or txt_records, a-records). Use for domains which are not associated with front door.
+module "dns_records" {
+  source      = "./vendor/modules/domains//dns/records"
+  hosted_zone = var.hosted_zone
+}

--- a/terraform/domains/environment_domains/terraform.tf
+++ b/terraform/domains/environment_domains/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+
+  required_version = "= 1.5.1"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.62.1"
+    }
+  }
+  backend "azurerm" {
+    container_name = "terraform-state"
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+}

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -1,0 +1,4 @@
+variable "hosted_zone" {
+  type    = map(any)
+  default = {}
+}

--- a/terraform/domains/infrastructure/.terraform.lock.hcl
+++ b/terraform/domains/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.62.1"
+  constraints = "3.62.1"
+  hashes = [
+    "h1:DjR9eGTQPL9YX1fF539MPOrKYLrEmBgrGSBYDJo2iNE=",
+    "zh:0fa21ac98474f3a2aeab1191628735ddf1fdb0767f935e8b0f7e259a335773cd",
+    "zh:45ca710ffc39d194e0a29ca6983117a180302f3e1babb425257a23a1f38bb974",
+    "zh:481fd2ace1cf52ebae940ec8c66d025d2582af3aaf67340b6afbfa7a19b86864",
+    "zh:4fd32a7442f052fdf48ce6379f001581312a3ca7a10da837ee1c4e46c2f882dc",
+    "zh:507fff425b941a0fd53a57a4b79763183d37fac7ba3d4aa46a74dadf13ee5ced",
+    "zh:a09964b92e227cbceec7bf62e92bb71638b74738e465e5dafd75899a3c098eab",
+    "zh:a64ac7583675b0e704c6d6d1de31595e99ac7c270fd3e180d5f50d3f81f18801",
+    "zh:b20f4dbbd39aab6a3833541704771794790485ce62a85730f1cd671cf064ea8a",
+    "zh:d03b5c537e40fae12a9dd7750f0e29820b54f58efb1be1c7005ffb0ad70c6876",
+    "zh:ed19a03b3da4dfc000d278ffe986c5b3ab7114ccbe1d59e8bd474f065cfad377",
+    "zh:f53bb11e7be3d109f8763cb90910d79044693be35968c06eb31aa48f5375db31",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/domains/infrastructure/config/zones.tfvars.json
+++ b/terraform/domains/infrastructure/config/zones.tfvars.json
@@ -1,0 +1,15 @@
+{
+    "hosted_zone": {
+      "schoolexperience.education.gov.uk": {
+        "caa_records": {},
+        "txt_records": {
+          "_dmarc": {
+            "value": "v=DMARC1;p=quarantine;sp=quarantine;pct=100;fo=1;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc-rua@education.gov.uk;ruf=mailto:DMARC.Forensic@education.gov.uk"
+          }
+        },
+        "resource_group_name": "s189p01-gsedomains-rg",
+        "front_door_name": "s189p01-gsedomains-fd"
+      }
+    },
+    "deploy_default_records": false
+  }

--- a/terraform/domains/infrastructure/config/zones_Terrafile
+++ b/terraform/domains/infrastructure/config/zones_Terrafile
@@ -1,0 +1,3 @@
+domains:
+    source:  "https://github.com/DFE-Digital/terraform-modules"
+    version: "testing"

--- a/terraform/domains/infrastructure/config/zones_Terrafile
+++ b/terraform/domains/infrastructure/config/zones_Terrafile
@@ -1,3 +1,3 @@
 domains:
     source:  "https://github.com/DFE-Digital/terraform-modules"
-    version: "testing"
+    version: "stable"

--- a/terraform/domains/infrastructure/main.tf
+++ b/terraform/domains/infrastructure/main.tf
@@ -1,0 +1,5 @@
+module "domains_infrastructure" {
+  source                 = "./vendor/modules/domains//domains/infrastructure"
+  hosted_zone            = var.hosted_zone
+  deploy_default_records = var.deploy_default_records
+}

--- a/terraform/domains/infrastructure/terraform.tf
+++ b/terraform/domains/infrastructure/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = "= 1.5.1"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "3.62.1"
+    }
+  }
+  backend "azurerm" {
+    container_name = "terraform-state"
+  }
+}
+
+provider "azurerm" {
+  features {}
+
+  skip_provider_registration = true
+}

--- a/terraform/domains/infrastructure/variables.tf
+++ b/terraform/domains/infrastructure/variables.tf
@@ -1,0 +1,7 @@
+variable "hosted_zone" {
+  type = map(any)
+}
+
+variable "deploy_default_records" {
+  default = true
+}


### PR DESCRIPTION
Adds Terraform code, config and Makefile commands to support managing DNS using Terraform

### Trello card
https://trello.com/c/iEt2nhFs

### Context
Allow management of the services DNS using Terraform

### Changes proposed in this pull request
[Deployed resource group](https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/3c033a0c-7a1c-4653-93cb-0f2a9f57a391/resourceGroups/s189p01-gsedomains-rg/overview)

### Guidance to review

