### PR TITLE
Update URLs

### DIFF
--- a/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
+++ b/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
@@ -1,15 +1,15 @@
 Dear ((candidate_name)),
 
-((school_name)) has turned down your school experience request for the following dates: 
+((school_name)) has turned down your school experience request for the following dates:
 * ((dates_requested))
 
-Your request was turned down for the following reasons: 
+Your request was turned down for the following reasons:
 ((rejection_reasons))
 
-#  Extra details from the school 
+#  Extra details from the school
 ((extra_details))
 
-# Make a new request 
+# Make a new request
 Request school experience at other schools - ((school_search_url))
 
 # Arrange independent experience
@@ -20,5 +20,5 @@ If you can’t find anything in your area you can arrange school experience inde
 
 Use our Get Into Teaching service by calling 0800 389 2500 (8:30am to 5:30pm, Mon to Fri) or by visiting https://getintoteaching.education.gov.uk/ to:
 
-* receive free one-to-one support and advice and get all your questions about teaching answered by our team of trained professionals - https://adviser-getintoteaching.education.gov.uk
+* receive free one-to-one support and advice and get all your questions about teaching answered by our team of trained professionals - https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
 * reserve your place on one of our free nationwide teaching events - https://getintoteaching.education.gov.uk/teaching-events

--- a/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
+++ b/app/notify/notify_email/candidate_request_rejection_nopiii.74f84226-539a-43b0-b887-d8ffc9348965.md
@@ -21,4 +21,4 @@ If you can’t find anything in your area you can arrange school experience inde
 Use our Get Into Teaching service by calling 0800 389 2500 (8:30am to 5:30pm, Mon to Fri) or by visiting https://getintoteaching.education.gov.uk/ to:
 
 * receive free one-to-one support and advice and get all your questions about teaching answered by our team of trained professionals - https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity
-* reserve your place on one of our free nationwide teaching events - https://getintoteaching.education.gov.uk/teaching-events
+* reserve your place on one of our free nationwide teaching events - https://getintoteaching.education.gov.uk/events

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -44,7 +44,7 @@
   </p>
 
    <p>
-    <a href = "https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity/?utm_source=schoolexperience.education.gov.uk&utm_medium=referral&utm_campaign=gse_completion">Sign up for a teacher training adviser</a>.
+    <a href = "https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity?utm_source=schoolexperience.education.gov.uk&utm_medium=referral&utm_campaign=gse_completion">Sign up for a teacher training adviser</a>.
   </p>
 
   </div>

--- a/app/views/candidates/registrations/placement_requests/show.html.erb
+++ b/app/views/candidates/registrations/placement_requests/show.html.erb
@@ -44,7 +44,7 @@
   </p>
 
    <p>
-    <a href = "https://adviser-getintoteaching.education.gov.uk/?utm_source=schoolexperience.education.gov.uk&utm_medium=referral&utm_campaign=gse_completion">Sign up for a teacher training adviser</a>.
+    <a href = "https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity/?utm_source=schoolexperience.education.gov.uk&utm_medium=referral&utm_campaign=gse_completion">Sign up for a teacher training adviser</a>.
   </p>
 
   </div>

--- a/app/views/schools/placement_requests/cancellations/_letter.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_letter.html.erb
@@ -74,7 +74,7 @@
     </p>
 
     <p>
-      Get free one-to-one <%= link_to 'support and advice', 'https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity' %>
+      Get free one-to-one <%= link_to 'support and advice', 'https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity?utm_source=http://schoolexperience.education.gov.uk&utm_medium=referral&utm_campaign=gse_cancellation' %>
       from a team of trained professionals.
     </p>
 

--- a/app/views/schools/placement_requests/cancellations/_letter.html.erb
+++ b/app/views/schools/placement_requests/cancellations/_letter.html.erb
@@ -74,7 +74,7 @@
     </p>
 
     <p>
-      Get free one-to-one <%= link_to 'support and advice', 'https://adviser-getintoteaching.education.gov.uk' %>
+      Get free one-to-one <%= link_to 'support and advice', 'https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity' %>
       from a team of trained professionals.
     </p>
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/a7PoPGOz/688-replace-links-to-get-an-adviser-site

### Context

Request from GIT following retirement of TA service as separate service.

### Changes proposed in this pull request

https://adviser-getintoteaching.education.gov.uk
->
https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity

Added UTMs where appropriate (i.e. all non Notify mailers)

### Guidance to review

Does this work?