### PR TITLE
To remove paas dev from workflow after merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,7 +349,7 @@ jobs:
       - name: Set matrix environments (Push to master)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
-            echo "MATRIX_ENVIRONMENTS={\"environment\":[\"Development\" , \"Staging\",\"Production\"]}" >> $GITHUB_ENV
+            echo "MATRIX_ENVIRONMENTS={\"environment\":[\"Staging\",\"Production\"]}" >> $GITHUB_ENV
             echo "MATRIX_AKS_ENVIRONMENTS={\"environment\":[\"development\",\"staging\",\"production\"]}" >> $GITHUB_ENV
 
       - name: Set matrix environments ( Review)


### PR DESCRIPTION
WHY: paas deployment for dev will not be necessary after deployment
HOW: Remove development from matrix

### Trello card
https://trello.com/c/gkhvqc5A/691-remove-dev-env-from-workflow
### Context
to remove dev env from workflow run
### Changes proposed in this pull request
development removed from the list
### Guidance to review

