### PR TITLE
Removed staging PAAS from build and deploy to be merged after Migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,7 +349,7 @@ jobs:
       - name: Set matrix environments (Push to master)
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
-            echo "MATRIX_ENVIRONMENTS={\"environment\":[\"Staging\",\"Production\"]}" >> $GITHUB_ENV
+            echo "MATRIX_ENVIRONMENTS={\"environment\":[\"Production\"]}" >> $GITHUB_ENV
             echo "MATRIX_AKS_ENVIRONMENTS={\"environment\":[\"development\",\"staging\",\"production\"]}" >> $GITHUB_ENV
 
       - name: Set matrix environments ( Review)

--- a/.github/workflows/database-copy.yml
+++ b/.github/workflows/database-copy.yml
@@ -10,7 +10,7 @@ jobs:
     name: Restore DB
     strategy:
       matrix:
-        environment: [staging, production]
+        environment: [production]
       max-parallel: 1
     uses: ./.github/workflows/paas_to_aks_db_backup_and_restore_manual.yml
     with:


### PR DESCRIPTION
WHY: Staging build and deploy for PAAS not necessary after Migration
HOW: by removing from the list of build environments

### Trello card

### Context
remove staging from build and db refresh
### Changes proposed in this pull request
remove staging from build and db refresh
### Guidance to review

