### PR TITLE
Dependabot sidekiq 6.5.12 update with nokogiri fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,8 @@ RUN yarn install && yarn cache clean
 # Install Gems removing artifacts
 COPY .ruby-version Gemfile Gemfile.lock ./
 # hadolint ignore=SC2046
-RUN gem install bundler --version='~> 2.3.4' && \
+RUN gem install nokogiri --version 1.15.3 --platform x86_64-linux && \
+    gem install bundler --version='~> 2.3.4' && \
     bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java && \
     bundle install --jobs=$(nproc --all) && \
     rm -rf /root/.bundle/cache && \

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.15.3-x86_64-linux)
+      racc (~> 1.4)
     notifications-ruby-client (5.4.0)
       jwt (>= 1.5, < 3)
     openid_connect (1.4.2)
@@ -398,7 +400,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.7.1)
-    rack (2.2.7)
+    rack (2.2.8)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-oauth2 (1.21.3)
@@ -555,10 +557,10 @@ GEM
       semantic_range (>= 2.3.0)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (6.5.5)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.12)
+      connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
-      redis (>= 4.5.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-cron (1.10.0)
       fugit (~> 1.8)
       globalid (>= 1.0.1)
@@ -651,6 +653,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   actionpack-cloudfront (>= 1.2.0)
@@ -715,7 +718,7 @@ DEPENDENCIES
   sentry-ruby
   sentry-sidekiq
   shakapacker (= 6.6.0)
-  shoulda-matchers (~> 5.3.0)
+  shoulda-matchers (~> 5.0)
   sidekiq (< 7)
   sidekiq-cron
   simplecov
@@ -730,7 +733,7 @@ DEPENDENCIES
   yabeda-http_requests
   yabeda-prometheus
   yabeda-puma-plugin
-  yabeda-rails (= 0.9.0)
+  yabeda-rails
   yabeda-sidekiq
 
 RUBY VERSION


### PR DESCRIPTION
### Trello card
[5278](https://trello.com/c/4L1ukRUv/5278-gse-rails-app-load-error-after-nokogiri-fix)

### Context
The Docker build fails because it does not contain the platform specific installation of the nokogiri gem. Changes through bundler were failing to work, so explicitly adding.

### Changes proposed in this pull request
Explicitly add the required platform specific version of nokogiri to the image.

### Guidance to review

