### PR TITLE
added az get credentials

### DIFF
--- a/.github/workflows/destroy_aks.yml
+++ b/.github/workflows/destroy_aks.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: K8 setup for review apps
+        shell: bash
+        run: |
+          az aks get-credentials -g s189t01-tsc-ts-rg -n s189t01-tsc-test-aks
+
       - name: Terraform Destroy
         run: |
             make ci review_aks terraform-destroy-aks PR_NUMBER=${{github.event.number}}


### PR DESCRIPTION
### Trello card
https://trello.com/c/hI9AAMsQ/800-fix-destroy-review-aks-bug
### Context
the destroy aks  review pr fails due to not getting context 
### Changes proposed in this pull request
  az aks get-credentials -g s189t01-tsc-ts-rg -n s189t01-tsc-test-aks
### Guidance to review

PR is destroyed