### PR TITLE
Changed labeler to use the current syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,38 +1,54 @@
 ---
 
 Style:
-  - app/**/*.scss
-  - app/**/*.css
-  
+- changed-files:
+  - any-glob-to-any-file:
+    - app/**/*.scss
+    - app/**/*.css
+
+
 Ruby:
-  - app/**/*.rb
-  - app/**/*.erb
-  - db/**/*.rb
-  - config/**/*.rb
-  - lib/**/*.rb
-  - lib/**/*.rake
+- changed-files:
+  - any-glob-to-any-file:
+    - app/**/*.rb
+    - app/**/*.erb
+    - db/**/*.rb
+    - config/**/*.rb
+    - lib/**/*.rb
+    - lib/**/*.rake
 
 Test:
-  - spec/**/*
-  - tests/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - spec/**/*
+    - tests/**/*
 
 DevOps:
-  - terraform/**/*
-  - .github/**/*.yml
+- changed-files:
+  - any-glob-to-any-file:
+    - terraform/**/*
+    - .github/**/*.yml
 
 Docker:
-  - Dockerfile 
-  - docker-run.sh
+- changed-files:
+  - any-glob-to-any-file:
+    - Dockerfile
+    - docker-run.sh
 
 Assets:
-  - public/assets/**/*
+- changed-files:
+  - any-glob-to-any-file: 'public/assets/**/*'
 
 Content:
-  - app/views/content/**/*
+- changed-files:
+  - any-glob-to-any-file: 'app/views/content/**/*'
 
 Config:
-  - config/**/*
+- changed-files:
+  - any-glob-to-any-file: 'config/**/*'
 
 Documentation:
-  - doc/**/*
-  - docs/**/*
+- changed-files:
+  - any-glob-to-any-file:
+    - doc/**/*
+    - docs/**/*


### PR DESCRIPTION
### Trello card
https://trello.com/c/rMgSHSgy/863-labeler-fix
### Context
WHY: The syntax has been changed in the target, leading to build failure
HOW: By changing the syntax to match the latest syntax
### Changes proposed in this pull request
labeler syntax changed to current


