### PR TITLE
Update school_types.yml

### DIFF
--- a/db/data/school_types.yml
+++ b/db/data/school_types.yml
@@ -36,3 +36,4 @@
 46: Academy 16 to 19 sponsor led
 49: Online provider
 56: Institution funded by other government department
+57: Academy secure 16 to 19


### PR DESCRIPTION
We need to add a new school type `Academy secure 16 to 19` So that such schools can offer placements to potential  candidates who are interested in teaching

### Trello card
https://trello.com/c/NmtqppdY/

### Context
We are numerous getting sentry errors due to a missing school type for a new GSE school, Oasis Restore

### Changes proposed in this pull request
- adds the new school type to the list

### Guidance to review

