### PR TITLE
Update govuk-frontend from `4.0.1` to `4.7.0`

### DIFF
--- a/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
+++ b/features/step_definitions/candidates/registrations/request_school_experience_placement_steps.rb
@@ -1,6 +1,6 @@
 Then("the {string} word count should say {string}") do |label_text, expectation|
   within(page.find("label", text: label_text).ancestor('div.govuk-form-group')) do
-    expect(page).to have_css("span.govuk-character-count__message", text: expectation)
+    expect(page).to have_css("div.govuk-character-count__message", text: expectation)
   end
 end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3317,9 +3317,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 govuk-frontend@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.0.1.tgz#bceff58ecb399272cba32bd2b357fe16198e3249"
-  integrity sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
+  integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"


### PR DESCRIPTION
This pull request upgrades the govuk-frontend library from version ^4.0.1 to 4.7.0. 

### Trello card
https://trello.com/c/D7upaa5C

### Context
Ahead of the breaking changes introduced by the release of 5.0, this upgrade brings new features and improvements to the govuk-frontend library, enhancing the user experience and keeping our application up-to-date with the latest design patterns. 

### Changes proposed in this pull request
This update is part of our ongoing effort to keep our dependencies current. Notably, 4.7.0 is the last upgrade before a major 5.0 release. While this PR doesn't include major breaking changes, it prepares us for the upcoming transition and allows us to identify and address any potential issues early on.

### Guidance to review
- Tested locally to ensure the application functions as expected.
-  Ensured all existing features are unaffected by the upgrade.
-  Checked for any deprecations or warnings during the build process.
-  Verified compatibility with other dependencies.
