### PR TITLE
Update dfe-analytics on Get school experience and switch on an entity table check

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "redis", "~> 4.7"
 
 gem 'kaminari'
 
-gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.5.3"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics", tag: "v1.11.6"
 
 gem "rolify"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: bfa569a60b4fca7545ca7b72764c526b65d913b9
-  tag: v1.5.3
+  revision: 33251ca61e4806fc7eb86538c24de578bfea0007
+  tag: v1.11.6
   specs:
-    dfe-analytics (1.5.3)
+    dfe-analytics (1.11.6)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -255,33 +255,32 @@ GEM
     geocoder (1.8.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.42.0)
-      google-apis-core (>= 0.9.0, < 2.a)
-    google-apis-core (0.9.1)
+    google-apis-bigquery_v2 (0.62.0)
+      google-apis-core (>= 0.12.0, < 2.a)
+    google-apis-core (0.12.0)
       addressable (~> 2.5, >= 2.5.1)
-      googleauth (>= 0.16.2, < 2.a)
+      googleauth (~> 1.9)
       httpclient (>= 2.8.1, < 3.a)
       mini_mime (~> 1.0)
       representable (~> 3.0)
       retriable (>= 2.0, < 4.a)
       rexml
-      webrick
-    google-cloud-bigquery (1.39.0)
+    google-cloud-bigquery (1.45.0)
       concurrent-ruby (~> 1.0)
       google-apis-bigquery_v2 (~> 0.1)
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    google-cloud-core (1.6.0)
-      google-cloud-env (~> 1.0)
+    google-cloud-core (1.6.1)
+      google-cloud-env (>= 1.0, < 3.a)
       google-cloud-errors (~> 1.0)
-    google-cloud-env (1.6.0)
-      faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.3.0)
-    googleauth (1.3.0)
-      faraday (>= 0.17.3, < 3.a)
+    google-cloud-env (2.1.0)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.3.1)
+    googleauth (1.9.1)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.1)
       jwt (>= 1.4, < 3.0)
-      memoist (~> 0.16)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
@@ -335,7 +334,6 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
-    memoist (0.16.2)
     meta-tags (2.17.0)
       actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
@@ -569,7 +567,7 @@ GEM
       fugit (~> 1.8)
       globalid (>= 1.0.1)
       sidekiq (>= 6)
-    signet (0.17.0)
+    signet (0.18.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -6,6 +6,7 @@ DfE::Analytics.configure do |config|
   # Whether to use ActiveJob or dispatch events immediately.
   #
   config.async = true
+  config.entity_table_checks_enabled = true
 
   # Which ActiveJob queue to put events on
   #


### PR DESCRIPTION
### Trello card
https://trello.com/c/dRaTmD3g/

### Context
Enable an [Entity Table Check job](https://github.com/DFE-Digital/dfe-analytics/blob/main/lib/dfe/analytics/entity_table_check_job.rb) on GIT which sends a row_count, 
a checksum and a timestamp for each entity table sent to BigQuery
This helps Data Insights team to confirm that database tables match BigQuery
and helps them debug them where they don’t

### Changes proposed in this pull request
- Update dfe-analytics gem to v1.11.6
- Enable entity table checks in DfE Analytics configuration

### Guidance to review
Check that:
- The gem is updated 
- enabled the check
- Things working as expected
- Scheduled the daily job
