### PR TITLE
Fixed db backup pipeline failures

### DIFF
--- a/.github/workflows/actions/database-backup/action.yml
+++ b/.github/workflows/actions/database-backup/action.yml
@@ -100,7 +100,7 @@ runs:
   - name: K8 setup
     shell: bash
     run: |
-      make ${{ inputs.environment }} get-cluster-credentials
+      make ci ${{ inputs.environment }} get-cluster-credentials
       make bin/konduit.sh
 
   - name: Setup postgres client

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ APPLICATION_SECRETS=SE-SECRETS
 INFRA_SECRETS=SE-INFRA-SECRETS
 
 .PHONY: development
-development:
+development: test-cluster
 	$(eval include global_config/development.sh)
 
 .PHONY: set-key-vault-names


### PR DESCRIPTION
### Trello card
  https://trello.com/c/RnXWAXvO/943-bug-school-experience-db-backup-is-failing
### Context
  DB backup failing for AUTO_APPROVE not set.
### Changes proposed in this pull request
   changed the following call
     make ${{ inputs.environment }} get-cluster-credentials
  to 
    make ci ${{ inputs.environment }} get-cluster-credentials

### Guidance to review
From command line execute make ci ${{ inputs.environment }} get-cluster-credentials , it should not ask approvals.