### PR TITLE
Downgrade sass-loader version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mini-css-extract-plugin": "^2.7.6",
     "postcss-preset-env": "^6.7.2",
     "sass": "^1.69.5",
-    "sass-loader": "^14.1.0",
+    "sass-loader": "^13.3.3",
     "semver": "^7.5.2",
     "shakapacker": "7.2.2",
     "stimulus": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5288,10 +5288,10 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-sass-loader@^14.1.0:
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-14.1.0.tgz#43ba90e0cd8a15a1e932e818c525b0115a0ce8a3"
-  integrity sha512-LS2mLeFWA+orYxHNu+O18Xe4jR0kyamNOOUsE3NyBP4DvIL+8stHpNX0arYTItdPe80kluIiJ7Wfe/9iHSRO0Q==
+sass-loader@^13.3.3:
+  version "13.3.3"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-13.3.3.tgz#60df5e858788cffb1a3215e5b92e9cba61e7e133"
+  integrity sha512-mt5YN2F1MOZr3d/wBRcZxeFgwgkH44wVc2zohO2YF6JiOMkiXe4BYRZpSu2sO1g71mo/j16txzUhsKZlqjVGzA==
   dependencies:
     neo-async "^2.6.2"
 


### PR DESCRIPTION
Due to ci-failures, temporarily downgrading this to the previous working version in an attempt to get the pipeline working fine again.
