### PR TITLE
Remove realistic job previews link from Get school experience

### DIFF
--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -91,10 +91,6 @@
 
     <div class="pagination-info higher">
       <div class="pagination-slice">
-      <div class="govuk-inset-text">
-       Do you think like a teacher? Try out responding to a <a href="https://teacherselect.qualtrics.com/jfe/form/SV_aXbiUM3xz0uVtuS?utm_source=schoolexperience.education.gov.uk&utm_medium=referral">variety of classroom scenarios</a> to see.
-      </div>
-      <hr/>
         <%= school_results_info @search %>
       </div>
 


### PR DESCRIPTION
### Trello card
https://trello.com/c/UEseqfYg/

### Context
The Realistic job previews (Klassen) pilot has ended

### Changes proposed in this pull request
This fix removes the link from Get school experience

### Guidance to review
The link highlighted in the screenshot should no longer be on the page.
![image](https://github.com/DFE-Digital/schools-experience/assets/7931750/3e10e54a-4e29-4802-b5f3-67c49d349010)
