### PR TITLE
Copy Changes on Manage GSE

### DIFF
--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -25,8 +25,16 @@
         <h1 class="govuk-heading-l">Manage school experience</h1>
 
         <p class="govuk-body-l">
-          You have not yet been granted access to the Manage school
-          experience service.
+          You do not have access to any schools yet
+        </p>
+
+        <p>
+          If you need access to a school, you should reach out to the approver within your organisation.
+        </p>
+        <p> If your approver has already granted you access, please contact
+          <a href="mailto:organise.school-experience@education.gov.uk">
+           DfE Sign-in support.
+          </a>
         </p>
 
         <%= render 'pages/request_organisation_access' %>

--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -12,14 +12,15 @@
                   aria_label: "outstanding bookings and requests for #{school.name}" %>
               <% end %>
             <% end %>
-            <% if Schools::ChangeSchool.request_approval_url %>
-              <div class= 'govuk-radios__divider'>or</div>
-              <%= f.govuk_radio_button :change_to_urn, "request access", label: { text: "Request access to another school" } %>
-            <% end %>
           <% end %>
 
           <%= f.govuk_submit "Continue" %>
         <% end %>
+        <p> If your school is not listed, please contact
+          <a href="mailto:organise.school-experience@education.gov.uk">
+           DfE Sign-in support.
+          </a>
+        </p>
       <% elsif @dfe_sign_in_add_service_url %>
         <h1 class="govuk-heading-l">Manage school experience</h1>
 

--- a/app/views/schools/dashboards/_profile_and_dates.html.erb
+++ b/app/views/schools/dashboards/_profile_and_dates.html.erb
@@ -5,6 +5,9 @@
       <li>
         <%= link_to "Update school profile", schools_on_boarding_profile_path %>
       </li>
+      <li>
+        <%= link_to "Manage users" %>
+      </li>
     </ul>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <p>Your profile is currently <strong><%= school_enabled_description @current_school %></strong>.</p>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -11,9 +11,13 @@
       </p>
 
       <p>
-        The service will enable you to advertise your school and allow
-        candidates to request experience dates. You'll be able to accept
-        or reject each request.
+        On this service you can:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>advertise experience at your school</li>
+          <li>allow candidates to request experience dates</li>
+          <li>accept or reject candidates requests for experience</li>
+          <li>add other members from your school</li>
+        </ul>
       </p>
 
       <p>

--- a/spec/views/schools/change_schools/show.html.erb_spec.rb
+++ b/spec/views/schools/change_schools/show.html.erb_spec.rb
@@ -97,8 +97,8 @@ describe 'schools/change_schools/show', type: :view do
 
     before { render }
 
-    specify 'there should be an request access option' do
-      expect(rendered).to have_css("input[type='radio'][value='request access']")
+    specify 'there should not be an request access option' do
+      expect(rendered).not_to have_css("input[type='radio'][value='request access']")
     end
   end
 end


### PR DESCRIPTION
### Trello card
[#5535 ](https://trello.com/c/KSbGXeZ5)

### Context
As part of the integration with the Identity only version of DfE Sign-in on Get School Experience
We are making changes to the copy on same pages.

### Changes proposed in this pull request
- Update copy on school show page to use bullet points for service description
- Remove request school radio button and add contact information for DfE Sign-in support
- Update school access message for users with no schools

### Guidance to review
- navigate to the pages to see the difference.
Before:
![image](https://github.com/DFE-Digital/schools-experience/assets/7931750/c79d8df5-2a4f-4de9-ad2c-de78776058a7)
After:
![Screenshot 2024-03-01 at 08 56 18](https://github.com/DFE-Digital/schools-experience/assets/7931750/ed92be06-d45c-431e-8a34-a609927469ef)

Before:
![image](https://github.com/DFE-Digital/schools-experience/assets/7931750/4844b34f-7a2a-485c-98b3-6c8a531e7bd9)

After:
![image](https://github.com/DFE-Digital/schools-experience/assets/7931750/dd4341b2-69cd-4b3a-925d-6e9feae44d9a)

