### PR TITLE
Allow School Administrators to invite users via School Dashboard in Manage School Experience

### DIFF
--- a/app/controllers/schools/users_controller.rb
+++ b/app/controllers/schools/users_controller.rb
@@ -1,0 +1,44 @@
+module Schools
+  class UsersController < BaseController
+    def index
+      @users = DFESignInAPI::OrganisationUsers.new(current_user.sub, current_school.urn).users
+      @dfe_sign_in_request_organisation_url =
+        Rails.application.config.x.dfe_sign_in_request_organisation_url.presence
+    end
+
+    def new
+      @user_invite = DFESignInAPI::UserInvite.new
+    end
+
+    def create
+      @user_invite = DFESignInAPI::UserInvite.new(user_params)
+      @user_invite.organisation_id = DFESignInAPI::Organisation.new(current_user.sub, current_school.urn).current_organisation_id
+
+      if params[:confirmed] == 'true'
+        if @user_invite.valid?
+          @user_invite.create
+          redirect_to schools_users_path, notice: "#{@user_invite.email} has been added."
+        else
+          render :new
+        end
+      else
+        render :show, locals: { user_invite: @user_invite }
+      end
+    end
+
+    def show
+      render :show
+    end
+
+    def edit
+      @user_invite = DFESignInAPI::UserInvite.new(user_params)
+      render :new, locals: { user_invite: @user_invite }
+    end
+
+  private
+
+    def user_params
+      params.require(:schools_dfe_sign_in_api_user_invite).permit(:email, :firstname, :lastname, :organisation_id)
+    end
+  end
+end

--- a/app/services/schools/dfe_sign_in_api/organisation.rb
+++ b/app/services/schools/dfe_sign_in_api/organisation.rb
@@ -1,0 +1,24 @@
+module Schools
+  module DFESignInAPI
+    class Organisation < Organisations
+      attr_accessor :current_school_urn
+
+      def initialize(user_uuid, current_school_urn)
+        super(user_uuid)
+        self.current_school_urn = current_school_urn
+      end
+
+      def current_organisation
+        organisations.find { |org| org['urn'].to_i == current_school_urn }
+      end
+
+      def current_organisation_ukprn
+        current_organisation['ukprn'] if current_organisation
+      end
+
+      def current_organisation_id
+        current_organisation['id'] if current_organisation
+      end
+    end
+  end
+end

--- a/app/services/schools/dfe_sign_in_api/organisation_users.rb
+++ b/app/services/schools/dfe_sign_in_api/organisation_users.rb
@@ -1,0 +1,29 @@
+module Schools
+  module DFESignInAPI
+    class OrganisationUsers < Client
+      attr_accessor :user_uuid, :current_school_urn
+
+      def initialize(user_uuid, current_school_urn)
+        self.user_uuid = user_uuid
+        self.current_school_urn = current_school_urn
+      end
+
+      def ukprn
+        Organisation.new(user_uuid, current_school_urn).current_organisation_ukprn
+      end
+
+      def users
+        @users ||= response&.fetch('users', nil)
+      end
+
+    private
+
+      def endpoint
+        URI::HTTPS.build(
+          host: Rails.configuration.x.dfe_sign_in_api_host,
+          path: ['/organisations', ukprn, 'users'].join('/')
+        )
+      end
+    end
+  end
+end

--- a/app/services/schools/dfe_sign_in_api/user_invite.rb
+++ b/app/services/schools/dfe_sign_in_api/user_invite.rb
@@ -1,0 +1,59 @@
+module Schools
+  module DFESignInAPI
+    class UserInvite < Client
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActiveRecord::AttributeAssignment
+
+      attribute :email, :string
+      attribute :firstname, :string
+      attribute :lastname, :string
+      attribute :organisation_id, :string
+
+      validates :firstname, presence: true, length: { maximum: 50 }
+      validates :lastname, presence: true, length: { maximum: 50 }
+      validates :email, presence: true, length: { maximum: 100 }
+      validates :email, email_format: true, if: -> { email.present? }
+      validates :organisation_id, presence: true
+
+      def create
+        @response = response
+      end
+
+    private
+
+      def response
+        raise ApiDisabled unless enabled?
+
+        resp = faraday.post(endpoint) do |req|
+          req.headers['Authorization'] = "bearer #{token}"
+          req.headers['Content-Type'] = 'application/json'
+          req.body = payload.to_json
+        end
+
+        resp.body
+      end
+
+      def service_id
+        ENV.fetch('DFE_SIGNIN_SCHOOL_EXPERIENCE_ADMIN_SERVICE_ID')
+      end
+
+      def endpoint
+        URI::HTTPS.build(
+          host: Rails.configuration.x.dfe_sign_in_api_host,
+          path: ['/services', service_id, 'invitations'].join('/')
+        )
+      end
+
+      def payload
+        super.merge(
+          sourceId: SecureRandom.uuid,
+          given_name: firstname,
+          family_name: lastname,
+          email: email,
+          organisation: organisation_id
+        )
+      end
+    end
+  end
+end

--- a/app/views/schools/change_schools/show.html.erb
+++ b/app/views/schools/change_schools/show.html.erb
@@ -12,20 +12,29 @@
                   aria_label: "outstanding bookings and requests for #{school.name}" %>
               <% end %>
             <% end %>
-            <% if Schools::ChangeSchool.request_approval_url %>
-              <div class= 'govuk-radios__divider'>or</div>
-              <%= f.govuk_radio_button :change_to_urn, "request access", label: { text: "Request access to another school" } %>
-            <% end %>
           <% end %>
 
           <%= f.govuk_submit "Continue" %>
         <% end %>
+        <p> If your school is not listed, please contact
+          <a href="mailto:organise.school-experience@education.gov.uk">
+           DfE Sign-in support.
+          </a>
+        </p>
       <% elsif @dfe_sign_in_add_service_url %>
         <h1 class="govuk-heading-l">Manage school experience</h1>
 
         <p class="govuk-body-l">
-          You have not yet been granted access to the Manage school
-          experience service.
+          You do not have access to any schools yet
+        </p>
+
+        <p>
+          If you need access to a school, you should reach out to the approver within your organisation.
+        </p>
+        <p> If your approver has already granted you access, please contact
+          <a href="mailto:organise.school-experience@education.gov.uk">
+           DfE Sign-in support.
+          </a>
         </p>
 
         <%= render 'pages/request_organisation_access' %>

--- a/app/views/schools/dashboards/_profile_and_dates.html.erb
+++ b/app/views/schools/dashboards/_profile_and_dates.html.erb
@@ -6,7 +6,7 @@
         <%= link_to "Update school profile", schools_on_boarding_profile_path %>
       </li>
       <li>
-        <%= link_to "Manage users" %>
+        <%= link_to "Manage users", schools_users_path %>
       </li>
     </ul>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/schools/dashboards/_profile_and_dates.html.erb
+++ b/app/views/schools/dashboards/_profile_and_dates.html.erb
@@ -5,6 +5,9 @@
       <li>
         <%= link_to "Update school profile", schools_on_boarding_profile_path %>
       </li>
+      <li>
+        <%= link_to "Manage users" %>
+      </li>
     </ul>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <p>Your profile is currently <strong><%= school_enabled_description @current_school %></strong>.</p>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -11,9 +11,13 @@
       </p>
 
       <p>
-        The service will enable you to advertise your school and allow
-        candidates to request experience dates. You'll be able to accept
-        or reject each request.
+        On this service you can:
+        <ul class="govuk-list govuk-list--bullet">
+          <li>advertise experience at your school</li>
+          <li>allow candidates to request experience dates</li>
+          <li>accept or reject candidates requests for experience</li>
+          <li>add other members from your school</li>
+        </ul>
       </p>
 
       <p>

--- a/app/views/schools/users/_form.html.erb
+++ b/app/views/schools/users/_form.html.erb
@@ -1,0 +1,25 @@
+<% self.page_title = 'Add user details' %>
+<% content_for :back_link do govuk_back_link; end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@user_invite, url: schools_users_path, method: :post, html: {novalidate: false}) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-xl govuk-!-margin-top-4"> Add user details </span>
+      <h1 class="govuk-heading-l"> Personal details </h1>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :firstname, autocomplete: 'given-name' %>
+
+      <%= f.govuk_text_field :lastname, autocomplete: 'family-name' %>
+
+      <%= f.govuk_email_field :email, autocomplete: 'on' %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+    <%= link_to "Cancel",  schools_users_path, 'aria-label': "Cancel user invite" %>
+  </div>
+</div>

--- a/app/views/schools/users/index.html.erb
+++ b/app/views/schools/users/index.html.erb
@@ -1,0 +1,60 @@
+<%
+  self.page_title = "Manage Users"
+
+  self.breadcrumbs = {
+    @current_school.name => schools_dashboard_path,
+    'users' => nil
+  }
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1>Manage users at <%= @current_school.name %> </h1>
+    <%= link_to 'Add user', new_schools_user_path, class: 'govuk-button' %>
+
+    <p>
+      Users will be able to:
+      <ul ul class="govuk-list govuk-list--bullet">
+        <li>advertise experience at your school</li>
+        <li>allow candidates to request experience</li>
+        <li>accept or reject candidates requests for experience</li>
+        <li>add other users from your school</li>
+      </ul>
+    </p>
+    <p> To remove and manage users, you should go to
+     <%= link_to 'DFE Sign-in', @dfe_sign_in_request_organisation_url %>
+    </p>
+
+    <% if @users.any? %>
+      <div class="pagination-info higher">
+        <div class="pagination-slice">
+        </div>
+      </div>
+      <table id="invited-users" class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header">Name</th>
+            <th class="govuk-table__header">Email</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @users.each do |user| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= "#{user['firstName']} #{user['lastName']}" %></td>
+              <td class="govuk-table__cell"><%= user['email'] %></td>
+            </tr>
+          <% end %>
+
+        </tbody>
+      </table>
+      <div class="pagination-info lower">
+      </div>
+    <% else %>
+      <p>
+        There are no other users in this school.
+      </p>
+    <% end %>
+
+    <%= govuk_link_to "Return to dashboard", schools_dashboard_path, secondary: true %>
+  </div>
+</div>

--- a/app/views/schools/users/new.html.erb
+++ b/app/views/schools/users/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "form", locals: { user_invite: @user_invite } %>

--- a/app/views/schools/users/show.html.erb
+++ b/app/views/schools/users/show.html.erb
@@ -1,0 +1,61 @@
+<% self.page_title = 'Check your answers' %>
+<% content_for :back_link do govuk_back_link; end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for(@user_invite, url: schools_users_path, method: :post) do |f| %>
+      <section id="personal-details">
+        <span class="govuk-caption-xl govuk-!-margin-top-4"> Add user </span>
+        <h1 class="govuk-heading-l"> Check your answers </h1>
+
+        <dl class="placement-details govuk-summary-list">
+          <div class="address govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              First name
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= @user_invite.firstname %>
+              <%= f.hidden_field :firstname, value: @user_invite.firstname %>
+            </dd>
+            <dd>
+              <%= link_to 'Change', edit_schools_user_path(schools_dfe_sign_in_api_user_invite: { firstname: @user_invite.firstname, lastname: @user_invite.lastname, email: @user_invite.email }) %>
+            </dd>
+          </div>
+
+          <div class="phone-number govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Last name
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= @user_invite.lastname %>
+              <%= f.hidden_field :lastname, value: @user_invite.lastname %>
+            </dd>
+            <dd>
+              <%= link_to 'Change', edit_schools_user_path(schools_dfe_sign_in_api_user_invite: { firstname: @user_invite.firstname, lastname: @user_invite.lastname, email: @user_invite.email }) %>
+            </dd>
+          </div>
+
+          <div class="email-address govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">
+              Email address
+            </dt>
+            <dd class="govuk-summary-list__value">
+              <%= @user_invite.email %>
+              <%= f.hidden_field :email, value: @user_invite.email %>
+            </dd>
+            <dd>
+              <%= link_to 'Change', edit_schools_user_path(schools_dfe_sign_in_api_user_invite: { firstname: @user_invite.firstname, lastname: @user_invite.lastname, email: @user_invite.email }) %>
+            </dd>
+          </div>
+          <%= hidden_field_tag :confirmed, true %>
+        </dl>
+        <div class="govuk-inset-text">
+          <p>The user will be sent an email to create an account and will have access to the school's dashboard.</p>
+        </div>
+
+          <%= f.govuk_submit 'Accept and submit', data: { prevent_double_click_target: "submitButton" } %>
+      </section>
+          <%= link_to "Cancel",  schools_users_path, 'aria-label': "Cancel user invite" %>
+    <% end %>
+  </div>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
   # dfe signin config, should be in credentials or env vars
   config.x.base_url = 'https://localhost:3000'
   config.x.oidc_client_id = 'schoolexperience'
-  config.x.oidc_client_secret = Rails.application.credentials[:dfe_pp_signin_secret]
+  config.x.oidc_client_secret = ENV['DFE_PP_SIGNIN_SECRET'] || Rails.application.credentials[:dfe_pp_signin_secret]
   config.x.oidc_host = 'pp-oidc.signin.education.gov.uk'
   config.x.dfe_sign_in_api_host = 'pp-api.signin.education.gov.uk'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   get '/cookies_policy', to: 'pages#cookies_policy'
   get '/schools_privacy_policy', to: 'pages#schools_privacy_policy'
   get '/schools/request_organisation', to: 'pages#schools_request_organisation'
+  get '/schools/users/edit', to: 'schools/users#edit', as: :edit_schools_user
   resources :service_updates, only: %i[index show]
   get '/service_update', to: 'service_updates#index'
   get '/help_and_support_access_needs', to: 'pages#help_and_support_access_needs'
@@ -63,6 +64,7 @@ Rails.application.routes.draw do
     resource :switch, only: %i[new show], controller: 'switch'
 
     resource :change_school, only: %i[show create], as: 'change', path: 'change', controller: 'change_schools'
+    resources :users, only: %i[index new create show], controller: 'users'
     resource :prepopulate_school_profiles, only: %i[create]
 
     resource :dashboard, only: :show

--- a/spec/services/schools/dfe_sign_in_api/organisation_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/organisation_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::DFESignInAPI::Organisation do
+  include_context "logged in DfE user"
+
+  let(:user_uuid) { '123456' }
+  let(:current_school_urn) { 987_654 }
+  let(:organisations_data) do
+    [
+      { 'id' => 1, 'urn' => '123456', 'name' => 'School A', 'ukprn' => '111111' },
+      { 'id' => 2, 'urn' => '987654', 'name' => 'School B', 'ukprn' => '222222' },
+      { 'id' => 3, 'urn' => '789012', 'name' => 'School C', 'ukprn' => '333333' }
+    ]
+  end
+  let(:response) { organisations_data }
+
+  subject { described_class.new(user_uuid, current_school_urn) }
+
+  before do
+    allow(subject).to receive(:response).and_return(response)
+  end
+
+  describe '#current_organisation' do
+    context 'when current school URN matches an organisation' do
+      it 'returns the details of the current organisation' do
+        expect(subject.current_organisation).to eq({ 'id' => 2, 'urn' => '987654', 'name' => 'School B', 'ukprn' => '222222' })
+      end
+    end
+
+    context 'when current school URN does not match any organisation' do
+      let(:current_school_urn) { 999_999 }
+
+      it 'returns nil' do
+        expect(subject.current_organisation).to be_nil
+      end
+    end
+  end
+
+  describe '#current_organisation_ukprn' do
+    context 'when current school URN matches an organisation' do
+      it 'returns the UKPRN of the current organisation' do
+        expect(subject.current_organisation_ukprn).to eq('222222')
+      end
+    end
+
+    context 'when current school URN does not match any organisation' do
+      let(:current_school_urn) { 999_999 }
+
+      it 'returns nil' do
+        expect(subject.current_organisation_ukprn).to be_nil
+      end
+    end
+  end
+
+  describe '#current_organisation_id' do
+    context 'when current school URN matches an organisation' do
+      it 'returns the ID of the current organisation' do
+        expect(subject.current_organisation_id).to eq(2)
+      end
+    end
+
+    context 'when current school URN does not match any organisation' do
+      let(:current_school_urn) { 999_999 }
+
+      it 'returns nil' do
+        expect(subject.current_organisation_id).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/schools/dfe_sign_in_api/organisation_users_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/organisation_users_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::DFESignInAPI::OrganisationUsers do
+  let(:user_uuid) { '123456' }
+  let(:current_school_urn) { '987654' }
+  let(:ukprn) { 'organisation-ukprn-id' }
+  let(:response) do
+    {
+      'ukprn' => ukprn,
+      'users' => [
+        {
+          'email' => 'user1@test.com',
+          'firstName' => 'user1',
+          'lastName' => 'test',
+          'userStatus' => 1,
+          'roles' => %w[role1]
+        },
+        {
+          'email' => 'user21@test.com',
+          'firstName' => 'user2',
+          'lastName' => 'test',
+          'roles' => %w[role1 role2]
+        }
+      ]
+    }
+  end
+
+  subject { described_class.new(user_uuid, current_school_urn) }
+
+  before do
+    allow(subject).to receive(:response).and_return(response)
+    allow_any_instance_of(Schools::DFESignInAPI::Organisation).to receive(:current_organisation_ukprn).and_return(ukprn)
+  end
+
+  describe '#initialize' do
+    it 'sets user_uuid' do
+      expect(subject.user_uuid).to eq(user_uuid)
+    end
+
+    it 'sets current_school_urn' do
+      expect(subject.current_school_urn).to eq(current_school_urn)
+    end
+  end
+
+  describe '#ukprn' do
+    it 'calls current_organisation_ukprn on Organisation' do
+      expect_any_instance_of(Schools::DFESignInAPI::Organisation).to receive(:current_organisation_ukprn).and_return(ukprn)
+      expect(subject.ukprn).to eq(ukprn)
+    end
+  end
+
+  describe '#users' do
+    context 'when valid response is received' do
+      it 'returns the users from the response' do
+        expect(subject.users).to eq(response['users'])
+      end
+    end
+
+    context 'when response is nil' do
+      let(:response) { nil }
+
+      it 'returns nil' do
+        expect(subject.users).to be_nil
+      end
+    end
+
+    context 'when response does not contain users' do
+      let(:response) { { 'ukprn' => ukprn } }
+
+      it 'returns an empty array' do
+        expect(subject.users).to eq(nil)
+      end
+    end
+  end
+end

--- a/spec/services/schools/dfe_sign_in_api/user_invite_spec.rb
+++ b/spec/services/schools/dfe_sign_in_api/user_invite_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require Rails.root.join("spec", "controllers", "schools", "session_context")
+
+describe Schools::DFESignInAPI::UserInvite, type: :model do
+  let(:user_invite) { described_class.new }
+
+  describe 'attributes' do
+    it { is_expected.to respond_to(:email) }
+    it { is_expected.to respond_to(:firstname) }
+    it { is_expected.to respond_to(:lastname) }
+    it { is_expected.to respond_to(:organisation_id) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:firstname) }
+    it { is_expected.to validate_presence_of(:lastname) }
+    it { is_expected.to validate_presence_of(:email) }
+    it { is_expected.to validate_length_of(:firstname).is_at_most(50) }
+    it { is_expected.to validate_length_of(:lastname).is_at_most(50) }
+    it { is_expected.to validate_length_of(:email).is_at_most(100) }
+    it { is_expected.to allow_value('valid@email.com').for(:email) }
+    it { is_expected.not_to allow_value('invalid_email').for(:email) }
+    it { is_expected.to validate_presence_of(:organisation_id) }
+  end
+
+  describe '#create' do
+    context 'when API is enabled' do
+      it 'makes a POST request to the API endpoint' do
+        expect(user_invite).to receive(:response)
+        user_invite.create
+      end
+    end
+
+    context 'when API is disabled' do
+      before { allow(user_invite).to receive(:enabled?).and_return(false) }
+
+      it 'raises an ApiDisabled error' do
+        expect { user_invite.create }.to raise_error(Schools::DFESignInAPI::UserInvite::ApiDisabled)
+      end
+    end
+  end
+end

--- a/spec/views/schools/change_schools/show.html.erb_spec.rb
+++ b/spec/views/schools/change_schools/show.html.erb_spec.rb
@@ -97,8 +97,8 @@ describe 'schools/change_schools/show', type: :view do
 
     before { render }
 
-    specify 'there should be an request access option' do
-      expect(rendered).to have_css("input[type='radio'][value='request access']")
+    specify 'there should not be an request access option' do
+      expect(rendered).not_to have_css("input[type='radio'][value='request access']")
     end
   end
 end


### PR DESCRIPTION
### Trello card
[#5535 ](https://trello.com/c/KSbGXeZ5)

### Context
We know that users have often had difficulty getting access to Get School Experience. Because of a 2 stage auth process that they have to do in order to get initial access to GSE. 

- Firstly, they had to request linkage to a school

- Secondly, they had to request the ‘role’ for get school experience

We want to enable school administrators to invite users to the school that they administer through 'School Dashboard'

### Changes proposed in this pull request
*  Updates preliminary copy on the GSE app
* Add users resource to `routes.rb`
* Adds links to manage users on the school dashboard
* Adds UsersController 
* Adds views to manage users in a school
* Adds DSI API service to fetch school's ukprn from DSI
* Adds DSI API service to fetch users in a school
* Adds DSI API service to add users to a school
* Adds relevant specs
