### PR TITLE
Improve error message for DBS certificate question on candidate flow

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,7 +188,7 @@ en:
         candidates/registrations/background_check:
           attributes:
             has_dbs_check:
-              inclusion: "Select an option"
+              inclusion: "Select whether you have a DBS certificate"
 
         candidates/registrations/contact_information:
           attributes:


### PR DESCRIPTION
### Trello card

https://trello.com/c/wUYLWrEk/389-content-dac-audit-error-handling-for-dbs-response

### Context

If a candidate doesn't click an option for this question, the error message is generic, which doesn't help with accessibility. This improves the error message.

<img width="570" alt="image" src="https://github.com/DFE-Digital/schools-experience/assets/35870975/929f7360-91a8-4012-8978-37e962733056">


### Changes proposed in this pull request

Select an option -> Select whether you have a DBS certificate

<img width="538" alt="image" src="https://github.com/DFE-Digital/schools-experience/assets/35870975/646336d8-2828-40d6-bba9-ff24e37f37e1">


### Guidance to review

- Does this render correctly on the candidate sign up flow?

