### PR TITLE
Amend typo in 'guide for candidates' link

### DIFF
--- a/app/views/candidates/home/index.html.erb
+++ b/app/views/candidates/home/index.html.erb
@@ -74,7 +74,7 @@ Visit schools to see how teachers plan lessons, manage classrooms and teach subj
         <ul class="govuk-list govuk-!-font-size-16 govuk-se-spaced-list">
           <li>
             <a href="<%= candidates_guide_for_candidates_path %>" class="govuk-!-font-weight-bold">
-              School experience: guide for candidate
+              School experience: guide for candidates
             </a>
           </li>
           <li>


### PR DESCRIPTION
### Trello card
N/A
### Context
This got removed during prior accessibility fixes. Needs changing.

### Changes proposed in this pull request

- Guide for candidate -> guide for candidates.
- 
### Guidance to review

