### PR TITLE
Update subjects.yml to fix error with GSE/API/CRM sync for 'Media Studies'

### DIFF
--- a/db/data/subjects.yml
+++ b/db/data/subjects.yml
@@ -17,7 +17,7 @@
 - History
 - Languages (other)
 - Maths
-- Media studies
+- Communication and media studies
 - Music
 - Physical Education
 - Physics


### PR DESCRIPTION
### Trello card

https://trello.com/c/17qAVbFG

### Context

- We've received support tickets on people trying to request a 'Media Studies'

- The GIT website have taken an approach of renaming their subjects in the subject list.

### Changes proposed in this pull request

Rename `Media studies` -> `Communication and Media studies` in `subjects.yml`

### Guidance to review

- Test the request flow where you state you want to teach Communication and Media Studies
- Try and manage a profile for this
- Try and onboard a new school
