### PR TITLE
Add links to privacy notice on matchback page

### DIFF
--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -38,7 +38,7 @@
                 disabled: personal_information.read_only %>
 
           <p>
-            Your details are protected under the terms of our <%= link_to 'privacy notice', 'https://schoolexperience.education.gov.uk/privacy_policy' %>.
+            Your details are protected under the terms of our <%= link_to 'privacy notice (opens in a new tab)', 'https://schoolexperience.education.gov.uk/privacy_policy', target: "_blank" %>.
           </p>
           <p>
             Our privacy notice explains how we use your personal data.

--- a/app/views/candidates/registrations/personal_informations/_form.html.erb
+++ b/app/views/candidates/registrations/personal_informations/_form.html.erb
@@ -37,6 +37,14 @@
                 readonly: personal_information.read_only,
                 disabled: personal_information.read_only %>
 
+          <p>
+            Your details are protected under the terms of our <%= link_to 'privacy notice', 'https://schoolexperience.education.gov.uk/privacy_policy' %>.
+          </p>
+          <p>
+            Our privacy notice explains how we use your personal data.
+            It's important you read this before requesting school experience.
+          </p>
+
           <%= f.govuk_submit 'Continue', data: { prevent_double_click_target: "submitButton" } %>
         <% end %>
       </div>


### PR DESCRIPTION
### Trello card

https://trello.com/c/xGsAiAp3

### Context

- As part of improving the foundations of the Get school experience service, we think it's a good idea to align how we surface information on the privacy notice at the start of the user request flow. This language is broadly similar to the Get Into Teaching website's approach.

### Changes proposed in this pull request

Add information on, and link to, privacy notice on the first page of the school experience sign up flow.

## Before

<img width="623" alt="image" src="https://github.com/DFE-Digital/schools-experience/assets/35870975/41192332-22dd-4efe-b41b-e9403ad872b9">


## After

<img width="497" alt="image" src="https://github.com/DFE-Digital/schools-experience/assets/35870975/16891a69-c0f5-4c1c-8590-ccf0752ab6d2">


### Guidance to review

- Does this look right?
- Do the links work?
- Does it avoid repetition of info throughout the flow?
