### PR TITLE
Update Ruby version and dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.0-alpine3.15
+FROM ruby:3.1.4-alpine3.18
 
 ENV RAILS_ENV=production \
     NODE_ENV=production \
@@ -24,8 +24,8 @@ RUN apk update && apk add -Uu --no-cache zlib-dev busybox ncurses
 
 # hadolint ignore=DL3018
 RUN apk add -U --no-cache bash build-base git tzdata libxml2 libxml2-dev \
-			postgresql-libs postgresql-dev nodejs yarn \
-            chromium=99.0.4844.84-r0 chromium-chromedriver=99.0.4844.84-r0
+    postgresql-libs postgresql-dev nodejs yarn \
+    chromium=99.0.4844.84-r0 chromium-chromedriver=99.0.4844.84-r0
 
 # Remove once base image ruby:3.1.0-alpine3.15 has been updated
 RUN apk add --no-cache gmp=6.2.1-r1 libretls=3.3.4-r3


### PR DESCRIPTION
Updates the base image in the Dockerfile from: 
`ruby:3.1.0-alpine3.15` to `ruby:3.1.4-alpine3.18` (to match what GiT is using)
