### PR TITLE
Add subjects to blacklist and remove from candidates dropdown menu

### DIFF
--- a/db/data/gitis_subject_blacklist.yml
+++ b/db/data/gitis_subject_blacklist.yml
@@ -2,3 +2,5 @@
 - Art
 - General science
 - Other
+- Physics with maths
+- Vocational health


### PR DESCRIPTION
### Trello card
https://trello.com/c/dMfTRcRJ/

### Context
Two subjects that we offer on school experience are not mirrored across the GIT ecosystem
This is because the GIT website removed these subjects from their services to better mirror Find/Apply.
In the spirit of ensuring consistency, it makes sense for us to remove these

### Changes proposed in this pull request.
- Adds physics with Maths and vocational health to `gitis_subject_blacklist`
- Refactor `Candidates::School#subjects` method to exclude blacklisted subjects

### Guidance to review

