### PR TITLE
Update 'media studies' subject name

### DIFF
--- a/db/data/subjects.yml
+++ b/db/data/subjects.yml
@@ -17,7 +17,7 @@
 - History
 - Languages (other)
 - Maths
-- Media studies
+- Communication and media studies
 - Music
 - Physical Education
 - Physics


### PR DESCRIPTION
### Trello card
https://trello.com/c/S5RFhozZ/

### Context
We’ve had a support query where a GSE user is unable to submit a request. 
This is because they want to submit for ‘Media Studies’ but the GIT API was renamed to 'Media and Communication Studies'

### Changes proposed in this pull request
- We've renamed it in this file for consistency and update the data as well.

### Guidance to review
- Preview the subjects list in the app to view the updates
