### PR TITLE
Remove copy on COVID procedures

### DIFF
--- a/app/views/candidates/home/guide_for_candidates.html.erb
+++ b/app/views/candidates/home/guide_for_candidates.html.erb
@@ -63,12 +63,6 @@
          Virtual experience can involve a presentation or Q&A session. Sometimes it can be a pre-recorded video of a lesson.
         </p>
 
-<h2 class="govuk-heading-m">How schools are managing the risk of COVID-19</h2>
-
-        <p>
-         Each school will have their own COVID-19 safety measures and these can change often. Schools will provide you with these details when you request experience with them.
-        </p>
-
  <h2 class="govuk-heading-m">Find school experience</h2>
 
       <p>


### PR DESCRIPTION
### Trello card

https://trello.com/c/ODlo5o8c

### Context

- Found this whilst checking some changes in another PR. Wanted to get views on removing this now we're into 2024.

### Changes proposed in this pull request

- Remove COVID paragraph in guidance for candidates page.

### Guidance to review

- Does this look right?
- Do you agree with removal?

