### PR TITLE
Fix full stop in anchor link

### DIFF
--- a/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/_letter.html.erb
@@ -40,7 +40,7 @@
 
     <p>
       Request school experience at other schools -
-      <%= link_to "Find school experience.", new_candidates_school_search_path %>
+      <%= link_to "Find school experience", new_candidates_school_search_path %>.
     </p>
   </section>
 


### PR DESCRIPTION
### Trello card

N/A

### Context

- Spotted this in another review, we shouldn't have full stops in anchor links.
- This is when a school is cancelling a confirmed booking

### Changes proposed in this pull request

Move full stop out of anchor link.

### Guidance to review

Is the full stop now out of the anchor link?
