### PR TITLE
Improve button groupings (first tranche)

### DIFF
--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -54,8 +54,13 @@
 
     <%= pagination_bar @bookings %>
 
-    <div>
-      <%= f.govuk_submit 'Save and return to dashboard' %>
+    <div class="govuk-button-group">
+      <p>
+        <%= f.govuk_submit 'Save and return to dashboard' %>
+      </p>
+      <p>
+        <%= link_to 'View earlier attendance records', schools_attendances_path %>
+      </p>
     </div>
 
   <% end %>
@@ -67,11 +72,14 @@
     There are no bookings that need their attendance to be confirmed.
   </p>
 
+<div class="govuk-button-group">
   <p>
     <%= govuk_link_to "Return to dashboard", schools_dashboard_path, secondary: true %>
   </p>
+  <p>
+    <%= link_to 'View earlier attendance records', schools_attendances_path %>
+  </p>
+</div>
 <% end %>
 
-<p>
-  <%= link_to 'View earlier attendance records', schools_attendances_path %>
-</p>
+

--- a/app/views/schools/confirm_attendance/show.html.erb
+++ b/app/views/schools/confirm_attendance/show.html.erb
@@ -55,12 +55,11 @@
     <%= pagination_bar @bookings %>
 
     <div class="govuk-button-group">
-      <p>
+
         <%= f.govuk_submit 'Save and return to dashboard' %>
-      </p>
-      <p>
+
         <%= link_to 'View earlier attendance records', schools_attendances_path %>
-      </p>
+
     </div>
 
   <% end %>
@@ -73,12 +72,11 @@
   </p>
 
 <div class="govuk-button-group">
-  <p>
+
     <%= govuk_link_to "Return to dashboard", schools_dashboard_path, secondary: true %>
-  </p>
-  <p>
+
     <%= link_to 'View earlier attendance records', schools_attendances_path %>
-  </p>
+
 </div>
 <% end %>
 

--- a/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
+++ b/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
@@ -2,7 +2,7 @@
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-visually-hidden">Warning</span>
-    You haven't entered any dates, your school will not appear in candidate
+    You haven't entered any dates so your school will not appear in candidate
     searches.
   </strong>
 </div>

--- a/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
+++ b/app/views/schools/dashboards/_no_placement_dates_warning.html.erb
@@ -1,8 +1,8 @@
-<div class="govuk-warning-text govuk-!-padding-top-7">
+<div class="govuk-warning-text">
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-visually-hidden">Warning</span>
     You haven't entered any dates, your school will not appear in candidate
-    searches
+    searches.
   </strong>
 </div>

--- a/app/views/schools/on_boarding/profiles/editing.html.erb
+++ b/app/views/schools/on_boarding/profiles/editing.html.erb
@@ -54,9 +54,7 @@
         <div class="govuk-!-margin-top-4">
           <div class="govuk-button-group">
             <%= govuk_link_to 'Preview profile', schools_on_boarding_preview_path, secondary: true %>
-          </div>
 
-          <div>
             <%= govuk_link_to 'Return to dashboard', schools_dashboard_path, secondary: true %>
           </div>
         </div>

--- a/app/views/schools/on_boarding/profiles/onboarding.html.erb
+++ b/app/views/schools/on_boarding/profiles/onboarding.html.erb
@@ -49,9 +49,7 @@
       <div class="govuk-button-group">
         <%= f.govuk_submit 'Accept and set up profile' %>
         <%= govuk_link_to 'Preview profile', schools_on_boarding_preview_path, secondary: true %>
-      </div>
 
-      <div>
         <%= govuk_link_to 'Return to dashboard', schools_dashboard_path, secondary: true %>
       </div>
     <% end %>

--- a/app/views/schools/placement_dates/index.html.erb
+++ b/app/views/schools/placement_dates/index.html.erb
@@ -9,10 +9,6 @@
 
 <h1>Manage dates</h1>
 
-<div>
-  <%= govuk_link_to "Add a date", new_schools_placement_date_path %>
-</div>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 
@@ -64,6 +60,7 @@
         <%- end -%>
         </tbody>
       </table>
+
     <%- else -%>
       <%= render partial: 'schools/dashboards/no_placement_dates_warning' %>
     <%- end -%>
@@ -71,8 +68,8 @@
   </div>
 </div>
 
+<div class="govuk-button-group">
+  <%= govuk_link_to "Add a date", new_schools_placement_date_path %>
 
-
-<div>
   <%= govuk_link_to "Return to dashboard", schools_dashboard_path, secondary: true %>
 </div>

--- a/app/views/schools/toggle_enabled/edit.html.erb
+++ b/app/views/schools/toggle_enabled/edit.html.erb
@@ -6,5 +6,9 @@
     <%= f.govuk_radio_button :enabled, false, label: { text: "Turn profile off" }, hint: nil %>
   <% end %>
 
+<div class="govuk-button-group">
   <%= f.govuk_submit 'Continue' %>
+  <%= link_to 'Return to dashboard', schools_dashboard_path %>
+</div>
+
 <% end %>

--- a/features/schools/placement_dates/index.feature
+++ b/features/schools/placement_dates/index.feature
@@ -38,7 +38,7 @@ Feature: Listing placement dates
   Scenario: Warning displayed when there are no dates
       Given my school has no placement dates
       When I am on the 'placement dates' page
-      Then there should be a "You haven't entered any dates, your school will not appear in candidate searches" warning
+      Then there should be a "You haven't entered any dates so your school will not appear in candidate searches" warning
 
   Scenario: The return to dashboard button
       Given I am on the 'placement dates' page


### PR DESCRIPTION
### Trello card

https://trello.com/c/QHKZbml7

### Context

- We have some issues relating to how our buttons are grouped, we too often rely on putting them on separate lines, which does not align with the Design System.

### Changes proposed in this pull request (changes in comments below)

- Improve button grouping on the confirm attendance page
- Add a back link on the 'toggle profile on/off' page and group this with existing buttons
- Improve button grouping on our onboarding flow
- Improve button grouping on our edit profile flow
- Improve button grouping on our 'add dates' page

### Guidance to review

Attendance page (you will need to login as a school with attendances to confirm (Holland Park) and one without (Outwood Academy Acklam)):
- https://get-school-experience-review-pr-4.test.teacherservices.cloud/schools/confirm_attendance

Toggle page on/off:
- https://get-school-experience-review-pr-4.test.teacherservices.cloud/schools/toggle_enabled/edit

Edit profile page (use any onboarded school)
- https://get-school-experience-review-pr-4.test.teacherservices.cloud/schools/on_boarding/profile#admin-contact-details-tab

Add dates (use any school with 'fixed dates'):
- https://get-school-experience-review-pr-4.test.teacherservices.cloud/schools/placement_dates

Onboarding flow (use any non-onboarded school and complete their profile details)
- https://get-school-experience-review-pr-4.test.teacherservices.cloud/schools/on_boarding/profile?

For the moment the main focus can be grouping - I can do separate PRs for changing buttons -> links if needed. For example, the return to dashboard buttons.