### PR TITLE
Filter hidden subjects in Schools `secondary_subjects`

### DIFF
--- a/app/models/bookings/subject.rb
+++ b/app/models/bookings/subject.rb
@@ -33,7 +33,7 @@ class Bookings::Subject < ApplicationRecord
     dependent: :restrict_with_exception
 
   default_scope -> { where.not(hidden: true) }
-  scope :secondary_subjects, -> { where(secondary_subject: true) }
+  scope :secondary_subjects, -> { where(secondary_subject: true).where.not(hidden: true) }
 
   scope :ordered_by_name, -> { order(name: 'asc') }
 end

--- a/app/models/candidates/placement_date_option.rb
+++ b/app/models/candidates/placement_date_option.rb
@@ -5,7 +5,7 @@ class Candidates::PlacementDateOption
       placement_date.placement_date_subjects.map do |placement_date_subject|
         new(
           placement_date_subject.date_and_subject_id,
-          placement_date_subject.bookings_subject&.name,
+          placement_date_subject.bookings_subject.name,
           placement_date.duration,
           placement_date.date,
           placement_date.virtual,


### PR DESCRIPTION
### Trello card
https://trello.com/c/NOHbwt7v

### Context
We're seeing issues with a few schools not able to receive requests.
This could be due to our removal of subjects: `physics with maths` and `vocational health`.

### Changes proposed in this pull request
* Refactor `secondary_subjects` scope in `Bookings::Subject` model to include only non-hidden secondary subjects
* Remove safe navigation from `bookings_subject` in `placement_date_option.rb`