### PR TITLE
Add breadcrumbs to pages without them

### DIFF
--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,3 +1,5 @@
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for feedback do |f| %>

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,5 +1,3 @@
-<% content_for :back_link do govuk_back_link; end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for feedback do |f| %>

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -3,6 +3,7 @@
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,
     'Choose how dates are displayed' => nil
+    }
 
 %>
 

--- a/app/views/schools/availability_preferences/edit.html.erb
+++ b/app/views/schools/availability_preferences/edit.html.erb
@@ -1,4 +1,10 @@
-<%- self.page_title = "Choose how dates are displayed" %>
+<%- self.page_title = "Choose how dates are displayed"
+
+  self.breadcrumbs = {
+    @current_school.name => schools_dashboard_path,
+    'Choose how dates are displayed' => nil
+
+%>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/confirmed_bookings/cancellations/notification_deliveries/show.html.erb
+++ b/app/views/schools/confirmed_bookings/cancellations/notification_deliveries/show.html.erb
@@ -11,7 +11,7 @@
       What happens next
     </h2>
     <p>
-      We’ve sent your response to <%= @cancellation.candidate_name %>
+      We’ve sent your response to <%= @cancellation.candidate_name %>.
     </p>
     <p>
       We've also sent them a text message asking them to check their inbox.

--- a/app/views/schools/contact_us/show.html.erb
+++ b/app/views/schools/contact_us/show.html.erb
@@ -1,5 +1,4 @@
 <% self.page_title = "Contact us" %>
-<% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Contact us</h1>

--- a/app/views/schools/contact_us/show.html.erb
+++ b/app/views/schools/contact_us/show.html.erb
@@ -1,5 +1,5 @@
 <% self.page_title = "Contact us" %>
-
+<% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Contact us</h1>

--- a/app/views/schools/organisation_access_requests/show.html.erb
+++ b/app/views/schools/organisation_access_requests/show.html.erb
@@ -1,4 +1,3 @@
-<% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
 <div id="dsi-org-access-request" class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <section>

--- a/app/views/schools/organisation_access_requests/show.html.erb
+++ b/app/views/schools/organisation_access_requests/show.html.erb
@@ -1,6 +1,7 @@
 <div id="dsi-org-access-request" class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <section>
+      <% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
       <%= page_heading "Request access to another organisation" %>
 
       <% if @dfe_sign_in_request_organisation_url %>

--- a/app/views/schools/organisation_access_requests/show.html.erb
+++ b/app/views/schools/organisation_access_requests/show.html.erb
@@ -1,7 +1,8 @@
+<% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
 <div id="dsi-org-access-request" class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <section>
-      <% content_for :back_link do govuk_back_link(schools_dashboard_path); end %>
+
       <%= page_heading "Request access to another organisation" %>
 
       <% if @dfe_sign_in_request_organisation_url %>

--- a/app/views/schools/placement_dates/close_confirmation.html.erb
+++ b/app/views/schools/placement_dates/close_confirmation.html.erb
@@ -12,7 +12,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= form_for @confirmation, url: schools_placement_date_close_path(@placement_date.id, confirmed: :confirmed) do |f| %>
-        <%= f.govuk_radio_buttons_fieldset :confirmed, legend: { text: "Are your sure you want to close the placement on #{@placement_date.date.to_formatted_s(:govuk)}?", class: "govuk-heading-l" } do %>
+        <%= f.govuk_radio_buttons_fieldset :confirmed, legend: { text: "Are you sure you want to close the placement on #{@placement_date.date.to_formatted_s(:govuk)}?", class: "govuk-heading-l" } do %>
           <%= f.govuk_radio_button :confirmed, true, label: { text: "Yes" } %>
           <%= f.govuk_radio_button :confirmed, false, label: { text: "No" } %>
         <% end %>

--- a/app/views/schools/placement_dates/close_confirmation.html.erb
+++ b/app/views/schools/placement_dates/close_confirmation.html.erb
@@ -1,6 +1,12 @@
 <% self.page_title = 'Close placement date' %>
 
-<% content_for :back_link do govuk_back_link; end %>
+<%
+  self.breadcrumbs = {
+    @current_school.name => schools_dashboard_path,
+    'Manage dates' => schools_placement_dates_path,
+    "Close placement on #{@placement_date.date.to_formatted_s(:govuk)}" => nil
+  }
+%>
 
 <div class="govuk-main-wrapper">
   <div class="govuk-grid-row">

--- a/app/views/schools/placement_dates/close_confirmation.html.erb
+++ b/app/views/schools/placement_dates/close_confirmation.html.erb
@@ -1,3 +1,7 @@
+<% self.page_title = 'Close placement date' %>
+
+<% content_for :back_link do govuk_back_link; end %>
+
 <div class="govuk-main-wrapper">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/schools/placement_requests/cancellations/notification_deliveries/show.html.erb
+++ b/app/views/schools/placement_requests/cancellations/notification_deliveries/show.html.erb
@@ -9,7 +9,7 @@
       What happens next
     </h2>
     <p>
-      We’ve sent your response to <%= @cancellation.candidate_name %>
+      We’ve sent your response to <%= @cancellation.candidate_name %>.
     </p>
 
     <%= govuk_link_to 'Return to requests', schools_placement_requests_path %>

--- a/app/views/schools/toggle_enabled/edit.html.erb
+++ b/app/views/schools/toggle_enabled/edit.html.erb
@@ -1,4 +1,11 @@
-<% self.page_title = "Toggle requests" %>
+<% self.page_title = "Toggle requests"
+
+  self.breadcrumbs = {
+    @current_school.name => schools_dashboard_path,
+    'Toggle requests' => nil
+  }
+
+%>
 
 <%= form_for @current_school, url: schools_enabled_path, method: 'patch' do |f| %>
   <%= f.govuk_radio_buttons_fieldset(:enabled) do %>

--- a/app/views/schools/toggle_enabled/edit.html.erb
+++ b/app/views/schools/toggle_enabled/edit.html.erb
@@ -2,7 +2,7 @@
 
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,
-    'Toggle requests' => nil
+    'Turn profile on or off' => nil
   }
 
 %>

--- a/app/views/schools/toggle_enabled/edit.html.erb
+++ b/app/views/schools/toggle_enabled/edit.html.erb
@@ -1,4 +1,4 @@
-<% self.page_title = "Toggle requests"
+<% self.page_title = "Turn profile on or off"
 
   self.breadcrumbs = {
     @current_school.name => schools_dashboard_path,

--- a/features/schools/toggle_enabling_and_disabling.feature
+++ b/features/schools/toggle_enabling_and_disabling.feature
@@ -9,7 +9,7 @@ Feature: Toggling being enabled and disabled
 
     Scenario: Page title
         Given I am on the 'toggle requests' page
-        Then the page title should be 'Toggle requests'
+        Then the page title should be 'Turn profile on or off'
 
     Scenario: Page contents
         Given I am on the 'toggle requests' page


### PR DESCRIPTION
### Trello card

https://trello.com/c/gapHzCUD

### Context

- Some pages lack breadcrumbs
- Some pages lack backlinks

### Changes proposed in this pull request

- Add breadcrumbs to the toggle profile page
- Add breadcrumbs to choose how dates are displayed page
- Add backlinks to contact us/request access to another organisation/close placement dates page

### Guidance to review

- Do breadcrumbs render on the profile on/off page?
- Do breadcrumbs render on the 'choose how dates are displayed' page?
- Do the breadcrumbs link to where you expect?
- Are backlinks appropriate in the other locations?
- Should we use breadcrumbs in the close placement date page?