### PR TITLE
[1797] Do not check dependencies in staging statuscake

### DIFF
--- a/terraform/aks/config/staging.tfvars.json
+++ b/terraform/aks/config/staging.tfvars.json
@@ -10,7 +10,7 @@
     "sidekiq_memory_max" : "1Gi",
       "statuscake_alerts": {
         "alert": {
-          "website_url": [ "https://staging.schoolexperience.education.gov.uk/healthcheck.json" ],
+          "website_url": [ "https://staging.schoolexperience.education.gov.uk/check" ],
           "contact_groups": [239498]
         }
       },


### PR DESCRIPTION
### Trello card
https://trello.com/c/ThDx6UzV

### Context
Alerts are too noisy in staging because of dependencies (DSI, GIT CRM...).

### Changes proposed in this pull request
Use the /check endpoint to check the app only.

### Guidance to review
Check URL