### PR TITLE
update govuk_design_system_formbuilder to 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'yabeda-sidekiq'
 
 gem 'dotenv-rails', '>= 2.7.6'
 
-gem 'govuk_design_system_formbuilder', '~> 3.1'
+gem 'govuk_design_system_formbuilder', '~> 4.0.0'
 gem 'notifications-ruby-client'
 
 gem 'acts_as_list'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,14 +286,14 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk_design_system_formbuilder (3.3.0)
+    govuk_design_system_formbuilder (4.0.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
+      html-attributes-utils (~> 1)
     hashdiff (1.0.1)
     hashids (1.0.6)
-    html-attributes-utils (0.9.2)
+    html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -359,6 +359,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.16.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
@@ -658,6 +660,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
@@ -688,7 +691,7 @@ DEPENDENCIES
   foreman
   geocoder
   get_into_teaching_api_client_faraday!
-  govuk_design_system_formbuilder (~> 3.1)
+  govuk_design_system_formbuilder (~> 4.0.0)
   hashids
   ice_cube
   invisible_captcha (>= 2.0.0)

--- a/app/views/candidates/schools/index.html.erb
+++ b/app/views/candidates/schools/index.html.erb
@@ -58,7 +58,7 @@
           <div class="filter">
             <%= f.govuk_collection_check_boxes :subjects, Candidates::School.subjects, :first,
               ->(subject) { "#{subject.last} (#{@search.subject_count(subject.first)})" },
-              classes: %w(search-subjects-checkboxes), hint: { text: t("helpers.hint.subjects") } %>
+              class: %w(search-subjects-checkboxes), hint: { text: t("helpers.hint.subjects") } %>
           </div>
 
           <div class="filter">


### PR DESCRIPTION
### Trello card
[Carry out dependency updates](https://trello.com/c/TJ6y33RP/5983-carry-out-dependency-updates-get-school-experience)

### Context
This updates the `govuk_design_system_formbuilder` gem to version 4.0.0 to match the Get Into Teaching service

### Changes proposed in this pull request
Gem update, and an update to the `classes:` parameter (now `class:`) following a breaking change in 4.0.0

### Guidance to review

