### PR TITLE
replace keyvault-yaml-secret with azcli

### DIFF
--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -19,16 +19,19 @@ jobs:
 
       - uses: Azure/login@v2
         with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+          creds: ${{ secrets.GSE_REPO_AZ_CREDENTIALS }}
 
-      - uses: DfE-Digital/keyvault-yaml-secret@v1
-        id:  keyvault-yaml-secret
+      - name: Fetch synk token from key vault
+        uses: azure/CLI@v2
+        id: fetch-keyvault-secret
         with:
-          keyvault: ${{ secrets.KEY_VAULT}}
-          secret: SE-INFRA-SECRETS
-          key: SLACK-WEBHOOK, SNYK-TOKEN
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          inlineScript: |
+            SNYK_TOKEN=$(az keyvault secret show --name "SNYK-TOKEN" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
+            echo "::add-mask::$SNYK_TOKEN"
+            echo "SNYK-TOKEN=$SNYK_TOKEN" >> $GITHUB_OUTPUT
+            SLACK_WEBHOOK=$(az keyvault secret show --name "SLACK-WEBHOOK" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
+            echo "::add-mask::$SLACK_WEBHOOK"
+            echo "SLACK-WEBHOOK=$SLACK_WEBHOOK" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@master
@@ -55,7 +58,7 @@ jobs:
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ steps.keyvault-yaml-secret.outputs.SNYK-TOKEN }}
+          SNYK_TOKEN: ${{ steps.fetch-keyvault-secret.outputs.SNYK-TOKEN }}
         with:
           image: ${{ env.DOCKER_REPOSITORY }}:master
           args: --severity-threshold=high --file=Dockerfile  --exclude-app-vulns
@@ -71,4 +74,4 @@ jobs:
            SLACK_COLOR: ${{env.SLACK_ERROR}}
            SLACK_MESSAGE: 'There has been a failure building the application'
            SLACK_TITLE: 'Failure Building Application'
-           SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK-WEBHOOK }}
+           SLACK_WEBHOOK: ${{ steps.fetch-keyvault-secret.outputs.SLACK-WEBHOOK }}

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -7,26 +7,29 @@ on:
 jobs:
   attach-to-trello:
     name: Link Trello card to this PR
-    runs-on: ubuntu-latest  
-    if: "!contains( 'dependabot[bot] snyk-bot' , github.actor )"  
+    runs-on: ubuntu-latest
+    if: "!contains( 'dependabot[bot] snyk-bot' , github.actor )"
     steps:
       - uses: Azure/login@v2
         with:
-            creds: ${{ secrets.AZURE_CREDENTIALS }}
+            creds: ${{ secrets.GSE_REPO_AZ_CREDENTIALS }}
 
-      - uses: DfE-Digital/keyvault-yaml-secret@v1
-        id:  keyvault-yaml-secret
+      - name: Fetch synk token from key vault
+        uses: azure/CLI@v2
+        id: fetch-keyvault-secret
         with:
-          keyvault: ${{ secrets.KEY_VAULT}}
-          secret: SE-INFRA-SECRETS
-          key: TRELLO-KEY , TRELLO-TOKEN
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          inlineScript: |
+            TRELLO_KEY=$(az keyvault secret show --name "TRELLO-KEY" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
+            echo "::add-mask::$TRELLO_KEY"
+            echo "TRELLO-KEY=$TRELLO_KEY" >> $GITHUB_OUTPUT
+            TRELLO_TOKEN=$(az keyvault secret show --name "TRELLO-TOKEN" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
+            echo "::add-mask::$TRELLO_TOKEN"
+            echo "TRELLO-TOKEN=$TRELLO_TOKEN" >> $GITHUB_OUTPUT
 
-      - name: Add Trello Comment 
+      - name: Add Trello Comment
         uses: DFE-Digital/github-actions/AddTrelloComment@master
         with:
-          MESSAGE:      ${{ github.event.pull_request.html_url }} 
-          CARD:         "${{ github.event.pull_request.body }}"           
-          TRELLO-KEY:   ${{ steps.keyvault-yaml-secret.outputs.TRELLO-KEY }}
-          TRELLO-TOKEN: ${{ steps.keyvault-yaml-secret.outputs.TRELLO-TOKEN }}
+          MESSAGE:      ${{ github.event.pull_request.html_url }}
+          CARD:         "${{ github.event.pull_request.body }}"
+          TRELLO-KEY:   ${{ steps.fetch-keyvault-secret.outputs.TRELLO-KEY }}
+          TRELLO-TOKEN: ${{ steps.fetch-keyvault-secret.outputs.TRELLO-TOKEN }}


### PR DESCRIPTION
### Trello card

https://trello.com/c/C1iKu3uI/1827-gse-fix-workflow-secrets

### Context

Replace keyvault-yaml-secret with azcli in failing workflows
- build-no-cache.yml
- trello.yml

### Changes proposed in this pull request

Update github workflows

### Guidance to review

Confirm workflows run successfully

see https://github.com/DFE-Digital/schools-experience/actions/runs/9159213206 and https://github.com/DFE-Digital/schools-experience/actions/runs/9158198801
