### PR TITLE
Surface location validation

### DIFF
--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -4,7 +4,8 @@ require 'geocoding_response_country'
 class Bookings::SchoolSearch < ApplicationRecord
   attr_reader :location_name, :country
 
-  validates :location, presence: true, length: { minimum: 2 }, if: -> { location.is_a?(String) }
+  validates :location, presence: true, if: -> { query.nil? }
+  validates :location, length: { minimum: 2 }, if: -> { location.is_a?(String) }
 
   # Despite this being an England-only service, we want to search the whole of the UK
   # so that we can return results to users who are near the border.

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -2,10 +2,18 @@ require 'geocoding_request'
 require 'geocoding_response_country'
 
 class Bookings::SchoolSearch < ApplicationRecord
-  attr_reader :location_name, :country
+  attr_reader :location_name, :location_attribute, :country
 
-  validates :location, presence: true, if: -> { query.nil? }
+  # NB: location could be a string (e.g. "Bury"), a hash in location_attribute (e.g. {:latitude=>"53.593", :longitude=>"-2.289"}) or nil if query is set
+  # validates :location, presence: true, unless: -> { [query].any? }
   validates :location, length: { minimum: 2 }, if: -> { location.is_a?(String) }
+  validate :location_query_validator
+
+  def location_query_validator
+    unless [location, location_attribute, query].any?
+      errors.add(:location, :blank)
+    end
+  end
 
   # Despite this being an England-only service, we want to search the whole of the UK
   # so that we can return results to users who are near the border.

--- a/app/models/bookings/school_search.rb
+++ b/app/models/bookings/school_search.rb
@@ -5,7 +5,6 @@ class Bookings::SchoolSearch < ApplicationRecord
   attr_reader :location_name, :location_attribute, :country
 
   # NB: location could be a string (e.g. "Bury"), a hash in location_attribute (e.g. {:latitude=>"53.593", :longitude=>"-2.289"}) or nil if query is set
-  # validates :location, presence: true, unless: -> { [query].any? }
   validates :location, length: { minimum: 2 }, if: -> { location.is_a?(String) }
   validate :location_query_validator
 

--- a/app/views/candidates/school_searches/new.html.erb
+++ b/app/views/candidates/school_searches/new.html.erb
@@ -23,6 +23,8 @@
                            "autocomplete-api-key-value": Rails.application.config.x.google_maps_key,
                            "autocomplete-error-value": @search.errors[:location].first }) do |f| %>
 
+        <%= f.govuk_error_summary %>
+
         <%= f.govuk_text_field :location, required: true, minlength: "2", label: { text: t('helpers.label.location') }, type: "search",
                                data: { "autocomplete-target": "nonJsInput" } %>
 

--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -132,7 +132,7 @@
       <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
 
       <p>
-       This statement was prepared on 3 May 2024. It was last reviewed on 30 May 2024.
+       This statement was prepared on 30 May 2024. It was last reviewed on 30 May 2024.
       </p>
 
       <p>

--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -132,7 +132,7 @@
       <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
 
       <p>
-       This statement was prepared on 3 May 2024. It was last reviewed on 3 May 2024.
+       This statement was prepared on 3 May 2024. It was last reviewed on 30 May 2024.
       </p>
 
       <p>

--- a/app/views/pages/accessibility_statement.html.erb
+++ b/app/views/pages/accessibility_statement.html.erb
@@ -112,10 +112,6 @@
       </p>
       <p>
          <ul class="govuk-list govuk-list--bullet">
-        <li>if a candidate tries to search for a school experience placement without entering a postcode,
-          we do not surface an error message.
-          This does not meet <%= link_to 'WCAG version 2.1 A – 3.3.1 Error Identification (opens in a new tab)', 'https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html' %>
-          and <%= link_to 'WCAG version 2.1 AA – 3.3.3 Error Suggestion (opens in a new tab)', 'https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html', target: "_blank" %>.</li>
         <li>if a school is populating their school experience profile,
           some questions within the form have checkboxes that do not
           share a common legend. This does not meet
@@ -136,7 +132,7 @@
       <h2 class="govuk-heading-m">Preparation of this accessibility statement</h2>
 
       <p>
-       This statement was prepared on 14 March 2024. It was last reviewed on 14 March 2024.
+       This statement was prepared on 3 May 2024. It was last reviewed on 3 May 2024.
       </p>
 
       <p>

--- a/app/views/schools/dashboards/_requests_and_bookings.html.erb
+++ b/app/views/schools/dashboards/_requests_and_bookings.html.erb
@@ -16,7 +16,7 @@
   <div class="govuk-grid-column-one-half">
     <div id="bookings" class="panel govuk-!-margin-bottom-5">
       <h2 class="govuk-heading-m">Upcoming bookings</h2>
-      <p>View, change or cancel candidate bookings and attendance</p>
+      <p>Manage candidate bookings and attendance</p>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
       <ul class="govuk-list">
         <li>
@@ -26,7 +26,6 @@
         <li>
           <%= link_to "Confirm booking attendance", schools_confirm_attendance_path  %>
           <%= numbered_circle(@outstanding_tasks[:bookings_pending_attendance_confirmation], id: 'confirm-attendance-counter', aria_label: 'attendances to confirm') %>
-          <p class="govuk-hint">Confirm if candidates have attended their school experience</p>
         </li>
       </ul>
    </div>

--- a/bin/shakapacker
+++ b/bin/shakapacker
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path('../Gemfile', __dir__)
 
 require "bundler/setup"
 require "shakapacker"

--- a/bin/shakapacker-dev-server
+++ b/bin/shakapacker-dev-server
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ENV["RAILS_ENV"] ||= "development"
-ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", __FILE__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path('../Gemfile', __dir__)
 
 require "bundler/setup"
 require "shakapacker"

--- a/bin/yarn
+++ b/bin/yarn
@@ -2,17 +2,17 @@
 
 APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
-  yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
-    select { |dir| File.expand_path(dir) != __dir__ }.
-    product(["yarn", "yarnpkg", "yarn.cmd", "yarn.ps1"]).
-    map { |dir, file| File.expand_path(file, dir) }.
-    find { |file| File.executable?(file) }
+  yarn = ENV["PATH"].split(File::PATH_SEPARATOR)
+    .reject { |dir| File.expand_path(dir) == __dir__ }
+    .product(["yarn", "yarnpkg", "yarn.cmd", "yarn.ps1"])
+    .map { |dir, file| File.expand_path(file, dir) }
+    .find { |file| File.executable?(file) }
 
   if yarn
     exec yarn, *ARGV
   else
-    $stderr.puts "Yarn executable was not detected in the system."
-    $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
+    warn "Yarn executable was not detected in the system."
+    warn "Download Yarn at https://yarnpkg.com/en/docs/install"
     exit 1
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -521,7 +521,7 @@ en:
             reason:
               blank: 'Cancellation reason is required'
             base:
-              no_rejection_category_selected: Chooose a reason for rejecting this candidate
+              no_rejection_category_selected: Choose a reason for rejecting this candidate
         bookings/school_search:
           attributes:
             location:

--- a/features/candidates/schools/search/results/filtering.feature
+++ b/features/candidates/schools/search/results/filtering.feature
@@ -22,7 +22,7 @@ Feature: Filtering school search results
         And it should have checkboxes for all subjects
 
     Scenario: Filtering while searching by current location (JS disabled)
-        Given there there are schools with the following attributes:
+        Given there are schools with the following attributes:
             | Name              | Phase     | Location   |
             | Manchester School | Secondary | Manchester |
             | Rochdale School   | Secondary | Rochdale   |
@@ -35,7 +35,7 @@ Feature: Filtering school search results
 
     @javascript
     Scenario: Filtering while searching by current location (JS enabled)
-        Given there there are schools with the following attributes:
+        Given there are schools with the following attributes:
             | Name              | Phase     | Location   |
             | Manchester School | Secondary | Manchester |
             | Rochdale School   | Secondary | Rochdale   |

--- a/features/candidates/schools/search/results/sorting.feature
+++ b/features/candidates/schools/search/results/sorting.feature
@@ -5,7 +5,7 @@ Feature: Schools search page sorting
 
     @javascript
     Scenario: Sorting by distance when searching by a specified location
-        Given there there are schools with the following attributes:
+        Given there are schools with the following attributes:
             | Name              | Location   |
             | Manchester School | Manchester |
             | Rochdale School   | Rochdale   |

--- a/features/schools/dashboard.feature
+++ b/features/schools/dashboard.feature
@@ -48,7 +48,7 @@ Feature: The School Dashboard
         Then I should see the following 'bookings' links:
             | Text                       | Hint                                                        | Path                        |
             | Manage upcoming bookings   | None                                                        | /schools/bookings           |
-            | Confirm booking attendance | Confirm if candidates have attended their school experience | /schools/confirm_attendance |
+            | Confirm booking attendance | None                                                        | /schools/confirm_attendance |
 
     Scenario: School profile panel
         Given my school has fully-onboarded

--- a/features/step_definitions/candidates/schools/sorting_steps.rb
+++ b/features/step_definitions/candidates/schools/sorting_steps.rb
@@ -1,4 +1,4 @@
-Given("there there are schools with the following attributes:") do |table|
+Given("there are schools with the following attributes:") do |table|
   def locate(place)
     {
       "Manchester" => Bookings::School::GEOFACTORY.point(-2.241, 53.481),

--- a/spec/models/bookings/placement_request/cancellation_spec.rb
+++ b/spec/models/bookings/placement_request/cancellation_spec.rb
@@ -36,7 +36,7 @@ describe Bookings::PlacementRequest::Cancellation, type: :model do
 
       subject { cancellation.errors.messages }
 
-      it { is_expected.to include(base: ["Chooose a reason for rejecting this candidate"]) }
+      it { is_expected.to include(base: ["Choose a reason for rejecting this candidate"]) }
 
       context "when there are rejection categories specified" do
         let(:cancellation) { build(:cancellation, fully_booked: true) }

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -16,12 +16,28 @@ describe Bookings::SchoolSearch do
 
   describe 'Validation' do
     subject { described_class.new({}) }
-    it { is_expected.to validate_presence_of(:location) }
     it { is_expected.to validate_length_of(:location).is_at_least(2) }
+    it { is_expected.not_to be_valid }
 
     context 'with a query parameter' do
-      subject { described_class.new({ query: "something" }) }
-      it { is_expected.to_not validate_presence_of(:location) }
+      subject { described_class.new({ query: "Somewhere" }) }
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a non-compliant UTF8 query string' do
+      # NB: non-compliant UTF8 query strings are handled elsewhere in the codebase
+      subject { described_class.new({ query: "Springfield\xa1" }) }
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a location hash' do
+      subject { described_class.new({ location: { longitude: 1.1, latitude: 2.2 } }) }
+      it { is_expected.to be_valid }
+    end
+
+    context 'with a location string' do
+      subject { described_class.new({ location: "John o'Groats" }) }
+      it { is_expected.to be_valid }
     end
   end
 

--- a/spec/models/bookings/school_search_spec.rb
+++ b/spec/models/bookings/school_search_spec.rb
@@ -16,7 +16,13 @@ describe Bookings::SchoolSearch do
 
   describe 'Validation' do
     subject { described_class.new({}) }
+    it { is_expected.to validate_presence_of(:location) }
     it { is_expected.to validate_length_of(:location).is_at_least(2) }
+
+    context 'with a query parameter' do
+      subject { described_class.new({ query: "something" }) }
+      it { is_expected.to_not validate_presence_of(:location) }
+    end
   end
 
   describe '#geolocation' do


### PR DESCRIPTION
validate for a location or query
small rubocop fixes on other files

### Trello card
[Surface a validation error](https://trello.com/c/NLPhh1Wh/5840-ensure-that-we-surface-a-validation-error-if-a-user-tries-to-search-for-a-school-experience-placement-with-no-postcode-on-gse)

### Context
The Schools Experience does not show an error if the location field is left blank when searching for a schools experience

This is a re-implementation of work originally done in PR https://github.com/DFE-Digital/schools-experience/pull/3159 - now using Rails validators and GOVUK frontend libraries

### Changes proposed in this pull request
Validate for location

### Guidance to review

