### PR TITLE
Disable rack-timeout logging

### DIFF
--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,0 +1,2 @@
+# Disable Rack::Timeout logging to reduce log noise
+Rack::Timeout::Logger.disable


### PR DESCRIPTION
### Trello card

N/A

### Context

Since shipping the log files to logit, there is a lot of noise being generated by rack-timeout.

### Changes proposed in this pull request
Disable log messages from tack-timeout

### Guidance to review

