### PR TITLE
Remove two ticks scheme copy

### DIFF
--- a/app/views/schools/on_boarding/disability_confidents/_form.html.erb
+++ b/app/views/schools/on_boarding/disability_confidents/_form.html.erb
@@ -13,20 +13,11 @@
 
         <div>
           <%= image_pack_tag 'static/images/disability-confident-small.png', alt: 'Disability confident logo' %>
-          <span class="govuk-hint">
-            This was previously known as the 'Two Ticks scheme'
-          </span>
         </div>
 
         <%= f.govuk_radio_button :is_disability_confident, "true", link_errors: true %>
         <%= f.govuk_radio_button :is_disability_confident, "false" %>
       <% end %>
-
-      <p>
-        Check if you're already signed up to the
-        <%= link_to 'scheme',
-          'https://www.gov.uk/government/publications/disability-confident-employers-that-have-signed-up' %>.
-      </p>
 
       <p>
         Find out more about how to become a

--- a/app/views/schools/on_boarding/disability_confidents/_form.html.erb
+++ b/app/views/schools/on_boarding/disability_confidents/_form.html.erb
@@ -21,8 +21,8 @@
 
       <p>
         Find out more about how to become a
-        <%= link_to 'Disability Confident employer.',
-          'https://disabilityconfident.campaign.gov.uk/' %>
+        <%= link_to 'Disability Confident employer',
+          'https://disabilityconfident.campaign.gov.uk/' %>.
       </p>
 
       <%= f.govuk_submit 'Continue' %>


### PR DESCRIPTION
### Trello card

- https://trello.com/c/HP4qUga0

### Context

- This scheme (two ticks) was replaced in 2013. We think enough time has passed to remove reference to it.

### Changes proposed in this pull request

- Remove reference to the two ticks scheme.

**After**
<img width="709" alt="image" src="https://github.com/DFE-Digital/schools-experience/assets/35870975/1c026280-b0a8-4ee4-8936-ef457e2d51a2">


### Guidance to review

