### PR TITLE
Scrape custom metrics

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -42,6 +42,8 @@ module "web_application" {
   probe_path             = "/check"
   web_external_hostnames = var.create_dsi_ingress ? [var.dsi_hostname] : []
   enable_logit               = var.enable_logit
+
+  enable_prometheus_monitoring  = var.enable_prometheus_monitoring
 }
 
 module "worker_application" {

--- a/terraform/aks/config/development.tfvars.json
+++ b/terraform/aks/config/development.tfvars.json
@@ -9,5 +9,6 @@
     "sidekiq_replicas" : 1,
     "sidekiq_memory_max" : "1Gi",
     "dsi_hostname": "development.schoolexperience.education.gov.uk",
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -25,5 +25,6 @@
       }
     },
     "dsi_hostname": "schoolexperience.education.gov.uk",
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/config/staging.tfvars.json
+++ b/terraform/aks/config/staging.tfvars.json
@@ -15,5 +15,6 @@
         }
       },
     "dsi_hostname": "staging.schoolexperience.education.gov.uk",
-    "enable_logit": true
+    "enable_logit": true,
+    "enable_prometheus_monitoring": true
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -158,6 +158,11 @@ variable "create_dsi_ingress" {
   default = false
 }
 variable "enable_logit" { default = false }
+variable "enable_prometheus_monitoring" {
+  type    = bool
+  default = false
+}
+
 locals {
   azure_credentials = try(jsondecode(var.azure_credentials_json), null)
   postgres_ssl_mode = var.enable_postgres_ssl ? "require" : "disable"


### PR DESCRIPTION
### Trello card
https://trello.com/c/Zlih3dRZ/1889-scrape-custom-metrics

### Context
Scrape custom metrics that are exported for gse,
which can then be used in dashboards and alerting

### Changes proposed in this pull request
Add enable_prometheus_monitoring to application deployments and set for each env

remove from review apps before merge

### Guidance to review
make development terraform-plan IMAGE_TAG=x

Review app metrics are visible in prometheus test (yabeda-rails, sidekiq, http_requests, puma)



