### PR TITLE
Scrape worker custom metrics

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -61,4 +61,6 @@ module "worker_application" {
   max_memory                 = var.sidekiq_memory_max
   replicas                   = var.sidekiq_replicas
   enable_logit               = var.enable_logit
+
+  enable_prometheus_monitoring  = var.enable_prometheus_monitoring
 }


### PR DESCRIPTION
### Trello card

https://trello.com/c/Zlih3dRZ/1889-scrape-custom-metrics

### Context

Scrape the worker process custom metrics

merge when ttps://github.com/DFE-Digital/terraform-modules/pull/110/commits/aacddbd753ba10580a0551dc9b0ca29bec940a4d is in STABLE

### Changes proposed in this pull request

Add enable_prometheus_monitoring to worker
Deployed using branch [1889-scrape-custom-metrics](https://github.com/DFE-Digital/terraform-modules/tree/1889-scrape-custom-metrics)

Remove from review tfvars before merge

### Guidance to review

make env terraform-plan
Check metrics are being collected for the review app (most starting with sidekiq)

