### PR TITLE
Remove reference to universal analytics from cookie policy 

### DIFF
--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -132,7 +132,7 @@
                 <strong>schoolex-session</strong>
               </td>
               <td class="govuk-table__cell">
-                Used to identify your current session with the School Experience Service
+                Used to identify your current session with the Get school experience and Manage school experience service. 
               </td>
               <td class="govuk-table__cell govuk-table__cell--numeric">
                 14 days

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -106,8 +106,7 @@
       </section>
       <section>
        
-                <strong>seen_cookie_message</strong>
-              </td>
+                            </td>
               <td class="govuk-table__cell">
                 Saves a cookie to let us know you’ve seen our cookie message
               </td>

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -25,7 +25,7 @@
       <section>
         <h3 class="govuk-heading-s">Measuring website usage (Google Analytics)</h3>
         <p>
-          We use Google Analytics software (Universal Analytics) to collect information about how you use this site. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example, improving site search.
+          We use Google Analytics to collect information about how you use this site. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example, improving site search.
         </p>
         <p>
           Google Analytics stores information about:

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -106,17 +106,7 @@
       </section>
       <section>
        
-                            </td>
-              <td class="govuk-table__cell">
-                Saves a cookie to let us know you’ve seen our cookie message
-              </td>
-              <td class="govuk-table__cell govuk-table__cell--numeric">
-                14 days
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
+                                 </section>
       <section>
         <h3 class="govuk-heading-m">Session Cookie</h3>
         <p>

--- a/app/views/pages/cookies_policy.html.erb
+++ b/app/views/pages/cookies_policy.html.erb
@@ -28,7 +28,7 @@
           We use Google Analytics to collect information about how you use this site. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example, improving site search.
         </p>
         <p>
-          Google Analytics stores information about:
+          Google Analytics stores information such as:
         </p>
         <ul class="govuk-list govuk-list--bullet">
           <li>the pages you visit on this site</li>
@@ -101,31 +101,11 @@
           </tbody>
         </table>
         <p>
-          You can opt out of <%= link_to 'Google Analytics cookies', 'https://tools.google.com/dlpage/gaoptout' %>
+          
         </p>
       </section>
       <section>
-        <h3 class="govuk-heading-m">Our cookie message</h3>
-        <p>
-          You may see a pop-up welcome message when you first visit the service. We’ll store a cookie so your computer knows you’ve seen it and knows not to show it again.
-        </p>
-        <table class="govuk-table">
-          <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th class="govuk-table__header" scope="col">
-                Name
-              </th>
-              <th class="govuk-table__header" scope="col">
-                Purpose
-              </th>
-              <th class="govuk-table__header govuk-table__header--numeric" scope="col">
-                Expires
-              </th>
-            </tr>
-          </thead>
-          <tbody class="govuk-table__body">
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
+       
                 <strong>seen_cookie_message</strong>
               </td>
               <td class="govuk-table__cell">


### PR DESCRIPTION
### Trello card
https://trello.com/c/hzAfNgD6
### Context
Remove references to UA from cookie policy 


