### PR TITLE
Remove unused seen_cookie_message spec

### DIFF
--- a/spec/requests/cookie_banner_spec.rb
+++ b/spec/requests/cookie_banner_spec.rb
@@ -1,16 +1,9 @@
 require 'rails_helper'
 
 describe "Displaying the cookie banner", type: :request do
-  let(:cookie_name) { 'seen_cookie_message' }
   let(:banner_contents) { /Cookies on the Get school experience service/ }
 
   context 'on the first visit (when the seen_cookie_message cookie is absent)' do
-    specify "the cookie should not be set to 'yes'" do
-      expect(cookies[cookie_name]).to be_nil
-      get candidates_root_path
-      expect(cookies[cookie_name]).to be_nil
-    end
-
     specify 'the page should display the cookie banner' do
       get candidates_root_path
       expect(response.body).to match(banner_contents)


### PR DESCRIPTION
### Trello card

https://trello.com/c/Ww7AoZHF

### Context

The `seen_cookie_message` was removed in #3241, this removes it's surrounding code from the cookies spec

### Changes proposed in this pull request

Removes mention of `seen_cookie_message` in the specs

### Guidance to review

