### PR TITLE
Set maintenance window for insights team

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -51,4 +51,6 @@ DfE::Analytics.configure do |config|
   # to all events we send to BigQuery.
   #
   # config.environment = ENV.fetch('RAILS_ENV', 'development')
+
+  config.bigquery_maintenance_window = "08-09-2024 18:00..08-09-2024 19:00"
 end


### PR DESCRIPTION
### Trello card

https://trello.com/c/bid52oYh/6366-set-a-maintenance-window-on-gse-for-insights-team

### Context

Request from digital insights team to add the maintenance window config so that they can do encryption of the big query production events table as part of the ongoing BQ assurance work.

### Changes proposed in this pull request

- Add maintenance window

### Guidance to review

