### PR TITLE
Upgrade Shakapacker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'geocoder'
 gem 'puma', '~> 6.4.2'
 
 # Transpile app-like JavaScript. Read more: https://github.com/shakacode/shakapacker
-gem 'shakapacker', '7.2.1'
+gem 'shakapacker', '8.0.1'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -601,7 +601,7 @@ GEM
     sentry-sidekiq (5.18.2)
       sentry-ruby (~> 5.18.2)
       sidekiq (>= 3.0)
-    shakapacker (7.2.1)
+    shakapacker (8.0.1)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -788,7 +788,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  shakapacker (= 7.2.1)
+  shakapacker (= 8.0.1)
   shoulda-matchers (~> 6.1)
   sidekiq (< 7)
   sidekiq-cron

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,14 +8,14 @@
     <%= csp_meta_tag %>
     <%= display_meta_tags %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
-    <%= tag :meta, property: 'og:image', content: asset_pack_url('static/node_modules/govuk-frontend/dist/govuk/assets/images/govuk-opengraph-image.png') %>
+    <%= tag :meta, property: 'og:image', content: asset_pack_url('static/assets/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#0b0c0c' %>
-    <%= favicon_link_tag asset_pack_path('static/node_modules/govuk-frontend/dist/govuk/assets/images/favicon.ico') %>
-    <%= favicon_link_tag asset_pack_path('static/node_modules/govuk-frontend/dist/govuk/assets/images/govuk-icon-mask.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
-    <%= favicon_link_tag asset_pack_path('static/node_modules/govuk-frontend/dist/govuk/assets/images/govuk-icon-180.png'), rel: 'govuk-icon-180', type: 'image/png', size: '180x180' %>
-    <%= favicon_link_tag asset_pack_path('static/node_modules/govuk-frontend/dist/govuk/assets/images/govuk-icon-192.png'), rel: 'govuk-icon-192', type: 'image/png', size: '192x192' %>
-    <%= favicon_link_tag asset_pack_path('static/node_modules/govuk-frontend/dist/govuk/assets/images/govuk-icon-512.png'), rel: 'govuk-icon-512', type: 'image/png', size: '512x512' %>
-    <%= favicon_link_tag asset_pack_path('static/node_modules/govuk-frontend/dist/govuk/assets/images/govuk-opengraph-image.png'), rel: 'apple-touch-icon', type: 'image/png' %>
+    <%= favicon_link_tag asset_pack_path('static/assets/images/favicon.ico') %>
+    <%= favicon_link_tag asset_pack_path('static/assets/images/govuk-icon-mask.svg'), rel: 'mask-icon', type: 'image/svg', color: "#0b0c0c" %>
+    <%= favicon_link_tag asset_pack_path('static/assets/images/govuk-icon-180.png'), rel: 'govuk-icon-180', type: 'image/png', size: '180x180' %>
+    <%= favicon_link_tag asset_pack_path('static/assets/images/govuk-icon-192.png'), rel: 'govuk-icon-192', type: 'image/png', size: '192x192' %>
+    <%= favicon_link_tag asset_pack_path('static/assets/images/govuk-icon-512.png'), rel: 'govuk-icon-512', type: 'image/png', size: '512x512' %>
+    <%= favicon_link_tag asset_pack_path('static/assets/images/govuk-opengraph-image.png'), rel: 'apple-touch-icon', type: 'image/png' %>
     <%= stylesheet_pack_tag 'application', media: 'all' %>
     <%= yield :head %>
   </head>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "sass": "^1.77.6",
     "sass-loader": "^15.0.0",
     "semver": "^7.5.2",
-    "shakapacker": "7.2.2",
+    "shakapacker": "8.0.1",
     "stimulus": "^3.2.2",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "5",
@@ -76,5 +76,6 @@
   ],
   "scripts": {
     "spec": "jest"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3301,7 +3301,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -5564,12 +5564,11 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@7.2.2:
-  version "7.2.2"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-7.2.2.tgz#58f565ce0a1b3efb91effaed982d0ac5811af57c"
-  integrity sha512-TSHEztaNcfhUqwap2arvAmvIm9YNbqlYjxaS4cYPxtqGH/2UQD98hKjztHBdphceOjTV6ea5Yj235egWh8E15Q==
+shakapacker@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-8.0.1.tgz#96c893ccc414d47aaf86689eb5ef732259c592c7"
+  integrity sha512-VjIWgJqh4680Kf2NSmupB3h6dWxlOkGvceJJuJZ0az/6wUL5d/ovmKUc2swrpWC8UgBY67YjXI92zT07EQevbQ==
   dependencies:
-    glob "^7.2.0"
     js-yaml "^4.1.0"
     path-complete-extname "^1.0.0"
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/V2PCc0U6/6340-upgrade-shakapacker-from-7-to-8-on-get-school-experience?filter=member:spencerldixon

### Context

Shakapacker needs to be upgraded to v8 inline with the Get Into Teaching website

### Changes proposed in this pull request

- Update shakapacker to v8.0.1
- Configure packageManager as per new requirements

### Guidance to review

