### PR TITLE
Fixed rubocop factory class name

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,11 +16,6 @@ Capybara/VisibilityMatcher:
   Exclude:
     - "features/step_definitions/candidates/schools/filtering_steps.rb"
 
-# Offense count: 36
-# This cop supports safe autocorrection (--autocorrect).
-FactoryBot/FactoryClassName:
-  Enabled: false
-
 # Offense count: 3
 # Configuration parameters: EnforcedStyle, AllowedGems, Include.
 # SupportedStyles: Gemfile, gems.rb, gemspec

--- a/spec/factories/api_factory.rb
+++ b/spec/factories/api_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :api_schools_experience_sign_up, class: GetIntoTeachingApiClient::SchoolsExperienceSignUp do
+  factory :api_schools_experience_sign_up, class: 'GetIntoTeachingApiClient::SchoolsExperienceSignUp' do
     candidate_id { SecureRandom.uuid }
     master_id { nil }
     merged { false }
@@ -28,12 +28,12 @@ FactoryBot.define do
     end
   end
 
-  factory :api_privacy_policy, class: GetIntoTeachingApiClient::PrivacyPolicy do
+  factory :api_privacy_policy, class: 'GetIntoTeachingApiClient::PrivacyPolicy' do
     id { SecureRandom.uuid }
     text { "policy text" }
   end
 
-  factory :api_teaching_subject, class: GetIntoTeachingApiClient::TeachingSubject do
+  factory :api_teaching_subject, class: 'GetIntoTeachingApiClient::TeachingSubject' do
     id { SecureRandom.uuid }
     sequence(:value) { |i| "Gitis Subject #{i}" }
   end

--- a/spec/factories/bookings/placement_request_factory.rb
+++ b/spec/factories/bookings/placement_request_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :placement_request, class: Bookings::PlacementRequest do
+  factory :placement_request, class: 'Bookings::PlacementRequest' do
     association \
       :school,
       :with_profile,

--- a/spec/factories/bookings/school_factory.rb
+++ b/spec/factories/bookings/school_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :bookings_school, class: Bookings::School do
+  factory :bookings_school, class: 'Bookings::School' do
     sequence(:name) { |n| "school #{n}" }
     coordinates { Bookings::School::GEOFACTORY.point(-2.241, 53.481) }
     fee { 0 }

--- a/spec/factories/candidates/feedback.rb
+++ b/spec/factories/candidates/feedback.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :candidates_feedback, class: Candidates::Feedback do
+  factory :candidates_feedback, class: 'Candidates::Feedback' do
     reason_for_using_service { 'something_else' }
     reason_for_using_service_explanation { 'testing the software' }
     rating { 'very_satisfied' }

--- a/spec/factories/candidates/registrations/availability_preference_factory.rb
+++ b/spec/factories/candidates/registrations/availability_preference_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :availability_preference, class: Candidates::Registrations::AvailabilityPreference do
+  factory :availability_preference, class: 'Candidates::Registrations::AvailabilityPreference' do
     urn { 11_048 }
     availability { 'Every second Friday' }
   end

--- a/spec/factories/candidates/registrations/background_check_factory.rb
+++ b/spec/factories/candidates/registrations/background_check_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :background_check, class: Candidates::Registrations::BackgroundCheck do
+  factory :background_check, class: 'Candidates::Registrations::BackgroundCheck' do
     urn { 11_048 }
     has_dbs_check { true }
   end

--- a/spec/factories/candidates/registrations/contact_information_factory.rb
+++ b/spec/factories/candidates/registrations/contact_information_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :contact_information, class: Candidates::Registrations::ContactInformation do
+  factory :contact_information, class: 'Candidates::Registrations::ContactInformation' do
     urn { 11_048 }
     building { 'New house' }
     street { 'Test street' }

--- a/spec/factories/candidates/registrations/education_factory.rb
+++ b/spec/factories/candidates/registrations/education_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :education, class: Candidates::Registrations::Education do
+  factory :education, class: 'Candidates::Registrations::Education' do
     urn { 11_048 }
     degree_stage { "Other" }
     degree_stage_explaination { "Khan academy, level 3" }

--- a/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/gitis_registration_session_factory.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :gitis_registration_session, parent: :registration_session,
-                                       class: Candidates::Registrations::GitisRegistrationSession do
+                                       class: 'Candidates::Registrations::GitisRegistrationSession' do
     gitis_contact { build(:api_schools_experience_sign_up_with_name) }
 
     initialize_with do

--- a/spec/factories/candidates/registrations/legacy_registration_session.rb
+++ b/spec/factories/candidates/registrations/legacy_registration_session.rb
@@ -1,6 +1,6 @@
 # TODO: SE-1877 remove this file
 FactoryBot.define do
-  factory :legacy_registration_session, class: Candidates::Registrations::RegistrationSession do
+  factory :legacy_registration_session, class: 'Candidates::Registrations::RegistrationSession' do
     transient do
       urn { 11_048 }
       bookings_placement_date_id { 16 }

--- a/spec/factories/candidates/registrations/personal_information_factory.rb
+++ b/spec/factories/candidates/registrations/personal_information_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :personal_information, class: Candidates::Registrations::PersonalInformation do
+  factory :personal_information, class: 'Candidates::Registrations::PersonalInformation' do
     urn { 11_048 }
     first_name { 'Testy' }
     last_name { 'Mc Test' }

--- a/spec/factories/candidates/registrations/placement_preference_factory.rb
+++ b/spec/factories/candidates/registrations/placement_preference_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :placement_preference, class: Candidates::Registrations::PlacementPreference do
+  factory :placement_preference, class: 'Candidates::Registrations::PlacementPreference' do
     urn { 11_048 }
     objectives { 'Become a teacher' }
   end

--- a/spec/factories/candidates/registrations/registration_session_factory.rb
+++ b/spec/factories/candidates/registrations/registration_session_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :registration_session, class: Candidates::Registrations::RegistrationSession do
+  factory :registration_session, class: 'Candidates::Registrations::RegistrationSession' do
     transient do
       current_time { DateTime.current }
       urn { 11_048 }

--- a/spec/factories/candidates/registrations/subject_and_date_information_factory.rb
+++ b/spec/factories/candidates/registrations/subject_and_date_information_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :subject_and_date_information, class: Candidates::Registrations::SubjectAndDateInformation do
+  factory :subject_and_date_information, class: 'Candidates::Registrations::SubjectAndDateInformation' do
     bookings_placement_date_id { create(:bookings_placement_date).id }
     bookings_subject_id { nil }
   end

--- a/spec/factories/candidates/registrations/teaching_preference_factory.rb
+++ b/spec/factories/candidates/registrations/teaching_preference_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :teaching_preference, class: Candidates::Registrations::TeachingPreference do
+  factory :teaching_preference, class: 'Candidates::Registrations::TeachingPreference' do
     transient do
       school { FactoryBot.create :bookings_school }
     end

--- a/spec/factories/schools/feedback.rb
+++ b/spec/factories/schools/feedback.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :schools_feedback, class: Schools::Feedback do
+  factory :schools_feedback, class: 'Schools::Feedback' do
     reason_for_using_service { 'something_else' }
     reason_for_using_service_explanation { 'testing the software' }
     rating { 'very_satisfied' }

--- a/spec/factories/schools/on_boarding/access_needs_detail_factory.rb
+++ b/spec/factories/schools/on_boarding/access_needs_detail_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :access_needs_detail, class: Schools::OnBoarding::AccessNeedsDetail do
+  factory :access_needs_detail, class: 'Schools::OnBoarding::AccessNeedsDetail' do
     description { 'Here are some details' }
   end
 end

--- a/spec/factories/schools/on_boarding/access_needs_policy_factory.rb
+++ b/spec/factories/schools/on_boarding/access_needs_policy_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :access_needs_policy, class: Schools::OnBoarding::AccessNeedsPolicy do
+  factory :access_needs_policy, class: 'Schools::OnBoarding::AccessNeedsPolicy' do
     has_access_needs_policy { true }
     url { 'https://example.com/access-needs-policy' }
   end

--- a/spec/factories/schools/on_boarding/access_needs_support_factory.rb
+++ b/spec/factories/schools/on_boarding/access_needs_support_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :access_needs_support, class: Schools::OnBoarding::AccessNeedsSupport do
+  factory :access_needs_support, class: 'Schools::OnBoarding::AccessNeedsSupport' do
     supports_access_needs { true }
   end
 end

--- a/spec/factories/schools/on_boarding/admin_contact_factory.rb
+++ b/spec/factories/schools/on_boarding/admin_contact_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :admin_contact, class: Schools::OnBoarding::AdminContact do
+  factory :admin_contact, class: 'Schools::OnBoarding::AdminContact' do
     email { 'g.chalmers@springfield.edu' }
     email_secondary { 's.skinner@springfield.edu' }
     phone { '+441234567890' }

--- a/spec/factories/schools/on_boarding/administration_fee_factory.rb
+++ b/spec/factories/schools/on_boarding/administration_fee_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :administration_fee, class: Schools::OnBoarding::AdministrationFee do
+  factory :administration_fee, class: 'Schools::OnBoarding::AdministrationFee' do
     amount_pounds { 100.99 }
     description { 'Generic administration fee' }
     interval { 'Daily' }

--- a/spec/factories/schools/on_boarding/candidate_requirement_factory.rb
+++ b/spec/factories/schools/on_boarding/candidate_requirement_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :candidate_requirement, class: Schools::OnBoarding::CandidateRequirement do
+  factory :candidate_requirement, class: 'Schools::OnBoarding::CandidateRequirement' do
     requirements { true }
     requirements_details { 'Gotta go fast' }
   end

--- a/spec/factories/schools/on_boarding/candidate_requirements_selection_factory.rb
+++ b/spec/factories/schools/on_boarding/candidate_requirements_selection_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :candidate_requirements_selection, class: Schools::OnBoarding::CandidateRequirementsSelection do
+  factory :candidate_requirements_selection, class: 'Schools::OnBoarding::CandidateRequirementsSelection' do
     selected_requirements { %w[on_teacher_training_course has_or_working_towards_degree live_locally provide_photo_identification other] }
     maximum_distance_from_school { 8 }
     photo_identification_details { 'Make sure photo is clear' }

--- a/spec/factories/schools/on_boarding/confirmation_factory.rb
+++ b/spec/factories/schools/on_boarding/confirmation_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :confirmation, class: Schools::OnBoarding::Confirmation do
+  factory :confirmation, class: 'Schools::OnBoarding::Confirmation' do
     acceptance { true }
   end
 end

--- a/spec/factories/schools/on_boarding/dbs_fee_factory.rb
+++ b/spec/factories/schools/on_boarding/dbs_fee_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :dbs_fee, class: Schools::OnBoarding::DBSFee do
+  factory :dbs_fee, class: 'Schools::OnBoarding::DBSFee' do
     amount_pounds { 200 }
     description { 'DBS check' }
     interval { 'One-off' }

--- a/spec/factories/schools/on_boarding/dbs_requirement_factory.rb
+++ b/spec/factories/schools/on_boarding/dbs_requirement_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :dbs_requirement, class: Schools::OnBoarding::DbsRequirement do
+  factory :dbs_requirement, class: 'Schools::OnBoarding::DbsRequirement' do
     dbs_policy_conditions { 'required' }
     dbs_policy_details { 'Must have recent dbs check' }
     no_dbs_policy_details { nil }

--- a/spec/factories/schools/on_boarding/description_factory.rb
+++ b/spec/factories/schools/on_boarding/description_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :description, class: Schools::OnBoarding::Description do
+  factory :description, class: 'Schools::OnBoarding::Description' do
     details { 'Horse archery' }
   end
 end

--- a/spec/factories/schools/on_boarding/disability_confident_factory.rb
+++ b/spec/factories/schools/on_boarding/disability_confident_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :disability_confident, class: Schools::OnBoarding::DisabilityConfident do
+  factory :disability_confident, class: 'Schools::OnBoarding::DisabilityConfident' do
     is_disability_confident { true }
   end
 end

--- a/spec/factories/schools/on_boarding/experience_outline_factory.rb
+++ b/spec/factories/schools/on_boarding/experience_outline_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :experience_outline, class: Schools::OnBoarding::ExperienceOutline do
+  factory :experience_outline, class: 'Schools::OnBoarding::ExperienceOutline' do
     candidate_experience { 'Mostly teaching' }
   end
 end

--- a/spec/factories/schools/on_boarding/fees_factory.rb
+++ b/spec/factories/schools/on_boarding/fees_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :fees, class: Schools::OnBoarding::Fees do
+  factory :fees, class: 'Schools::OnBoarding::Fees' do
     selected_fees { %w[administration_fees dbs_fees other_fees] }
     dbs_fees_specified { true }
   end

--- a/spec/factories/schools/on_boarding/key_stage_list_factory.rb
+++ b/spec/factories/schools/on_boarding/key_stage_list_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :key_stage_list, class: Schools::OnBoarding::KeyStageList do
+  factory :key_stage_list, class: 'Schools::OnBoarding::KeyStageList' do
     early_years { true }
     key_stage_1 { true }
     key_stage_2 { true }

--- a/spec/factories/schools/on_boarding/other_fee_factory.rb
+++ b/spec/factories/schools/on_boarding/other_fee_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :other_fee, class: Schools::OnBoarding::OtherFee do
+  factory :other_fee, class: 'Schools::OnBoarding::OtherFee' do
     amount_pounds { 300 }
     description { 'Falconry lessons' }
     interval { 'One-off' }

--- a/spec/factories/schools/on_boarding/phases_list_factory.rb
+++ b/spec/factories/schools/on_boarding/phases_list_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :phases_list, class: Schools::OnBoarding::PhasesList do
+  factory :phases_list, class: 'Schools::OnBoarding::PhasesList' do
     primary { true }
     secondary { true }
     college { true }

--- a/spec/factories/schools/on_boarding/teacher_training_factory.rb
+++ b/spec/factories/schools/on_boarding/teacher_training_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :teacher_training, class: Schools::OnBoarding::TeacherTraining do
+  factory :teacher_training, class: 'Schools::OnBoarding::TeacherTraining' do
     provides_teacher_training { true }
     teacher_training_details { 'We offer teach training in house' }
     teacher_training_url { 'https://example.com' }


### PR DESCRIPTION
### Trello card

https://trello.com/c/vOignwZ1/7002-clear-up-linting-errors-on-get-school-experience

### Context

A recent rubocop bump on Get school experience uncovered over 6,000 linting errors

An attempt to autocorrect these linting errors didn’t work as other tests then started to break

Instead the errors have been moved to .rubocop_todo.yml

### Changes proposed in this pull request

- Fixes 36 `FactoryBot/FactoryClassName` instances

### Guidance to review

