### PR TITLE
Create nonprod db backup storage via terraform

### DIFF
--- a/terraform/aks/config/development.tfvars.json
+++ b/terraform/aks/config/development.tfvars.json
@@ -4,7 +4,7 @@
     "environment": "development",
     "key_vault_resource_group":  "s189t01-gse-dv-rg",
     "infra_key_vault_name": "s189t01-gse-dv-inf-kv",
-    "azure_enable_backup_storage": false,
+    "azure_enable_backup_storage": true,
     "enable_monitoring": false,
     "sidekiq_replicas" : 1,
     "sidekiq_memory_max" : "1Gi",

--- a/terraform/aks/config/staging.tfvars.json
+++ b/terraform/aks/config/staging.tfvars.json
@@ -3,7 +3,7 @@
     "namespace": "git-test",
     "environment": "staging",
     "infra_key_vault_name": "s189t01-gse-stg-inf-kv",
-    "azure_enable_backup_storage": false,
+    "azure_enable_backup_storage": true,
     "key_vault_resource_group":  "s189t01-gse-stg-rg",
     "enable_monitoring": false,
     "sidekiq_replicas" : 2,


### PR DESCRIPTION
### Trello card

https://trello.com/c/E83HBQc9/2189-gse-plan-for-dr-test

### Context

Non prod database backup storage accounts appear to have been created manually, with a different naming standard.
They should be created by terraform, so they work with the new backup & restore workflow templates.

### Changes proposed in this pull request

Set azure_enable_backup_storage to true for development and staging envs.

### Guidance to review

make development/staging terraform-plan
