### PR TITLE
Move workflow secrets to github

### DIFF
--- a/.github/workflows/build-no-cache.yml
+++ b/.github/workflows/build-no-cache.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   build:
     name: Build
-    environment: review
     runs-on: ubuntu-latest
 
     steps:
@@ -22,21 +21,6 @@ jobs:
 
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
-
-      - uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch synk token from key vault
-        uses: azure/CLI@v2
-        id: fetch-keyvault-secret
-        with:
-          inlineScript: |
-            SNYK_TOKEN=$(az keyvault secret show --name "SNYK-TOKEN" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SNYK_TOKEN"
-            echo "SNYK-TOKEN=$SNYK_TOKEN" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@master
@@ -63,7 +47,7 @@ jobs:
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ steps.fetch-keyvault-secret.outputs.SNYK-TOKEN }}
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{ env.DOCKER_REPOSITORY }}:master
           args: --severity-threshold=high --file=Dockerfile  --exclude-app-vulns

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,6 @@ jobs:
 
   security_tests:
     name: Security Tests
-    environment: review
     runs-on: ubuntu-latest
     needs: [build]
     steps:
@@ -150,12 +149,6 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
-      - uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -163,20 +156,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Fetch synk token from key vault
-        uses: azure/CLI@v2
-        id: fetch-synk-token
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SNYK-TOKEN" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SNYK-TOKEN=$SECRET_VALUE" >> $GITHUB_OUTPUT
-
       - name: Run Snyk to check Docker image for vulnerabilities
         uses: snyk/actions/docker@master
         env:
-          SNYK_TOKEN: ${{ steps.fetch-synk-token.outputs.SNYK-TOKEN }}
-
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           image: ${{needs.build.outputs.DOCKER_IMAGE}}
           args: --severity-threshold=high --file=Dockerfile --exclude-app-vulns --policy-path=/.snyk
@@ -275,7 +258,6 @@ jobs:
 
   sonarcloud:
     name: SonarCloud
-    environment: review
     runs-on: ubuntu-latest
     needs: [selenium_cucumber_tests, cucumber_tests, security_tests, spec_tests]
     steps:
@@ -286,12 +268,6 @@ jobs:
       - name: set-up-environment
         uses: DFE-Digital/github-actions/set-up-environment@master
 
-      - uses: Azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Download Test Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -300,20 +276,11 @@ jobs:
       - name: Fixup report file paths
         run: sudo sed -i "s?/app/app?/github/workspace/app?" ${{ github.workspace }}/out/${{ env.code-coverage-artifact-name }}/coverage.json
 
-      - name: Fetch Sonar token from key vault
-        uses: azure/CLI@v2
-        id: fetch-sonar-token
-        with:
-          inlineScript: |
-            SECRET_VALUE=$(az keyvault secret show --name "SONAR-TOKEN" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$SECRET_VALUE"
-            echo "SONAR-TOKEN=$SECRET_VALUE" >> $GITHUB_OUTPUT
-
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ steps.fetch-sonar-token.outputs.SONAR-TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: >
             -Dsonar.ruby.rubocop.reportPath=./out/${{ env.rubocop-artifact-name }}/rubocop-result.json
@@ -322,7 +289,6 @@ jobs:
   prepare:
     name: Configure Matrix Deployments
     needs: [sonarcloud]
-
     runs-on: ubuntu-latest
     outputs:
       matrix_environments: ${{ env.MATRIX_ENVIRONMENTS }}
@@ -479,7 +445,6 @@ jobs:
           SLACK_TITLE: Failure in Post-Development Deploy
           SLACK_MESSAGE: Failure with initialising ${{matrix.environment}} deployment for ${{env.APPLICATION}}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
 
   owasp:
     name: "OWASP Test"

--- a/.github/workflows/trello.yml
+++ b/.github/workflows/trello.yml
@@ -11,32 +11,13 @@ permissions:
 jobs:
   attach-to-trello:
     name: Link Trello card to this PR
-    environment: review
     runs-on: ubuntu-latest
     if: "!contains( 'dependabot[bot] snyk-bot' , github.actor )"
     steps:
-      - uses: Azure/login@v2
-        with:
-            client-id: ${{ secrets.AZURE_CLIENT_ID }}
-            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Fetch synk token from key vault
-        uses: azure/CLI@v2
-        id: fetch-keyvault-secret
-        with:
-          inlineScript: |
-            TRELLO_KEY=$(az keyvault secret show --name "TRELLO-KEY" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$TRELLO_KEY"
-            echo "TRELLO-KEY=$TRELLO_KEY" >> $GITHUB_OUTPUT
-            TRELLO_TOKEN=$(az keyvault secret show --name "TRELLO-TOKEN" --vault-name "${{ secrets.INF_KEY_VAULT}}" --query "value" -o tsv)
-            echo "::add-mask::$TRELLO_TOKEN"
-            echo "TRELLO-TOKEN=$TRELLO_TOKEN" >> $GITHUB_OUTPUT
-
       - name: Add Trello Comment
         uses: DFE-Digital/github-actions/AddTrelloComment@master
         with:
           MESSAGE:      ${{ github.event.pull_request.html_url }}
           CARD:         "${{ github.event.pull_request.body }}"
-          TRELLO-KEY:   ${{ steps.fetch-keyvault-secret.outputs.TRELLO-KEY }}
-          TRELLO-TOKEN: ${{ steps.fetch-keyvault-secret.outputs.TRELLO-TOKEN }}
+          TRELLO-KEY:   ${{ secrets.TRELLO_KEY }}
+          TRELLO-TOKEN: ${{ secrets.TRELLO_TOKEN }}


### PR DESCRIPTION
### Trello card

https://trello.com/c/CAZOMOph/2294-remove-kv-secrets-from-build-and-test-workflow

### Context

Move workflow only secrets from azure keyvault to github secrets.
This removes the github environment from non deploy steps, and makes more sense for a workflow secret.

### Changes proposed in this pull request

Updates to workflows

### Guidance to review

Check workflows all run correctly for this PR
manual build-no-cache: https://github.com/DFE-Digital/schools-experience/actions/runs/13942489603
