### PR TITLE
Add admin email contact to pii

### DIFF
--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -1,5 +1,5 @@
 ---
-:shared: 
+:shared:
   :users_roles:
   - user_id
   :users:
@@ -11,6 +11,9 @@
   - coordinates
   :bookings_candidates:
   - id
+  :bookings_profiles:
+  - admin_contact_email
+  - admin_contact_email_secondary
   :bookings_placement_requests:
   - candidate_id
   :events:


### PR DESCRIPTION
### Trello card
[Allow admin school fields to be passed to big query](https://trello.com/c/ERLQAXLK/7809-allow-school-admin-fields-to-be-passed-to-bigquery)

### Context
We need to be able to find out who school admin contacts are for Get school experience so we can contact them when needed

### Changes proposed in this pull request
Update PII field list

### Guidance to review

