### PR TITLE
Upgrade govuk-frontend to version 5.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "custom-event-polyfill": "^1.0.7",
     "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete",
     "express": "4.21.1",
-    "govuk-frontend": "^5.8.0",
+    "govuk-frontend": "5.9.0",
     "js-cookie": "^3.0.5",
     "json5": "2.2.3",
     "mini-css-extract-plugin": "^2.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3647,10 +3647,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.8.0.tgz#da1b03cb4f2ba1f6036be0dac3c5327c3405174c"
-  integrity sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==
+govuk-frontend@5.9.0:
+  version "5.9.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.9.0.tgz#4064ac692019e60f030d6311c49330a6454a5689"
+  integrity sha512-8NzmyoDtRFYyHs413DfNPR8Zo6qw6Q02Mruxml/Yfy+EueaOI/JZ4gVM8d0pqzJmTiMcJuHhvxqYEgBRmqeoyA==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"


### PR DESCRIPTION
Updated the govuk-frontend dependency from 5.8.0 to 5.9.0 in package.json and yarn.lock to incorporate the latest features and fixes.

### Trello card
[Upgrade govuk-frontend to version 5.9.0](https://trello.com/c/R0n4bcik/7946-bump-frontend-to-590-for-get-school-experience)

### Context
Regular update to govuk-frontend

### Changes proposed in this pull request

### Guidance to review

