### PR TITLE
Add the master image to the build cache list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,6 +96,7 @@ jobs:
               echo ${{ env.DOCKER_REPOSITORY }}:review-${{ steps.sha.outputs.short }}
               echo ${{ env.DOCKER_REPOSITORY }}:PR-${{ github.event.number }}
               echo ${{ env.DOCKER_REPOSITORY }}:${{ env.BRANCH_TAG }}
+              echo ${{ env.DOCKER_REPOSITORY }}:master
               echo EOF
             } >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
### Trello card

### Context

After updating the build workflow, realised I dropped the master image from the docker build cache list

### Changes proposed in this pull request

Adding it back in

### Guidance to review

see the build runs correctly using master as a cache option
https://github.com/DFE-Digital/schools-experience/actions/runs/16777424058

