### PR TITLE
Remove libpng 1.6.55-r0 pin from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk add -U --no-cache bash build-base git tzdata libxml2 libxml2-dev \
     chromium chromium-chromedriver
 
 # Upgrade libpng to 1.6.55-0 to address synk vuln https://security.snyk.io/vuln/SNYK-ALPINE321-LIBPNG-15338682
-RUN apk add -U --no-cache libpng=1.6.55-r0
+#RUN apk add -U --no-cache libpng=1.6.55-r0
 
 # Copy Entrypoint script
 COPY script/docker-entrypoint.sh .


### PR DESCRIPTION
### Trello card

n/a

### Context

Remove libpng 1.6.55-r0 pin from Dockerfile, which was added for a snyk vulnerability
The build now requires a later version

Might need to break the cache for master once this is merged

### Changes proposed in this pull request

Dockerfile update

### Guidance to review

see https://github.com/DFE-Digital/schools-experience/actions/runs/24667685243 (build without cache)
https://github.com/DFE-Digital/schools-experience/actions/runs/24667134801

