### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: DFE-Digital/github-actions/set-up-environment@master
 
       - name: Lint Dockerfile
-        uses: brpaz/hadolint-action@master
+        uses: brpaz/hadolint-action@f49a60108f34b589e16e00be852f810e8ddb2484 # Pinned at head of master as of 10th March 2021
         with:
           dockerfile: "Dockerfile"
 


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR