### PR TITLE
2683 - Correction to GCP credentials

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -39,5 +39,5 @@ jobs:
           validation-plan: ${{ matrix.validation_plan }}
           service: ${{ vars.TEAMS_MSG_SERVICE_NAME }}
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
-          gcp-wip: projects/737868692824/locations/global/workloadIdentityPools/refer-serious-misconduct/providers/refer-serious-misconduct
-          gcp-project-id: refer-serious-misconduct
+          gcp-wip: projects/574582782335/locations/global/workloadIdentityPools/schools-experience/providers/schools-experience
+          gcp-project-id: get-into-teaching


### PR DESCRIPTION
### Context

Correction to a validate infra workflow to detect any changes in SD Infra Terraform 

### Changes proposed in this pull request

Correction to the GCP credentials in GitHub action workflow validate-infrastructure.yml.

### Guidance to review

To validate the workflow once available. Make a test branch with a change to terraform/domains/environment_domains/config/production.tfvars.json **limit**. Run the workflow against that branch. It must produce a post in the SD Infra Alerts Teams channel with description **Domains environment infrastructure drift detected in production**

Manually test changes by altering terraform/domains/environment_domains/config/production.tfvars.json **limit** and running locally the following command.
`make production domains-plan`
This will produce a Terraform update in place.

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
