### PR TITLE
2683 - Additional CI and terraform-init logic for false positive dock…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ production: production-cluster
 ci:
 	$(eval AUTO_APPROVE=-auto-approve)
 	$(eval SKIP_AZURE_LOGIN=true)
+	$(eval export USE_STABLE_IMAGE_TAG=true)
 
 clean:
 	[ ! -f fetch_config.rb ]  \
@@ -92,7 +93,17 @@ composed-variables:
 	$(eval STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}tfstate${CONFIG_SHORT}sa)
 
 terraform-init: composed-variables set-azure-account
-	$(if ${IMAGE_TAG}, , $(eval IMAGE_TAG=master))
+	# If running in validation (ci), force stable image except override image for validation (terraform-plan), not deploy
+	$(if $(and $(USE_STABLE_IMAGE_TAG),$(filter terraform-plan,$(MAKECMDGOALS))), \
+		$(eval export IMAGE_TAG=master) \
+		$(eval export IMAGE_TAG_PREFIX=), \
+	)
+
+	# Otherwise fall back safely
+	$(if $(IMAGE_TAG), , $(eval IMAGE_TAG=master))
+
+	# Ensure prefix defaults correctly
+	$(if $(IMAGE_TAG_PREFIX), , $(eval IMAGE_TAG_PREFIX=sha))
 
 	rm -rf terraform/aks/vendor/modules/aks
 	git -c advice.detachedHead=false clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git terraform/aks/vendor/modules/aks
@@ -106,7 +117,9 @@ terraform-init: composed-variables set-azure-account
 	$(eval export TF_VAR_config_short=${CONFIG_SHORT})
 	$(eval export TF_VAR_service_name=${SERVICE_NAME})
 	$(eval export TF_VAR_service_short=${SERVICE_SHORT})
-	$(eval export TF_VAR_docker_image=${DOCKER_REPOSITORY}:${IMAGE_TAG_PREFIX}-${IMAGE_TAG})
+	$(if $(IMAGE_TAG_PREFIX), $(eval export TF_VAR_docker_image=${DOCKER_REPOSITORY}:${IMAGE_TAG_PREFIX}-${IMAGE_TAG}), \
+        $(eval export TF_VAR_docker_image=${DOCKER_REPOSITORY}:${IMAGE_TAG}))
+
 
 terraform-plan: terraform-init
 	terraform -chdir=terraform/aks plan ${DETAILED_EXITCODE} -var-file "config/${CONFIG}.tfvars.json"


### PR DESCRIPTION
### Context

The validate infra workflow is producing a false positive result on the docker image as it's using the full sha instead of the sha tag created during deployment.

### Changes proposed in this pull request

Correction to the Makefile to eliminate false positive changes in the docker image.
ci and terraform-init changed to calculate the correct docker image to use in the terraform-plan.

### Guidance to review

This can only be tested by merging to main and running the workflow.

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally