### PR TITLE
2683 -  terraform-init reverted and logic now managed in the action

### DIFF
--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -41,3 +41,6 @@ jobs:
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL_INFRA }}
           gcp-wip: projects/574582782335/locations/global/workloadIdentityPools/schools-experience/providers/schools-experience
           gcp-project-id: get-into-teaching
+          target-branch: master
+          sha-type: short
+          image-prefix: sha-

--- a/.github/workflows/validate-infrastructure.yml
+++ b/.github/workflows/validate-infrastructure.yml
@@ -43,4 +43,3 @@ jobs:
           gcp-project-id: get-into-teaching
           target-branch: master
           sha-type: short
-          image-prefix: sha-

--- a/Makefile
+++ b/Makefile
@@ -93,17 +93,7 @@ composed-variables:
 	$(eval STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}tfstate${CONFIG_SHORT}sa)
 
 terraform-init: composed-variables set-azure-account
-	# If running in validation (ci), force stable image except override image for validation (terraform-plan), not deploy
-	$(if $(and $(USE_STABLE_IMAGE_TAG),$(filter terraform-plan,$(MAKECMDGOALS))), \
-		$(eval export IMAGE_TAG=master) \
-		$(eval export IMAGE_TAG_PREFIX=), \
-	)
-
-	# Otherwise fall back safely
-	$(if $(IMAGE_TAG), , $(eval IMAGE_TAG=master))
-
-	# Ensure prefix defaults correctly
-	$(if $(IMAGE_TAG_PREFIX), , $(eval IMAGE_TAG_PREFIX=sha))
+	$(if ${IMAGE_TAG}, , $(eval IMAGE_TAG=master))
 
 	rm -rf terraform/aks/vendor/modules/aks
 	git -c advice.detachedHead=false clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git terraform/aks/vendor/modules/aks
@@ -117,9 +107,7 @@ terraform-init: composed-variables set-azure-account
 	$(eval export TF_VAR_config_short=${CONFIG_SHORT})
 	$(eval export TF_VAR_service_name=${SERVICE_NAME})
 	$(eval export TF_VAR_service_short=${SERVICE_SHORT})
-	$(if $(IMAGE_TAG_PREFIX), $(eval export TF_VAR_docker_image=${DOCKER_REPOSITORY}:${IMAGE_TAG_PREFIX}-${IMAGE_TAG}), \
-        $(eval export TF_VAR_docker_image=${DOCKER_REPOSITORY}:${IMAGE_TAG}))
-
+	$(eval export TF_VAR_docker_image=${DOCKER_REPOSITORY}:${IMAGE_TAG_PREFIX}-${IMAGE_TAG})
 
 terraform-plan: terraform-init
 	terraform -chdir=terraform/aks plan ${DETAILED_EXITCODE} -var-file "config/${CONFIG}.tfvars.json"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ REGION=UK South
 SERVICE_NAME=get-school-experience
 SERVICE_SHORT=gse
 DOCKER_REPOSITORY=ghcr.io/dfe-digital/schools-experience
+IMAGE_TAG ?= master
 
 ifndef VERBOSE
 .SILENT:
@@ -61,7 +62,6 @@ production: production-cluster
 ci:
 	$(eval AUTO_APPROVE=-auto-approve)
 	$(eval SKIP_AZURE_LOGIN=true)
-	$(eval export USE_STABLE_IMAGE_TAG=true)
 
 clean:
 	[ ! -f fetch_config.rb ]  \
@@ -93,8 +93,6 @@ composed-variables:
 	$(eval STORAGE_ACCOUNT_NAME=${AZURE_RESOURCE_PREFIX}${SERVICE_SHORT}tfstate${CONFIG_SHORT}sa)
 
 terraform-init: composed-variables set-azure-account
-	$(if ${IMAGE_TAG}, , $(eval IMAGE_TAG=master))
-
 	rm -rf terraform/aks/vendor/modules/aks
 	git -c advice.detachedHead=false clone --depth=1 --single-branch --branch ${TERRAFORM_MODULES_TAG} https://github.com/DFE-Digital/terraform-modules.git terraform/aks/vendor/modules/aks
 


### PR DESCRIPTION
### Context

The validate infra workflow is producing a false positive result on the docker image as it's using the full sha instead of the sha tag created during deployment.

### Changes proposed in this pull request

Makefile set back to the original for terraform-init.
ci and terraform-init changed to calculate the correct docker image to use in the terraform-plan.

They rely on updated github-actions/validate-infra [updated ](https://github.com/DFE-Digital/github-actions/tree/test-validate-infra) which needs to be merged first.

### Guidance to review

Use the Validate Infra workflow and point it at the branch. It should succeed and give three green ticks against the 3 jobs but the AKS infrastructure should report a drift against the docker image. There is no way around this. This drift will produce a MS Teams channel workflow card reporting the failure.
Once merged into main the drift will disappear. 

### Link to Trello card

https://trello.com/c/p76gfyrn/2683-schedule-validate-infra-workflow

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally