### PR TITLE
2809 - Upgrade Postgres in production

### DIFF
--- a/terraform/aks/config/production.tfvars.json
+++ b/terraform/aks/config/production.tfvars.json
@@ -1,33 +1,41 @@
 {
-    "cluster": "production",
-    "namespace": "git-production",
-    "environment": "production",
-    "azure_enable_backup_storage": true,
-    "enable_monitoring": true,
-    "infra_key_vault_name": "s189p01-gse-pd-inf-kv",
-    "statuscake_password_name": "SC-PASSWORD",
-    "sidekiq_replicas" : 2,
-    "app_replicas" : 2,
-    "sidekiq_memory_max" : "2Gi",
-    "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
-    "postgres_enable_high_availability": true,
-    "azure_maintenance_window": {
-      "day_of_week": 0,
-      "start_hour": 3,
-      "start_minute": 0
-    },
-    "key_vault_resource_group":  "s189p01-gse-pd-rg",
-    "statuscake_alerts": {
-      "alert": {
-        "website_url": [ "https://schoolexperience.education.gov.uk/healthcheck.json" ],
-        "ssl_url": [ "https://schoolexperience.education.gov.uk" ],
-        "contact_groups": [239498, 282453]
-      }
-    },
-    "dsi_hostname": "schoolexperience.education.gov.uk",
-    "enable_logit": true,
-    "enable_prometheus_monitoring": true,
-    "dataset_name": "gse_events_production",
-    "enable_dfe_analytics_federated_auth": true,
-    "send_traffic_to_maintenance_page": false
+  "cluster": "production",
+  "namespace": "git-production",
+  "environment": "production",
+  "azure_enable_backup_storage": true,
+  "enable_monitoring": true,
+  "infra_key_vault_name": "s189p01-gse-pd-inf-kv",
+  "statuscake_password_name": "SC-PASSWORD",
+  "sidekiq_replicas": 2,
+  "app_replicas": 2,
+  "sidekiq_memory_max": "2Gi",
+  "postgres_flexible_server_sku": "GP_Standard_D2ds_v5",
+  "postgres_enable_high_availability": true,
+  "azure_maintenance_window": {
+    "day_of_week": 0,
+    "start_hour": 3,
+    "start_minute": 0
+  },
+  "key_vault_resource_group": "s189p01-gse-pd-rg",
+  "statuscake_alerts": {
+    "alert": {
+      "website_url": [
+        "https://schoolexperience.education.gov.uk/healthcheck.json"
+      ],
+      "ssl_url": [
+        "https://schoolexperience.education.gov.uk"
+      ],
+      "contact_groups": [
+        239498,
+        282453
+      ]
+    }
+  },
+  "dsi_hostname": "schoolexperience.education.gov.uk",
+  "enable_logit": true,
+  "enable_prometheus_monitoring": true,
+  "dataset_name": "gse_events_production",
+  "enable_dfe_analytics_federated_auth": true,
+  "send_traffic_to_maintenance_page": false,
+  "postgres_version": 17
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -1,7 +1,7 @@
 variable "postgres_version" {
   description = "Version of PostgreSQL to use."
   type        = number
-  default     = 14
+  default     = 17
 }
 
 variable "cluster" {


### PR DESCRIPTION
### Trello card

https://trello.com/c/6Ey6BDbj/2809-upgrade-gse-postgres-version

### Context

These changes are required to upgrade PostgreSQL Flexible server version from 14 to 17.

### Changes proposed in this pull request

The version of Postgres has been added as version 17 to production and the default has been updated from 14 to 17.

### Guidance to review

This has been successfully implemented in review, development and staging.