### PR TITLE
Update guide_for_candidates.html.erb for clarity

### DIFF
--- a/app/views/candidates/home/guide_for_candidates.html.erb
+++ b/app/views/candidates/home/guide_for_candidates.html.erb
@@ -20,7 +20,7 @@
   <h2 class="govuk-heading-m">Eligibility</h2>
 
    <p>
-         You can request school experience if you:
+         You can request a school visit if you:
           <ul class="govuk-list govuk-list--bullet">
             <li>are aged 18 or over</li>
             <li>have a degree (or are studying for one)</li>
@@ -31,7 +31,7 @@
     <h2 class="govuk-heading-m">What to expect</h2>
 
        <p>
-        Your school experience will usually be one or 2 days long, but can sometimes be as long as 3 weeks.
+        Your school visit will usually be one or 2 days long, but can sometimes be as long as 3 weeks.
        </p>
 
        <p>

--- a/app/views/candidates/home/guide_for_candidates.html.erb
+++ b/app/views/candidates/home/guide_for_candidates.html.erb
@@ -5,23 +5,17 @@
     <h1 class="govuk-heading-xl">School experience: guide for candidates</h1>
 
         <p>
-         School experience allows you to learn more about teaching by visiting schools.
+         If you're thinking about becoming a teacher, you may want to visit a school to learn more about what life in the classroom can be like before you apply for teacher training.
         </p>
 
          <p>
-         It can help you:
+         Visiting a school can help you:
           <ul class="govuk-list govuk-list--bullet">
             <li>decide if you want to train to be a teacher</li>
             <li>discover which setting you’d prefer to teach in (primary or secondary)</li>
             <li>build a relationship with a school you might want to work with later</li>
         </ul>
     </p>
-
-  <h2 class="govuk-heading-m">When to get your school experience</h2>
-
-        <p>
-         If you’re considering going into teaching, you may want to do school experience before you apply for teacher training.
-        </p>
 
   <h2 class="govuk-heading-m">Eligibility</h2>
 
@@ -37,15 +31,15 @@
     <h2 class="govuk-heading-m">What to expect</h2>
 
        <p>
-        School experience is usually one or 2 days long, but can sometimes be as long as 3 weeks.
+        Your school experience will usually be one or 2 days long, but can sometimes be as long as 3 weeks.
        </p>
 
        <p>
-        You can choose to do virtual or in-school experience, depending on what schools offer.
+        You can choose to attend virtually or in-person, depending on what schools offer.
       </p>
 
          <p>
-           During your experience, you'll get to do things like:
+           You'll get to do things like:
             <ul class="govuk-list govuk-list--bullet">
               <li>observe lessons</li>
               <li>see how teachers manage a classroom</li>
@@ -60,7 +54,7 @@
         </p>
 
         <p>
-         Virtual experience can involve a presentation or Q&A session. Sometimes it can be a pre-recorded video of a lesson.
+         Virtual experience can involve a presentation or a questions and answers session. Sometimes it can be a pre-recorded video of a lesson.
         </p>
 
  <h2 class="govuk-heading-m">Find school experience</h2>


### PR DESCRIPTION
Revised text for clarity and readability in the guide for candidates.

### Trello card
https://trello.com/c/jif4Z2bU/9270-adjust-gse-description-to-avoid-confusion-with-provider-experience-requirements

### Context
We need to make clear that the service cannot necessarily provide the experience some teacher training providers require for their courses.

### Changes proposed in this pull request
Content changes for clarity

### Guidance to review

